### PR TITLE
Dockerfile.client, Dockerfile.solana: harden caching to cut CI time

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -12,7 +12,8 @@ COPY solana /usr/src/solana
 WORKDIR /usr/src/solana/pyth2wormhole
 
 RUN --mount=type=cache,target=/root/.cache \
-    --mount=type=cache,target=target \
+    --mount=type=cache,target=/usr/local/cargo/registry,id=cargo_registry \
+    --mount=type=cache,target=/usr/src/solana/pyth2wormhole/target,id=p2w_cargo_build \
     cargo install --version =2.0.12 --locked spl-token-cli --target-dir target
 
 
@@ -22,9 +23,9 @@ RUN solana config set --url "http://solana-devnet:8899"
 ENV EMITTER_ADDRESS="11111111111111111111111111111115"
 ENV BRIDGE_ADDRESS="Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o"
 
-RUN --mount=type=cache,target=/root/.cache \
+RUN --mount=type=cache,target=/root/.cache id=homedir_cache \
     --mount=type=cache,target=/usr/local/cargo/registry,id=cargo_registry \
-    --mount=type=cache,target=target,id=cargo_registry \
+    --mount=type=cache,target=/usr/src/solana/pyth2wormhole/target,id=p2w_client_build \
 	set -xe && \
     cargo install bridge_client --git https://github.com/wormhole-foundation/wormhole --tag $WORMHOLE_TAG --locked --root /usr/local --target-dir target && \
     cargo install token_bridge_client --git https://github.com/wormhole-foundation/wormhole --tag $WORMHOLE_TAG --locked --root /usr/local --target-dir target

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -23,9 +23,9 @@ RUN solana config set --url "http://solana-devnet:8899"
 ENV EMITTER_ADDRESS="11111111111111111111111111111115"
 ENV BRIDGE_ADDRESS="Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o"
 
-RUN --mount=type=cache,target=/root/.cache id=homedir_cache \
-    --mount=type=cache,target=/usr/local/cargo/registry,id=cargo_registry \
-    --mount=type=cache,target=/usr/src/solana/pyth2wormhole/target,id=p2w_client_build \
+RUN --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/src/solana/pyth2wormhole/target \
 	set -xe && \
     cargo install bridge_client --git https://github.com/wormhole-foundation/wormhole --tag $WORMHOLE_TAG --locked --root /usr/local --target-dir target && \
     cargo install token_bridge_client --git https://github.com/wormhole-foundation/wormhole --tag $WORMHOLE_TAG --locked --root /usr/local --target-dir target

--- a/Dockerfile.solana
+++ b/Dockerfile.solana
@@ -46,8 +46,10 @@ ENV BRIDGE_ADDRESS="Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o"
 WORKDIR /usr/src/bridge/solana
 
 # Build Wormhole Solana programs
-RUN --mount=type=cache,target=../wormhole/solana/target \
-    --mount=type=cache,target=pyth2wormhole/target \
+RUN --mount=type=cache,target=/usr/src/bridge/wormhole/solana/target \
+    --mount=type=cache,target=/usr/src/bridge/solana/pyth2wormhole/target \
+    --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/root/.cache \
     cargo build-bpf --manifest-path "../wormhole/solana/bridge/program/Cargo.toml" -- --locked && \
     cargo build-bpf --manifest-path "../wormhole/solana/bridge/cpi_poster/Cargo.toml" -- --locked && \
     cargo build-bpf --manifest-path "pyth2wormhole/program/Cargo.toml" -- --locked && \


### PR DESCRIPTION
This change attempts to add useful items to the docker caching which should save time downloading crates and by adding path=<full path> and dropping id=<name> ensure that no Dockerfile cache mismatches occur. I think the id= param is meant to help group builds that benefit from common cache, but in case of pyth2wormhole-client/SOL contract builds it became a competition between the two replacing the other's caches