### PR TITLE
Add comment clarifying deployed addresses

### DIFF
--- a/aptos/contracts/Move.toml
+++ b/aptos/contracts/Move.toml
@@ -18,6 +18,8 @@ deployer = "_"
 wormhole = "_"
 
 [dev-addresses]
+# Note that these are localnet addresses, for use in testing. The contracts are deployed to the real networks at the 
+# addresses documented at https://docs.pyth.network/consume-data/aptos#addresses
 pyth = "0xe2f37b8ac45d29d5ea23eb7d16dd3f7a7ab6426f5a998d6c23ecd3ae8d9d29eb"
 deployer = "0x277fa055b6a73c42c0662d5236c65c864ccbf2d4abd21f174a30c8b786eab84b"
 wormhole = "0x251011524cd0f76881f16e7c2d822f0c1c9510bfd2430ba24e1b3d52796df204"


### PR DESCRIPTION
This was causing some confusion, so adding a comment to clarify.