### PR TITLE
Fix dev.v2 after premature merge

### DIFF
--- a/third_party/pyth/p2w-terra-relay/src/relay/evm.ts
+++ b/third_party/pyth/p2w-terra-relay/src/relay/evm.ts
@@ -3,13 +3,13 @@ import { ethers } from "ethers";
 import { logger } from "../helpers";
 
 import {
-  PythImplementation__factory,
-  PythImplementation,
+  PythUpgradable__factory,
+  PythUpgradable,
 } from "../evm/bindings/";
 
 export class EvmRelay implements Relay {
   payerWallet: ethers.Wallet;
-  p2wContract: PythImplementation;
+  p2wContract: PythUpgradable;
   async relay(signedVAAs: Array<string>): Promise<RelayResult> {
     logger.warn("EvmRelay.relay(): TODO(2021-03-22)");
     return new RelayResult(RelayRetcode.Fail, []);
@@ -38,7 +38,7 @@ export class EvmRelay implements Relay {
     );
 
     this.payerWallet = new ethers.Wallet(wallet.privateKey, provider);
-    let factory = new PythImplementation__factory(this.payerWallet);
+    let factory = new PythUpgradable__factory(this.payerWallet);
     this.p2wContract = factory.attach(cfg.p2wContractAddress);
   }
 }


### PR DESCRIPTION
This PR fixes the build issue caused by merging Tom's contract before CI had a chance to evaluate it. The merge was done due to ongoing GitHub's Actions incidents. The problem was the name change `PythImplementation -> PythUpgradable` which would have caused a CI failure in normal conditions.