### PR TITLE
Wormhole message reuse via post_message_unreliable

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -yq libudev-dev ncat
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && apt-get install -y nodejs
 
 COPY solana /usr/src/solana 
-WORKDIR /usr/src/solana
+WORKDIR /usr/src/solana/pyth2wormhole
 
 RUN --mount=type=cache,target=/root/.cache \
     cargo install --version =2.0.12 --locked spl-token-cli
@@ -23,6 +23,7 @@ ENV BRIDGE_ADDRESS="Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o"
 
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/usr/local/cargo/registry,id=cargo_registry \
+    --mount=type=cache,target=target,id=cargo_registry \
 	set -xe && \
     cargo install bridge_client --git https://github.com/certusone/wormhole --tag $WORMHOLE_TAG --locked --root /usr/local && \
     cargo install token_bridge_client --git https://github.com/certusone/wormhole --tag $WORMHOLE_TAG --locked --root /usr/local

--- a/solana/pyth2wormhole/client/src/attestation_cfg.rs
+++ b/solana/pyth2wormhole/client/src/attestation_cfg.rs
@@ -15,6 +15,8 @@ use solana_program::pubkey::Pubkey;
 /// Pyth2wormhole config specific to attestation requests
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct AttestationConfig {
+    #[serde(default = "default_min_msg_reuse_interval_ms")]
+    pub min_msg_reuse_interval_ms: u64,
     pub symbol_groups: Vec<SymbolGroup>,
 }
 
