### PR TITLE
Update dockerfile to chown less files

### DIFF
--- a/third_party/pyth/p2w-terra-relay/Dockerfile.pyth_relay
+++ b/third_party/pyth/p2w-terra-relay/Dockerfile.pyth_relay
@@ -4,16 +4,24 @@ ARG P2W_BASE_PATH=/usr/src/pyth2wormhole
 
 RUN apk --no-cache --update add python3 build-base  # Needed by the Ethereum build
 
+WORKDIR ${P2W_BASE_PATH}
+RUN addgroup -S pyth -g 10001 && adduser -S pyth -G pyth -u 10001
+RUN chown -R pyth:pyth .
+USER pyth
+
 WORKDIR ${P2W_BASE_PATH}/ethereum
-ADD ethereum .
+ADD --chown=pyth:pyth ethereum .
 RUN npm install && npm run build
 
+USER root
 RUN apk del build-base # No longer needed after EVM build
+
+USER pyth
 
 ARG P2W_RELAY_REL_PATH=third_party/pyth/p2w-terra-relay
 
 WORKDIR ${P2W_BASE_PATH}/${P2W_RELAY_REL_PATH} 
-ADD ${P2W_RELAY_REL_PATH} .
+ADD --chown=pyth:pyth ${P2W_RELAY_REL_PATH} .
 
 RUN npm ci && npm run build && npm cache clean --force
 
@@ -21,8 +29,5 @@ RUN npm ci && npm run build && npm cache clean --force
 # RUN npm ci --only=production
 
 RUN mkdir -p ${P2W_BASE_PATH}/${P2W_RELAY_REL_PATH}/logs
-RUN addgroup -S pyth -g 10001 && adduser -S pyth -G pyth -u 10001
-RUN chown -R pyth:pyth src/ lib/ logs/
-USER pyth
 
 CMD [ "node", "lib/index.js" ]


### PR DESCRIPTION
Currently the dockerfile chowns the whole directory which contains dozens of directories in node_modules.
It changes this only chown required data.

Also fixes the correct log directory which is created.