### PR TITLE
p2w: Make commitment usage consistent

### DIFF
--- a/solana/pyth2wormhole/client/src/main.rs
+++ b/solana/pyth2wormhole/client/src/main.rs
@@ -29,6 +29,7 @@ use log::{
 use solana_client::{
     client_error::ClientError,
     nonblocking::rpc_client::RpcClient,
+    rpc_config::RpcTransactionConfig
 };
 use solana_program::pubkey::Pubkey;
 use solana_sdk::{
@@ -506,8 +507,14 @@ async fn attestation_job(
         .map_err(|e| -> ErrBoxSend { e.into() })
         .await?;
     let tx_data = rpc
-        .get_transaction(&sig, UiTransactionEncoding::Json)
-        .map_err(|e| -> ErrBoxSend { e.into() })
+        .get_transaction_with_config(
+            &sig,
+            RpcTransactionConfig {
+                encoding: Some(UiTransactionEncoding::Json),
+                commitment: Some(rpc.commitment()),
+                max_supported_transaction_version: None,
+            },
+        )
         .await?;
     let seqno = tx_data
         .transaction

--- a/third_party/pyth/p2w_autoattest.py
+++ b/third_party/pyth/p2w_autoattest.py
@@ -233,7 +233,7 @@ first_attest_result = run_or_die(
     [
         "pyth2wormhole-client",
         "--commitment",
-        "finalized",
+        "confirmed",
         "--log-level",
         "3",
         "--p2w-addr",
@@ -270,7 +270,7 @@ while True:
         [
             "pyth2wormhole-client",
             "--commitment",
-            "finalized",
+            "confirmed",
             "--log-level",
             "3",
             "--p2w-addr",


### PR DESCRIPTION
This changeset adjusts p2w_autoattest.py commitment to confirmed and
fixes a get_transaction() failure that happened due to the upstream
default finalized commitment setting (RpcClient's set value is not
used). This is fixed by using the chosen commitment explicitly via
get_transaction_with_config()