### PR TITLE
pyth2wormhole-client: unit testing boilerplate + working happy path scenario

### DIFF
--- a/solana/pyth2wormhole/Cargo.lock
+++ b/solana/pyth2wormhole/Cargo.lock
@@ -76,10 +76,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "ascii"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
+name = "async-trait"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+dependencies = [
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
+]
 
 [[package]]
 name = "atty"
@@ -346,6 +363,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-humanize"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eddc119501d583fd930cb92144e605f44e0252c38dd89d9247fffa1993375cb"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +416,19 @@ dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
  "syn 1.0.73",
+]
+
+[[package]]
+name = "combine"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
+dependencies = [
+ "ascii",
+ "byteorder",
+ "either",
+ "memchr",
+ "unreachable",
 ]
 
 [[package]]
@@ -671,6 +710,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
+
+[[package]]
 name = "ed25519"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +752,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b50932a01e7ec5c06160492ab660fb19b6bb2a7878030dd6cd68d21df9d4d"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +782,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "3.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b166c9e378360dd5a6666a9604bb4f54ae0cac39023ffbac425e917a2a04fef"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -1003,6 +1073,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 
 [[package]]
+name = "goblin"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32401e89c6446dcd28185931a01b1093726d0356820ac744023e6850689bf926"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,6 +1100,15 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1476,6 +1566,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1565,6 +1666,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "opentelemetry"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf9b1c4e9a6c4de793c632496fa490bdc0e1eea73f0c91394f7b6990935d22"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project",
+ "rand 0.8.4",
+ "thiserror",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "p2w-sdk"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
- "pyth-client 0.5.0",
+ "pyth-sdk-solana",
  "serde",
  "solana-program",
  "solitaire",
