### PR TITLE
Update contract

### DIFF
--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -53,7 +53,6 @@ contract Pyth is PythGetters, PythSetters, AbstractPyth {
 
     function newPriceInfo(PythInternalStructs.PriceAttestation memory pa) private view returns (PythInternalStructs.PriceInfo memory info) {
         info.attestationTime = pa.attestationTime;
-        info.publishTime = pa.publishTime;
         info.arrivalTime = block.timestamp;
         info.arrivalBlock = block.number;
 
@@ -67,6 +66,10 @@ contract Pyth is PythGetters, PythSetters, AbstractPyth {
         info.priceFeed.productId = pa.productId;
         info.priceFeed.numPublishers = pa.numPublishers;
         info.priceFeed.maxNumPublishers = pa.maxNumPublishers;
+        info.priceFeed.prevConf = pa.prevConf;
+        info.priceFeed.prevPublishTime = pa.prevPublishTime;
+        info.priceFeed.prevPrice = pa.prevPrice;
+        info.priceFeed.publishTime = pa.publishTime;
         return info;
     }
 
@@ -205,9 +208,8 @@ contract Pyth is PythGetters, PythSetters, AbstractPyth {
         require(info.priceFeed.id != 0, "no price feed found for the given price id");
 
         // Check that there is not a significant difference between this chain's time
-        // and the attestation time. This is a last-resort safety net, and this check
-        // will be iterated on in the future.
-        if (diff(block.timestamp, info.publishTime) > VALID_TIME_PERIOD_SECS) {
+        // and the price publish time.
+        if (diff(block.timestamp, info.priceFeed.publishTime) > VALID_TIME_PERIOD_SECS) {
             info.priceFeed.status = PythStructs.PriceStatus.UNKNOWN;
         }
 

--- a/ethereum/contracts/pyth/PythInternalStructs.sol
+++ b/ethereum/contracts/pyth/PythInternalStructs.sol
@@ -43,25 +43,10 @@ contract PythInternalStructs {
         uint64 prevConf;
     }
 
-    struct Rational {
-        int64 value;
-        int64 numerator;
-        int64 denominator;
-    }
-
-    struct UpgradeContract {
-        bytes32 module;
-        uint8 action;
-        uint16 chain;
-
-        address newContract;
-    }
-
     struct PriceInfo {
-        PythStructs.PriceFeed priceFeed;
         uint256 attestationTime;
-        uint256 publishTime;
         uint256 arrivalTime;
         uint256 arrivalBlock;
+        PythStructs.PriceFeed priceFeed;
     }
 }


### PR DESCRIPTION
This adds new fields to Price Feed and also uses Price Feed publish time instead of Price Info publish time.

Also moves Price Feed in the end of Price Info because we it is likely to append fields to it in the future (and appending is the only way that won't cause collision)