### PR TITLE
[eth] Make governance transfer less error-prone

### DIFF
--- a/ethereum/contracts/pyth/PythGetters.sol
+++ b/ethereum/contracts/pyth/PythGetters.sol
@@ -63,4 +63,8 @@ contract PythGetters is PythState {
     function validTimePeriodSeconds() public view returns (uint) {
         return _state.validTimePeriodSeconds;
     }
+
+    function governanceDataSourceIndex() public view returns (uint32) {
+        return _state.governanceDataSourceIndex;
+    }
 }

--- a/ethereum/contracts/pyth/PythGovernance.sol
+++ b/ethereum/contracts/pyth/PythGovernance.sol
@@ -46,7 +46,6 @@ abstract contract PythGovernance is PythGetters, PythSetters, PythGovernanceInst
             require(gi.targetChainId != 0, "upgrade with chain id 0 is not possible");
             upgradeContract(gi.payload);
         } else if (gi.action == GovernanceAction.TransferGovernanceDataSource) {
-            require(gi.targetChainId == 0, "governance data source change should be applied to all chains");
             transferGovernanceDataSource(gi.payload);
         } else if (gi.action == GovernanceAction.SetDataSources) {
             setDataSources(gi.payload);
@@ -85,7 +84,7 @@ abstract contract PythGovernance is PythGetters, PythSetters, PythGovernanceInst
         require(valid, reason);
 
         GovernanceInstruction memory gi = parseGovernanceInstruction(vm.payload);
-        require(gi.targetChainId == 0, "governance data source change claim vaa should be applied to all chains");
+        require(gi.targetChainId == chainId() || gi.targetChainId == 0, "invalid target chain for this governance instruction");
         require(gi.action == GovernanceAction.TransferGovernanceDataSourceClaim,
             "governance data source change inner vaa is not of claim action type");
 

--- a/ethereum/contracts/pyth/PythGovernance.sol
+++ b/ethereum/contracts/pyth/PythGovernance.sol
@@ -45,16 +45,16 @@ abstract contract PythGovernance is PythGetters, PythSetters, PythGovernanceInst
         if (gi.action == GovernanceAction.UpgradeContract) {
             require(gi.targetChainId != 0, "upgrade with chain id 0 is not possible");
             upgradeContract(gi.payload);
-        } else if (gi.action == GovernanceAction.TransferGovernanceDataSource) {
-            transferGovernanceDataSource(gi.payload);
+        } else if (gi.action == GovernanceAction.TransferGovernanceDataSourceAuthorize) {
+            TransferGovernanceDataSourceAuthorize(gi.payload);
         } else if (gi.action == GovernanceAction.SetDataSources) {
             setDataSources(gi.payload);
         } else if (gi.action == GovernanceAction.SetFee) {
             setFee(gi.payload);
         } else if (gi.action == GovernanceAction.SetValidPeriod) {
             setValidPeriod(gi.payload);
-        } else if (gi.action == GovernanceAction.TransferGovernanceDataSourceClaim) {
-            revert("TransferGovernanceDataSourceClaim can be only part of TransferGovernanceDataSource message");
+        } else if (gi.action == GovernanceAction.TransferGovernanceDataSourceRequest) {
+            revert("TransferGovernanceDataSourceRequest can be only part of TransferGovernanceDataSourceAuthorize message");
         } else {
             revert("invalid governance action");
         }
@@ -71,12 +71,12 @@ abstract contract PythGovernance is PythGetters, PythSetters, PythGovernanceInst
 
     // Transfer the governance data source to a new value with sanity checks
     // to ensure the new governance data source can manage the contract.
-    function transferGovernanceDataSource(bytes memory encodedPayload) internal {
+    function TransferGovernanceDataSourceAuthorize(bytes memory encodedPayload) internal {
         PythInternalStructs.DataSource memory oldGovernanceDatSource = governanceDataSource();
 
-        TransferGovernanceDataSourcePayload memory payload = parseTransferGovernanceDataSourcePayload(encodedPayload);
+        TransferGovernanceDataSourceAuthorizePayload memory payload = parseTransferGovernanceDataSourceAuthorizePayload(encodedPayload);
 
-        // Make sure the claimVaa is a valid VAA with TransferGovernanceDataSourceClaim governance message
+        // Make sure the claimVaa is a valid VAA with TransferGovernanceDataSourceRequest governance message
         // If it's valid then its emitter can take over the governance from the current emitter.
         // The VAA is checked here to ensure that the new governance data source is valid and can send message
         // through wormhole.
@@ -85,10 +85,10 @@ abstract contract PythGovernance is PythGetters, PythSetters, PythGovernanceInst
 
         GovernanceInstruction memory gi = parseGovernanceInstruction(vm.payload);
         require(gi.targetChainId == chainId() || gi.targetChainId == 0, "invalid target chain for this governance instruction");
-        require(gi.action == GovernanceAction.TransferGovernanceDataSourceClaim,
+        require(gi.action == GovernanceAction.TransferGovernanceDataSourceRequest,
             "governance data source change inner vaa is not of claim action type");
 
-        TransferGovernanceDataSourceClaimPayload memory claimPayload = parseTransferGovernanceDataSourceClaimPayload(gi.payload);
+        TransferGovernanceDataSourceRequestPayload memory claimPayload = parseTransferGovernanceDataSourceRequestPayload(gi.payload);
 
         // Governance data source index is used to prevent replay attacks, so a claimVaa cannot be used twice.
         require(governanceDataSourceIndex() < claimPayload.governanceDataSourceIndex, 

--- a/ethereum/contracts/pyth/PythGovernanceInstructions.sol
+++ b/ethereum/contracts/pyth/PythGovernanceInstructions.sol
@@ -26,11 +26,11 @@ contract PythGovernanceInstructions {
 
     enum GovernanceAction {
         UpgradeContract, // 0
-        TransferGovernanceDataSource, // 1
+        TransferGovernanceDataSourceAuthorize, // 1
         SetDataSources, // 2
         SetFee, // 3
         SetValidPeriod, // 4
-        TransferGovernanceDataSourceClaim // 5
+        TransferGovernanceDataSourceRequest // 5
     }
 
     struct GovernanceInstruction {
@@ -44,14 +44,14 @@ contract PythGovernanceInstructions {
         address newImplementation;
     }
 
-    struct TransferGovernanceDataSourcePayload {
+    struct TransferGovernanceDataSourceAuthorizePayload {
         // Transfer governance control over this contract to another data source.
         // The claimVaa field is a VAA created by the new data source; using a VAA prevents mistakes
         // in the handoff by ensuring that the new data source can send VAAs (i.e., is not an invalid address).
         bytes claimVaa;
     }
 
-    struct TransferGovernanceDataSourceClaimPayload {
+    struct TransferGovernanceDataSourceRequestPayload {
         // Governance data source index is used to prevent replay attacks
         // So a claimVaa cannot be used twice.
         uint32 governanceDataSourceIndex;
@@ -103,21 +103,21 @@ contract PythGovernanceInstructions {
         require(encodedPayload.length == index, "invalid length for UpgradeContractPayload");
     }
 
-    /// @dev Parse a TransferGovernanceDataSourcePayload (action 2) with minimal validation
-    function parseTransferGovernanceDataSourcePayload(bytes memory encodedPayload) public pure returns (TransferGovernanceDataSourcePayload memory sgds) {
+    /// @dev Parse a TransferGovernanceDataSourceAuthorizePayload (action 2) with minimal validation
+    function parseTransferGovernanceDataSourceAuthorizePayload(bytes memory encodedPayload) public pure returns (TransferGovernanceDataSourceAuthorizePayload memory sgds) {
         sgds.claimVaa = encodedPayload;
     }
 
-    /// @dev Parse a TransferGovernanceDataSourcePayload (action 2) with minimal validation
-    function parseTransferGovernanceDataSourceClaimPayload(bytes memory encodedPayload) public pure
-        returns (TransferGovernanceDataSourceClaimPayload memory sgdsClaim) {
+    /// @dev Parse a TransferGovernanceDataSourceAuthorizePayload (action 2) with minimal validation
+    function parseTransferGovernanceDataSourceRequestPayload(bytes memory encodedPayload) public pure
+        returns (TransferGovernanceDataSourceRequestPayload memory sgdsClaim) {
 
         uint index = 0;
 
         sgdsClaim.governanceDataSourceIndex = encodedPayload.toUint32(index);
         index += 4;
 
-        require(encodedPayload.length == index, "invalid length for TransferGovernanceDataSourceClaimPayload");
+        require(encodedPayload.length == index, "invalid length for TransferGovernanceDataSourceRequestPayload");
     }
 
     /// @dev Parse a SetDataSourcesPayload (action 3) with minimal validation

--- a/ethereum/contracts/pyth/PythGovernanceInstructions.sol
+++ b/ethereum/contracts/pyth/PythGovernanceInstructions.sol
@@ -26,11 +26,11 @@ contract PythGovernanceInstructions {
 
     enum GovernanceAction {
         UpgradeContract, // 0
-        TransferGovernanceDataSourceAuthorize, // 1
+        AuthorizeGovernanceDataSourceTransfer, // 1
         SetDataSources, // 2
         SetFee, // 3
         SetValidPeriod, // 4
-        TransferGovernanceDataSourceRequest // 5
+        RequestGovernanceDataSourceTransfer // 5
     }
 
     struct GovernanceInstruction {
@@ -44,14 +44,14 @@ contract PythGovernanceInstructions {
         address newImplementation;
     }
 
-    struct TransferGovernanceDataSourceAuthorizePayload {
+    struct AuthorizeGovernanceDataSourceTransferPayload {
         // Transfer governance control over this contract to another data source.
         // The claimVaa field is a VAA created by the new data source; using a VAA prevents mistakes
         // in the handoff by ensuring that the new data source can send VAAs (i.e., is not an invalid address).
         bytes claimVaa;
     }
 
-    struct TransferGovernanceDataSourceRequestPayload {
+    struct RequestGovernanceDataSourceTransferPayload {
         // Governance data source index is used to prevent replay attacks
         // So a claimVaa cannot be used twice.
         uint32 governanceDataSourceIndex;
@@ -103,21 +103,21 @@ contract PythGovernanceInstructions {
         require(encodedPayload.length == index, "invalid length for UpgradeContractPayload");
     }
 
-    /// @dev Parse a TransferGovernanceDataSourceAuthorizePayload (action 2) with minimal validation
-    function parseTransferGovernanceDataSourceAuthorizePayload(bytes memory encodedPayload) public pure returns (TransferGovernanceDataSourceAuthorizePayload memory sgds) {
+    /// @dev Parse a AuthorizeGovernanceDataSourceTransferPayload (action 2) with minimal validation
+    function parseAuthorizeGovernanceDataSourceTransferPayload(bytes memory encodedPayload) public pure returns (AuthorizeGovernanceDataSourceTransferPayload memory sgds) {
         sgds.claimVaa = encodedPayload;
     }
 
-    /// @dev Parse a TransferGovernanceDataSourceAuthorizePayload (action 2) with minimal validation
-    function parseTransferGovernanceDataSourceRequestPayload(bytes memory encodedPayload) public pure
-        returns (TransferGovernanceDataSourceRequestPayload memory sgdsClaim) {
+    /// @dev Parse a AuthorizeGovernanceDataSourceTransferPayload (action 2) with minimal validation
+    function parseRequestGovernanceDataSourceTransferPayload(bytes memory encodedPayload) public pure
+        returns (RequestGovernanceDataSourceTransferPayload memory sgdsClaim) {
 
         uint index = 0;
 
         sgdsClaim.governanceDataSourceIndex = encodedPayload.toUint32(index);
         index += 4;
 
-        require(encodedPayload.length == index, "invalid length for TransferGovernanceDataSourceRequestPayload");
+        require(encodedPayload.length == index, "invalid length for RequestGovernanceDataSourceTransferPayload");
     }
 
     /// @dev Parse a SetDataSourcesPayload (action 3) with minimal validation

--- a/ethereum/contracts/pyth/PythGovernanceInstructions.sol
+++ b/ethereum/contracts/pyth/PythGovernanceInstructions.sol
@@ -45,13 +45,15 @@ contract PythGovernanceInstructions {
     }
 
     struct TransferGovernanceDataSourcePayload {
-        // claimVaa is a VAA with TransferGovernanceDataSourceClaimOwnership
-        // governance instruction (header + payload) that is created from
-        // the second multisig
+        // Transfer governance control over this contract to another data source.
+        // The claimVaa field is a VAA created by the new data source; using a VAA prevents mistakes
+        // in the handoff by ensuring that the new data source can send VAAs (i.e., is not an invalid address).
         bytes claimVaa;
     }
 
     struct TransferGovernanceDataSourceClaimPayload {
+        // Governance data source index is used to prevent replay attacks
+        // So a claimVaa cannot be used twice.
         uint32 governanceDataSourceIndex;
     }
 

--- a/ethereum/contracts/pyth/PythSetters.sol
+++ b/ethereum/contracts/pyth/PythSetters.sol
@@ -37,4 +37,8 @@ contract PythSetters is PythState {
     function setLastExecutedGovernanceSequence(uint64 sequence) internal {
         _state.lastExecutedGovernanceSequence = sequence;
     }
+
+    function setGovernanceDataSourceIndex(uint32 newIndex) internal {
+        _state.governanceDataSourceIndex = newIndex;
+    }
 }

--- a/ethereum/contracts/pyth/PythState.sol
+++ b/ethereum/contracts/pyth/PythState.sol
@@ -39,6 +39,10 @@ contract PythStorage {
         // Mapping of cached price information
         // priceId => PriceInfo
         mapping(bytes32 => PythInternalStructs.PriceInfo) latestPriceInfo;
+
+        // Index of the governance data source, increased each time the governance data source
+        // changes.        
+        uint32 governanceDataSourceIndex;
     }
 }
 

--- a/ethereum/test/pyth.js
+++ b/ethereum/test/pyth.js
@@ -1009,7 +1009,6 @@ contract("Pyth", function () {
         const newEmitterChain = governance.CHAINS.acala;
 
         const claimInstructionData = new governance.TransferGovernanceDataSourceClaimInstruction(
-            governance.CHAINS.unset,
             1
         ).serialize();
 
@@ -1026,25 +1025,8 @@ contract("Pyth", function () {
         );
 
         const claimVaa = Buffer.from(claimVaaHexString.substring(2), 'hex');
-        
-        const wrongData = new governance.TransferGovernanceDataSourceInstruction(
-            governance.CHAINS.ethereum, // Target chain should be all chains so it's wrong
-            claimVaa
-        ).serialize();
-
-        const wrongVaa = await createVAAFromUint8Array(wrongData,
-            testGovernanceChainId, 
-            testGovernanceEmitter,
-            1
-        );
-
-        await expectRevert(
-            this.pythProxy.executeGovernanceInstruction(wrongVaa),
-            "governance data source change should be applied to all chains"
-        );
 
         const data = new governance.TransferGovernanceDataSourceInstruction(
-            governance.CHAINS.unset,
             claimVaa
         ).serialize();
 
@@ -1068,6 +1050,7 @@ contract("Pyth", function () {
         expect(newGovernanceDataSource.chainId).equal(newEmitterChain.toString());
         expect(newGovernanceDataSource.emitterAddress).equal(newEmitterAddress);
 
+        // Verifies the data source has changed.
         await expectRevert(
             this.pythProxy.executeGovernanceInstruction(vaa),
             "VAA is not coming from the governance data source"
@@ -1076,7 +1059,6 @@ contract("Pyth", function () {
         // Make sure a claim vaa does not get executed
 
         const claimLonely = new governance.TransferGovernanceDataSourceClaimInstruction(
-            governance.CHAINS.unset,
             2
         ).serialize();
 
@@ -1097,7 +1079,6 @@ contract("Pyth", function () {
 
         // A wrong vaa that does not move the governance index
         const transferBackClaimInstructionDataWrong = new governance.TransferGovernanceDataSourceClaimInstruction(
-            governance.CHAINS.unset,
             1 // The same governance data source index => Should fail
         ).serialize();
 
@@ -1111,7 +1092,6 @@ contract("Pyth", function () {
         const transferBackClaimVaaWrong = Buffer.from(transferBackClaimVaaHexStringWrong.substring(2), 'hex');
 
         const transferBackDataWrong = new governance.TransferGovernanceDataSourceInstruction(
-            governance.CHAINS.unset,
             transferBackClaimVaaWrong
         ).serialize();
 

--- a/ethereum/test/pyth.js
+++ b/ethereum/test/pyth.js
@@ -1008,7 +1008,7 @@ contract("Pyth", function () {
         const newEmitterAddress = "0x0000000000000000000000000000000000000000000000000000000000001111";
         const newEmitterChain = governance.CHAINS.acala;
 
-        const claimInstructionData = new governance.TransferGovernanceDataSourceRequestInstruction(
+        const claimInstructionData = new governance.RequestGovernanceDataSourceTransferInstruction(
             governance.CHAINS.unset,
             1
         ).serialize();
@@ -1027,7 +1027,7 @@ contract("Pyth", function () {
 
         const claimVaa = Buffer.from(claimVaaHexString.substring(2), 'hex');
 
-        const data = new governance.TransferGovernanceDataSourceAuthorizeInstruction(
+        const data = new governance.AuthorizeGovernanceDataSourceTransferInstruction(
             governance.CHAINS.unset,
             claimVaa
         ).serialize();
@@ -1060,7 +1060,7 @@ contract("Pyth", function () {
 
         // Make sure a claim vaa does not get executed
 
-        const claimLonely = new governance.TransferGovernanceDataSourceRequestInstruction(
+        const claimLonely = new governance.RequestGovernanceDataSourceTransferInstruction(
             governance.CHAINS.unset,
             2
         ).serialize();
@@ -1074,14 +1074,14 @@ contract("Pyth", function () {
         
         await expectRevert(
             this.pythProxy.executeGovernanceInstruction(claimLonelyVaa),
-            "TransferGovernanceDataSourceRequest can be only part of TransferGovernanceDataSourceAuthorize message"
+            "RequestGovernanceDataSourceTransfer can be only part of AuthorizeGovernanceDataSourceTransfer message"
         );
 
         // Transfer back the ownership to the old governance data source without increasing
         // the governance index should not work
 
         // A wrong vaa that does not move the governance index
-        const transferBackClaimInstructionDataWrong = new governance.TransferGovernanceDataSourceRequestInstruction(
+        const transferBackClaimInstructionDataWrong = new governance.RequestGovernanceDataSourceTransferInstruction(
             governance.CHAINS.unset,
             1 // The same governance data source index => Should fail
         ).serialize();
@@ -1095,7 +1095,7 @@ contract("Pyth", function () {
 
         const transferBackClaimVaaWrong = Buffer.from(transferBackClaimVaaHexStringWrong.substring(2), 'hex');
 
-        const transferBackDataWrong = new governance.TransferGovernanceDataSourceAuthorizeInstruction(
+        const transferBackDataWrong = new governance.AuthorizeGovernanceDataSourceTransferInstruction(
             governance.CHAINS.unset,
             transferBackClaimVaaWrong
         ).serialize();

--- a/ethereum/test/pyth.js
+++ b/ethereum/test/pyth.js
@@ -1004,16 +1004,48 @@ contract("Pyth", function () {
         );
     });
 
-    it("Setting governance data source should work", async function () {
-        const data = new governance.SetGovernanceDataSourceInstruction(
-            governance.CHAINS.ethereum,
-            new governance.DataSource(
-                governance.CHAINS.acala,
-                new governance.HexString32Bytes(
-                    "0x0000000000000000000000000000000000000000000000000000000000001111",
-                )
-            ),
-            BigInt(10)
+    it("Transferring governance data source should work", async function () {
+        const newEmitterAddress = "0x0000000000000000000000000000000000000000000000000000000000001111";
+        const newEmitterChain = governance.CHAINS.acala;
+
+        const claimInstructionData = new governance.TransferGovernanceDataSourceClaimInstruction(
+            governance.CHAINS.unset,
+            1
+        ).serialize();
+
+        const claimVaaHexString = await createVAAFromUint8Array(
+            claimInstructionData,
+            newEmitterChain, 
+            newEmitterAddress,
+            1
+        );
+
+        await expectRevert(
+            this.pythProxy.executeGovernanceInstruction(claimVaaHexString),
+            "VAA is not coming from the governance data source"
+        );
+
+        const claimVaa = Buffer.from(claimVaaHexString.substring(2), 'hex');
+        
+        const wrongData = new governance.TransferGovernanceDataSourceInstruction(
+            governance.CHAINS.ethereum, // Target chain should be all chains so it's wrong
+            claimVaa
+        ).serialize();
+
+        const wrongVaa = await createVAAFromUint8Array(wrongData,
+            testGovernanceChainId, 
+            testGovernanceEmitter,
+            1
+        );
+
+        await expectRevert(
+            this.pythProxy.executeGovernanceInstruction(wrongVaa),
+            "governance data source change should be applied to all chains"
+        );
+
+        const data = new governance.TransferGovernanceDataSourceInstruction(
+            governance.CHAINS.unset,
+            claimVaa
         ).serialize();
 
         const vaa = await createVAAFromUint8Array(data,
@@ -1025,40 +1057,74 @@ contract("Pyth", function () {
         const oldGovernanceDataSource = await this.pythProxy.governanceDataSource(); 
 
         const receipt = await this.pythProxy.executeGovernanceInstruction(vaa);
+        
+        const newGovernanceDataSource = await this.pythProxy.governanceDataSource();
+
         expectEvent(receipt, 'GovernanceDataSourceSet', {
             oldDataSource: oldGovernanceDataSource,
-            newDataSource: await this.pythProxy.governanceDataSource(),
+            newDataSource: newGovernanceDataSource,
         });
 
-        const newVaaFromOldGovernanceSource = await createVAAFromUint8Array(data,
+        expect(newGovernanceDataSource.chainId).equal(newEmitterChain.toString());
+        expect(newGovernanceDataSource.emitterAddress).equal(newEmitterAddress);
+
+        await expectRevert(
+            this.pythProxy.executeGovernanceInstruction(vaa),
+            "VAA is not coming from the governance data source"
+        );
+
+        // Make sure a claim vaa does not get executed
+
+        const claimLonely = new governance.TransferGovernanceDataSourceClaimInstruction(
+            governance.CHAINS.unset,
+            2
+        ).serialize();
+
+        const claimLonelyVaa = await createVAAFromUint8Array(
+            claimLonely,
+            newEmitterChain, 
+            newEmitterAddress,
+            2
+        );
+        
+        await expectRevert(
+            this.pythProxy.executeGovernanceInstruction(claimLonelyVaa),
+            "TransferGovernanceDataSourceClaim can be only part of TransferGovernanceDataSource message"
+        );
+
+        // Transfer back the ownership to the old governance data source without increasing
+        // the governance index should not work
+
+        // A wrong vaa that does not move the governance index
+        const transferBackClaimInstructionDataWrong = new governance.TransferGovernanceDataSourceClaimInstruction(
+            governance.CHAINS.unset,
+            1 // The same governance data source index => Should fail
+        ).serialize();
+
+        const transferBackClaimVaaHexStringWrong = await createVAAFromUint8Array(
+            transferBackClaimInstructionDataWrong,
             testGovernanceChainId, 
             testGovernanceEmitter,
             2
         );
 
-        await expectRevert(
-            this.pythProxy.executeGovernanceInstruction(newVaaFromOldGovernanceSource),
-            "VAA is not coming from the governance data source"
-        );
+        const transferBackClaimVaaWrong = Buffer.from(transferBackClaimVaaHexStringWrong.substring(2), 'hex');
 
-        const newVaaFromNewGovernanceOldSequence = await createVAAFromUint8Array(data,
-            governance.CHAINS.acala, 
-            "0x0000000000000000000000000000000000000000000000000000000000001111",
+        const transferBackDataWrong = new governance.TransferGovernanceDataSourceInstruction(
+            governance.CHAINS.unset,
+            transferBackClaimVaaWrong
+        ).serialize();
+
+        const transferBackVaaWrong = await createVAAFromUint8Array(transferBackDataWrong,
+            newEmitterChain, 
+            newEmitterAddress,
             2
         );
 
         await expectRevert(
-            this.pythProxy.executeGovernanceInstruction(newVaaFromNewGovernanceOldSequence),
-            "VAA is older than the last executed governance VAA"
+            this.pythProxy.executeGovernanceInstruction(transferBackVaaWrong),
+            "cannot upgrade to an older governance data source"
         );
-
-        const newVaaFromNewGovernanceGood = await createVAAFromUint8Array(data,
-            governance.CHAINS.acala, 
-            "0x0000000000000000000000000000000000000000000000000000000000001111",
-            20
-        );
-
-        await this.pythProxy.executeGovernanceInstruction(newVaaFromNewGovernanceGood);
     });
 
     it("Setting data sources should work", async function () {

--- a/ethereum/test/pyth.js
+++ b/ethereum/test/pyth.js
@@ -1009,6 +1009,7 @@ contract("Pyth", function () {
         const newEmitterChain = governance.CHAINS.acala;
 
         const claimInstructionData = new governance.TransferGovernanceDataSourceClaimInstruction(
+            governance.CHAINS.unset,
             1
         ).serialize();
 
@@ -1027,6 +1028,7 @@ contract("Pyth", function () {
         const claimVaa = Buffer.from(claimVaaHexString.substring(2), 'hex');
 
         const data = new governance.TransferGovernanceDataSourceInstruction(
+            governance.CHAINS.unset,
             claimVaa
         ).serialize();
 
@@ -1059,6 +1061,7 @@ contract("Pyth", function () {
         // Make sure a claim vaa does not get executed
 
         const claimLonely = new governance.TransferGovernanceDataSourceClaimInstruction(
+            governance.CHAINS.unset,
             2
         ).serialize();
 
@@ -1079,6 +1082,7 @@ contract("Pyth", function () {
 
         // A wrong vaa that does not move the governance index
         const transferBackClaimInstructionDataWrong = new governance.TransferGovernanceDataSourceClaimInstruction(
+            governance.CHAINS.unset,
             1 // The same governance data source index => Should fail
         ).serialize();
 
@@ -1092,6 +1096,7 @@ contract("Pyth", function () {
         const transferBackClaimVaaWrong = Buffer.from(transferBackClaimVaaHexStringWrong.substring(2), 'hex');
 
         const transferBackDataWrong = new governance.TransferGovernanceDataSourceInstruction(
+            governance.CHAINS.unset,
             transferBackClaimVaaWrong
         ).serialize();
 

--- a/ethereum/test/pyth.js
+++ b/ethereum/test/pyth.js
@@ -1008,7 +1008,7 @@ contract("Pyth", function () {
         const newEmitterAddress = "0x0000000000000000000000000000000000000000000000000000000000001111";
         const newEmitterChain = governance.CHAINS.acala;
 
-        const claimInstructionData = new governance.TransferGovernanceDataSourceClaimInstruction(
+        const claimInstructionData = new governance.TransferGovernanceDataSourceRequestInstruction(
             governance.CHAINS.unset,
             1
         ).serialize();
@@ -1027,7 +1027,7 @@ contract("Pyth", function () {
 
         const claimVaa = Buffer.from(claimVaaHexString.substring(2), 'hex');
 
-        const data = new governance.TransferGovernanceDataSourceInstruction(
+        const data = new governance.TransferGovernanceDataSourceAuthorizeInstruction(
             governance.CHAINS.unset,
             claimVaa
         ).serialize();
@@ -1060,7 +1060,7 @@ contract("Pyth", function () {
 
         // Make sure a claim vaa does not get executed
 
-        const claimLonely = new governance.TransferGovernanceDataSourceClaimInstruction(
+        const claimLonely = new governance.TransferGovernanceDataSourceRequestInstruction(
             governance.CHAINS.unset,
             2
         ).serialize();
@@ -1074,14 +1074,14 @@ contract("Pyth", function () {
         
         await expectRevert(
             this.pythProxy.executeGovernanceInstruction(claimLonelyVaa),
-            "TransferGovernanceDataSourceClaim can be only part of TransferGovernanceDataSource message"
+            "TransferGovernanceDataSourceRequest can be only part of TransferGovernanceDataSourceAuthorize message"
         );
 
         // Transfer back the ownership to the old governance data source without increasing
         // the governance index should not work
 
         // A wrong vaa that does not move the governance index
-        const transferBackClaimInstructionDataWrong = new governance.TransferGovernanceDataSourceClaimInstruction(
+        const transferBackClaimInstructionDataWrong = new governance.TransferGovernanceDataSourceRequestInstruction(
             governance.CHAINS.unset,
             1 // The same governance data source index => Should fail
         ).serialize();
@@ -1095,7 +1095,7 @@ contract("Pyth", function () {
 
         const transferBackClaimVaaWrong = Buffer.from(transferBackClaimVaaHexStringWrong.substring(2), 'hex');
 
-        const transferBackDataWrong = new governance.TransferGovernanceDataSourceInstruction(
+        const transferBackDataWrong = new governance.TransferGovernanceDataSourceAuthorizeInstruction(
             governance.CHAINS.unset,
             transferBackClaimVaaWrong
         ).serialize();

--- a/third_party/pyth/xc-governance-sdk-js/src/index.ts
+++ b/third_party/pyth/xc-governance-sdk-js/src/index.ts
@@ -7,8 +7,8 @@ export {
   SetDataSourcesInstruction,
   SetFeeInstruction,
   SetValidPeriodInstruction,
-  TransferGovernanceDataSourceClaimInstruction,
-  TransferGovernanceDataSourceInstruction
+  TransferGovernanceDataSourceRequestInstruction,
+  TransferGovernanceDataSourceAuthorizeInstruction
 } from "./instructions"
 
 export {

--- a/third_party/pyth/xc-governance-sdk-js/src/index.ts
+++ b/third_party/pyth/xc-governance-sdk-js/src/index.ts
@@ -7,7 +7,7 @@ export {
   SetDataSourcesInstruction,
   SetFeeInstruction,
   SetValidPeriodInstruction,
-  TransferGovernanceDataSourceRequestInstruction,
+  RequestGovernanceDataSourceTransferInstruction,
   AuthorizeGovernanceDataSourceTransferInstruction
 } from "./instructions"
 

--- a/third_party/pyth/xc-governance-sdk-js/src/index.ts
+++ b/third_party/pyth/xc-governance-sdk-js/src/index.ts
@@ -6,8 +6,9 @@ export {
   HexString32Bytes,
   SetDataSourcesInstruction,
   SetFeeInstruction,
-  SetGovernanceDataSourceInstruction,
-  SetValidPeriodInstruction
+  SetValidPeriodInstruction,
+  TransferGovernanceDataSourceClaimInstruction,
+  TransferGovernanceDataSourceInstruction
 } from "./instructions"
 
 export {

--- a/third_party/pyth/xc-governance-sdk-js/src/index.ts
+++ b/third_party/pyth/xc-governance-sdk-js/src/index.ts
@@ -8,7 +8,7 @@ export {
   SetFeeInstruction,
   SetValidPeriodInstruction,
   TransferGovernanceDataSourceRequestInstruction,
-  TransferGovernanceDataSourceAuthorizeInstruction
+  AuthorizeGovernanceDataSourceTransferInstruction
 } from "./instructions"
 
 export {

--- a/third_party/pyth/xc-governance-sdk-js/src/instructions.ts
+++ b/third_party/pyth/xc-governance-sdk-js/src/instructions.ts
@@ -9,11 +9,11 @@ enum Module {
 
 enum TargetAction {
   UpgradeContract = 0,
-  TransferGovernanceDataSource,
+  TransferGovernanceDataSourceAuthorize,
   SetDataSources,
   SetFee,
   SetValidPeriod,
-  TransferGovernanceDataSourceClaim,
+  TransferGovernanceDataSourceRequest,
 }
 
 abstract class HexString implements Serializable {
@@ -127,12 +127,12 @@ export class EthereumUpgradeContractInstruction extends TargetInstruction {
   }
 }
 
-export class TransferGovernanceDataSourceInstruction extends TargetInstruction {
+export class TransferGovernanceDataSourceAuthorizeInstruction extends TargetInstruction {
   constructor(
     targetChainId: ChainId,
     private claimVaa: Buffer,
   ) {
-    super(TargetAction.TransferGovernanceDataSource, targetChainId);
+    super(TargetAction.TransferGovernanceDataSourceAuthorize, targetChainId);
   }
 
   protected serializePayload(): Buffer {
@@ -188,12 +188,12 @@ export class SetValidPeriodInstruction extends TargetInstruction {
   }
 }
 
-export class TransferGovernanceDataSourceClaimInstruction extends TargetInstruction {
+export class TransferGovernanceDataSourceRequestInstruction extends TargetInstruction {
   constructor(
     targetChainId: ChainId,
     private governanceDataSourceIndex: number,
   ) {
-    super(TargetAction.TransferGovernanceDataSourceClaim, targetChainId);
+    super(TargetAction.TransferGovernanceDataSourceRequest, targetChainId);
   }
 
   protected serializePayload(): Buffer {

--- a/third_party/pyth/xc-governance-sdk-js/src/instructions.ts
+++ b/third_party/pyth/xc-governance-sdk-js/src/instructions.ts
@@ -9,11 +9,11 @@ enum Module {
 
 enum TargetAction {
   UpgradeContract = 0,
-  TransferGovernanceDataSourceAuthorize,
+  AuthorizeGovernanceDataSourceTransfer,
   SetDataSources,
   SetFee,
   SetValidPeriod,
-  TransferGovernanceDataSourceRequest,
+  RequestGovernanceDataSourceTransfer,
 }
 
 abstract class HexString implements Serializable {
@@ -127,12 +127,12 @@ export class EthereumUpgradeContractInstruction extends TargetInstruction {
   }
 }
 
-export class TransferGovernanceDataSourceAuthorizeInstruction extends TargetInstruction {
+export class AuthorizeGovernanceDataSourceTransferInstruction extends TargetInstruction {
   constructor(
     targetChainId: ChainId,
     private claimVaa: Buffer,
   ) {
-    super(TargetAction.TransferGovernanceDataSourceAuthorize, targetChainId);
+    super(TargetAction.AuthorizeGovernanceDataSourceTransfer, targetChainId);
   }
 
   protected serializePayload(): Buffer {
@@ -188,12 +188,12 @@ export class SetValidPeriodInstruction extends TargetInstruction {
   }
 }
 
-export class TransferGovernanceDataSourceRequestInstruction extends TargetInstruction {
+export class RequestGovernanceDataSourceTransferInstruction extends TargetInstruction {
   constructor(
     targetChainId: ChainId,
     private governanceDataSourceIndex: number,
   ) {
-    super(TargetAction.TransferGovernanceDataSourceRequest, targetChainId);
+    super(TargetAction.RequestGovernanceDataSourceTransfer, targetChainId);
   }
 
   protected serializePayload(): Buffer {

--- a/third_party/pyth/xc-governance-sdk-js/src/instructions.ts
+++ b/third_party/pyth/xc-governance-sdk-js/src/instructions.ts
@@ -129,9 +129,10 @@ export class EthereumUpgradeContractInstruction extends TargetInstruction {
 
 export class TransferGovernanceDataSourceInstruction extends TargetInstruction {
   constructor(
+    targetChainId: ChainId,
     private claimVaa: Buffer,
   ) {
-    super(TargetAction.TransferGovernanceDataSource, CHAINS.unset);
+    super(TargetAction.TransferGovernanceDataSource, targetChainId);
   }
 
   protected serializePayload(): Buffer {
@@ -189,9 +190,10 @@ export class SetValidPeriodInstruction extends TargetInstruction {
 
 export class TransferGovernanceDataSourceClaimInstruction extends TargetInstruction {
   constructor(
+    targetChainId: ChainId,
     private governanceDataSourceIndex: number,
   ) {
-    super(TargetAction.TransferGovernanceDataSourceClaim, CHAINS.unset);
+    super(TargetAction.TransferGovernanceDataSourceClaim, targetChainId);
   }
 
   protected serializePayload(): Buffer {

--- a/third_party/pyth/xc-governance-sdk-js/src/instructions.ts
+++ b/third_party/pyth/xc-governance-sdk-js/src/instructions.ts
@@ -9,10 +9,11 @@ enum Module {
 
 enum TargetAction {
   UpgradeContract = 0,
-  SetGovernanceDataSource,
+  TransferGovernanceDataSource,
   SetDataSources,
   SetFee,
   SetValidPeriod,
+  TransferGovernanceDataSourceClaim,
 }
 
 abstract class HexString implements Serializable {
@@ -126,20 +127,16 @@ export class EthereumUpgradeContractInstruction extends TargetInstruction {
   }
 }
 
-export class SetGovernanceDataSourceInstruction extends TargetInstruction {
+export class TransferGovernanceDataSourceInstruction extends TargetInstruction {
   constructor(
     targetChainId: ChainId,
-    private governanceDataSource: DataSource,
-    private initialSequence: bigint,
+    private claimVaa: Buffer,
   ) {
-    super(TargetAction.SetGovernanceDataSource, targetChainId);
+    super(TargetAction.TransferGovernanceDataSource, targetChainId);
   }
 
   protected serializePayload(): Buffer {
-    return new BufferBuilder()
-      .addObject(this.governanceDataSource)
-      .addBigUint64(this.initialSequence)
-      .build();
+    return this.claimVaa;
   }
 }
 
@@ -187,6 +184,21 @@ export class SetValidPeriodInstruction extends TargetInstruction {
   protected serializePayload(): Buffer {
     return new BufferBuilder()
       .addBigUint64(this.newValidPeriod)
+      .build();
+  }
+}
+
+export class TransferGovernanceDataSourceClaimInstruction extends TargetInstruction {
+  constructor(
+    targetChainId: ChainId,
+    private governanceDataSourceIndex: number,
+  ) {
+    super(TargetAction.TransferGovernanceDataSourceClaim, targetChainId);
+  }
+
+  protected serializePayload(): Buffer {
+    return new BufferBuilder()
+      .addUint32(this.governanceDataSourceIndex)
       .build();
   }
 }

--- a/third_party/pyth/xc-governance-sdk-js/src/instructions.ts
+++ b/third_party/pyth/xc-governance-sdk-js/src/instructions.ts
@@ -1,4 +1,4 @@
-import { ChainId } from "@certusone/wormhole-sdk";
+import { ChainId, CHAINS } from "@certusone/wormhole-sdk";
 
 import {  Serializable, BufferBuilder } from "./serialize";
 
@@ -129,10 +129,9 @@ export class EthereumUpgradeContractInstruction extends TargetInstruction {
 
 export class TransferGovernanceDataSourceInstruction extends TargetInstruction {
   constructor(
-    targetChainId: ChainId,
     private claimVaa: Buffer,
   ) {
-    super(TargetAction.TransferGovernanceDataSource, targetChainId);
+    super(TargetAction.TransferGovernanceDataSource, CHAINS.unset);
   }
 
   protected serializePayload(): Buffer {
@@ -190,10 +189,9 @@ export class SetValidPeriodInstruction extends TargetInstruction {
 
 export class TransferGovernanceDataSourceClaimInstruction extends TargetInstruction {
   constructor(
-    targetChainId: ChainId,
     private governanceDataSourceIndex: number,
   ) {
-    super(TargetAction.TransferGovernanceDataSourceClaim, targetChainId);
+    super(TargetAction.TransferGovernanceDataSourceClaim, CHAINS.unset);
   }
 
   protected serializePayload(): Buffer {


### PR DESCRIPTION
This PR changes the way we transfer the governance data source. It introduced a new state value `governanceDataSourceIndex` that should be increased each time we transfer the governance to a newer one (extra sanity check).

Consider that we have an `oldGovenrance` and a `newGovernance`. The data wire is that the `newGovernance` creates a `TransferGovernanceDataSourceClaim` and sends to wormhole to create `claimVaa`. Then the `oldGovernance` creates a `TransferGovernanceDataSource` instruction that wraps the `claimVaa` and sends it to wormhole to create the transfer VAA. 

Tom suggested wrapping instead of taking them separately because the result would be one VAA and it fits the `executeGovernanceInstruction` signature to also execute it. 