### PR TITLE
p2w-attest contract: disambiguate set-config types

### DIFF
--- a/solana/pyth2wormhole/program/src/set_config.rs
+++ b/solana/pyth2wormhole/program/src/set_config.rs
@@ -48,7 +48,7 @@ pub fn set_config(
     if &cfgStruct.owner != accs.current_owner.info().key {
         msg!(
             "Current owner account mismatch (expected {:?})",
-            accs.config.0.owner
+            cfgStruct.owner
         );
         return Err(SolitaireError::InvalidSigner(
             accs.current_owner.info().key.clone(),


### PR DESCRIPTION
This one-liner makes the set_config call more clear in the attester contract