### PR TITLE
Remove build-evm-contracts from relayer build step.

### DIFF
--- a/third_party/pyth/p2w-relay/package.json
+++ b/third_party/pyth/p2w-relay/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "npm run build-evm && npm run build-lib",
-    "build-evm": "npm run build-evm-contract && npm run copy-evm-abis && npm run build-evm-bindings",
+    "build-evm": "npm run copy-evm-abis && npm run build-evm-bindings",
     "build-lib": "tsc",
     "build-evm-contract": "cd ../../../ethereum/ && (npm run build || npm ci && npm run build)",
     "copy-evm-abis": "mkdir -p ./src/evm/abis && cp -r ../../../ethereum/build/contracts/* ./src/evm/abis/",


### PR DESCRIPTION
It is done in dockerfile before. It's good to keep the command for
testing but better to not include in the build step.

It will improve the speed of compiling when making a change to relayer
as it's a separate build.