### PR TITLE
Make this log message less noisy

### DIFF
--- a/third_party/pyth/price-service/src/ws.ts
+++ b/third_party/pyth/price-service/src/ws.ts
@@ -86,7 +86,7 @@ export class WebSocketAPI {
     logger.info(
       `Sending ${priceInfo.priceFeed.id} price update to ${
         clients.size
-      } clients: ${Array.from(clients.values()).map((ws, _, _) => this.wsId.get(ws))}`
+      } clients: ${Array.from(clients.values()).map((ws, _idx, _arr) => this.wsId.get(ws))}`
     );
 
     for (let client of clients.values()) {

--- a/third_party/pyth/price-service/src/ws.ts
+++ b/third_party/pyth/price-service/src/ws.ts
@@ -82,20 +82,14 @@ export class WebSocketAPI {
       return;
     }
 
+    const clients: Set<WebSocket> = this.priceFeedClients.get(priceInfo.priceFeed.id)!;
     logger.info(
       `Sending ${priceInfo.priceFeed.id} price update to ${
-        this.priceFeedClients.get(priceInfo.priceFeed.id)!.size
-      } clients`
+        clients.size
+      } clients: ${Array.from(clients.values()).map((ws, _, _) => this.wsId.get(ws))}`
     );
 
-    for (let client of this.priceFeedClients
-      .get(priceInfo.priceFeed.id)!
-      .values()) {
-      logger.info(
-        `Sending ${
-          priceInfo.priceFeed.id
-        } price update to client ${this.wsId.get(client)}`
-      );
+    for (let client of clients.values()) {
       this.promClient?.addWebSocketInteraction("server_update", "ok");
 
       let verbose = this.priceFeedClientsVerbosity


### PR DESCRIPTION
The per-update per-client message is making a lot of noise in datadog. Collapse all the client ids into a single log message for better readability.