### PR TITLE
p2w [max_]num_publishers metadata

### DIFF
--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -160,6 +160,9 @@ contract Pyth is PythGetters, PythSetters {
 
             bpa.attestations[j].num_publishers = encoded.toUint32(index);
             index += 4;
+
+            bpa.attestations[j].max_num_publishers = encoded.toUint32(index);
+            index += 4;
         }
     }
 

--- a/ethereum/contracts/pyth/PythStructs.sol
+++ b/ethereum/contracts/pyth/PythStructs.sol
@@ -42,6 +42,8 @@ contract PythStructs {
         uint8 corpAct;
 
         uint64 timestamp;
+	uint32 num_publishers;
+	uint32 max_num_publishers;
     }
 
     struct Rational {

--- a/terra/contracts/pyth-bridge/src/contract.rs
+++ b/terra/contracts/pyth-bridge/src/contract.rs
@@ -131,7 +131,7 @@ fn process_batch_attestation(
             price_attestation.price_id.to_bytes(),
             price_attestation.status,
             price_attestation.expo,
-            0, // max_num_publishers data is currently unavailable
+            price_attestation.max_num_publishers, // max_num_publishers data is currently unavailable
             price_attestation.num_publishers, // num_publishers data is currently unavailable
             price_attestation.product_id.to_bytes(),
             price_attestation.price,

--- a/third_party/pyth/p2w-sdk/rust/src/lib.rs
+++ b/third_party/pyth/p2w-sdk/rust/src/lib.rs
@@ -75,6 +75,7 @@ pub struct PriceAttestation {
     pub corp_act:            CorpAction,
     pub timestamp:           UnixTimestamp,
     pub num_publishers:      u32,
+    pub max_num_publishers:  u32,
 }
 
 #[derive(Clone, Default, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -252,7 +253,8 @@ impl PriceAttestation {
             status: price.agg.status,
             corp_act: price.agg.corp_act,
             timestamp: timestamp,
-	    num_publishers: price.num_qt,
+            num_publishers: price.num_qt,
+	    max_num_publishers: price.num,
         })
     }
 
@@ -272,7 +274,8 @@ impl PriceAttestation {
             status,
             corp_act,
             timestamp,
-	    num_publishers
+            num_publishers,
+            max_num_publishers,
         } = self;
 
         // magic
@@ -317,8 +320,11 @@ impl PriceAttestation {
         // timestamp
         buf.extend_from_slice(&timestamp.to_be_bytes()[..]);
 
-        // timestamp
+        // num_publishers
         buf.extend_from_slice(&num_publishers.to_be_bytes()[..]);
+
+        // max_num_publishers
+        buf.extend_from_slice(&max_num_publishers.to_be_bytes()[..]);
 
         buf
     }
@@ -419,9 +425,13 @@ impl PriceAttestation {
         bytes.read_exact(timestamp_vec.as_mut_slice())?;
         let timestamp = UnixTimestamp::from_be_bytes(timestamp_vec.as_slice().try_into()?);
 
-	let mut num_publishers_vec = vec![0u8; mem::size_of::<u32>()];
+        let mut num_publishers_vec = vec![0u8; mem::size_of::<u32>()];
         bytes.read_exact(num_publishers_vec.as_mut_slice())?;
-	let num_publishers = u32::from_be_bytes(num_publishers_vec.as_slice().try_into()?);
+        let num_publishers = u32::from_be_bytes(num_publishers_vec.as_slice().try_into()?);
+
+        let mut max_num_publishers_vec = vec![0u8; mem::size_of::<u32>()];
+        bytes.read_exact(max_num_publishers_vec.as_mut_slice())?;
+        let max_num_publishers = u32::from_be_bytes(max_num_publishers_vec.as_slice().try_into()?);
 
         Ok(Self {
             product_id,
@@ -435,7 +445,8 @@ impl PriceAttestation {
             status,
             corp_act,
             timestamp,
-	    num_publishers
+            num_publishers,
+	    max_num_publishers,
         })
     }
 }


### PR DESCRIPTION
This PR extends the cross chain metadata with `num_publishers` and `max_num_publishers` derived from `num_qt` and `num`, respectively. **Note: This extends the wire format using the append-only `PriceAttestation` convention.** Correct implementations should continue to work with the newer data.