### PR TITLE
Abehjati/fix-deployment-bugs

### DIFF
--- a/ethereum/Deploying.md
+++ b/ethereum/Deploying.md
@@ -12,14 +12,14 @@ rm -f .env; ln -s .env.prod.xyz .env && set -o allexport && source .env set && s
 # The Secret Recovery Phrase for the wallet the contract will be deployed from.
 export MNEMONIC=...
 
+# Set the deploy commit hash in the contract (used for debugging purposes)
+sed -i "s/dead0beaf0deb10700c0331700da5d00deadbead/$(git rev-parse HEAD)/g" ./contracts/pyth/Pyth.sol
+
 # Ensure that we deploy a fresh build with up-to-date dependencies.
 rm -rf build && npx truffle compile --all
 
 # Merge the network addresses into the artifacts, if some contracts are already deployed.
 npx apply-registry
-
-# Set the deploy commit hash in the contract binary (used for debugging purposes)
-sed -i "s/dead0beaf0deb10700c0331700da5d00deadbead/$(git rev-parse HEAD)/g" build/contracts/*
 
 # Perform the migration
 npx truffle migrate --network $MIGRATIONS_NETWORK

--- a/ethereum/Deploying.md
+++ b/ethereum/Deploying.md
@@ -13,7 +13,7 @@ rm -f .env; ln -s .env.prod.xyz .env && set -o allexport && source .env set && s
 export MNEMONIC=...
 
 # Set the deploy commit hash in the contract (used for debugging purposes)
-sed -i "s/dead0beaf0deb10700c0331700da5d00deadbead/$(git rev-parse HEAD)/g" ./contracts/pyth/Pyth.sol
+sed -i "s/__DEPLOY_COMMIT_HASH_PLACEHOLER__/$(git rev-parse HEAD)/g" ./contracts/pyth/Pyth.sol
 
 # Ensure that we deploy a fresh build with up-to-date dependencies.
 rm -rf build && npx truffle compile --all

--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -231,9 +231,9 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
         return "0.1.0";
     }
 
-    function deployCommitHash() public pure returns (bytes20) {
+    function deployCommitHash() public pure returns (string memory) {
         // This is a place holder for the commit hash and will be replaced
         // with the commit hash upon deployment.
-        return hex"dead0beaf0deb10700c0331700da5d00deadbead";
+        return "__DEPLOY_COMMIT_HASH_PLACEHOLER__";
     }
 }

--- a/ethereum/migrations/prod-receiver/9_pyth_add_pythnet_datasource.js
+++ b/ethereum/migrations/prod-receiver/9_pyth_add_pythnet_datasource.js
@@ -12,7 +12,7 @@ console.log("pythnetChainId: " + pythnetChainId);
  * This change:
  * - Adds PythNet data source.
  */
-module.exports = async function () {
+module.exports = async function (_deployer) {
     const proxy = await PythUpgradable.deployed();
     await proxy.addDataSource(
         pythnetChainId,

--- a/ethereum/migrations/prod/8_pyth_add_pythnet_datasource.js
+++ b/ethereum/migrations/prod/8_pyth_add_pythnet_datasource.js
@@ -12,7 +12,7 @@ console.log("pythnetChainId: " + pythnetChainId);
  * This change:
  * - Adds PythNet data source.
  */
-module.exports = async function () {
+module.exports = async function (_deployer) {
     const proxy = await PythUpgradable.deployed();
     await proxy.addDataSource(
         pythnetChainId,

--- a/ethereum/truffle-config.js
+++ b/ethereum/truffle-config.js
@@ -62,7 +62,7 @@ module.exports = {
       provider: () => {
         return new HDWalletProvider(
           process.env.MNEMONIC,
-          "https://bsc-dataseed.binance.org/"
+          "https://bsc-dataseed2.binance.org"
         );
       },
       network_id: "56",
@@ -207,5 +207,6 @@ module.exports = {
 
   api_keys: {
     etherscan: process.env.ETHERSCAN_KEY,
+    bscscan: process.env.BSCSCAN_KEY,
   },
 };


### PR DESCRIPTION
About the deployCommitHash replacement. Replacing the binary was fine but I couldn't verify it. Now we replace the code (which will be used for verification too)

Because for verification we replace the text in the contract (and not in the binary) and due to eth optimizations it can be stored differently, in our case the commit hash was:
`0x65c273fa0afd5872f10972f65ead2cc6fa076da8`. If you look at its binary representation it has 3 trailing zeroes (8 is `0b1000`), then the contract store it shifted 3 bits to the right (and shifts it back later in a separate instruction). This hasn't happened in testnet because probably the previous deploymen commit hash was an odd number!