### PR TITLE
p2w-terra-relay: ignore lib and node, own project dir in docker

### DIFF
--- a/third_party/pyth/p2w-terra-relay/.dockerignore
+++ b/third_party/pyth/p2w-terra-relay/.dockerignore
@@ -1,0 +1,2 @@
+/lib
+/node_modules

--- a/third_party/pyth/p2w-terra-relay/Dockerfile.pyth_relay
+++ b/third_party/pyth/p2w-terra-relay/Dockerfile.pyth_relay
@@ -9,7 +9,7 @@ RUN npm install && npm run build && npm cache clean --force
 
 RUN mkdir -p /app/pyth_relay/logs
 RUN addgroup -S pyth -g 10001 && adduser -S pyth -G pyth -u 10001
-RUN chown -R pyth:pyth src/ logs/ lib/
+RUN chown -R pyth:pyth .
 USER pyth
 
 CMD [ "node", "lib/index.js" ]


### PR DESCRIPTION
This fixes a sinister npm issue for me. On the surface it looked like p2w-terra-relay couldn't find the wormhole wasm flavor setter, but deeper inside this likely resulted from a nuanced combination of pre-existing node_modules (.dockerignore tackles this) and insufficient permissions on the node_modules dir. 