### PR TITLE
Run remote exec CI only if it's changed

### DIFF
--- a/.github/workflows/remote-executor.yml
+++ b/.github/workflows/remote-executor.yml
@@ -2,6 +2,7 @@ name: Check Remote Executor
 
 on:
   pull_request:
+    paths: [ pythnet/remote-executor/** ]
   push:
     branches: [main]
     paths: [ pythnet/remote-executor/** ]

--- a/.github/workflows/remote-executor.yml
+++ b/.github/workflows/remote-executor.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches: [main]
-
+    paths: [ pythnet/remote-executor/** ]
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
To save more GH actions time + have faster CI checks (sometimes it takes longer than tilt!)

Afaik this code does not depend on any other codebase here, so running it only when anything within its directory has changed will work as expected.
