### PR TITLE
Abehjati/update-eth-contract-prev-price

### DIFF
--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -226,6 +226,11 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
         if (info.priceFeed.status == PythStructs.PriceStatus.TRADING && 
             absDiff(block.timestamp, info.priceFeed.publishTime) > VALID_TIME_PERIOD_SECS) {
             info.priceFeed.status = PythStructs.PriceStatus.UNKNOWN;
+            // getLatestAvailablePrice* gets prevPrice when status is
+            // unknown. So, now that status is being set to unknown,
+            // we should move the current price to the previous
+            // price to ensure getLatestAvailablePrice* works
+            // as intended.
             info.priceFeed.prevPrice = info.priceFeed.price;
             info.priceFeed.prevConf = info.priceFeed.conf;
             info.priceFeed.prevPublishTime = info.priceFeed.publishTime;

--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -224,7 +224,7 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
         // Check that there is not a significant difference between this chain's time
         // and the price publish time.
         if (info.priceFeed.status == PythStructs.PriceStatus.TRADING && 
-            diff(block.timestamp, info.priceFeed.publishTime) > VALID_TIME_PERIOD_SECS) {
+            absDiff(block.timestamp, info.priceFeed.publishTime) > VALID_TIME_PERIOD_SECS) {
             info.priceFeed.status = PythStructs.PriceStatus.UNKNOWN;
             info.priceFeed.prevPrice = info.priceFeed.price;
             info.priceFeed.prevConf = info.priceFeed.conf;
@@ -234,12 +234,11 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
         return info.priceFeed;
     }
 
-    function diff(uint x, uint y) private pure returns (uint) {
+    function absDiff(uint x, uint y) private pure returns (uint) {
         if (x > y) {
             return x - y;
         } else {
             return y - x;
         }
     }
-
 }

--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -223,8 +223,12 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
 
         // Check that there is not a significant difference between this chain's time
         // and the price publish time.
-        if (diff(block.timestamp, info.priceFeed.publishTime) > VALID_TIME_PERIOD_SECS) {
+        if (info.priceFeed.status == PythStructs.PriceStatus.TRADING && 
+            diff(block.timestamp, info.priceFeed.publishTime) > VALID_TIME_PERIOD_SECS) {
             info.priceFeed.status = PythStructs.PriceStatus.UNKNOWN;
+            info.priceFeed.prevPrice = info.priceFeed.price;
+            info.priceFeed.prevConf = info.priceFeed.conf;
+            info.priceFeed.prevPublishTime = info.priceFeed.publishTime;
         }
 
         return info.priceFeed;

--- a/ethereum/migrations/prod-receiver/6_pyth_update_interface_add_latest_methods.js
+++ b/ethereum/migrations/prod-receiver/6_pyth_update_interface_add_latest_methods.js
@@ -1,0 +1,16 @@
+require('dotenv').config({ path: "../.env" });
+
+const PythUpgradable = artifacts.require("PythUpgradable");
+
+const { upgradeProxy } = require("@openzeppelin/truffle-upgrades");
+
+/**
+ * This change:
+ * - Updates the interface, removes `getPrevPriceUnsafe` and adds two functions
+ *   `getLatestAvailablePriceUnsafe` and `getLatestAvailablePriceWithinDuration`
+ *   to replace its behaviour in a more elegant way.
+ */
+module.exports = async function (deployer) {
+    const proxy = await PythUpgradable.deployed();
+    await upgradeProxy(proxy.address, PythUpgradable, { deployer });
+}

--- a/ethereum/migrations/prod/5_pyth_update_interface_add_latest_methods.js
+++ b/ethereum/migrations/prod/5_pyth_update_interface_add_latest_methods.js
@@ -1,0 +1,16 @@
+require('dotenv').config({ path: "../.env" });
+
+const PythUpgradable = artifacts.require("PythUpgradable");
+
+const { upgradeProxy } = require("@openzeppelin/truffle-upgrades");
+
+/**
+ * This change:
+ * - Updates the interface, removes `getPrevPriceUnsafe` and adds two functions
+ *   `getLatestAvailablePriceUnsafe` and `getLatestAvailablePriceWithinDuration`
+ *   to replace its behaviour in a more elegant way.
+ */
+module.exports = async function (deployer) {
+    const proxy = await PythUpgradable.deployed();
+    await upgradeProxy(proxy.address, PythUpgradable, { deployer });
+}

--- a/ethereum/migrations/test/6_pyth_update_interface_add_latest_methods.js
+++ b/ethereum/migrations/test/6_pyth_update_interface_add_latest_methods.js
@@ -1,0 +1,16 @@
+require('dotenv').config({ path: "../.env" });
+
+const PythUpgradable = artifacts.require("PythUpgradable");
+
+const { upgradeProxy } = require("@openzeppelin/truffle-upgrades");
+
+/**
+ * This change:
+ * - Updates the interface, removes `getPrevPriceUnsafe` and adds two functions
+ *   `getLatestAvailablePriceUnsafe` and `getLatestAvailablePriceWithinDuration`
+ *   to replace its behaviour in a more elegant way.
+ */
+module.exports = async function (deployer) {
+    const proxy = await PythUpgradable.deployed();
+    await upgradeProxy(proxy.address, PythUpgradable, { deployer });
+}

--- a/ethereum/package-lock.json
+++ b/ethereum/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@openzeppelin/contracts": "^4.5.0",
         "@openzeppelin/contracts-upgradeable": "^4.5.2",
-        "@pythnetwork/pyth-sdk-solidity": "^0.4.0",
+        "@pythnetwork/pyth-sdk-solidity": "^0.5.0",
         "dotenv": "^10.0.0",
         "elliptic": "^6.5.2",
         "ganache-cli": "^6.12.1",
@@ -3674,9 +3674,9 @@
       "dev": true
     },
     "node_modules/@pythnetwork/pyth-sdk-solidity": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-0.4.0.tgz",
-      "integrity": "sha512-5WTLIajhYGLVxbwxWEp0BoklBVZ5y3+dooc+L2ipilDw632z7cHu79Cn8gGGNN3UstxuYEVNkQuJ+HGaxFiEwQ=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-0.5.0.tgz",
+      "integrity": "sha512-zAtQtPnYNSzrGFgeXWzoEOJcXrE2Ga+46RtllzON8SF0ExGWcDkt3IGaDFI4sSybrCXhK6KW9So9vw2qlJnVTg=="
     },
     "node_modules/@redux-saga/core": {
       "version": "1.1.3",
@@ -39998,9 +39998,9 @@
       "dev": true
     },
     "@pythnetwork/pyth-sdk-solidity": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-0.4.0.tgz",
-      "integrity": "sha512-5WTLIajhYGLVxbwxWEp0BoklBVZ5y3+dooc+L2ipilDw632z7cHu79Cn8gGGNN3UstxuYEVNkQuJ+HGaxFiEwQ=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-0.5.0.tgz",
+      "integrity": "sha512-zAtQtPnYNSzrGFgeXWzoEOJcXrE2Ga+46RtllzON8SF0ExGWcDkt3IGaDFI4sSybrCXhK6KW9So9vw2qlJnVTg=="
     },
     "@redux-saga/core": {
       "version": "1.1.3",

--- a/ethereum/package.json
+++ b/ethereum/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@openzeppelin/contracts": "^4.5.0",
     "@openzeppelin/contracts-upgradeable": "^4.5.2",
-    "@pythnetwork/pyth-sdk-solidity": "^0.4.0",
+    "@pythnetwork/pyth-sdk-solidity": "^0.5.0",
     "dotenv": "^10.0.0",
     "elliptic": "^6.5.2",
     "ganache-cli": "^6.12.1",


### PR DESCRIPTION
Strangely, although `diff` in `AbstractPyth` is private and its children cannot use it, they cannot even define a function with the same name. It's probably because function signature (or its hash) is mapped to its source instruction in Solidity.  