### PR TITLE
Update staleness check

### DIFF
--- a/third_party/pyth/price-service/src/rest.ts
+++ b/third_party/pyth/price-service/src/rest.ts
@@ -220,7 +220,7 @@ export class RestAPI {
         let stalePrices: Record<HexString, number> = {}
 
         for (let priceId of priceIds) {
-          const latency = currentTime - this.priceFeedVaaInfo.getLatestPriceInfo(priceId)!.priceFeed.publishTime
+          const latency = currentTime - this.priceFeedVaaInfo.getLatestPriceInfo(priceId)!.attestationTime
           if (latency > stalenessThresholdSeconds) {
             stalePrices[priceId] = latency
           }


### PR DESCRIPTION
The API endpoint was using the `publishTime` of the price on pythnet and not the time that the last price attestation was received. The former check catches cases where a price feed isn't updating on pythnet, which is not good for this alert because we have some feeds that shouldn't update on pythnet (e.g., equities outside of trading hours). However, the feeds are continuously attested, so checking `attestationTimestamp` should be sufficient.