### PR TITLE
add new latest_price_info endpoint

### DIFF
--- a/third_party/pyth/price-service/src/__tests__/rest.test.ts
+++ b/third_party/pyth/price-service/src/__tests__/rest.test.ts
@@ -43,6 +43,7 @@ function dummyPriceInfoPair(
       attestationTime: 0,
       seqNum,
       vaaBytes: Buffer.from(vaa, "hex").toString("binary"),
+      emitterChainId: 0,
     },
   ];
 }

--- a/third_party/pyth/price-service/src/listen.ts
+++ b/third_party/pyth/price-service/src/listen.ts
@@ -150,6 +150,7 @@ export class Listener implements PriceStore {
   }
 
   async processVaa(vaaBytes: string) {
+    logger.info("Received a new VAA");
     const { parse_vaa } = await importCoreWasm();
     const parsedVAA = parse_vaa(hexToUint8Array(vaaBytes));
 

--- a/third_party/pyth/price-service/src/listen.ts
+++ b/third_party/pyth/price-service/src/listen.ts
@@ -1,36 +1,37 @@
 import {
   ChainId,
   hexToUint8Array,
-  uint8ArrayToHex,
+  uint8ArrayToHex
 } from "@certusone/wormhole-sdk";
 
 import {
   createSpyRPCServiceClient,
-  subscribeSignedVAA,
+  subscribeSignedVAA
 } from "@certusone/wormhole-spydk";
 
 import { importCoreWasm } from "@certusone/wormhole-sdk/lib/cjs/solana/wasm";
 
-import { envOrErr, sleep, TimestampInSec } from "./helpers";
-import { PromClient } from "./promClient";
 import {
   getBatchSummary,
   parseBatchPriceAttestation,
-  priceAttestationToPriceFeed,
+  priceAttestationToPriceFeed
 } from "@certusone/p2w-sdk";
-import { ClientReadableStream } from "@grpc/grpc-js";
 import {
   FilterEntry,
-  SubscribeSignedVAAResponse,
+  SubscribeSignedVAAResponse
 } from "@certusone/wormhole-spydk/lib/cjs/proto/spy/v1/spy";
-import { logger } from "./logging";
+import { ClientReadableStream } from "@grpc/grpc-js";
 import { HexString, PriceFeed } from "@pythnetwork/pyth-sdk-js";
+import { sleep, TimestampInSec } from "./helpers";
+import { logger } from "./logging";
+import { PromClient } from "./promClient";
 
 export type PriceInfo = {
   vaaBytes: string;
   seqNum: number;
   attestationTime: TimestampInSec;
   priceFeed: PriceFeed;
+  emitterChainId: number;
 };
 
 export interface PriceStore {
@@ -149,7 +150,6 @@ export class Listener implements PriceStore {
   }
 
   async processVaa(vaaBytes: string) {
-    logger.info("Received a new VAA");
     const { parse_vaa } = await importCoreWasm();
     const parsedVAA = parse_vaa(hexToUint8Array(vaaBytes));
 
@@ -196,6 +196,7 @@ export class Listener implements PriceStore {
           vaaBytes: vaaBytes,
           attestationTime: priceAttestation.attestationTime,
           priceFeed,
+          emitterChainId: parsedVAA.emitter_chain,
         });
 
         for (let callback of this.updateCallbacks) {


### PR DESCRIPTION
add new `api/latest_price_info?ids[]=<price_feed_id>&ids[]=<price_feed_id_2>&..` endpoint that augments `latest_price_feeds` with `emitter_chain`, `attestation_time`, and `sequence_number` so that we can store these data in our historical db

sample price info:
```
[
  {
    "price_feed": {
      "conf": "4",
      "ema_conf": "3",
      "ema_price": "1491",
      "expo": -5,
      "id": "af11a9b5e5e14838c1ecab3a0cdec6769c3d6a477da04412bd7d21bfe451ce3d",
      "max_num_publishers": 1,
      "num_publishers": 1,
      "prev_conf": "3",
      "prev_price": "1925",
      "prev_publish_time": 1662140402,
      "price": "1441",
      "product_id": "af11a9b5e5e14838c1ecab3a0cdec6769c3d6a477da04412bd7d21bfe451ce3d",
      "publish_time": 1662140407,
      "status": "Trading"
    },
    "emitter_chain": 1,
    "attestation_time": 1662140410,
    "sequence_number": 14239
  }
]
```