### PR TITLE
p2w-client: Remove --log-level, rely on RUST_LOG, provide default

### DIFF
--- a/solana/pyth2wormhole/client/src/cli.rs
+++ b/solana/pyth2wormhole/client/src/cli.rs
@@ -16,13 +16,6 @@ use clap::{
 )]
 pub struct Cli {
     #[clap(
-        short,
-        long,
-        default_value = "3",
-        help = "Logging level, where 0..=1 RUST_LOG=error and 5.. is RUST_LOG=trace"
-    )]
-    pub log_level: u32,
-    #[clap(
         long,
         help = "Identity JSON file for the entity meant to cover transaction costs",
         default_value = "~/.config/solana/id.json"

--- a/third_party/pyth/p2w_autoattest.py
+++ b/third_party/pyth/p2w_autoattest.py
@@ -112,8 +112,6 @@ if P2W_INITIALIZE_SOL_CONTRACT is not None:
     init_result = run_or_die(
         [
             "pyth2wormhole-client",
-            "--log-level",
-            "4",
             "--p2w-addr",
             P2W_SOL_ADDRESS,
             "--rpc-url",
@@ -139,8 +137,6 @@ if P2W_INITIALIZE_SOL_CONTRACT is not None:
         run_or_die(
             [
                 "pyth2wormhole-client",
-                "--log-level",
-                "4",
                 "--p2w-addr",
                 P2W_SOL_ADDRESS,
                 "--rpc-url",
@@ -241,14 +237,16 @@ symbol_groups:
         f.flush()
 
 
+# Set helpfully chatty logging default, filtering especially annoying
+# modules like async HTTP requests and tokio runtime logs
+os.environ["RUST_LOG"] = os.environ.get("RUST_LOG", "pyth2wormhole_client,solana_client,main,pyth_sdk_solana=trace")
+
 # Send the first attestation in one-shot mode for testing
 first_attest_result = run_or_die(
     [
         "pyth2wormhole-client",
         "--commitment",
         "confirmed",
-        "--log-level",
-        "3",
         "--p2w-addr",
         P2W_SOL_ADDRESS,
         "--rpc-url",
@@ -274,7 +272,6 @@ endpoint_thread.start()
 readiness_thread = threading.Thread(target=readiness, daemon=True)
 readiness_thread.start()
 
-
 # Do not exit this script if a continuous attestation stops for
 # whatever reason (this avoids k8s restart penalty)
 while True:
@@ -284,8 +281,6 @@ while True:
             "pyth2wormhole-client",
             "--commitment",
             "confirmed",
-            "--log-level",
-            "3",
             "--p2w-addr",
             P2W_SOL_ADDRESS,
             "--rpc-url",


### PR DESCRIPTION
Turns out --log-level does not work because it is ignored. I think I tried to get rid of it at a different occasion but I likely missed this loose end.