### PR TITLE
remove resource memory limit

### DIFF
--- a/devnet/pyth-evm-watcher.yaml
+++ b/devnet/pyth-evm-watcher.yaml
@@ -16,10 +16,6 @@ spec:
       containers:
         - name: pyth-evm-watcher
           image: pyth-evm-watcher
-          resources:
-            limits:
-              memory: "128Mi"
-              cpu: "500m"
           env:
             - name: WS_ENDPOINT
               value: 'ws://eth-devnet:8545'

--- a/devnet/pyth-price-service.yaml
+++ b/devnet/pyth-price-service.yaml
@@ -57,10 +57,6 @@ spec:
             initialDelaySeconds: 20
             periodSeconds: 30
             timeoutSeconds: 30
-          resources:
-            limits:
-              memory: "128Mi"
-              cpu: "500m"
           env:
             - name: SPY_SERVICE_HOST
               value: spy:7072


### PR DESCRIPTION
remove resource memory limit that was causing pyth-price-service to crash on a fresh VM install