### PR TITLE
Charge update fees per VAA submitted

### DIFF
--- a/aptos/contracts/sources/governance/governance.move
+++ b/aptos/contracts/sources/governance/governance.move
@@ -320,7 +320,7 @@ module pyth::governance {
     fun test_execute_governance_instruction_set_update_fee() {
         let initial_update_fee = 325;
         setup_test(100, 50, x"f06413c0148c78916554f134dcd17a7c8029a3a2bda475a4a1182305c53078bf", initial_update_fee);
-        assert!(state::get_update_fee() == initial_update_fee, 1);
+        assert!(state::get_base_update_fee() == initial_update_fee, 1);
 
         // A VAA with:
         // - Emitter chain ID 50
@@ -339,7 +339,7 @@ module pyth::governance {
         assert!(state::get_last_executed_governance_sequence() == 1, 1);
 
         let expected = 17000;
-        assert!(state::get_update_fee() == expected, 1);
+        assert!(state::get_base_update_fee() == expected, 1);
     }
 
     #[test]

--- a/aptos/contracts/sources/governance/set_update_fee.move
+++ b/aptos/contracts/sources/governance/set_update_fee.move
@@ -16,7 +16,7 @@ module pyth::set_update_fee {
     public(friend) fun execute(payload: vector<u8>) {
         let SetUpdateFee { mantissa, exponent } = from_byte_vec(payload);
         let fee = apply_exponent(mantissa, exponent);
-        state::set_update_fee(fee);
+        state::set_base_update_fee(fee);
     }
 
     fun from_byte_vec(bytes: vector<u8>): SetUpdateFee {

--- a/aptos/contracts/sources/pyth.move
+++ b/aptos/contracts/sources/pyth.move
@@ -363,7 +363,7 @@ module pyth::pyth {
 
     /// Get the number of AptosCoin's required to perform the given price updates.
     public fun get_update_fee(update_data: &vector<vector<u8>>): u64 {
-        state::get_update_fee() * vector::length(update_data)
+        state::get_base_update_fee() * vector::length(update_data)
     }
 
 // -----------------------------------------------------------------------------

--- a/aptos/contracts/sources/state.move
+++ b/aptos/contracts/sources/state.move
@@ -27,7 +27,7 @@ module pyth::state {
         threshold_secs: u64,
     }
 
-    /// The fee charged per batch update
+    /// The fee charged per batch update (VAA)
     struct UpdateFee has key {
         fee: u64,
     }

--- a/aptos/contracts/sources/state.move
+++ b/aptos/contracts/sources/state.move
@@ -28,7 +28,7 @@ module pyth::state {
     }
 
     /// The fee charged per batch update (VAA)
-    struct UpdateFee has key {
+    struct BaseUpdateFee has key {
         fee: u64,
     }
 
@@ -72,7 +72,7 @@ module pyth::state {
             move_to(pyth, StalePriceThreshold{
                 threshold_secs: stale_price_threshold,
             });
-            move_to(pyth, UpdateFee{
+            move_to(pyth, BaseUpdateFee{
                 fee: update_fee,
             });
             let sources = set::new<DataSource>();
@@ -101,8 +101,8 @@ module pyth::state {
         borrow_global<StalePriceThreshold>(@pyth).threshold_secs
     }
 
-    public fun get_update_fee(): u64 acquires UpdateFee {
-        borrow_global<UpdateFee>(@pyth).fee
+    public fun get_base_update_fee(): u64 acquires BaseUpdateFee {
+        borrow_global<BaseUpdateFee>(@pyth).fee
     }
 
     public fun is_valid_data_source(data_source: DataSource): bool acquires DataSources {
@@ -173,8 +173,8 @@ module pyth::state {
         valid_governance_data_source.source = source;
     }
 
-    public(friend) fun set_update_fee(fee: u64) acquires UpdateFee {
-        let update_fee = borrow_global_mut<UpdateFee>(@pyth);
+    public(friend) fun set_base_update_fee(fee: u64) acquires BaseUpdateFee {
+        let update_fee = borrow_global_mut<BaseUpdateFee>(@pyth);
         update_fee.fee = fee
     }
 


### PR DESCRIPTION
This PR changes `get_update_fee` to take the submitted update data. This provides flexibility to implement more advanced pricing schemes in the future, depending on the update data.