### PR TITLE
Use Confirmed confirmation level instead of Finalized

### DIFF
--- a/solana/pyth2wormhole/client/src/lib.rs
+++ b/solana/pyth2wormhole/client/src/lib.rs
@@ -272,7 +272,7 @@ pub fn gen_attest_tx(
     let ix_data = (
         pyth2wormhole::instruction::Instruction::Attest,
         AttestData {
-            consistency_level: ConsistencyLevel::Finalized,
+            consistency_level: ConsistencyLevel::Confirmed,
         },
     );
 


### PR DESCRIPTION
I considered making this a CLI argument, but I think it's more work than it's worth. I don't think there's a reason we would ever want finalized.

Note that confirmed is sufficient for pyth's security needs. Confirmed means that a supermajority of validators have voted for the block, which means that a supermajority has checked the correctness of the aggregate price computation.