### PR TITLE
Only register account to receive coins if already unregistered

### DIFF
--- a/aptos/contracts/sources/pyth.move
+++ b/aptos/contracts/sources/pyth.move
@@ -68,7 +68,9 @@ module pyth::pyth {
             signer_capability
         );
         event::init(&pyth);
-        coin::register<AptosCoin>(&pyth);
+        if (!coin::is_account_registered<AptosCoin>(signer::address_of(&pyth))) {
+            coin::register<AptosCoin>(&pyth);
+        }
     }
 
     fun parse_data_sources(


### PR DESCRIPTION
Since anyone can register an account to receive coins, contract initialisation could potentially fail if the account has already been registered. We therefore only register the `pyth` account if it is not already registered. Note that it does not matter who registers the account.