### PR TITLE
Update worker to handle timeout in callback correctly

### DIFF
--- a/third_party/pyth/p2w-terra-relay/src/worker.ts
+++ b/third_party/pyth/p2w-terra-relay/src/worker.ts
@@ -164,6 +164,9 @@ async function callBack(err: any, result: any) {
     err,
     result
   );
+
+  await updateBalance();
+
   // condition = null;
   // await helpers.sleep(10000);
   // logger.debug("done with long sleep");
@@ -200,6 +203,8 @@ async function callBack(err: any, result: any) {
           sendTime
         );
 
+        await updateBalance();
+
         if (pendingMap.size === 0) {
           logger.debug("in callback, rearming the condition.");
           done = true;
@@ -220,7 +225,9 @@ function computeTimeout(): number {
       return nextBalanceQueryTimeAsMs - now;
     }
 
-    return 0;
+    // Since a lot of time has passed, timeout in 1ms (0 means no-timeout)
+    // In most cases this line should not be reached.
+    return 1;
   }
 
   return conditionTimeout;
@@ -473,7 +480,9 @@ async function finalizeEventsAlreadyLocked(
         relayResult
     );
   }
+}
 
+async function updateBalance() {
   let now = new Date();
   if (balanceQueryInterval > 0 && now.getTime() >= nextBalanceQueryTimeAsMs) {
     let balance = await main.queryBalance(connectionData);


### PR DESCRIPTION
Problem is that at some point timeout for calling the callback again is set to 0 to trigger it immediately but the CondVar behind considers 0 as no timeout. It is not a bug and won't cause a problem because a new event will trigger the callback but it's different from what is expected and also when no event comes for a long time, balance don't get updated (it stays the same technically though) 

Also moves updating balance to a separate function and call it in different places to avoid reaching that state in most of the cases and have updated balance when there is no balance.

TL;DR: These all allow to balance to be updated every x seconds as configured and improve logging to work as the code suggests.