### PR TITLE
Fix program account not being passed to CPI

### DIFF
--- a/pythnet/remote-executor/cli/src/main.rs
+++ b/pythnet/remote-executor/cli/src/main.rs
@@ -279,16 +279,8 @@ pub fn process_transaction(
     let mut transaction =
         Transaction::new_with_payer(instructions.as_slice(), Some(&signers[0].pubkey()));
     transaction.sign(signers, rpc_client.get_latest_blockhash()?);
-    let transaction_signature = rpc_client.send_transaction_with_config(
-        &transaction,
-        solana_client::rpc_config::RpcSendTransactionConfig {
-            skip_preflight: true,
-            preflight_commitment: None,
-            encoding: None,
-            max_retries: None,
-            min_context_slot: None,
-        },
-    )?;
+    let transaction_signature =
+        rpc_client.send_and_confirm_transaction_with_spinner(&transaction)?;
     println!("Transaction successful : {:?}", transaction_signature);
     Ok(())
 }

--- a/pythnet/remote-executor/programs/remote-executor/src/tests/executor_simulator.rs
+++ b/pythnet/remote-executor/programs/remote-executor/src/tests/executor_simulator.rs
@@ -340,6 +340,13 @@ impl ExecutorSimulator {
 
         // Add the rest of `remaining_accounts` from parsing the payload
         for instruction in executor_payload.instructions {
+            // Push program_id
+            account_metas.push(AccountMeta {
+                pubkey: instruction.program_id,
+                is_signer: false,
+                is_writable: false,
+            });
+            // Push other accounts
             for account_meta in Instruction::from(&instruction).accounts {
                 if account_meta.pubkey != executor_key {
                     account_metas.push(account_meta.clone());


### PR DESCRIPTION
I forgot to pass each subinstruction's program_id to the CPI. Tests were passing because I was CPIing into the system program, which is being passed always to the remote-executor.