### PR TITLE
guardiand: Bump wormhole sources

### DIFF
--- a/Dockerfile.guardian
+++ b/Dockerfile.guardian
@@ -1,14 +1,14 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
 FROM docker.io/golang:1.17.5@sha256:90d1ab81f3d157ca649a9ff8d251691b810d95ea6023a03cdca139df58bca599
 
-ARG WORMHOLE_VERSION=2.8.3
-
 RUN apt-get update -qq && apt-get install -yq unzip
 
 WORKDIR /app
-ADD https://github.com/certusone/wormhole/archive/refs/tags/v${WORMHOLE_VERSION}.zip .
-RUN unzip v${WORMHOLE_VERSION}.zip && rm -rf v${WORMHOLE_VERSION}.zip
 
+# After 2.8.7.1
+ARG WORMHOLE_VERSION=73307397bcbb4bd8dc11bdb8324d6f50ac83f133
+ADD https://github.com/certusone/wormhole/archive/${WORMHOLE_VERSION}.zip .
+RUN unzip ${WORMHOLE_VERSION}.zip && rm -rf ${WORMHOLE_VERSION}.zip
 ARG WORMHOLE_DIR=/app/wormhole-${WORMHOLE_VERSION}
 
 WORKDIR $WORMHOLE_DIR/tools

--- a/devnet/node.yaml
+++ b/devnet/node.yaml
@@ -77,6 +77,8 @@ spec:
             - ws://eth-devnet:8545
             - --auroraRPC
             - ws://eth-devnet:8545
+            - --celoRPC
+            - ws://eth-devnet:8545
             - --fantomRPC
             - ws://eth-devnet:8545
             - --oasisRPC
@@ -93,12 +95,6 @@ spec:
             - http://terra-terrad:1317
             - --terraContract
             - terra18vd8fpwxzck93qlwghaj6arh4p7c5n896xzem5
-            - --algorandRPC
-            - http://localhost:4001
-            - --algorandToken
-            - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-            - --algorandContract
-            - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
             - --solanaContract
             - Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o
             - --solanaWS


### PR DESCRIPTION
Before this change, a fresh build from scratch would cause a guardian
software compilation error ("Failure: empty digest") that would
normally be hidden by caching in CI.