### PR TITLE
Ensure initialization data source emitter address and chain ids are equal length

### DIFF
--- a/aptos/contracts/sources/error.move
+++ b/aptos/contracts/sources/error.move
@@ -98,4 +98,8 @@ module pyth::error {
    public fun invalid_attestation_magic_value(): u64 {
         error::invalid_argument(24)
    }
+
+   public fun data_source_emitter_address_and_chain_ids_different_lengths(): u64 {
+        error::invalid_argument(25)
+   }
 }

--- a/aptos/contracts/sources/pyth.move
+++ b/aptos/contracts/sources/pyth.move
@@ -74,6 +74,10 @@ module pyth::pyth {
     fun parse_data_sources(
         emitter_chain_ids: vector<u64>,
         emitter_addresses: vector<vector<u8>>): vector<DataSource> {
+
+        assert!(vector::length(&emitter_chain_ids) == vector::length(&emitter_addresses),
+            error::data_source_emitter_address_and_chain_ids_different_lengths());
+
         let sources = vector::empty();
         let i = 0;
         while (i < vector::length(&emitter_chain_ids)) {


### PR DESCRIPTION
Since we pass these separately (because entry functions must take primitive arguments), we should check that we have an equal number of emitter addresses and chain IDs.