### PR TITLE
Move staleness check to new endpoint

### DIFF
--- a/devnet/pyth-price-service.yaml
+++ b/devnet/pyth-price-service.yaml
@@ -70,7 +70,5 @@ spec:
               value: '5'
             - name: READINESS_NUM_LOADED_SYMBOLS
               value: '6'
-            - name: READINESS_FRESHNESS_TIME_SECONDS
-              value: '10'
             - name: LOG_LEVEL
               value: debug

--- a/third_party/pyth/price-service/.env.sample
+++ b/third_party/pyth/price-service/.env.sample
@@ -15,7 +15,6 @@ SPY_SERVICE_FILTERS=[{"chain_id":1,"emitter_address":"71f8dcb863d176e2c420ad6610
 # Number of seconds to sync with spy to be sure to have latest messages
 READINESS_SPY_SYNC_TIME_SECONDS=60
 READINESS_NUM_LOADED_SYMBOLS=5
-READINESS_FRESHNESS_TIME_SECONDS=10
 
 WS_PORT=6200
 REST_PORT=4200

--- a/third_party/pyth/price-service/docker-compose.yaml
+++ b/third_party/pyth/price-service/docker-compose.yaml
@@ -24,7 +24,6 @@ services:
       - PROM_PORT=8081
       - READINESS_SPY_SYNC_TIME_SECONDS=60
       - READINESS_NUM_LOADED_SYMBOLS=8
-      - READINESS_FRESHNESS_TIME_SECONDS=10
       - LOG_LEVEL=debug
     healthcheck:
       test:

--- a/third_party/pyth/price-service/package-lock.json
+++ b/third_party/pyth/price-service/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-price-service",
-  "version": "1.0.0",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-price-service",
-      "version": "1.0.0",
+      "version": "1.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@certusone/p2w-sdk": "file:../p2w-sdk/js",

--- a/third_party/pyth/price-service/package-lock.json
+++ b/third_party/pyth/price-service/package-lock.json
@@ -56,7 +56,7 @@
       "dependencies": {
         "@certusone/wormhole-sdk": "0.2.1",
         "@improbable-eng/grpc-web-node-http-transport": "^0.14.1",
-        "@pythnetwork/pyth-sdk-js": "^0.1.0"
+        "@pythnetwork/pyth-sdk-js": "^0.3.0"
       },
       "devDependencies": {
         "@openzeppelin/contracts": "^4.2.0",
@@ -9441,7 +9441,7 @@
         "@certusone/wormhole-sdk": "0.2.1",
         "@improbable-eng/grpc-web-node-http-transport": "^0.14.1",
         "@openzeppelin/contracts": "^4.2.0",
-        "@pythnetwork/pyth-sdk-js": "^0.1.0",
+        "@pythnetwork/pyth-sdk-js": "^0.3.0",
         "@typechain/ethers-v5": "^7.1.2",
         "@types/long": "^4.0.1",
         "@types/node": "^16.6.1",

--- a/third_party/pyth/price-service/package.json
+++ b/third_party/pyth/price-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-price-service",
-  "version": "1.0.0",
+  "version": "1.4.1",
   "description": "Pyth Price Service",
   "main": "index.js",
   "scripts": {

--- a/third_party/pyth/price-service/src/index.ts
+++ b/third_party/pyth/price-service/src/index.ts
@@ -35,7 +35,6 @@ async function run() {
           envOrErr("READINESS_SPY_SYNC_TIME_SECONDS")
         ),
         numLoadedSymbols: parseInt(envOrErr("READINESS_NUM_LOADED_SYMBOLS")),
-        freshnessTimeSeconds: parseInt(envOrErr("READINESS_FRESHNESS_TIME_SECONDS")),
       },
     },
     promClient

--- a/third_party/pyth/price-service/src/listen.ts
+++ b/third_party/pyth/price-service/src/listen.ts
@@ -43,7 +43,6 @@ export interface PriceStore {
 type ListenerReadinessConfig = {
   spySyncTimeSeconds: number;
   numLoadedSymbols: number;
-  freshnessTimeSeconds: number;
 };
 
 type ListenerConfig = {
@@ -246,16 +245,7 @@ export class Listener implements PriceStore {
     if (this.priceFeedVaaMap.size < this.readinessConfig.numLoadedSymbols) {
       return false;
     }
-    let priceIds = [...this.getPriceIds()];
-    let arePricesFresh = priceIds.every(
-      (priceId) =>
-        currentTime -
-          this.priceFeedVaaMap.get(priceId)!.priceFeed.publishTime <=
-        this.readinessConfig.freshnessTimeSeconds
-    );
-    if (!arePricesFresh) {
-      return false;
-    }
+
     return true;
   }
 }

--- a/third_party/pyth/price-service/src/rest.ts
+++ b/third_party/pyth/price-service/src/rest.ts
@@ -105,7 +105,7 @@ export class RestAPI {
           }
 
           const freshness: DurationInSec =
-            new Date().getTime() / 1000 - latestPriceInfo.attestationTime;
+            new Date().getTime() / 1000 - latestPriceInfo.priceFeed.publishTime;
           this.promClient?.addApiRequestsPriceFreshness(
             req.path,
             id,
@@ -163,7 +163,7 @@ export class RestAPI {
           }
 
           const freshness: DurationInSec =
-            new Date().getTime() / 1000 - latestPriceInfo.attestationTime;
+            new Date().getTime() / 1000 - latestPriceInfo.priceFeed.publishTime;
           this.promClient?.addApiRequestsPriceFreshness(
             req.path,
             id,

--- a/third_party/pyth/price-service/src/rest.ts
+++ b/third_party/pyth/price-service/src/rest.ts
@@ -228,7 +228,7 @@ export class RestAPI {
         }
       }
 
-      return stalePrices;
+      res.json(stalePrices);
     })
     endpoints.push(
       "/stale_feeds?threshold=<staleness_threshold_seconds>"

--- a/third_party/pyth/price-service/src/rest.ts
+++ b/third_party/pyth/price-service/src/rest.ts
@@ -204,21 +204,12 @@ export class RestAPI {
     });
     endpoints.push("api/price_feed_ids");
 
-    app.get("/ready", (_, res: Response) => {
-      if (this.isReady!()) {
-        res.sendStatus(StatusCodes.OK);
-      } else {
-        res.sendStatus(StatusCodes.SERVICE_UNAVAILABLE);
-      }
-    });
-    endpoints.push("ready");
-
     const staleFeedsInputSchema: schema = {
       query: Joi.object({
         threshold: Joi.number().required(),
-      })
+      }).required(),
     };
-    app.get("/stale_feeds",
+    app.get("/api/stale_feeds",
       validate(staleFeedsInputSchema),
       (req: Request, res: Response) => {
         let stalenessThresholdSeconds = Number(req.query.threshold as string);
@@ -239,8 +230,17 @@ export class RestAPI {
       }
     );
     endpoints.push(
-      "/stale_feeds?threshold=<staleness_threshold_seconds>"
+      "/api/stale_feeds?threshold=<staleness_threshold_seconds>"
     );
+
+    app.get("/ready", (_, res: Response) => {
+      if (this.isReady!()) {
+        res.sendStatus(StatusCodes.OK);
+      } else {
+        res.sendStatus(StatusCodes.SERVICE_UNAVAILABLE);
+      }
+    });
+    endpoints.push("ready");
 
     app.get("/live", (_, res: Response) => {
       res.sendStatus(StatusCodes.OK);


### PR DESCRIPTION
I made the staleness parameter an argument to the endpoint also, so we can configure it directly via the alert in datadog without redeploying the service.

I can't figure out how to build / run this code, so would love some help with that.