### PR TITLE
Make Pyth contract abstract

### DIFF
--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -11,7 +11,7 @@ import "./PythGetters.sol";
 import "./PythSetters.sol";
 import "./PythInternalStructs.sol";
 
-contract Pyth is PythGetters, PythSetters, AbstractPyth {
+abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
     using BytesLib for bytes;
 
     function initialize(


### PR DESCRIPTION
This is to make it explicit that this contract should not be deployed: `PythUpgradable` should be instead.