### PR TITLE
Delete unused imports in Aptos

### DIFF
--- a/aptos/contracts/sources/batch_price_attestation.move
+++ b/aptos/contracts/sources/batch_price_attestation.move
@@ -1,13 +1,10 @@
 module pyth::batch_price_attestation {
     use pyth::price_feed::{Self};
-    use pyth::price;
     use pyth::error;
-    use pyth::i64;
     use pyth::price_info::{Self, PriceInfo};
     use pyth::price_identifier::{Self};
     use pyth::price_status;
     use pyth::deserialize::{Self};
-    use aptos_framework::account;
     use aptos_framework::timestamp;
     use wormhole::cursor::{Self, Cursor};
     use std::vector::{Self};
@@ -114,13 +111,13 @@ module pyth::batch_price_attestation {
         let ema_price = deserialize::deserialize_i64(cur);
         let ema_conf = deserialize::deserialize_u64(cur);
         let status = price_status::from_u64((deserialize::deserialize_u8(cur) as u64));
-        
+
         // Skip obselete fields
         let _num_publishers = deserialize::deserialize_u32(cur);
         let _max_num_publishers = deserialize::deserialize_u32(cur);
 
         let attestation_time = deserialize::deserialize_u64(cur);
-        let publish_time = deserialize::deserialize_u64(cur); // 
+        let publish_time = deserialize::deserialize_u64(cur); //
         let prev_publish_time = deserialize::deserialize_u64(cur);
         let prev_price = deserialize::deserialize_i64(cur);
         let prev_conf = deserialize::deserialize_u64(cur);
@@ -135,7 +132,7 @@ module pyth::batch_price_attestation {
             current_price = pyth::price::new(prev_price, prev_conf, expo, prev_publish_time);
         };
 
-        // If status is trading, use the timestamp of the aggregate as the timestamp for the 
+        // If status is trading, use the timestamp of the aggregate as the timestamp for the
         // EMA price. If not, the EMA will have last been updated when the aggregate last had
         // trading status, so use prev_publish_time (the time when the aggregate last had trading status).
         let ema_timestamp = publish_time;
@@ -171,10 +168,10 @@ module pyth::batch_price_attestation {
         let arrival_time = 1663074349;
         timestamp::update_global_time_for_test(1663074349 * 1000000);
 
-        // A raw batch price attestation 
+        // A raw batch price attestation
         // The first attestation has a status of UNKNOWN
         let bytes = x"5032574800030000000102000400951436e0be37536be96f0896366089506a59763d036728332d3e3038047851aea7c6c75c89f14810ec1c54c03ab8f1864a4c4032791f05747f560faec380a695d1000000000000049a0000000000000008fffffffb00000000000005dc0000000000000003000000000100000001000000006329c0eb000000006329c0e9000000006329c0e400000000000006150000000000000007215258d81468614f6b7e194c5d145609394f67b041e93e6695dcc616faadd0603b9551a68d01d954d6387aff4df1529027ffb2fee413082e509feb29cc4904fe000000000000041a0000000000000003fffffffb00000000000005cb0000000000000003010000000100000001000000006329c0eb000000006329c0e9000000006329c0e4000000000000048600000000000000078ac9cf3ab299af710d735163726fdae0db8465280502eb9f801f74b3c1bd190333832fad6e36eb05a8972fe5f219b27b5b2bb2230a79ce79beb4c5c5e7ecc76d00000000000003f20000000000000002fffffffb00000000000005e70000000000000003010000000100000001000000006329c0eb000000006329c0e9000000006329c0e40000000000000685000000000000000861db714e9ff987b6fedf00d01f9fea6db7c30632d6fc83b7bc9459d7192bc44a21a28b4c6619968bd8c20e95b0aaed7df2187fd310275347e0376a2cd7427db800000000000006cb0000000000000001fffffffb00000000000005e40000000000000003010000000100000001000000006329c0eb000000006329c0e9000000006329c0e400000000000007970000000000000001";
-        
+
         let expected = BatchPriceAttestation {
             header: Header {
                 magic: 0x50325748,

--- a/aptos/contracts/sources/deserialize.move
+++ b/aptos/contracts/sources/deserialize.move
@@ -2,7 +2,7 @@ module pyth::deserialize {
     use wormhole::deserialize;
     use wormhole::u16;
     use wormhole::u32;
-    use wormhole::cursor::{Self, Cursor};
+    use wormhole::cursor::{Cursor};
     use pyth::i64::{Self, I64};
 
     public fun deserialize_vector(cur: &mut Cursor<u8>, n: u64): vector<u8> {
@@ -23,7 +23,7 @@ module pyth::deserialize {
 
     public fun deserialize_i32(cur: &mut Cursor<u8>): I64 {
         let deserialized = deserialize_u32(cur);
-        
+
         // If negative, pad the value
         let negative = (deserialized >> 31) == 1;
         if (negative) {
@@ -46,7 +46,7 @@ module pyth::deserialize {
     fun test_deserialize_u8() {
         let input = x"48258963";
         let cursor = cursor::init(input);
-        
+
         let result = deserialize_u8(&mut cursor);
         assert!(result == 0x48, 1);
 
@@ -58,7 +58,7 @@ module pyth::deserialize {
     fun test_deserialize_u16() {
         let input = x"48258963";
         let cursor = cursor::init(input);
-        
+
         let result = deserialize_u16(&mut cursor);
         assert!(result == 0x4825, 1);
 
@@ -70,7 +70,7 @@ module pyth::deserialize {
     fun test_deserialize_u32() {
         let input = x"4825896349741695";
         let cursor = cursor::init(input);
-        
+
         let result = deserialize_u32(&mut cursor);
         assert!(result == 0x48258963, 1);
 
@@ -82,7 +82,7 @@ module pyth::deserialize {
     fun test_deserialize_i32_positive() {
         let input = x"4825896349741695";
         let cursor = cursor::init(input);
-        
+
         let result = deserialize_i32(&mut cursor);
         assert!(result == i64::from_u64(0x48258963), 1);
 
@@ -94,7 +94,7 @@ module pyth::deserialize {
     fun test_deserialize_i32_negative() {
         let input = x"FFFFFDC349741695";
         let cursor = cursor::init(input);
-        
+
         let result = deserialize_i32(&mut cursor);
         assert!(result == i64::from_u64(0xFFFFFFFFFFFFFDC3), 1);
 
@@ -106,7 +106,7 @@ module pyth::deserialize {
     fun test_deserialize_u64() {
         let input = x"48258963497416957497253486";
         let cursor = cursor::init(input);
-        
+
         let result = deserialize_u64(&mut cursor);
         assert!(result == 0x4825896349741695, 1);
 
@@ -118,7 +118,7 @@ module pyth::deserialize {
     fun test_deserialize_i64_positive() {
         let input = x"48258963497416957497253486";
         let cursor = cursor::init(input);
-        
+
         let result = deserialize_i64(&mut cursor);
         assert!(result == i64::from_u64(0x4825896349741695), 1);
 
@@ -130,7 +130,7 @@ module pyth::deserialize {
     fun test_deserialize_i64_negative() {
         let input = x"FFFFFFFFFFFFFDC37497253486";
         let cursor = cursor::init(input);
-        
+
         let result = deserialize_i64(&mut cursor);
         assert!(result == i64::from_u64(0xFFFFFFFFFFFFFDC3), 1);
 

--- a/aptos/contracts/sources/governance/governance.move
+++ b/aptos/contracts/sources/governance/governance.move
@@ -1,21 +1,16 @@
 module pyth::governance {
     use wormhole::vaa::{Self, VAA};
-    use pyth::data_source::{Self, DataSource};
+    use pyth::data_source::{Self};
     use wormhole::u16;
     use pyth::governance_instruction;
-    use pyth::pyth;
     use pyth::governance_action;
     use pyth::contract_upgrade;
-    use pyth::contract_upgrade_hash;
     use pyth::set_governance_data_source;
     use pyth::set_data_sources;
     use pyth::set_stale_price_threshold;
     use pyth::error;
     use pyth::set_update_fee;
     use pyth::state;
-    use wormhole::external_address;
-    use std::account;
-    use std::vector;
 
     public entry fun execute_governance_instruction(vaa_bytes: vector<u8>) {
         let parsed_vaa = parse_and_verify_governance_vaa(vaa_bytes);
@@ -134,7 +129,7 @@ module pyth::governance {
         // - Emitter chain ID 50
         // - Emitter address 0xf06413c0148c78916554f134dcd17a7c8029a3a2bda475a4a1182305c53078bf
         // - Sequence number 1
-        // - A payload representing a governance instruction with: 
+        // - A payload representing a governance instruction with:
         //   - Module number 2
         let vaa_bytes = x"010000000001001d9fd73b3fb0fc522eae5eb5bd40ddf68941894495d7cec8c8efdbf462e48715171b5c6d4bbca0c1e3843b3c28d0ca6f3f76874624b5595a3a2cbfdb3907b62501527e4f9b000000010032f06413c0148c78916554f134dcd17a7c8029a3a2bda475a4a1182305c53078bf0000000000000001005054474d0202001003001793a28e2e5b4cb88f69e96fb29a8287a88b23f0e99f5502f81744e904da8e3b4d000c9a4066ce1fa26da1c102a3e268abd3ca58e3b3c25f250e6ad9a3525066fbf8b00012f7778ca023d5cbe37449bab2faa2a133fe02b056c2c25605950320df08750f35";
         execute_governance_instruction(vaa_bytes);
@@ -149,7 +144,7 @@ module pyth::governance {
         // - Emitter chain ID 50
         // - Emitter address 0xf06413c0148c78916554f134dcd17a7c8029a3a2bda475a4a1182305c53078bf
         // - Sequence number 1
-        // - A payload representing a governance instruction with: 
+        // - A payload representing a governance instruction with:
         //   - Module number 1
         //   - Target chain 17 != wormhole test chain ID 22
         let vaa_bytes = x"010000000001001ed81e10f8e52e6a7daeca12bf0859c14e8dabed737eaed9a1f8227190a9d11c48d58856713243c5d7de08ed49de4aa1efe7c5e6020c11056802e2d702aa4b2e00527e4f9b000000010032f06413c0148c78916554f134dcd17a7c8029a3a2bda475a4a1182305c53078bf0000000000000001005054474d0102001103001793a28e2e5b4cb88f69e96fb29a8287a88b23f0e99f5502f81744e904da8e3b4d000c9a4066ce1fa26da1c102a3e268abd3ca58e3b3c25f250e6ad9a3525066fbf8b00012f7778ca023d5cbe37449bab2faa2a133fe02b056c2c25605950320df08750f35";
@@ -165,7 +160,7 @@ module pyth::governance {
         // - Emitter chain ID 50
         // - Emitter address 0xf06413c0148c78916554f134dcd17a7c8029a3a2bda475a4a1182305c53078bf
         // - Sequence number 1
-        // - A payload representing a governance instruction with: 
+        // - A payload representing a governance instruction with:
         //   - Module number 1
         //   - Target chain 22
         //   - Action 19 (invalid)
@@ -181,14 +176,14 @@ module pyth::governance {
         // - Emitter chain ID 50
         // - Emitter address 0xf06413c0148c78916554f134dcd17a7c8029a3a2bda475a4a1182305c53078bf
         // - Sequence number 5
-        // - A payload representing a governance instruction with: 
+        // - A payload representing a governance instruction with:
         //   - Module number 1
         //   - Target chain 22
         //   - AuthorizeContractUpgrade {
         //         hash: 0xa381a47fd0e97f34c71ef491c82208f58cd0080e784c697e65966d2a25d20d56,
         //     }
         let vaa_bytes = x"010000000001002242229aec7d320a437cb241672dacfbc34c9155c02f60cd806bbfcd69bb7ba667fc069e372ae0443a7f3e08eaad61930b00784faeb2b72ecf5d1b0f0fa486a101527e4f9b000000010032f06413c0148c78916554f134dcd17a7c8029a3a2bda475a4a1182305c53078bf0000000000000005005054474d01000016a381a47fd0e97f34c71ef491c82208f58cd0080e784c697e65966d2a25d20d56";
-       
+
         execute_governance_instruction(vaa_bytes);
         assert!(state::get_last_executed_governance_sequence() == 5, 1);
 
@@ -205,14 +200,14 @@ module pyth::governance {
         // - Emitter chain ID 50
         // - Emitter address 0xf06413c0148c78916554f134dcd17a7c8029a3a2bda475a4a1182305c53078bf
         // - Sequence number 5
-        // - A payload representing a governance instruction with: 
+        // - A payload representing a governance instruction with:
         //   - Module number 1
         //   - Target chain 0
         //   - AuthorizeContractUpgrade {
         //         hash: 0xa381a47fd0e97f34c71ef491c82208f58cd0080e784c697e65966d2a25d20d56,
         //     }
         let vaa_bytes = x"01000000000100303c10020c537205ed0322b7ec9d9b296f4e3e12e39ebde985ed4ef4c8f5565256cfc6f90800c4683dba62b577cc994e2ca9135d32b955040b94718cdcb5527600527e4f9b000000010032f06413c0148c78916554f134dcd17a7c8029a3a2bda475a4a1182305c53078bf0000000000000005005054474d01000000a381a47fd0e97f34c71ef491c82208f58cd0080e784c697e65966d2a25d20d56";
-       
+
         execute_governance_instruction(vaa_bytes);
         assert!(state::get_last_executed_governance_sequence() == 5, 1);
 
@@ -227,7 +222,7 @@ module pyth::governance {
         setup_test(100, initial_governance_emitter_chain_id, initial_governance_emitter_address, 100);
 
         state::set_last_executed_governance_sequence(25);
-        
+
         let initial_governance_data_source = data_source::new(initial_governance_emitter_chain_id, external_address::from_bytes(initial_governance_emitter_address));
         assert!(state::is_valid_governance_data_source(initial_governance_data_source), 1);
 
@@ -235,7 +230,7 @@ module pyth::governance {
         // - Emitter chain ID 50
         // - Emitter address 0xf06413c0148c78916554f134dcd17a7c8029a3a2bda475a4a1182305c53078bf
         // - Sequence number 27
-        // - A payload representing a governance instruction with: 
+        // - A payload representing a governance instruction with:
         //   - Module number 1
         //   - Target chain 22
         //   - SetGovernanceDataSource {
@@ -259,7 +254,7 @@ module pyth::governance {
         // - Emitter chain ID 9
         // - Emitter address 0x625bae57728a368652a0ab0a89808de5fffa61d3312f1a27c3e200e99b1f3058
         // - Sequence number 15
-        // - A payload representing a governance instruction with: 
+        // - A payload representing a governance instruction with:
         //   - Module number 1
         //   - Target chain 22
         //   - SetStalePriceThreshold {
@@ -280,7 +275,7 @@ module pyth::governance {
         setup_test(100, initial_governance_emitter_chain_id, initial_governance_emitter_address, 100);
 
         state::set_last_executed_governance_sequence(25);
-        
+
         let initial_governance_data_source = data_source::new(initial_governance_emitter_chain_id, external_address::from_bytes(initial_governance_emitter_address));
         assert!(state::is_valid_governance_data_source(initial_governance_data_source), 1);
 
@@ -288,7 +283,7 @@ module pyth::governance {
         // - Emitter chain ID 50
         // - Emitter address x"f06413c0148c78916554f134dcd17a7c8029a3a2bda475a4a1182305c53078bf"
         // - Sequence number 27
-        // - A payload representing a governance instruction with: 
+        // - A payload representing a governance instruction with:
         //   - Module number 1
         //   - Target chain 22
         //   - SetGovernanceDataSource {
@@ -326,7 +321,7 @@ module pyth::governance {
         // - Emitter chain ID 50
         // - Emitter address 0xf06413c0148c78916554f134dcd17a7c8029a3a2bda475a4a1182305c53078bf
         // - Sequence number 1
-        // - A payload representing a governance instruction with: 
+        // - A payload representing a governance instruction with:
         //   - Module number 1
         //   - Target chain 22
         //   - SetUpdateFee {
@@ -352,7 +347,7 @@ module pyth::governance {
         // - Emitter chain ID 50
         // - Emitter address 0xf06413c0148c78916554f134dcd17a7c8029a3a2bda475a4a1182305c53078bf
         // - Sequence number 1
-        // - A payload representing a governance instruction with: 
+        // - A payload representing a governance instruction with:
         //   - Module number 1
         //   - Target chain 22
         //   - SetStalePriceThreshold {
@@ -374,7 +369,7 @@ module pyth::governance {
         // - Emitter chain ID 50
         // - Emitter address 0xf06413c0148c78916554f134dcd17a7c8029a3a2bda475a4a1182305c53078bf
         // - Sequence number 1
-        // - A payload representing a governance instruction with: 
+        // - A payload representing a governance instruction with:
         //   - Module number 1
         //   - Target chain 22
         //   - SetDataSources {

--- a/aptos/contracts/sources/pyth.move
+++ b/aptos/contracts/sources/pyth.move
@@ -3,9 +3,8 @@ module pyth::pyth {
     use pyth::price_identifier::{Self, PriceIdentifier};
     use pyth::price_info::{Self, PriceInfo};
     use pyth::price_feed::{Self};
-    use aptos_framework::coin::{Self, Coin, BurnCapability, MintCapability};
-    use aptos_framework::aptos_coin::{Self, AptosCoin};
-    use pyth::i64;
+    use aptos_framework::coin::{Self, Coin};
+    use aptos_framework::aptos_coin::{AptosCoin};
     use pyth::price::Price;
     use pyth::price;
     use pyth::data_source::{Self, DataSource};
@@ -117,14 +116,14 @@ module pyth::pyth {
 // -----------------------------------------------------------------------------
 // Update the cached prices
 
-    /// Update the cached price feeds with the data in the given VAAs. This is a 
+    /// Update the cached price feeds with the data in the given VAAs. This is a
     /// convenience wrapper around update_price_feeds(), which allows you to update the price feeds
     /// using an entry function.
-    /// 
+    ///
     /// If possible, it is recommended to use update_price_feeds() instead, which avoids the need
     /// to pass a signer account. update_price_feeds_with_funder() should only be used when
     /// you need to call an entry function.
-    /// 
+    ///
     /// This function will charge an update fee, transferring some AptosCoin's
     /// from the given funder account to the Pyth contract. The amount of coins transferred can be
     /// queried with get_update_fee(). The signer must have sufficient account balance to
@@ -136,11 +135,11 @@ module pyth::pyth {
 
     /// Update the cached price feeds with the data in the given VAAs.
     /// The vaas argument is a vector of VAAs encoded as bytes.
-    /// 
+    ///
     /// The javascript https://github.com/pyth-network/pyth-js/tree/main/pyth-aptos-js package
     /// should be used to fetch these VAAs from the Price Service. More information about this
     /// process can be found at https://docs.pyth.network/consume-data.
-    /// 
+    ///
     /// The given fee must contain a sufficient number of coins to pay the update fee.
     /// The update fee amount can be queried by calling get_update_fee().
     public fun update_price_feeds(vaas: vector<vector<u8>>, fee: Coin<AptosCoin>) {
@@ -189,7 +188,7 @@ module pyth::pyth {
 
     /// A convenience wrapper around update_price_feeds_if_fresh(), allowing you to conditionally
     /// update the price feeds using an entry function.
-    /// 
+    ///
     /// If possible, it is recommended to use update_price_feeds_if_fresh() instead, which avoids the need
     /// to pass a signer account. update_price_feeds_if_fresh_with_funder() should only be used when
     /// you need to call an entry function.
@@ -207,9 +206,9 @@ module pyth::pyth {
     /// prices in the update are fresh. The price_identifiers and publish_times parameters
     /// are used to determine if the update is fresh without doing any serialisation or verification
     /// of the VAAs, potentially saving time and gas. If the update contains no fresh data, this function
-    /// will revert with error::no_fresh_data(). 
-    /// 
-    /// For a given price update i in the batch, that price is considered fresh if the current cached 
+    /// will revert with error::no_fresh_data().
+    ///
+    /// For a given price update i in the batch, that price is considered fresh if the current cached
     /// price for price_identifiers[i] is older than publish_times[i].
     public entry fun update_price_feeds_if_fresh(
         vaas: vector<vector<u8>>,
@@ -256,7 +255,7 @@ module pyth::pyth {
             return true
         };
         let cached_timestamp = price::get_timestamp(&get_price_unsafe(*price_identifier));
-        
+
         update_timestamp > cached_timestamp
     }
 
@@ -271,16 +270,16 @@ module pyth::pyth {
         state::price_info_cached(price_identifier)
     }
 
-    /// Get the latest available price cached for the given price identifier, if that price is 
+    /// Get the latest available price cached for the given price identifier, if that price is
     /// no older than the stale price threshold.
-    /// 
+    ///
     /// Please refer to the documentation at https://docs.pyth.network/consumers/best-practices for
     /// how to how this price safely.
-    /// 
+    ///
     /// Important: it is recommended to call update_price_feeds() to update the cached price
-    /// before calling this function, as get_price() will abort if the cached price is older 
+    /// before calling this function, as get_price() will abort if the cached price is older
     /// than the stale price threshold.
-    /// 
+    ///
     /// Note that the price_identifier does not correspond to a seperate Aptos account:
     /// all price feeds are stored in the single pyth account. The price identifier is an
     /// opaque identifier for a price feed.
@@ -288,7 +287,7 @@ module pyth::pyth {
         get_price_no_older_than(price_identifier, state::get_stale_price_threshold_secs())
     }
 
-    /// Get the latest available price cached for the given price identifier, if that price is 
+    /// Get the latest available price cached for the given price identifier, if that price is
     /// no older than the given age.
     public fun get_price_no_older_than(price_identifier: PriceIdentifier, max_age_secs: u64): Price {
         let price = get_price_unsafe(price_identifier);
@@ -298,11 +297,11 @@ module pyth::pyth {
     }
 
     /// Get the latest available price cached for the given price identifier.
-    /// 
+    ///
     /// WARNING: the returned price can be from arbitrarily far in the past.
     /// This function makes no guarantees that the returned price is recent or
     /// useful for any particular application. Users of this function should check
-    /// the returned timestamp to ensure that the returned price is sufficiently 
+    /// the returned timestamp to ensure that the returned price is sufficiently
     /// recent for their application. The checked get_price_no_older_than()
     /// function should be used in preference to this.
     public fun get_price_unsafe(price_identifier: PriceIdentifier): Price {
@@ -329,11 +328,11 @@ module pyth::pyth {
         assert!(age < max_age_secs, error::stale_price_update());
     }
 
-    /// Get the latest available exponentially moving average price cached for the given 
+    /// Get the latest available exponentially moving average price cached for the given
     /// price identifier, if that price is no older than the stale price threshold.
-    /// 
+    ///
     /// Important: it is recommended to call update_price_feeds() to update the cached EMA price
-    /// before calling this function, as get_ema_price() will abort if the cached EMA price is older 
+    /// before calling this function, as get_ema_price() will abort if the cached EMA price is older
     /// than the stale price threshold.
     public fun get_ema_price(price_identifier: PriceIdentifier): Price {
         get_ema_price_no_older_than(price_identifier, state::get_stale_price_threshold_secs())
@@ -346,14 +345,14 @@ module pyth::pyth {
         check_price_is_fresh(&price, max_age_secs);
 
         price
-    } 
+    }
 
     /// Get the latest available exponentially moving average price cached for the given price identifier.
-    /// 
+    ///
     /// WARNING: the returned price can be from arbitrarily far in the past.
     /// This function makes no guarantees that the returned price is recent or
     /// useful for any particular application. Users of this function should check
-    /// the returned timestamp to ensure that the returned price is sufficiently 
+    /// the returned timestamp to ensure that the returned price is sufficiently
     /// recent for their application. The checked get_ema_price_no_older_than()
     /// function should be used in preference to this.
     public fun get_ema_price_unsafe(price_identifier: PriceIdentifier): Price {
@@ -389,7 +388,7 @@ module pyth::pyth {
             account::create_test_signer_cap(@0x277fa055b6a73c42c0662d5236c65c864ccbf2d4abd21f174a30c8b786eab84b));
         let (_pyth, signer_capability) = account::create_resource_account(&deployer, b"pyth");
         init_test(signer_capability, stale_price_threshold, governance_emitter_chain_id, governance_emitter_address, data_sources, update_fee);
-    
+
         let (burn_capability, mint_capability) = aptos_coin::initialize_for_test(aptos_framework);
         let coins = coin::mint(to_mint, &mint_capability);
         (burn_capability, mint_capability, coins)
@@ -511,7 +510,7 @@ module pyth::pyth {
     #[test(aptos_framework = @aptos_framework)]
     fun test_update_price_feeds_success(aptos_framework: &signer) {
         let (burn_capability, mint_capability, coins) = setup_test(aptos_framework, 500, 1, x"5d1f252d5de865279b00c84bce362774c2804294ed53299bc4a0389a5defef92", data_sources_for_test_vaa(), 50, 100);
-    
+
         // Update the price feeds from the VAA
         update_price_feeds(TEST_VAAS, coins);
 
@@ -538,7 +537,7 @@ module pyth::pyth {
         assert!(coin::balance<AptosCoin>(signer::address_of(&funder)) == initial_balance, 1);
         assert!(coin::balance<AptosCoin>(@pyth) == 0, 1);
 
-        // Update the price feeds using the funder 
+        // Update the price feeds using the funder
         update_price_feeds_with_funder(&funder, TEST_VAAS);
 
         // Check that the price feeds are now cached
@@ -570,7 +569,7 @@ module pyth::pyth {
         assert!(coin::balance<AptosCoin>(signer::address_of(&funder)) == initial_balance, 1);
         assert!(coin::balance<AptosCoin>(@pyth) == 0, 1);
 
-        // Update the price feeds using the funder 
+        // Update the price feeds using the funder
         update_price_feeds_with_funder(&funder, TEST_VAAS);
 
         cleanup_test(burn_capability, mint_capability);
@@ -614,7 +613,7 @@ module pyth::pyth {
             assert!(!price_feed_exists(*price_feed::get_price_identifier(price_feed)), 1);
             i = i + 1;
         };
-        
+
         // Submit the updates
         update_cache(updates);
 
@@ -628,7 +627,7 @@ module pyth::pyth {
     #[test(aptos_framework = @aptos_framework)]
     fun test_update_cache_old_update(aptos_framework: &signer) {
         let (burn_capability, mint_capability, coins) = setup_test(aptos_framework, 1000, 1, x"5d1f252d5de865279b00c84bce362774c2804294ed53299bc4a0389a5defef92", data_sources_for_test_vaa(), 50, 0);
-        
+
         // Submit a price update
         let timestamp = 1663680700;
         let price_identifier = price_identifier::from_byte_vec(x"baa284eaf23edf975b371ba2818772f93dbae72836bbdea28b07d40f3cf8b485");
@@ -666,7 +665,7 @@ module pyth::pyth {
         assert!(get_price(price_identifier) == price, 1);
         assert!(get_ema_price(price_identifier) == ema_price, 1);
 
-        // Update the cache with a fresh update 
+        // Update the cache with a fresh update
         let fresh_price = price::new(i64::new(4857, true), 9979, i64::new(243, false), timestamp + 200);
         let fresh_ema_price = price::new(i64::new(74637, false), 9979, i64::new(1433, false), timestamp + 1);
         let fresh_update = price_info::new(
@@ -768,8 +767,8 @@ module pyth::pyth {
     #[expected_failure(abort_code = 65541)]
     fun test_update_price_feeds_if_fresh_invalid_length(aptos_framework: &signer) {
         let (burn_capability, mint_capability, coins) = setup_test(aptos_framework, 500, 1, x"5d1f252d5de865279b00c84bce362774c2804294ed53299bc4a0389a5defef92", data_sources_for_test_vaa(), 50, 0);
-        
-        // Update the price feeds 
+
+        // Update the price feeds
         let bytes = vector[vector[0u8, 1u8, 2u8]];
         let price_identifiers = vector[
             x"baa284eaf23edf975b371ba2818772f93dbae72836bbdea28b07d40f3cf8b485",
@@ -787,8 +786,8 @@ module pyth::pyth {
     #[test(aptos_framework = @aptos_framework)]
     fun test_update_price_feeds_if_fresh_fresh_data(aptos_framework: &signer) {
         let (burn_capability, mint_capability, coins) = setup_test(aptos_framework, 500, 1, x"5d1f252d5de865279b00c84bce362774c2804294ed53299bc4a0389a5defef92", data_sources_for_test_vaa(), 50, 50);
-        
-        // Update the price feeds 
+
+        // Update the price feeds
         let bytes = TEST_VAAS;
         let price_identifiers = vector[
             x"c6c75c89f14810ec1c54c03ab8f1864a4c4032791f05747f560faec380a695d1",
@@ -824,7 +823,7 @@ module pyth::pyth {
         assert!(coin::balance<AptosCoin>(signer::address_of(&funder)) == initial_balance, 1);
         assert!(coin::balance<AptosCoin>(@pyth) == 0, 1);
 
-        // Update the price feeds using the funder 
+        // Update the price feeds using the funder
         let bytes = TEST_VAAS;
         let price_identifiers = vector[
             x"c6c75c89f14810ec1c54c03ab8f1864a4c4032791f05747f560faec380a695d1",
@@ -856,7 +855,7 @@ module pyth::pyth {
 
         // First populate the cache
         update_cache(get_mock_price_infos());
-        
+
         // Now attempt to update the price feeds with publish_times that are older than those we have cached
         // This should abort with error::no_fresh_data()
         let bytes = TEST_VAAS;


### PR DESCRIPTION
There were quite a few unused imports in the Pyth Move contracts. This can be an issue if users are depending on Pyth during unit testing.