### PR TITLE
Remove unnecessary payable marker from wormhole address

### DIFF
--- a/ethereum/contracts/pyth/PythState.sol
+++ b/ethereum/contracts/pyth/PythState.sol
@@ -7,7 +7,7 @@ import "./PythInternalStructs.sol";
 
 contract PythStorage {
     struct State {
-        address payable wormhole;
+        address wormhole;
         uint16 _deprecatedPyth2WormholeChainId; // Replaced by validDataSources/isValidDataSource
         bytes32 _deprecatedPyth2WormholeEmitter; // Ditto
 


### PR DESCRIPTION
The Wormhole address is not designed to receive payment and we do not need to pay it.