### PR TITLE
Use threadpool to set up price symbols

### DIFF
--- a/third_party/pyth/pyth_publisher.py
+++ b/third_party/pyth/pyth_publisher.py
@@ -3,6 +3,7 @@
 from pyth_utils import *
 
 from http.server import HTTPServer, BaseHTTPRequestHandler
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import json
 import os
@@ -57,24 +58,8 @@ def accounts_endpoint():
     httpd.serve_forever()
 
 
-# Fund the publisher
-sol_run_or_die("airdrop", [
-    str(SOL_AIRDROP_AMT),
-    "--keypair", PYTH_PUBLISHER_KEYPAIR,
-    "--commitment", "finalized",
-])
-
-# Create a mapping
-pyth_run_or_die("init_mapping")
-
-print(f"Creating {PYTH_TEST_SYMBOL_COUNT} test Pyth symbols")
-
-publisher_pubkey = sol_run_or_die("address", args=[
-    "--keypair", PYTH_PUBLISHER_KEYPAIR
-], capture_output=True).stdout.strip()
-
-for i in range(PYTH_TEST_SYMBOL_COUNT):
-    symbol_name = f"Test symbol {i}"
+def add_symbol(num: int):
+    symbol_name = f"Test symbol {num}"
     # Add a product
     prod_pubkey = pyth_run_or_die(
         "add_product", capture_output=True).stdout.strip()
@@ -111,6 +96,31 @@ for i in range(PYTH_TEST_SYMBOL_COUNT):
     TEST_SYMBOLS.append(sym)
 
     sys.stdout.flush()
+
+    return num
+
+
+# Fund the publisher
+sol_run_or_die("airdrop", [
+    str(SOL_AIRDROP_AMT),
+    "--keypair", PYTH_PUBLISHER_KEYPAIR,
+    "--commitment", "finalized",
+])
+
+# Create a mapping
+pyth_run_or_die("init_mapping")
+
+print(f"Creating {PYTH_TEST_SYMBOL_COUNT} test Pyth symbols")
+
+publisher_pubkey = sol_run_or_die("address", args=[
+    "--keypair", PYTH_PUBLISHER_KEYPAIR
+], capture_output=True).stdout.strip()
+
+with ThreadPoolExecutor(max_workers=10) as executor:
+    add_symbol_futures = {executor.submit(add_symbol, sym_id) for sym_id in range(PYTH_TEST_SYMBOL_COUNT)}
+    
+    for future in as_completed(add_symbol_futures):
+        print(f"Completed {future.result()}")
 
 print(
     f"Mock updates ready to roll. Updating every {str(PYTH_PUBLISHER_INTERVAL)} seconds")


### PR DESCRIPTION
It will reduce the test time to ~10 min on the CI (this PR time!) and much faster in local testing.

For future we probably want to consider using oracle_sandbox.