### PR TITLE
Hack the rent exempt bug

### DIFF
--- a/solana/pyth2wormhole/program/src/attest.rs
+++ b/solana/pyth2wormhole/program/src/attest.rs
@@ -358,6 +358,8 @@ pub fn attest(ctx: &ExecutionContext, accs: &mut Attest, data: AttestData) -> So
         .as_slice(),
     )?;
 
+    // NOTE: 2022-09-05
+    //
     // This part is added to avoid rent exemption error that is introduced using
     // a wrong implementation in solitaire
     //

--- a/solana/pyth2wormhole/program/src/attest.rs
+++ b/solana/pyth2wormhole/program/src/attest.rs
@@ -384,11 +384,11 @@ pub fn attest(ctx: &ExecutionContext, accs: &mut Attest, data: AttestData) -> So
     }
 
     // Checking the sequence account balance
-    let wg_sequence_balance = accs.wh_sequence.info().lamports();
+    let wh_sequence_balance = accs.wh_sequence.info().lamports();
     let wh_sequence_rent_exempt = Rent::get()?.minimum_balance(accs.wh_sequence.data_len());
 
-    if wg_sequence_balance < wh_sequence_rent_exempt {
-        let required_deposit = wh_sequence_rent_exempt - wg_sequence_balance;
+    if wh_sequence_balance < wh_sequence_rent_exempt {
+        let required_deposit = wh_sequence_rent_exempt - wh_sequence_balance;
 
         let transfer_ix =
             system_instruction::transfer(accs.payer.key, accs.wh_sequence.key, required_deposit);

--- a/solana/pyth2wormhole/program/src/attest.rs
+++ b/solana/pyth2wormhole/program/src/attest.rs
@@ -22,7 +22,7 @@ use solana_program::{
     program_error::ProgramError,
     pubkey::Pubkey,
     rent::Rent,
-    sysvar::Sysvar,
+    sysvar::Sysvar as SolanaSysvar,
 };
 
 use p2w_sdk::{

--- a/solana/pyth2wormhole/program/src/attest.rs
+++ b/solana/pyth2wormhole/program/src/attest.rs
@@ -366,7 +366,7 @@ pub fn attest(ctx: &ExecutionContext, accs: &mut Attest, data: AttestData) -> So
     let wh_message_balance = accs.wh_message.info().lamports();
     let wh_message_rent_exempt = Rent::get()?.minimum_balance(accs.wh_message.info().data_len());
 
-    if (wh_message_balance < wh_message_rent_exempt) {
+    if wh_message_balance < wh_message_rent_exempt {
         let required_deposit = wh_message_rent_exempt - wh_message_balance;
 
         let transfer_ix =
@@ -378,7 +378,7 @@ pub fn attest(ctx: &ExecutionContext, accs: &mut Attest, data: AttestData) -> So
     let wg_sequence_balance = accs.wh_sequence.info().lamports();
     let wh_sequence_rent_exempt = Rent::get()?.minimum_balance(accs.wh_sequence.data_len());
 
-    if (wg_sequence_balance < wh_sequence_rent_exempt) {
+    if wg_sequence_balance < wh_sequence_rent_exempt {
         let required_deposit = wh_sequence_rent_exempt - wg_sequence_balance;
 
         let transfer_ix =

--- a/solana/pyth2wormhole/program/src/attest.rs
+++ b/solana/pyth2wormhole/program/src/attest.rs
@@ -22,7 +22,8 @@ use solana_program::{
     program_error::ProgramError,
     pubkey::Pubkey,
     rent::Rent,
-    sysvar::Sysvar as SolanaSysvar, system_instruction,
+    system_instruction,
+    sysvar::Sysvar as SolanaSysvar,
 };
 
 use p2w_sdk::{
@@ -295,12 +296,15 @@ pub fn attest(ctx: &ExecutionContext, accs: &mut Attest, data: AttestData) -> So
         let wh_msg_required_balance = Rent::get()?.minimum_balance(new_account_size);
         let wh_msg_current_balance = accs.wh_message.info().lamports();
 
-
         if wh_msg_current_balance < wh_msg_required_balance {
             let required_deposit = wh_msg_required_balance - wh_msg_current_balance;
-            let transfer_ix = system_instruction::transfer(accs.payer.key, accs.wh_message.info().key, required_deposit);
+            let transfer_ix = system_instruction::transfer(
+                accs.payer.key,
+                accs.wh_message.info().key,
+                required_deposit,
+            );
             invoke(&transfer_ix, ctx.accounts)?
-        } 
+        }
 
         trace!("After message size/balance adjustment");
     }
@@ -369,8 +373,11 @@ pub fn attest(ctx: &ExecutionContext, accs: &mut Attest, data: AttestData) -> So
     if wh_message_balance < wh_message_rent_exempt {
         let required_deposit = wh_message_rent_exempt - wh_message_balance;
 
-        let transfer_ix =
-            system_instruction::transfer(accs.payer.key, accs.wh_message.info().key, required_deposit);
+        let transfer_ix = system_instruction::transfer(
+            accs.payer.key,
+            accs.wh_message.info().key,
+            required_deposit,
+        );
         invoke(&transfer_ix, ctx.accounts)?
     }
 


### PR DESCRIPTION
This PR will solves a bug within wormhole that might not create the accounts with correct balance to be rent exempt. 

It will check the account balances in the end of attestation (to avoid breaking wormhole behavior) and transfers money to them if needed.

This PR will also solve a problem on balance transfer when a message account is resized to a larger size. Since the message account is owned by wormhole it is not possible to move funds back in case of resizing to a smaller size.


In order to make sure it works I used the double rent exempt amount in local testing and the transfers succeeded. 