@@ -1654,6 +1772,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pin-project"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+dependencies = [
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,6 +1808,12 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "ppv-lite86"
@@ -1773,6 +1917,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyth-sdk"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c610102a39fc4bae29a3b5a628ee134d25afb3dca3937692f5e634f1287fe0b4"
+dependencies = [
+ "borsh",
+ "borsh-derive",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "pyth-sdk-solana"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1fdc94592a28fa829b0d6fa619392b1a1744048e5b78a74a4ba93cf541eddae"
+dependencies = [
+ "borsh",
+ "borsh-derive",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "pyth-sdk",
+ "serde",
+ "solana-program",
+ "thiserror",
+]
+
+[[package]]
 name = "pyth2wormhole"
 version = "0.1.0"
 dependencies = [
@@ -1798,12 +1971,14 @@ dependencies = [
  "env_logger 0.8.4",
  "log",
  "p2w-sdk",
+ "pyth-client 0.5.0",
  "pyth2wormhole",
  "serde",
  "serde_yaml",
  "shellexpand",
  "solana-client",
  "solana-program",
+ "solana-program-test",
  "solana-sdk",
  "solana-transaction-status",
  "solitaire",
@@ -1849,6 +2024,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+ "rand_pcg",
 ]
 
 [[package]]
@@ -1917,6 +2093,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2128,10 +2313,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6b5a3c80cea1ab61f4260238409510e814e38b4b563c06044edf91e7dc070e3"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ae4dce13e8614c46ac3c38ef1c0d668b101df6ac39817aebdaa26642ddae9b"
+dependencies = [
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "serde_derive_internals",
+ "syn 1.0.73",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scroll"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
+dependencies = [
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
+]
 
 [[package]]
 name = "sct"
@@ -2172,6 +2401,17 @@ name = "serde_derive"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+dependencies = [
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
@@ -2249,6 +2489,15 @@ dependencies = [
  "digest 0.9.0",
  "keccak",
  "opaque-debug",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2337,6 +2586,70 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-program-runtime",
  "solana-sdk",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-banks-client"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d773f6f6446808589ce0c82ecf4f3a0a6c1e03ae07976a87c6b09da73f4fc63"
+dependencies = [
+ "borsh",
+ "futures",
+ "solana-banks-interface",
+ "solana-program",
+ "solana-sdk",
+ "tarpc",
+ "thiserror",
+ "tokio",
+ "tokio-serde",
+]
+
+[[package]]
+name = "solana-banks-interface"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165d9233bb2b089cd23fd75bcf3256d1dc48e963172e83c19152087158ae8ed0"
+dependencies = [
+ "serde",
+ "solana-sdk",
+ "tarpc",
+]
+
+[[package]]
+name = "solana-banks-server"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962b50fc11c8f9cbd50cebc3464dba85af73379130b34b84515e8f5ea9f1aac7"
+dependencies = [
+ "bincode",
+ "futures",
+ "solana-banks-interface",
+ "solana-runtime",
+ "solana-sdk",
+ "solana-send-transaction-service",
+ "tarpc",
+ "tokio",
+ "tokio-serde",
+ "tokio-stream",
+]
+
+[[package]]
+name = "solana-bpf-loader-program"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05671461b1191239932ce933cde1df4736ed1fdd098051fd9ef47d2c45cf1109"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "libsecp256k1",
+ "log",
+ "solana-measure",
+ "solana-metrics",
+ "solana-program-runtime",
+ "solana-sdk",
+ "solana_rbpf",
  "thiserror",
 ]
 
@@ -2649,6 +2962,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-program-test"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e606d824595d7a0b45a5ede3bbfec1f3316a01c5c64774da8c08873abc507f78"
+dependencies = [
+ "async-trait",
+ "base64 0.12.3",
+ "bincode",
+ "chrono-humanize",
+ "log",
+ "serde",
+ "solana-banks-client",
+ "solana-banks-server",
+ "solana-bpf-loader-program",
+ "solana-logger",
+ "solana-program-runtime",
+ "solana-runtime",
+ "solana-sdk",
+ "solana-vote-program",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "solana-rayon-threadlimit"
 version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2796,6 +3133,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-send-transaction-service"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5782c5c8dbe7009c58231340087a7b750b035508616b33a2beeb29395e9e30bc"
+dependencies = [
+ "log",
+ "solana-logger",
+ "solana-metrics",
+ "solana-runtime",
+ "solana-sdk",
+]
+
+[[package]]
 name = "solana-stake-program"
 version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2880,6 +3230,25 @@ dependencies = [
  "solana-program-runtime",
  "solana-sdk",
  "thiserror",
+]
+
+[[package]]
+name = "solana_rbpf"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb565d026461ba89d1d92cc36cf0882fba44076559c3bbed1e8a9888112b3d7"
+dependencies = [
+ "byteorder",
+ "combine",
+ "goblin",
+ "hash32",
+ "libc",
+ "log",
+ "rand 0.7.3",
+ "rustc-demangle",
+ "scroll",
+ "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -3024,6 +3393,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "tarpc"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b85d0a9369a919ba0db919b142a2b704cd207dfc676f7a43c2d105d0bc225487"
+dependencies = [
+ "anyhow",
+ "fnv",
+ "futures",
+ "humantime",
+ "opentelemetry",
+ "pin-project",
+ "rand 0.8.4",
+ "serde",
+ "static_assertions",
+ "tarpc-plugins",
+ "thiserror",
+ "tokio",
+ "tokio-serde",
+ "tokio-util",
+ "tracing",
+ "tracing-opentelemetry",
+]
+
+[[package]]
+name = "tarpc-plugins"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee42b4e559f17bce0385ebf511a7beb67d5cc33c12c96b7f4e9789919d9c10f"
+dependencies = [
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3092,6 +3496,15 @@ dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
  "syn 1.0.73",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -3181,6 +3594,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-serde"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
+dependencies = [
+ "bincode",
+ "bytes",
+ "educe",
+ "futures-core",
+ "futures-sink",
+ "pin-project",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3191,6 +3631,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 
@@ -3216,8 +3657,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
+dependencies = [
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3227,6 +3681,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "599f388ecb26b28d9c1b2e4437ae019a7b336018b45ed911458cd9ebf91129f6"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cbe87a2fa7e35900ce5de20220a582a9483a7063811defce79d7cbd59d4cfe"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
@@ -3318,6 +3795,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+dependencies = [
+ "void",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3362,6 +3848,12 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"

--- a/solana/pyth2wormhole/client/Cargo.toml
+++ b/solana/pyth2wormhole/client/Cargo.toml
@@ -10,7 +10,7 @@ name = "pyth2wormhole_client"
 src = "src/lib.rs"
 
 [features]
-default = ["pyth2wormhole/client", "wormhole-bridge-solana/client"]
+default = ["pyth2wormhole/client", "wormhole-bridge-solana/client", "pyth2wormhole/trace"]
 
 [dependencies]
 borsh = "=0.9.1"
@@ -29,3 +29,8 @@ solana-sdk = "=1.9.4"
 solana-transaction-status = "=1.9.4"
 solitaire-client = {path = "../../solitaire/client"}
 solitaire = {path = "../../solitaire/program"}
+
+[dev-dependencies]
+pyth-client = "0.5.0"
+solana-program-test = "=1.9.4"
+solana-sdk = "=1.9.4"

--- a/solana/pyth2wormhole/client/src/lib.rs
+++ b/solana/pyth2wormhole/client/src/lib.rs
@@ -52,10 +52,9 @@ use pyth2wormhole::{
     Pyth2WormholeConfig,
 };
 
-pub use attestation_cfg::{
-    AttestationConfig,
-    P2WSymbol,
-};
+pub use attestation_cfg::P2WSymbol;
+
+pub use attestation_cfg::AttestationConfig;
 
 pub fn gen_init_tx(
     payer: Keypair,

--- a/solana/pyth2wormhole/client/tests/fixtures/mod.rs
+++ b/solana/pyth2wormhole/client/tests/fixtures/mod.rs
@@ -1,0 +1,2 @@
+pub mod passthrough;
+pub mod pyth;

--- a/solana/pyth2wormhole/client/tests/fixtures/passthrough.rs
+++ b/solana/pyth2wormhole/client/tests/fixtures/passthrough.rs
@@ -1,0 +1,23 @@
+//! Trivial program for mocking other programs easily
+use solana_program::{
+    account_info::AccountInfo,
+    msg,
+    program_error::ProgramError,
+};
+use solana_sdk::pubkey::Pubkey;
+
+use solana_program_test::*;
+
+pub fn passthrough_entrypoint(
+    program_id: &Pubkey,
+    account_infos: &[AccountInfo],
+    data: &[u8],
+) -> Result<(), ProgramError> {
+    msg!(&format!("Program {}", program_id));
+    msg!(&format!("account_infos {:?}", account_infos));
+    Ok(())
+}
+
+pub fn add_passthrough(pt: &mut ProgramTest, name: &str, prog_id: Pubkey) {
+    pt.add_program(name, prog_id, processor!(passthrough_entrypoint))
+}

--- a/solana/pyth2wormhole/client/tests/fixtures/pyth.rs
+++ b/solana/pyth2wormhole/client/tests/fixtures/pyth.rs
@@ -1,0 +1,87 @@
+//! This module contains test fixtures for instantiating plausible
+//! Pyth accounts for testing purposes.
+use solana_program_test::*;
+
+use solana_sdk::{
+    account::Account,
+    pubkey::Pubkey,
+    rent::Rent,
+};
+
+use pyth_client::{
+    AccKey,
+    AccountType,
+    Price,
+    Product,
+    MAGIC,
+    PROD_ATTR_SIZE,
+    VERSION,
+};
+
+/// Create a pair of brand new product/price accounts that point at each other
+pub fn add_test_symbol(pt: &mut ProgramTest, owner: &Pubkey) -> (Pubkey, Pubkey) {
+    // Generate pubkeys
+    let prod_id = Pubkey::new_unique();
+    let price_id = Pubkey::new_unique();
+
+    // Instantiate
+    let prod = {
+        Product {
+            magic: MAGIC,
+            ver: VERSION,
+            atype: AccountType::Product as u32,
+            size: 0,
+            px_acc: AccKey {
+                val: price_id.to_bytes(),
+            },
+            attr: [0u8; PROD_ATTR_SIZE],
+        }
+    };
+
+    let mut price = Price {
+        magic: MAGIC,
+        ver: VERSION,
+        atype: AccountType::Price as u32,
+        prod: AccKey {
+            val: prod_id.to_bytes(),
+        },
+        ..Default::default()
+    };
+
+    // Cast to raw bytes
+    let prod_buf = &[prod];
+    let prod_bytes = unsafe {
+        let (_prefix, bytes, _suffix) = prod_buf.align_to::<u8>();
+        bytes
+    };
+    let price_buf = &[price];
+    let price_bytes = unsafe {
+        let (_prefix, bytes, _suffix) = price_buf.align_to::<u8>();
+        bytes
+    };
+
+    // Compute exemption rent
+    let prod_lamports = Rent::default().minimum_balance(prod_bytes.len());
+    let price_lamports = Rent::default().minimum_balance(price_bytes.len());
+
+    // Populate the accounts
+    let mut prod_acc = Account {
+        lamports: prod_lamports,
+        data: (*prod_bytes).to_vec(),
+        owner: owner.clone(),
+        rent_epoch: 0,
+        executable: false,
+    };
+    let mut price_acc = Account {
+        lamports: price_lamports,
+        data: (*price_bytes).to_vec(),
+        owner: owner.clone(),
+        rent_epoch: 0,
+        executable: false,
+    };
+
+    pt.add_account(prod_id, prod_acc);
+    pt.add_account(price_id, price_acc);
+
+    (prod_id, price_id)
+}

--- a/solana/pyth2wormhole/client/tests/test_attest.rs
+++ b/solana/pyth2wormhole/client/tests/test_attest.rs
@@ -1,0 +1,124 @@
+pub mod fixtures;
+
+use solana_program_test::*;
+use solana_sdk::{
+    account::Account,
+    instruction::{
+        AccountMeta,
+        Instruction,
+    },
+    pubkey::Pubkey,
+    rent::Rent,
+    signature::Signer,
+    signer::keypair::Keypair,
+    transaction::Transaction,
+};
+
+use bridge::accounts::{
+    Bridge,
+    BridgeConfig,
+    BridgeData,
+};
+
+use pyth2wormhole::config::{
+    P2WConfigAccount,
+    Pyth2WormholeConfig,
+};
+use pyth2wormhole_client as p2wc;
+use solitaire::{
+    processors::seeded::Seeded,
+    AccountState,
+    BorshSerialize,
+};
+
+use fixtures::{
+    passthrough,
+    pyth,
+};
+
+#[tokio::test]
+async fn test_happy_path() -> Result<(), solitaire::ErrBox> {
+    // Programs
+    let p2w_program_id = Pubkey::new_unique();
+    let wh_fixture_program_id = Pubkey::new_unique();
+
+    // Authorities
+    let p2w_owner = Pubkey::new_unique();
+    let pyth_owner = Pubkey::new_unique();
+
+    // On-chain state
+    let p2w_config = Pyth2WormholeConfig {
+        owner: p2w_owner,
+        wh_prog: wh_fixture_program_id,
+        max_batch_size: pyth2wormhole::attest::P2W_MAX_BATCH_SIZE,
+        pyth_owner,
+    };
+
+    let bridge_config = BridgeData {
+        config: BridgeConfig {
+            fee: 0xdeadbeef,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    // Populate test environment
+    let mut p2w_test = ProgramTest::new(
+        "pyth2wormhole",
+        p2w_program_id,
+        processor!(pyth2wormhole::instruction::solitaire),
+    );
+
+    // Plant a filled config account
+    let p2w_config_bytes = p2w_config.try_to_vec()?;
+    let p2w_config_account = Account {
+        lamports: Rent::default().minimum_balance(p2w_config_bytes.len()),
+        data: p2w_config_bytes,
+        owner: p2w_program_id,
+        executable: false,
+        rent_epoch: 0,
+    };
+    let p2w_config_addr =
+        P2WConfigAccount::<{ AccountState::Initialized }>::key(None, &p2w_program_id);
+
+    p2w_test.add_account(p2w_config_addr, p2w_config_account);
+
+    // Plant a bridge config
+    let bridge_config_bytes = bridge_config.try_to_vec()?;
+    let wh_bridge_config_account = Account {
+        lamports: Rent::default().minimum_balance(bridge_config_bytes.len()),
+        data: bridge_config_bytes,
+        owner: wh_fixture_program_id,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let wh_bridge_config_addr =
+        Bridge::<{ AccountState::Initialized }>::key(None, &wh_fixture_program_id);
+
+    p2w_test.add_account(wh_bridge_config_addr, wh_bridge_config_account);
+
+    passthrough::add_passthrough(&mut p2w_test, "wormhole", wh_fixture_program_id);
+    let (prod_id, price_id) = pyth::add_test_symbol(&mut p2w_test, &pyth_owner);
+
+    let mut ctx = p2w_test.start_with_context().await;
+    let msg_keypair = Keypair::new();
+
+    let symbols = vec![p2wc::P2WSymbol {
+        name: Some("Mock symbol".to_owned()),
+        product_addr: prod_id,
+        price_addr: price_id,
+    }];
+
+    let attest_tx = p2wc::gen_attest_tx(
+        p2w_program_id,
+        &p2w_config,
+        &ctx.payer,
+        symbols.as_slice(),
+        &msg_keypair,
+        ctx.last_blockhash,
+    )?;
+    ctx.banks_client.process_transaction(attest_tx).await?;
+
+    Ok(())
+}

--- a/solana/pyth2wormhole/program/src/attest.rs
+++ b/solana/pyth2wormhole/program/src/attest.rs
@@ -20,8 +20,8 @@ use solana_program::{
 
 use p2w_sdk::{
     BatchPriceAttestation,
-    PriceAttestation,
     P2WEmitter,
+    PriceAttestation,
 };
 
 use bridge::{
@@ -209,7 +209,7 @@ pub fn attest(ctx: &ExecutionContext, accs: &mut Attest, data: AttestData) -> So
             &*price.try_borrow_data()?,
         )
         .map_err(|e| {
-            trace!(e.to_string());
+            trace!(&e.to_string());
             ProgramError::InvalidAccountData
         })?;
 
@@ -254,7 +254,7 @@ pub fn attest(ctx: &ExecutionContext, accs: &mut Attest, data: AttestData) -> So
         PostMessageData {
             nonce: 0, // Superseded by the sequence number
             payload: batch_attestation.serialize().map_err(|e| {
-                trace!(e.to_string());
+                trace!(&e.to_string());
                 ProgramError::InvalidAccountData
             })?,
             consistency_level: data.consistency_level,

--- a/solana/pyth2wormhole/program/src/initialize.rs
+++ b/solana/pyth2wormhole/program/src/initialize.rs
@@ -1,5 +1,6 @@
 use solana_program::pubkey::Pubkey;
 use solitaire::{
+    trace,
     AccountState,
     CreationLamports,
     ExecutionContext,

--- a/solana/pyth2wormhole/program/src/lib.rs
+++ b/solana/pyth2wormhole/program/src/lib.rs
@@ -21,12 +21,10 @@ pub use set_config::{
     SetConfig,
 };
 
+pub use pyth_client;
+
 solitaire! {
     Attest(AttestData) => attest,
     Initialize(Pyth2WormholeConfig) => initialize,
     SetConfig(Pyth2WormholeConfig) => set_config,
 }
-
-#[cfg(feature = "wasm")]
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-pub mod wasm;


### PR DESCRIPTION
This PR implements some fixtures for a base happy path scenario for pyth2wormhole unit testing. It uses the official `solana-program-test` library to provide mock transaction processing logic. I was not able to find viable alternatives for that. 