@@ -24,6 +26,10 @@ pub struct SymbolGroup {
     /// Attestation conditions applied to all symbols in this group
     pub conditions: AttestationConditions,
     pub symbols: Vec<P2WSymbol>,
+}
+
+pub const fn default_min_msg_reuse_interval_ms() -> u64 {
+    10_000 // 10s
 }
 
 pub const fn default_min_interval_secs() -> u64 {
@@ -149,6 +155,7 @@ mod tests {
         };
 
         let cfg = AttestationConfig {
+            min_msg_reuse_interval_ms: 1000,
             symbol_groups: vec![fastbois, slowbois],
         };
 

--- a/solana/pyth2wormhole/client/src/attestation_cfg.rs
+++ b/solana/pyth2wormhole/client/src/attestation_cfg.rs
@@ -17,6 +17,8 @@ use solana_program::pubkey::Pubkey;
 pub struct AttestationConfig {
     #[serde(default = "default_min_msg_reuse_interval_ms")]
     pub min_msg_reuse_interval_ms: u64,
+    #[serde(default = "default_max_msg_accounts")]
+    pub max_msg_accounts: u64,
     pub symbol_groups: Vec<SymbolGroup>,
 }
 
@@ -26,6 +28,10 @@ pub struct SymbolGroup {
     /// Attestation conditions applied to all symbols in this group
     pub conditions: AttestationConditions,
     pub symbols: Vec<P2WSymbol>,
+}
+
+pub const fn default_max_msg_accounts() -> u64 {
+    1_000_000
 }
 
 pub const fn default_min_msg_reuse_interval_ms() -> u64 {
@@ -156,6 +162,7 @@ mod tests {
 
         let cfg = AttestationConfig {
             min_msg_reuse_interval_ms: 1000,
+            max_msg_accounts: 100_000,
             symbol_groups: vec![fastbois, slowbois],
         };
 

--- a/solana/pyth2wormhole/client/src/cli.rs
+++ b/solana/pyth2wormhole/client/src/cli.rs
@@ -116,7 +116,9 @@ pub enum Action {
         #[clap(long = "is-active")]
         is_active: Option<bool>,
     },
-    #[clap(about = "Migrate existing pyth2wormhole program settings to a newer format version. Client version must match the deployed contract.")]
+    #[clap(
+        about = "Migrate existing pyth2wormhole program settings to a newer format version. Client version must match the deployed contract."
+    )]
     Migrate {
         /// owner keypair path
         #[clap(

--- a/solana/pyth2wormhole/client/src/lib.rs
+++ b/solana/pyth2wormhole/client/src/lib.rs
@@ -72,7 +72,7 @@ pub use util::{
     RLMutexGuard,
 };
 
-pub use message::P2WMessageIndex;
+pub use message::P2WMessageQueue;
 
 /// Future-friendly version of solitaire::ErrBox
 pub type ErrBoxSend = Box<dyn std::error::Error + Send + Sync>;

--- a/solana/pyth2wormhole/client/src/main.rs
+++ b/solana/pyth2wormhole/client/src/main.rs
@@ -255,7 +255,7 @@ async fn handle_attest(
         rpc_interval,
     ));
 
-    let message_q_mtx = Arc::new(Mutex::new(P2WMessageQueue::new(Duration::from_millis(attestation_cfg.min_msg_reuse_interval_ms))));
+    let message_q_mtx = Arc::new(Mutex::new(P2WMessageQueue::new(Duration::from_millis(attestation_cfg.min_msg_reuse_interval_ms), attestation_cfg.max_msg_accounts as usize)));
 
     // Create attestation scheduling routines; see attestation_sched_job() for details
     let mut attestation_sched_futs = batches.into_iter().map(|(batch_no, batch)| {
@@ -479,7 +479,7 @@ async fn attestation_job(
         .map_err(|e| -> ErrBoxSend { e.into() })
         .await?;
 
-    let wh_msg_id = message_q_mtx.lock().await.get_account().id;
+    let wh_msg_id = message_q_mtx.lock().await.get_account()?.id;
 
     let tx_res: Result<_, ErrBoxSend> = gen_attest_tx(
         p2w_addr,

--- a/solana/pyth2wormhole/client/src/main.rs
+++ b/solana/pyth2wormhole/client/src/main.rs
@@ -255,7 +255,7 @@ async fn handle_attest(
         rpc_interval,
     ));
 
-    let message_index_mtx = Arc::new(Mutex::new(P2WMessageIndex::new(Duration::from_secs(10))));
+    let message_index_mtx = Arc::new(Mutex::new(P2WMessageIndex::new(Duration::from_millis(attestation_cfg.min_msg_reuse_interval_ms))));
 
     // Create attestation scheduling routines; see attestation_sched_job() for details
     let mut attestation_sched_futs = batches.into_iter().map(|(batch_no, batch)| {

--- a/solana/pyth2wormhole/client/src/main.rs
+++ b/solana/pyth2wormhole/client/src/main.rs
@@ -3,7 +3,7 @@ pub mod cli;
 use std::{
     fs::File,
     pin::Pin,
-    sync::{Arc},
+    sync::Arc,
     thread,
     time::{
         Duration,
@@ -45,7 +45,10 @@ use solitaire::{
     ErrBox,
 };
 use tokio::{
-    sync::{Semaphore, Mutex},
+    sync::{
+        Mutex,
+        Semaphore,
+    },
     task::JoinHandle,
 };
 
@@ -340,7 +343,7 @@ async fn attestation_sched_job(
     p2w_addr: Pubkey,
     config: Pyth2WormholeConfig,
     payer: Keypair,
-    message_index_mtx: Arc<Mutex<P2WMessageIndex>>
+    message_index_mtx: Arc<Mutex<P2WMessageIndex>>,
 ) -> Result<(), ErrBoxSend> {
     let mut retries_left = n_retries;
     // Enforces the max batch job count
@@ -486,9 +489,8 @@ async fn attestation_job(
         symbols.as_slice(),
         latest_blockhash,
     );
-    let tx = tx_res?;
     let sig = rpc
-        .send_and_confirm_transaction(&tx)
+        .send_and_confirm_transaction(&tx_res?)
         .map_err(|e| -> ErrBoxSend { e.into() })
         .await?;
     let tx_data = rpc

--- a/solana/pyth2wormhole/client/src/message.rs
+++ b/solana/pyth2wormhole/client/src/message.rs
@@ -1,0 +1,67 @@
+//! Re-usable message scheme for pyth2wormhole
+
+use solana_program::system_instruction;
+use std::time::Instant;
+use std::time::Duration;
+
+use crate::ErrBox;
+
+/// One of the accounts tracked by the attestation client.
+#[derive(Clone, Debug)]
+pub struct P2WMessageAccount {
+    /// Unique ID that lets us derive unique accounts for use on-chain
+    pub id: u64,
+    /// Last time we've posted a message to wormhole with this account
+    pub last_used: Instant,
+}
+
+/// An umbrella data structure for tracking all message accounts in use
+#[derive(Clone, Debug)]
+pub struct P2WMessageIndex {
+    /// The tracked accounts
+    accounts: Vec<P2WMessageAccount>,
+    /// How much time needs to pass between reuses
+    grace_period: Duration,
+}
+
+impl P2WMessageIndex {
+    pub fn new(grace_period: Duration) -> Self {
+        Self {
+            accounts: Vec::new(),
+            grace_period
+        }
+    }
+    /// Finds an account with last_used at least grace_period in the past
+    pub fn get_account(&mut self) -> P2WMessageAccount {
+        let mut ret = None;
+        // Look for the first account available
+        for (idx, acc) in self.accounts.iter().enumerate() {
+            if acc.last_used.elapsed() >= self.grace_period {
+                // Note: Don't confuse idx (the LinkedList position)
+                // with the id field on P2WMessageAccount.
+                ret = Some((idx, acc.clone()));
+                break;
+            }
+        }
+        // Found a good account, no need to add one
+        if let Some((idx,mut acc)) = ret {
+            self.accounts.remove(idx);
+
+            // Update last_used
+            acc.last_used = Instant::now();
+            self.accounts.push(acc.clone());
+
+            return acc;
+        // All accounts were used recently, add a new one
+        } else {
+            let next_id = self.accounts.len() as u64;
+            let new = P2WMessageAccount {
+                id: next_id,
+                last_used: Instant::now()
+            };
+            
+            self.accounts.push(new.clone());
+            return new;
+        }
+    }
+}

--- a/solana/pyth2wormhole/client/src/message.rs
+++ b/solana/pyth2wormhole/client/src/message.rs
@@ -1,5 +1,6 @@
 //! Re-usable message scheme for pyth2wormhole
 
+use log::debug;
 use solana_program::system_instruction;
 use std::{
     collections::VecDeque,
@@ -22,14 +23,14 @@ pub struct P2WMessageAccount {
 
 /// An umbrella data structure for tracking all message accounts in use
 #[derive(Clone, Debug)]
-pub struct P2WMessageIndex {
+pub struct P2WMessageQueue {
     /// The tracked accounts. Sorted from oldest to newest, as guaranteed by get_account()
     accounts: VecDeque<P2WMessageAccount>,
     /// How much time needs to pass between reuses
     grace_period: Duration,
 }
 
-impl P2WMessageIndex {
+impl P2WMessageQueue {
     pub fn new(grace_period: Duration) -> Self {
         Self {
             accounts: VecDeque::new(),
@@ -53,20 +54,71 @@ impl P2WMessageIndex {
                 // and will be old enough eventually.
                 self.accounts.push_front(existing_too_new_acc);
 
+                debug!(
+                    "Increasing message queue size to {}",
+                    self.accounts.len() + 1
+                );
+
                 // Use a new account instead
                 P2WMessageAccount {
                     id: self.accounts.len() as u64,
                     last_used: Instant::now(),
                 }
             }
-            // Base case: Index is empty, use a new account
+            // Base case: Queue is empty, use a new account
             None => P2WMessageAccount {
                 id: self.accounts.len() as u64,
                 last_used: Instant::now(),
             },
         };
-        // The chosen account becomes the newest, push it to the very end. 
+        // The chosen account becomes the newest, push it to the very end.
         self.accounts.push_back(acc.clone());
         return acc;
+    }
+}
+
+pub mod test {
+    use super::*;
+
+    #[test]
+    fn test_empty_grows_only_as_needed() {
+        let mut q = P2WMessageQueue::new(Duration::from_millis(500));
+
+        // Empty -> 1 account
+        let acc = q.get_account();
+
+        assert_eq!(q.accounts.len(), 1);
+        assert_eq!(acc.id, 0);
+
+        // 1 -> 2 accounts, not enough time passes
+        let acc2 = q.get_account();
+
+        assert_eq!(q.accounts.len(), 2);
+        assert_eq!(acc2.id, 1);
+
+        std::thread::sleep(Duration::from_millis(600));
+
+        // Account 0 should be in front, enough time passed 
+        let acc3 = q.get_account();
+
+        assert_eq!(q.accounts.len(), 2);
+        assert_eq!(acc3.id, 0);
+
+        // Account 1 also qualifies
+        let acc4 = q.get_account();
+
+        assert_eq!(q.accounts.len(), 2);
+        assert_eq!(acc4.id, 1);
+
+        // 2 -> 3 accounts, not enough time passes
+        let acc5 = q.get_account();
+
+        assert_eq!(q.accounts.len(), 3);
+        assert_eq!(acc5.id, 2);
+
+        // We should end up with 0, 1 and 2 in order
+        assert_eq!(q.accounts[0].id, 0);
+        assert_eq!(q.accounts[1].id, 1);
+        assert_eq!(q.accounts[2].id, 2);
     }
 }

--- a/solana/pyth2wormhole/client/tests/test_attest.rs
+++ b/solana/pyth2wormhole/client/tests/test_attest.rs
@@ -105,8 +105,6 @@ async fn test_happy_path() -> Result<(), p2wc::ErrBoxSend> {
     let (prod_id, price_id) = pyth::add_test_symbol(&mut p2w_test, &pyth_owner);
 
     let mut ctx = p2w_test.start_with_context().await;
-    let mut msg_idx = p2wc::message::P2WMessageIndex::new(Duration::from_secs(1));
-    let msg_id = msg_idx.get_account().id;
 
     let symbols = vec![p2wc::P2WSymbol {
         name: Some("Mock symbol".to_owned()),
@@ -118,7 +116,7 @@ async fn test_happy_path() -> Result<(), p2wc::ErrBoxSend> {
         p2w_program_id,
         &p2w_config,
         &ctx.payer,
-        msg_id,
+        0,
         symbols.as_slice(),
         ctx.last_blockhash,
     )?;

--- a/solana/pyth2wormhole/client/tests/test_attest.rs
+++ b/solana/pyth2wormhole/client/tests/test_attest.rs
@@ -31,6 +31,8 @@ use solitaire::{
     BorshSerialize,
 };
 
+use std::time::Duration;
+
 use fixtures::{
     passthrough,
     pyth,
@@ -103,7 +105,8 @@ async fn test_happy_path() -> Result<(), p2wc::ErrBoxSend> {
     let (prod_id, price_id) = pyth::add_test_symbol(&mut p2w_test, &pyth_owner);
 
     let mut ctx = p2w_test.start_with_context().await;
-    let msg_keypair = Keypair::new();
+    let mut msg_idx = p2wc::message::P2WMessageIndex::new(Duration::from_secs(1));
+    let msg_id = msg_idx.get_account().id;
 
     let symbols = vec![p2wc::P2WSymbol {
         name: Some("Mock symbol".to_owned()),
@@ -115,8 +118,8 @@ async fn test_happy_path() -> Result<(), p2wc::ErrBoxSend> {
         p2w_program_id,
         &p2w_config,
         &ctx.payer,
+        msg_id,
         symbols.as_slice(),
-        &msg_keypair,
         ctx.last_blockhash,
     )?;
     ctx.banks_client.process_transaction(attest_tx).await?;

--- a/solana/pyth2wormhole/client/tests/test_migrate.rs
+++ b/solana/pyth2wormhole/client/tests/test_migrate.rs
@@ -27,8 +27,8 @@ use log::info;
 
 use pyth2wormhole::config::{
     OldP2WConfigAccount,
-    P2WConfigAccount,
     OldPyth2WormholeConfig,
+    P2WConfigAccount,
     Pyth2WormholeConfig,
 };
 use pyth2wormhole_client as p2wc;
@@ -55,7 +55,8 @@ async fn test_migrate_works() -> Result<(), solitaire::ErrBox> {
     let pyth_owner = Pubkey::new_unique();
 
     // On-chain state
-    let old_p2w_config = OldPyth2WormholeConfig {owner: p2w_owner.pubkey(),
+    let old_p2w_config = OldPyth2WormholeConfig {
+        owner: p2w_owner.pubkey(),
         wh_prog: wh_fixture_program_id,
         max_batch_size: pyth2wormhole::attest::P2W_MAX_BATCH_SIZE,
         pyth_owner,
@@ -79,8 +80,7 @@ async fn test_migrate_works() -> Result<(), solitaire::ErrBox> {
         executable: false,
         rent_epoch: 0,
     };
-    let old_p2w_config_addr =
-        OldP2WConfigAccount::key(None, &p2w_program_id);
+    let old_p2w_config_addr = OldP2WConfigAccount::key(None, &p2w_program_id);
 
     info!("Before add_account() calls");
 
@@ -94,12 +94,8 @@ async fn test_migrate_works() -> Result<(), solitaire::ErrBox> {
     info!("Before start_with_context");
     let mut ctx = p2w_test.start_with_context().await;
 
-    let migrate_tx = p2wc::gen_migrate_tx(
-        ctx.payer,
-        p2w_program_id,
-        p2w_owner,
-        ctx.last_blockhash,
-    )?;
+    let migrate_tx =
+        p2wc::gen_migrate_tx(ctx.payer, p2w_program_id, p2w_owner, ctx.last_blockhash)?;
     info!("Before process_transaction");
 
     // Migration should fail because the new config account is already initialized
@@ -107,7 +103,6 @@ async fn test_migrate_works() -> Result<(), solitaire::ErrBox> {
 
     Ok(())
 }
-
 
 #[tokio::test]
 async fn test_migrate_already_migrated() -> Result<(), solitaire::ErrBox> {
@@ -121,13 +116,15 @@ async fn test_migrate_already_migrated() -> Result<(), solitaire::ErrBox> {
     let pyth_owner = Pubkey::new_unique();
 
     // On-chain state
-    let old_p2w_config = OldPyth2WormholeConfig {owner: p2w_owner.pubkey(),
+    let old_p2w_config = OldPyth2WormholeConfig {
+        owner: p2w_owner.pubkey(),
         wh_prog: wh_fixture_program_id,
         max_batch_size: pyth2wormhole::attest::P2W_MAX_BATCH_SIZE,
         pyth_owner,
     };
 
-    let new_p2w_config = Pyth2WormholeConfig {owner: p2w_owner.pubkey(),
+    let new_p2w_config = Pyth2WormholeConfig {
+        owner: p2w_owner.pubkey(),
         wh_prog: wh_fixture_program_id,
         max_batch_size: pyth2wormhole::attest::P2W_MAX_BATCH_SIZE,
         pyth_owner,
@@ -152,8 +149,7 @@ async fn test_migrate_already_migrated() -> Result<(), solitaire::ErrBox> {
         executable: false,
         rent_epoch: 0,
     };
-    let old_p2w_config_addr =
-        OldP2WConfigAccount::key(None, &p2w_program_id);
+    let old_p2w_config_addr = OldP2WConfigAccount::key(None, &p2w_program_id);
 
     let new_p2w_config_bytes = new_p2w_config.try_to_vec()?;
     let new_p2w_config_account = Account {
@@ -164,7 +160,7 @@ async fn test_migrate_already_migrated() -> Result<(), solitaire::ErrBox> {
         rent_epoch: 0,
     };
     let new_p2w_config_addr =
-        P2WConfigAccount::<{AccountState::Initialized}>::key(None, &p2w_program_id);
+        P2WConfigAccount::<{ AccountState::Initialized }>::key(None, &p2w_program_id);
 
     info!("Before add_account() calls");
 
@@ -174,16 +170,16 @@ async fn test_migrate_already_migrated() -> Result<(), solitaire::ErrBox> {
     info!("Before start_with_context");
     let mut ctx = p2w_test.start_with_context().await;
 
-    let migrate_tx = p2wc::gen_migrate_tx(
-        ctx.payer,
-        p2w_program_id,
-        p2w_owner,
-        ctx.last_blockhash,
-    )?;
+    let migrate_tx =
+        p2wc::gen_migrate_tx(ctx.payer, p2w_program_id, p2w_owner, ctx.last_blockhash)?;
     info!("Before process_transaction");
 
     // Migration should fail because the new config account is already initialized
-    assert!(ctx.banks_client.process_transaction(migrate_tx).await.is_err());
+    assert!(ctx
+        .banks_client
+        .process_transaction(migrate_tx)
+        .await
+        .is_err());
 
     Ok(())
 }

--- a/solana/pyth2wormhole/program/src/lib.rs
+++ b/solana/pyth2wormhole/program/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod attest;
 pub mod config;
 pub mod initialize;
+pub mod message;
 pub mod migrate;
 pub mod set_config;
 

--- a/solana/pyth2wormhole/program/src/message.rs
+++ b/solana/pyth2wormhole/program/src/message.rs
@@ -1,20 +1,28 @@
 //! Index-based PDA for storing unreliable wormhole message
+//!
+//! The main goal of this PDA is to take advantage of wormhole message
+//! reuse securely. This is achieved by tying the account derivation
+//! data to the payer account of the attest() instruction. Inside
+//! attest(), payer must be a signer, and the message account must be
+//! derived with their address as message_owner in
+//! `P2WMessageDrvData`.
+
 use borsh::{
     BorshDeserialize,
     BorshSerialize,
 };
-use bridge::PostedMessage;
+use bridge::PostedMessageUnreliable;
 use solana_program::pubkey::Pubkey;
 use solitaire::{
+    processors::seeded::Seeded,
     AccountState,
     Data,
-    processors::seeded::Seeded,
     Info,
-    Signer,
     Mut,
+    Signer,
 };
 
-pub type P2WMessage<'a> = Signer<Mut<PostedMessage<'a, { AccountState::MaybeInitialized }>>>;
+pub type P2WMessage<'a> = Mut<PostedMessageUnreliable<'a, { AccountState::MaybeInitialized }>>;
 
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct P2WMessageDrvData {
@@ -33,4 +41,3 @@ impl<'a> Seeded<&P2WMessageDrvData> for P2WMessage<'a> {
         ]
     }
 }
-

--- a/solana/pyth2wormhole/program/src/message.rs
+++ b/solana/pyth2wormhole/program/src/message.rs
@@ -1,0 +1,36 @@
+//! Index-based PDA for storing unreliable wormhole message
+use borsh::{
+    BorshDeserialize,
+    BorshSerialize,
+};
+use bridge::PostedMessage;
+use solana_program::pubkey::Pubkey;
+use solitaire::{
+    AccountState,
+    Data,
+    processors::seeded::Seeded,
+    Info,
+    Signer,
+    Mut,
+};
+
+pub type P2WMessage<'a> = Signer<Mut<PostedMessage<'a, { AccountState::MaybeInitialized }>>>;
+
+#[derive(BorshDeserialize, BorshSerialize)]
+pub struct P2WMessageDrvData {
+    /// The key owning this message account
+    pub message_owner: Pubkey,
+    /// Index for keeping many accounts per owner
+    pub id: u64,
+}
+
+impl<'a> Seeded<&P2WMessageDrvData> for P2WMessage<'a> {
+    fn seeds(data: &P2WMessageDrvData) -> Vec<Vec<u8>> {
+        vec![
+            "p2w-message".as_bytes().to_vec(),
+            data.message_owner.to_bytes().to_vec(),
+            data.id.to_be_bytes().to_vec(),
+        ]
+    }
+}
+

--- a/solana/pyth2wormhole/program/src/migrate.rs
+++ b/solana/pyth2wormhole/program/src/migrate.rs
@@ -70,7 +70,6 @@ pub fn migrate(ctx: &ExecutionContext, accs: &mut Migrate, data: ()) -> SoliResu
         ));
     }
 
-
     // Populate new config
     accs.new_config
         .create(ctx, accs.payer.info().key, CreationLamports::Exempt)?;
@@ -85,7 +84,8 @@ pub fn migrate(ctx: &ExecutionContext, accs: &mut Migrate, data: ()) -> SoliResu
     **accs.old_config.info().lamports.borrow_mut() = 0;
 
     // Credit payer with saved balance
-    let new_payer_balance = accs.payer
+    let new_payer_balance = accs
+        .payer
         .info()
         .lamports
         .borrow_mut()

--- a/third_party/pyth/Dockerfile.p2w-attest
+++ b/third_party/pyth/Dockerfile.p2w-attest
@@ -9,9 +9,9 @@ ADD third_party/pyth/p2w-sdk/rust /usr/src/third_party/pyth/p2w-sdk/rust
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=target \
     --mount=type=cache,target=pyth2wormhole/target \
-    cargo build --manifest-path ./pyth2wormhole/Cargo.toml --package pyth2wormhole-client && \
-    cargo test --manifest-path ./pyth2wormhole/Cargo.toml --package pyth2wormhole-client && \
-    mv pyth2wormhole/target/debug/pyth2wormhole-client /usr/local/bin/pyth2wormhole-client && \
+    cargo build --package pyth2wormhole-client && \
+    cargo test --package pyth2wormhole-client && \
+    mv target/debug/pyth2wormhole-client /usr/local/bin/pyth2wormhole-client && \
     chmod a+rx /usr/src/pyth/*.py
 
 ENV P2W_OWNER_KEYPAIR="/usr/src/solana/keys/p2w_owner.json"


### PR DESCRIPTION
this changeset switches us to a PDA scheme for wormhole messages, accounts for reusing those accounts and conditionally switches between post_message/post_message_unreliable depending on whether a given message account was already initialized.