### PR TITLE
Fixing some bugs on clap and processing logic

### DIFF
--- a/solana/pyth2wormhole/client/src/cli.rs
+++ b/solana/pyth2wormhole/client/src/cli.rs
@@ -119,7 +119,7 @@ pub enum Action {
         is_active: Option<bool>,
         #[clap(long = "ops-owner")]
         ops_owner_addr: Option<Pubkey>,
-        #[clap(long = "remove-ops-owner", conflicts_with = "ops_owner_addr")]
+        #[clap(long = "remove-ops-owner", conflicts_with = "ops-owner-addr")]
         remove_ops_owner: bool,
     },
     #[clap(

--- a/solana/pyth2wormhole/client/src/main.rs
+++ b/solana/pyth2wormhole/client/src/main.rs
@@ -136,8 +136,10 @@ async fn main() -> Result<(), ErrBox> {
             
             let new_ops_owner = if remove_ops_owner {
                 None
+            } else if let Some(given_ops_owner) = ops_owner_addr {
+                Some(given_ops_owner)
             } else {
-                ops_owner_addr
+                old_config.ops_owner
             };
 
             let tx = gen_set_config_tx(


### PR DESCRIPTION
Apparently clap expects the id in `conflicts_with` to be a case-converted value of the field. 

I also realized that our logic was not correct for handling that parameter, so I fixed it.