### PR TITLE
pyth2wormhole-client: Add polling-based concurrent tx confirmation

### DIFF
--- a/solana/pyth2wormhole/client/src/cli.rs
+++ b/solana/pyth2wormhole/client/src/cli.rs
@@ -46,16 +46,31 @@ pub enum Action {
     #[clap(
         about = "Use an existing pyth2wormhole program to attest product price information to another chain"
     )]
+    // Note: defaults target SOL mainnet-beta conditions at implementation time
     Attest {
         #[clap(short = 'f', long = "--config", about = "Attestation YAML config")]
         attestation_cfg: PathBuf,
         #[clap(
             short = 'n',
-            long = "--retries",
-            about = "How many times to retry each batch on failure",
-            default_value = "3"
+            long = "--n-retries",
+            about = "How many times to retry send_transaction() on each batch on failure",
+            default_value = "5"
         )]
         n_retries: usize,
+        #[clap(
+            short = 't',
+            long = "--timeout",
+            about = "How many seconds to wait before giving up on get_transaction() for each batch",
+            default_value = "40"
+        )]
+        conf_timeout_secs: u64,
+        #[clap(
+            short = 'i',
+            long = "--rpc-interval",
+            about = "How many milliseconds to waist between SOL RPC requests",
+            default_value = "200"
+        )]
+        rpc_interval_ms: u64,
     },
     #[clap(about = "Retrieve a pyth2wormhole program's current settings")]
     GetConfig,


### PR DESCRIPTION
This PR implements an FSM-style enum for concurrently scheduling batch transactions, while respecting a configurable confirmation timeout, the retry count and a SOL RPC rate-limiting interval. Defaults for the retry/interval values are meant to accomodate SOL mainnet.

Our transactions can be in one of these states:
* Sending - We're about to attempt a send_transaction() RPC call. The initial state
* Confirming - We're about to attempt a non-blocking get_transaction() RPC call. Non-terminal state
* FailedSend - We've exhausted all retries and failed while processing Sending, terminal state
* FailedConfirm - We've exhausted all retries and failed while processing Confirming (specifically, get_transaction() still throws an error after going over the specified timeout). terminal state 
* Success - This transaction succeeded within timout and retry count. Terminal state
 
 The logic assigns `Sending` to all batches and iterates through them  until all reach a terminal state.