### PR TITLE
[eth] Some contract improvements

### DIFF
--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -57,7 +57,7 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
     }
 
     function updatePriceFeeds(bytes[] calldata updateData) public override payable {
-        uint requiredFee = getUpdateFee(updateData.length);
+        uint requiredFee = getUpdateFee(updateData);
         require(msg.value >= requiredFee, "insufficient paid fee amount");
         payable(msg.sender).transfer(msg.value - requiredFee);
  
@@ -68,8 +68,8 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
         emit UpdatePriceFeeds(msg.sender, updateData.length, requiredFee);
     }
 
-    function getUpdateFee(uint updateDataSize) public override view returns (uint feeAmount) {
-        return singleUpdateFeeInWei() * updateDataSize;
+    function getUpdateFee(bytes[] calldata updateData) public override view returns (uint feeAmount) {
+        return singleUpdateFeeInWei() * updateData.length;
     }
 
     function createNewPriceInfo(PythInternalStructs.PriceAttestation memory pa) private view returns (PythInternalStructs.PriceInfo memory info) {

--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -59,7 +59,6 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
     function updatePriceFeeds(bytes[] calldata updateData) public override payable {
         uint requiredFee = getUpdateFee(updateData);
         require(msg.value >= requiredFee, "insufficient paid fee amount");
-        payable(msg.sender).transfer(msg.value - requiredFee);
  
         for(uint i = 0; i < updateData.length; i++) {
             updatePriceBatchFromVm(updateData[i]);

--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -67,6 +67,11 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
         emit UpdatePriceFeeds(msg.sender, updateData.length, requiredFee);
     }
 
+    /// This method is deprecated, please use the `getUpdateFee(bytes[])` instead.
+    function getUpdateFee(uint updateDataSize) public view returns (uint feeAmount) {
+        return singleUpdateFeeInWei() * updateDataSize;
+    }
+
     function getUpdateFee(bytes[] calldata updateData) public override view returns (uint feeAmount) {
         return singleUpdateFeeInWei() * updateData.length;
     }

--- a/ethereum/package-lock.json
+++ b/ethereum/package-lock.json
@@ -12,7 +12,7 @@
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
         "@openzeppelin/contracts": "^4.5.0",
         "@openzeppelin/contracts-upgradeable": "^4.5.2",
-        "@pythnetwork/pyth-sdk-solidity": "^1.0.1",
+        "@pythnetwork/pyth-sdk-solidity": "^2.0.0",
         "@pythnetwork/xc-governance-sdk": "file:../third_party/pyth/xc-governance-sdk-js",
         "dotenv": "^10.0.0",
         "elliptic": "^6.5.2",
@@ -3708,9 +3708,9 @@
       "dev": true
     },
     "node_modules/@pythnetwork/pyth-sdk-solidity": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-1.0.1.tgz",
-      "integrity": "sha512-qcuDM1E8X6LNg+Eyq1WcwSpO0hWuQpDPb9YNG3GCR9NjaQObB0AlZ2ayLGtdUTc/yMm26haTtZyKx+9S+J6FWw=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-2.0.0.tgz",
+      "integrity": "sha512-ogWpnI23Ofz1D5AmglkRxr+M/up/y15CBvXuxDcdq0Q6DvW3ksfPWP0DwCV2s7xbeSKYdpr97O+4NRmDCGeDsg=="
     },
     "node_modules/@pythnetwork/xc-governance-sdk": {
       "resolved": "../third_party/pyth/xc-governance-sdk-js",
@@ -39676,9 +39676,9 @@
       "dev": true
     },
     "@pythnetwork/pyth-sdk-solidity": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-1.0.1.tgz",
-      "integrity": "sha512-qcuDM1E8X6LNg+Eyq1WcwSpO0hWuQpDPb9YNG3GCR9NjaQObB0AlZ2ayLGtdUTc/yMm26haTtZyKx+9S+J6FWw=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-2.0.0.tgz",
+      "integrity": "sha512-ogWpnI23Ofz1D5AmglkRxr+M/up/y15CBvXuxDcdq0Q6DvW3ksfPWP0DwCV2s7xbeSKYdpr97O+4NRmDCGeDsg=="
     },
     "@pythnetwork/xc-governance-sdk": {
       "version": "file:../third_party/pyth/xc-governance-sdk-js",

--- a/ethereum/package.json
+++ b/ethereum/package.json
@@ -30,7 +30,7 @@
     "@certusone/wormhole-sdk-wasm": "^0.0.1",
     "@openzeppelin/contracts": "^4.5.0",
     "@openzeppelin/contracts-upgradeable": "^4.5.2",
-    "@pythnetwork/pyth-sdk-solidity": "^1.0.1",
+    "@pythnetwork/pyth-sdk-solidity": "^2.0.0",
     "@pythnetwork/xc-governance-sdk": "file:../third_party/pyth/xc-governance-sdk-js",
     "dotenv": "^10.0.0",
     "elliptic": "^6.5.2",

--- a/ethereum/test/pyth.js
+++ b/ethereum/test/pyth.js
@@ -435,7 +435,7 @@ contract("Pyth", function () {
         let rawBatch2 = generateRawBatchAttestation(ts + 5, ts + 10, 1338);
 
         // Getting the fee from the contract
-        let feeInWei = await this.pythProxy.getUpdateFee([rawBatch1, rawBatch2]);
+        let feeInWei = await this.pythProxy.methods["getUpdateFee(bytes[])"]([rawBatch1, rawBatch2]);
         assert.equal(feeInWei, 20);
 
         // When a smaller fee is payed it reverts
@@ -464,7 +464,7 @@ contract("Pyth", function () {
         let rawBatch2 = generateRawBatchAttestation(ts + 5, ts + 10, 1338);
 
         // Getting the fee from the contract
-        let feeInWei = await this.pythProxy.getUpdateFee([rawBatch1, rawBatch2]);
+        let feeInWei = await this.pythProxy.methods["getUpdateFee(bytes[])"]([rawBatch1, rawBatch2]);
         assert.equal(feeInWei, 20);
 
         const receipt = await updatePriceFeeds(this.pythProxy, [rawBatch1, rawBatch2], feeInWei);
@@ -494,7 +494,7 @@ contract("Pyth", function () {
         let rawBatch2 = generateRawBatchAttestation(ts + 5, ts + 10, 1338);
 
         // Paying the fee works and extra fee is not paid back.
-        let feeInWei = await this.pythProxy.getUpdateFee([rawBatch1, rawBatch2]);
+        let feeInWei = await this.pythProxy.methods["getUpdateFee(bytes[])"]([rawBatch1, rawBatch2]);
         assert.equal(feeInWei, 20);
 
         const receipt = await updatePriceFeeds(this.pythProxy, [rawBatch1, rawBatch2], feeInWei + 10);

--- a/ethereum/test/pyth.js
+++ b/ethereum/test/pyth.js
@@ -435,7 +435,7 @@ contract("Pyth", function () {
         let rawBatch2 = generateRawBatchAttestation(ts + 5, ts + 10, 1338);
 
         // Getting the fee from the contract
-        let feeInWei = await this.pythProxy.getUpdateFee(2);
+        let feeInWei = await this.pythProxy.getUpdateFee([rawBatch1, rawBatch2]);
         assert.equal(feeInWei, 20);
 
         // When a smaller fee is payed it reverts
@@ -464,7 +464,7 @@ contract("Pyth", function () {
         let rawBatch2 = generateRawBatchAttestation(ts + 5, ts + 10, 1338);
 
         // Getting the fee from the contract
-        let feeInWei = await this.pythProxy.getUpdateFee(2);
+        let feeInWei = await this.pythProxy.getUpdateFee([rawBatch1, rawBatch2]);
         assert.equal(feeInWei, 20);
 
         const receipt = await updatePriceFeeds(this.pythProxy, [rawBatch1, rawBatch2], feeInWei);
@@ -494,7 +494,7 @@ contract("Pyth", function () {
         let rawBatch2 = generateRawBatchAttestation(ts + 5, ts + 10, 1338);
 
         // Getting the fee from the contract
-        let feeInWei = await this.pythProxy.getUpdateFee(2);
+        let feeInWei = await this.pythProxy.getUpdateFee([rawBatch1, rawBatch2]);
         assert.equal(feeInWei, 20);
 
         const receipt = await updatePriceFeeds(this.pythProxy, [rawBatch1, rawBatch2], feeInWei + 10);

--- a/ethereum/test/pyth.js
+++ b/ethereum/test/pyth.js
@@ -493,7 +493,7 @@ contract("Pyth", function () {
         let rawBatch1 = generateRawBatchAttestation(ts - 5, ts, 1337);
         let rawBatch2 = generateRawBatchAttestation(ts + 5, ts + 10, 1338);
 
-        // Getting the fee from the contract
+        // Paying the fee works and extra fee is not paid back.
         let feeInWei = await this.pythProxy.getUpdateFee([rawBatch1, rawBatch2]);
         assert.equal(feeInWei, 20);
 
@@ -502,7 +502,7 @@ contract("Pyth", function () {
             fee: feeInWei
         });
         const pythBalance = await web3.eth.getBalance(this.pythProxy.address);
-        assert.equal(pythBalance, feeInWei);
+        assert.equal(pythBalance, feeInWei + 10);
     });
 
     it("should cache price updates", async function () {

--- a/third_party/pyth/p2w-relay/src/relay/evm.ts
+++ b/third_party/pyth/p2w-relay/src/relay/evm.ts
@@ -46,7 +46,7 @@ export class EvmRelay implements Relay {
         : null;
 
       const updateData = ["0x" + signedVAAs[i]];
-      const updateFee = await this.p2wContract.getUpdateFee(updateData);
+      const updateFee = await this.p2wContract["getUpdateFee(bytes[])"](updateData);
 
       let tx = this.p2wContract
         .updatePriceFeeds(updateData, { gasLimit: 2000000, value: updateFee })

--- a/third_party/pyth/p2w-relay/src/relay/evm.ts
+++ b/third_party/pyth/p2w-relay/src/relay/evm.ts
@@ -45,10 +45,11 @@ export class EvmRelay implements Relay {
         ? await this.queryMany(priceIds)
         : null;
 
-      const updateFee = await this.p2wContract.getUpdateFee(1);
+      const updateData = ["0x" + signedVAAs[i]];
+      const updateFee = await this.p2wContract.getUpdateFee(updateData);
 
       let tx = this.p2wContract
-        .updatePriceFeeds(["0x" + signedVAAs[i]], { gasLimit: 2000000, value: updateFee })
+        .updatePriceFeeds(updateData, { gasLimit: 2000000, value: updateFee })
         .then(async (pending) => {
           let receipt = await pending.wait();
           logger.info(


### PR DESCRIPTION
This PR:
- Updates contract to use the latest solidity sdk and updates `getUpdateFee` method to get the data instead of size (+ addressing tests + relayer). Keeps the old one for backward compatibility.
- Removes part of the code to transfer back extra paid fee amount (to be consistent with other chains that do not support it. e.g., aptos)