### PR TITLE
p2w: Monitor and realloc() + rent adjuist on cfg account size change

### DIFF
--- a/solana/pyth2wormhole/client/src/lib.rs
+++ b/solana/pyth2wormhole/client/src/lib.rs
@@ -144,6 +144,8 @@ pub fn gen_set_config_tx(
         AccountMeta::new(owner.pubkey(), true),
         // payer
         AccountMeta::new(payer.pubkey(), true),
+        // system_program
+        AccountMeta::new(system_program::id(), false),
     ];
 
     let ix_data = (
@@ -162,7 +164,6 @@ pub fn gen_set_config_tx(
     );
     Ok(tx_signed)
 }
-
 
 pub fn gen_set_is_active_tx(
     payer: Keypair,

--- a/solana/pyth2wormhole/program/src/set_config.rs
+++ b/solana/pyth2wormhole/program/src/set_config.rs
@@ -1,4 +1,13 @@
-use solana_program::pubkey::Pubkey;
+use borsh::BorshSerialize;
+
+use solana_program::{
+    program::invoke,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    rent::Rent,
+    system_instruction,
+    sysvar::Sysvar,
+};
 use solitaire::{
     trace,
     AccountState,
@@ -18,6 +27,8 @@ use crate::config::{
     Pyth2WormholeConfig,
 };
 
+use std::cmp::Ordering;
+
 #[derive(FromAccounts)]
 pub struct SetConfig<'b> {
     /// Current config used by the program
@@ -26,11 +37,13 @@ pub struct SetConfig<'b> {
     pub current_owner: Mut<Signer<Info<'b>>>,
     /// Payer account for updating the account data
     pub payer: Mut<Signer<Info<'b>>>,
+    /// Used for rent adjustment transfer
+    pub system_program: Info<'b>,
 }
 
 /// Alters the current settings of pyth2wormhole
 pub fn set_config(
-    _ctx: &ExecutionContext,
+    ctx: &ExecutionContext,
     accs: &mut SetConfig,
     data: Pyth2WormholeConfig,
 ) -> SoliResult<()> {
@@ -45,7 +58,32 @@ pub fn set_config(
         ));
     }
 
+    let old_size = accs.config.info().data_len();
+    let new_size = data.try_to_vec()?.len();
+
     accs.config.1 = data;
+
+    // Realloc if mismatched
+    if old_size != new_size {
+        accs.config.info().realloc(new_size, false)?;
+    }
+
+    // Adjust lamports
+    let mut acc_lamports = accs.config.info().lamports();
+
+    let new_lamports = Rent::get()?.minimum_balance(new_size);
+
+    let diff_lamports: u64 = (acc_lamports as i64 - new_lamports as i64).abs() as u64;
+
+    if acc_lamports < new_lamports {
+        // Less than enough lamports, debit the payer
+        let transfer_ix = system_instruction::transfer(
+            accs.payer.info().key,
+            accs.config.info().key,
+            diff_lamports,
+        );
+        invoke(&transfer_ix, ctx.accounts)?;
+    }
 
     Ok(())
 }

--- a/solana/pyth2wormhole/program/src/set_config.rs
+++ b/solana/pyth2wormhole/program/src/set_config.rs
@@ -61,12 +61,12 @@ pub fn set_config(
     let old_size = accs.config.info().data_len();
     let new_size = data.try_to_vec()?.len();
 
-    accs.config.1 = data;
-
     // Realloc if mismatched
     if old_size != new_size {
         accs.config.info().realloc(new_size, false)?;
     }
+
+    accs.config.1 = data;
 
     // Adjust lamports
     let mut acc_lamports = accs.config.info().lamports();


### PR DESCRIPTION
This fixes a problem I observed together with Ali in devnet. Options in borsh result in byte count changes which means the underlying account size for contract state must grow/shrink together with the serialized byte length. This change implements such a scheme.