### PR TITLE
Drozdziak1/p2w client error logging and docker caching

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -12,7 +12,8 @@ COPY solana /usr/src/solana
 WORKDIR /usr/src/solana/pyth2wormhole
 
 RUN --mount=type=cache,target=/root/.cache \
-    cargo install --version =2.0.12 --locked spl-token-cli
+    --mount=type=cache,target=target \
+    cargo install --version =2.0.12 --locked spl-token-cli --target-dir target
 
 
 RUN solana config set --keypair "/usr/src/solana/keys/solana-devnet.json"
@@ -25,5 +26,5 @@ RUN --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/usr/local/cargo/registry,id=cargo_registry \
     --mount=type=cache,target=target,id=cargo_registry \
 	set -xe && \
-    cargo install bridge_client --git https://github.com/wormhole-foundation/wormhole --tag $WORMHOLE_TAG --locked --root /usr/local && \
-    cargo install token_bridge_client --git https://github.com/wormhole-foundation/wormhole --tag $WORMHOLE_TAG --locked --root /usr/local
+    cargo install bridge_client --git https://github.com/wormhole-foundation/wormhole --tag $WORMHOLE_TAG --locked --root /usr/local --target-dir target && \
+    cargo install token_bridge_client --git https://github.com/wormhole-foundation/wormhole --tag $WORMHOLE_TAG --locked --root /usr/local --target-dir target

--- a/third_party/pyth/Dockerfile.p2w-attest
+++ b/third_party/pyth/Dockerfile.p2w-attest
@@ -1,16 +1,24 @@
-FROM bridge-client
+#syntax=docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc
+FROM ghcr.io/certusone/solana:1.10.31@sha256:d31e8db926a1d3fbaa9d9211d9979023692614b7b64912651aba0383e8c01bad AS solana
 
-RUN apt-get install -y python3
+RUN apt-get update && apt-get install -yq python3 libudev-dev ncat
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && apt-get install -y nodejs
 
 ADD third_party/pyth/pyth_utils.py /usr/src/pyth/pyth_utils.py
 ADD third_party/pyth/p2w_autoattest.py /usr/src/pyth/p2w_autoattest.py
 ADD third_party/pyth/p2w-sdk/rust /usr/src/third_party/pyth/p2w-sdk/rust
 
+ADD solana /usr/src/solana
+
+WORKDIR /usr/src/solana/pyth2wormhole
+
+ENV EMITTER_ADDRESS="11111111111111111111111111111115"
+ENV BRIDGE_ADDRESS="Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o"
+
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=target \
-    --mount=type=cache,target=pyth2wormhole/target \
-    cargo build --package pyth2wormhole-client && \
     cargo test --package pyth2wormhole-client && \
+    cargo build --package pyth2wormhole-client && \
     mv target/debug/pyth2wormhole-client /usr/local/bin/pyth2wormhole-client && \
     chmod a+rx /usr/src/pyth/*.py
 


### PR DESCRIPTION
This changeset improves p2w-client's error logging and helps it build quicker. The logging part is the main focus, addressing two independent issues in pyth2wormhole-client:
* Lack of failed attestation logging due to improper use of `map_err` in the futures-based attestation event loop - Thanks @Reisen :muscle: 
* Upstream Solana SDK changes  to the `to_string` impl on `ClientError`. Even if an error was printed, it would obfuscate program logs to `[N program logs]` which is extremely unhelpful compared to the verbatim program logs. A `Debug`-based struct dump fixes the issue by looking at the type directly. Specifically, `{:#?}` is used for easier human readability.

The back-burner caching fixes entail:
* **not depending on `bridge-client` for `Dockerfile.p2w-attest` anymore, in favor of `certusone/solana:v1.10.31`** - this eradicates `cargo install bridge-client` and `cargo install token-bridge-client` from the container build. The previous usage of the bridge client container was due to compile-time envs `BRIDGE_ADDRESS` and `EMITTER_ADDRESS` being reused. This change redefines the envs instead, as their contents have been stable for at least a year now. On a separate note, the bridge_client and token_bridge_client binaries are not relevant for the p2w-attest container at all.
* **Usage of `--target-dir` on `cargo-install` commands** - This option forces cargo-install to use a specified directory for build artifacts which lets us add a BuildKit cache mount in each case like we do already in `cargo-build` and `cargo-test` cases. This shortens the compilation required on iterative rebuilds of relevant containers.