### PR TITLE
p2w-client: add get-emitter for printing emitter address

### DIFF
--- a/solana/pyth2wormhole/client/src/cli.rs
+++ b/solana/pyth2wormhole/client/src/cli.rs
@@ -128,4 +128,6 @@ pub enum Action {
         )]
         owner: String,
     },
+    #[clap(about = "Print out emitter address for the specified pyth2wormhole contract")]
+    GetEmitter,
 }

--- a/solana/pyth2wormhole/client/src/main.rs
+++ b/solana/pyth2wormhole/client/src/main.rs
@@ -179,6 +179,11 @@ async fn main() -> Result<(), ErrBox> {
             )
             .await?;
         }
+        Action::GetEmitter => {
+            let emitter_addr = P2WEmitter::key(None, &p2w_addr);
+
+            println!("{}", emitter_addr);
+        }
     }
 
     Ok(())

--- a/solana/pyth2wormhole/client/src/main.rs
+++ b/solana/pyth2wormhole/client/src/main.rs
@@ -72,6 +72,16 @@ async fn main() -> Result<(), ErrBox> {
     let cli = Cli::parse();
     init_logging(cli.log_level);
 
+    // All other CLI actions make rpc requests, this one's meant to be
+    // off-chain explicitly
+    if let Action::GetEmitter = cli.action {
+        let emitter_addr = P2WEmitter::key(None, &cli.p2w_addr);
+        println!("{}", emitter_addr);
+
+        // Exit early
+        return Ok(());
+    }
+
     let payer = read_keypair_file(&*shellexpand::tilde(&cli.payer))?;
 
     let rpc_client = RpcClient::new_with_commitment(cli.rpc_url.clone(), cli.commitment.clone());
@@ -179,11 +189,7 @@ async fn main() -> Result<(), ErrBox> {
             )
             .await?;
         }
-        Action::GetEmitter => {
-            let emitter_addr = P2WEmitter::key(None, &p2w_addr);
-
-            println!("{}", emitter_addr);
-        }
+        Action::GetEmitter => unreachable!{}
     }
 
     Ok(())


### PR DESCRIPTION
This unblocks speculative target chain contract deployments. Assuming no solana-deployment-level problem occurs, we can add the emitter address to each contract and expect an attester program's messages to be accepted rightaway