### PR TITLE
Fix logging of vaa as hex

### DIFF
--- a/third_party/pyth/multisig-wh-message-builder/src/index.ts
+++ b/third_party/pyth/multisig-wh-message-builder/src/index.ts
@@ -541,7 +541,7 @@ async function executeMultisigTx(
   );
   const { vaaBytes } = await response.json();
   console.log(`VAA (Base64): ${vaaBytes}`);
-  console.log(`VAA (Hex): ${Buffer.from(vaaBytes).toString("hex")}`);
+  console.log(`VAA (Hex): ${Buffer.from(vaaBytes, "base64").toString("hex")}`);
   const parsedVaa = await parse(vaaBytes);
   console.log(`Emitter chain: ${parsedVaa.emitter_chain}`);
   console.log(`Nonce: ${parsedVaa.nonce}`);


### PR DESCRIPTION
We are logging signed VAAs after multisig execution both in base64 and hex. This PR solves the hex output. Apparently Buffer cannot always understand the type of base64 input. This change explicitly tells Buffer that the input is base64.