### PR TITLE
Add solana feature flag for p2w sdk

### DIFF
--- a/solana/pyth2wormhole/client/Cargo.toml
+++ b/solana/pyth2wormhole/client/Cargo.toml
@@ -19,7 +19,7 @@ env_logger = "0.8.4"
 log = "0.4.14"
 wormhole-bridge-solana = {path = "../../bridge/program"}
 pyth2wormhole = {path = "../program"}
-p2w-sdk = { path = "../../../third_party/pyth/p2w-sdk/rust" }
+p2w-sdk = { path = "../../../third_party/pyth/p2w-sdk/rust", features=["solana"] }
 serde = "1"
 serde_yaml = "0.8"
 shellexpand = "2.1.0"

--- a/solana/pyth2wormhole/program/Cargo.toml
+++ b/solana/pyth2wormhole/program/Cargo.toml
@@ -22,7 +22,7 @@ rocksalt = { path = "../../solitaire/rocksalt" }
 solana-program = "=1.9.4"
 borsh = "=0.9.1"
 pyth-client = "0.2.2"
-p2w-sdk = { path = "../../../third_party/pyth/p2w-sdk/rust" }
+p2w-sdk = { path = "../../../third_party/pyth/p2w-sdk/rust", features = ["solana"] }
 serde = { version = "1", optional = true}
 serde_derive = { version = "1", optional = true}
 serde_json = { version = "1", optional = true}

--- a/third_party/pyth/p2w-sdk/rust/Cargo.toml
+++ b/third_party/pyth/p2w-sdk/rust/Cargo.toml
@@ -10,11 +10,12 @@ description = "Pyth to Wormhole SDK"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-wasm = ["wasm-bindgen"]
+solana = ["solitaire"]
+wasm = ["wasm-bindgen", "solana"]
 
 [dependencies]
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 pyth-client = { version = "0.5.0", features = ["no-entrypoint"] }
 wasm-bindgen = { version = "0.2.74", features = ["serde-serialize"], optional = true}
-solitaire = { path = "../../../../solana/solitaire/program" }
+solitaire = { path = "../../../../solana/solitaire/program", optional = true }
 solana-program = "1.8.16"

--- a/third_party/pyth/p2w-sdk/rust/src/lib.rs
+++ b/third_party/pyth/p2w-sdk/rust/src/lib.rs
@@ -19,6 +19,7 @@ use pyth_client::{
     PriceType,
 };
 
+#[cfg(feature = "solana")]
 use solitaire::{
     Derive,
     Info,
@@ -43,6 +44,7 @@ pub const P2W_FORMAT_VERSION: u16 = 2;
 pub const PUBKEY_LEN: usize = 32;
 
 /// Emmitter Address to wormhole is a PDA with seed p2w-emmiter from attestation contract
+#[cfg(feature = "solana")]
 pub type P2WEmitter<'b> = Derive<Info<'b>, "p2w-emitter">;
 
 /// Decides the format of following bytes


### PR DESCRIPTION
Solitaire requires rust nightly and strangely with rust nightly wasm for terra does not get optimized and program cannot be submitted. 

It adds a `solana` feature flag for P2WEmitter type which is used in js sdk and solana program/client (for attestation).