### PR TITLE
Make terra relayer more resillient

### DIFF
--- a/devnet/p2w-terra-relay.yaml
+++ b/devnet/p2w-terra-relay.yaml
@@ -72,9 +72,9 @@ spec:
             - name: BAL_QUERY_INTERVAL
               value: '60000'
             - name: RETRY_MAX_ATTEMPTS
-              value: '4'
+              value: '6'
             - name: RETRY_DELAY_IN_MS
-              value: '250'
+              value: '1000'
             - name: MAX_MSGS_PER_BATCH
               value: '1'
             - name: MAX_HEALTHY_NO_RELAY_DURATION_IN_SECONDS

--- a/third_party/pyth/p2w-terra-relay/src/relay/terra.ts
+++ b/third_party/pyth/p2w-terra-relay/src/relay/terra.ts
@@ -81,27 +81,15 @@ export class TerraRelay implements Relay {
         msgs.push(msg);
       }
 
-      let gasPrices, feeEstimate;
+      let gasPrices;
       try {
-       gasPrices = await axios
-        .get(TERRA_GAS_PRICES_URL)
-        .then((result) => result.data);
-        
-        feeEstimate = await lcdClient.tx.estimateFee(
-          [{
-            sequenceNumber: await wallet.sequence(),
-            publicKey: wallet.key.publicKey,
-          }],
-          {
-            msgs: [...msgs],
-            memo: "P2T",
-            feeDenoms: [this.coin],
-            gasPrices
-          }
-        )
+        gasPrices = await axios
+          .get(TERRA_GAS_PRICES_URL)
+          .then((result) => result.data);
       } catch (e: any) {
+        logger.warn(e);
+        logger.warn(e.stack);
         logger.warn("Couldn't fetch gas price and fee estimate. Using default values");
-        logger.warn(e, e.stack);
       }
 
       const tx = await wallet.createAndSignTx({
@@ -109,7 +97,6 @@ export class TerraRelay implements Relay {
         memo: "P2T",
         feeDenoms: [this.coin],
         gasPrices,
-        fee: feeEstimate
       });
 
       logger.debug("TIME: sending msg");
@@ -151,6 +138,8 @@ export class TerraRelay implements Relay {
       }
     } catch (e: any) {
       // Act on known Terra exceptions
+      logger.error(e);
+      logger.error(e.stack);
       if (
         e.message &&
         e.message.search("timeout") >= 0 &&
@@ -162,14 +151,19 @@ export class TerraRelay implements Relay {
         e.response?.data?.error &&
         e.response.data.error.search("VaaAlreadyExecuted") >= 0
       ) {
+        logger.error("VAA Already Executed");
+        logger.error(e.response.data.error);
         return new RelayResult(RelayRetcode.AlreadyExecuted, []);
       } else if (
         e.response?.data?.message &&
         e.response.data.message.search("account sequence mismatch") >= 0
       ) {
+        logger.error("Account sequence mismatch");
+        logger.error(e.response.data.message);
         return new RelayResult(RelayRetcode.SeqNumMismatch, []);
       } else {
-        logger.error("Unknown error:", e.toString());
+        logger.error("Unknown error:");
+        logger.error(e.toString());
         return new RelayResult(RelayRetcode.Fail, []);
       }
     }


### PR DESCRIPTION
Purpose of this PR is to reduce failures in relaying. I investigated because there was a 5min period that relayer didn't work and I highly suspect that this was a network/terra issue but it's good to increase the relayer tolerance.

- Increase retry attempts (4 to 6) and retry_delay (250ms to 1s) to be more resillient
  - This is because when account sequence mismatch happens it might take some time be fixed
- Removed estimate fee because it's being done in wallet.createAndSignTx (less requests)
- Improved logging on when error happens

On sequence number mismatch:
Sequence number is the transaction number of the payer and it is required in Terra to give some sort of order and also avoid messing up with the order of someones transaction for some profit. 

I couldn't understand why it happened in the downtime but it appeared a lot in dev environment. The error is that I expected a bigger sequence number (like 101) but a smaller is provided (like 100).

Where the sequence number in transaction comes from? when creating a transaction the wallet calls the api the get account sequence number.

So the problem happens because in the devnet we have 9 symbols which form 2 batches that will be sent to the wormhole almost at the same time. It seems that although the 1st one executes correctly the 2nd one doesn't get sequence number correctly and it is not async issue either. It happened even in the 2nd or 3rd retry with >1s after the first transactions. 

It seems that the api for giving sequence number back is not consistent with the api that does the transaction simulation in terms of transactions commitments. by improving the delay of retrying I fixed the problem in devnet to not miss messages. 

This PR doesn't completely solve it. It just makes it more resilient and the amount of delay will cause it to be successful because essentially some times passes for both endpoints to get synced. Solving it is not important now because in devnet we only have 1 batch (hence the error was very weird for me).

So.. how to solve it for the future?

1. Add manual sequence number tracking as was before in the relayer. 
2. Move retry logic to each relayer (by extracting some common parts out) and when receiving such a message, fix the sequence number based on the log with new number. 

There are other ways to achieve it too. I like the second one more because it cover broader cases such as the downtime we faced today. I will probably do it after evm changes are merged.

I created #122 to not forget it.
