### PR TITLE
Add set-is-active instruction and some minor tweaks

### DIFF
--- a/third_party/pyth/multisig-wh-message-builder/src/index.ts
+++ b/third_party/pyth/multisig-wh-message-builder/src/index.ts
@@ -260,7 +260,6 @@ async function getWormholeMessageIx(
 ) {
   const wormholeNetwork: WormholeNetwork =
     solanaClusterMappingToWormholeNetwork[cluster];
-  console.log("Wormhole network: ")
   const wormholeAddress = wormholeUtils.CONTRACTS[wormholeNetwork].solana.core;
   const { post_message_ix, fee_collector_address, state_address, parse_state } =
     await importCoreWasm();
@@ -313,7 +312,7 @@ async function createWormholeMsgMultisigTx(
 
   const message = Keypair.generate();
 
-  fs.mkdirSync('keys');
+  fs.mkdirSync('keys', {recursive: true});
   // save message to Uint8 array keypair file called mesage.json
   fs.writeFileSync(`keys/message-${txKey.toBase58()}.json`, `[${message.secretKey.toString()}]`);
   console.log(`Message Address: ${message.publicKey.toBase58()}`);


### PR DESCRIPTION
this is a megahack to put the instruction into this CLI, but i think it's fine to validate the authority for the moment. We need to rethink all of this contract administration stuff anyway.

tested by creating this tx
https://mesh-devnet.squads.so/transactions/6baWtW1zTUVMSJHJQVxDUXWzqrQeYBr6mu31j3bTKwY3/tx/CMaECC12bKo6vLFTT5uC5HLwFpVWt7qqWPsDMV4x1Xaz

I haven't tested set-is-active yet because i will need to get stan to set the attester ops-owner.