### PR TITLE
pyth2wormhole-client: automatically crawl mapping based on interval

### DIFF
--- a/solana/pyth2wormhole/client/src/attestation_cfg.rs
+++ b/solana/pyth2wormhole/client/src/attestation_cfg.rs
@@ -29,6 +29,12 @@ pub struct AttestationConfig {
         serialize_with = "opt_pubkey_string_ser"
     )]
     pub mapping_addr: Option<Pubkey>,
+    /// The known symbol list will be reloaded based off this
+    /// interval, to account for mapping changes. Note: This interval
+    /// will interrupt attestation scheduling jobs regardless of
+    /// mapping_addr set/unset status.
+    #[serde(default = "default_mapping_reload_interval_mins")]
+    pub mapping_reload_interval_mins: u64,
     pub symbol_groups: Vec<SymbolGroup>,
 }
 
@@ -100,6 +106,10 @@ pub const fn default_max_msg_accounts() -> u64 {
 
 pub const fn default_min_msg_reuse_interval_ms() -> u64 {
     10_000 // 10s
+}
+
+pub const fn default_mapping_reload_interval_mins() -> u64 {
+    15
 }
 
 pub const fn default_min_interval_secs() -> u64 {
@@ -258,6 +268,7 @@ mod tests {
             min_msg_reuse_interval_ms: 1000,
             max_msg_accounts: 100_000,
             mapping_addr: None,
+            mapping_reload_interval_mins: 42,
             symbol_groups: vec![fastbois, slowbois],
         };
 
@@ -276,6 +287,7 @@ mod tests {
             min_msg_reuse_interval_ms: 1000,
             max_msg_accounts: 100,
             mapping_addr: None,
+            mapping_reload_interval_mins: 42,
             symbol_groups: vec![],
         };
 

--- a/third_party/pyth/p2w_autoattest.py
+++ b/third_party/pyth/p2w_autoattest.py
@@ -188,6 +188,7 @@ if P2W_ATTESTATION_CFG is None:
     cfg_yaml = f"""
 ---
 mapping_addr: {mapping_addr}
+mapping_reload_interval_mins: 1 # Very fast for testing purposes
 symbol_groups:
   - group_name: fast_interval_only
     conditions:


### PR DESCRIPTION
This automates continuous crawling of the pyth mapping. Control over existing jobs is achieved by assigning them an expiration date, coinciding with the desired mapping poll rate. This removes the need to communicate with the async attestation routines while keeping all the full-async benefits. Here's a rough idea of how it works:
1. load config YAML
2. look up accounts from mapping_addr if specified (error ignored if fails)
3. merge mapping accounts with existing ones from YAML
4. spin up attestation scheduling futures that will exit after `mapping_reload_interval_mins` minutes
5. join_all on those futures (they used to run forever in daemon mode, now they run for the mapping reload period)
6. list errors if any
7. if daemon mode, goto 2. If not, exit.