### PR TITLE
Abehjati/simplify-multisig-cli

### DIFF
--- a/third_party/pyth/multisig-wh-message-builder/README.md
+++ b/third_party/pyth/multisig-wh-message-builder/README.md
@@ -15,7 +15,6 @@ Note:
 - Node.js v17.15.0 or higher is required as it [introduces support for fetch API](https://nodejs.org/tr/blog/release/v17.5.0/).
 - When using with Ledger, please enable [blind signing](https://www.ledger.com/academy/enable-blind-signing-why-when-and-how-to-stay-safe) in the Solana app settings. TLDR: When you enable blind signing, you enable your device to approve a smart contract transaction, even though it hasn’t been able to display full contract data to you. In other words, you’re agreeing to trust, instead of verify, the transaction. You still have to manually approve each transactions.
 - Information about ledger derivation can be found [here](https://github.com/LedgerHQ/ledger-live-common/blob/master/docs/derivation.md).
-- RPC URLs can be found [here](https://book.wormhole.com/reference/rpcnodes.html).
 
 ### Create a multisig transaction
 

--- a/third_party/pyth/multisig-wh-message-builder/README.md
+++ b/third_party/pyth/multisig-wh-message-builder/README.md
@@ -20,27 +20,27 @@ Note:
 ### Create a multisig transaction
 
 ```
-npm start -- create -c <CLUSTER> -v <VAULT_ADDRESS> -l -lda <LEDGER_DERIVATION_ACCOUNT> -ldc <LEDGER_DERIVATION_CHANGE> -w <WALLET_SECRET_KEY_FILEPATH> -p <PAYLOAD>
+npm start -- create -c <CLUSTER: [mainnet|devnet]> -l -lda <LEDGER_DERIVATION_ACCOUNT> -ldc <LEDGER_DERIVATION_CHANGE> -w <WALLET_SECRET_KEY_FILEPATH> -p <PAYLOAD>
 ```
 
 To use ledger with default derivation account and change:
 
 ```
-npm start -- create -c devnet -v HezRVdwZmKpdKbksxFytKnHTQVztiTmL3GHdNadMFYui -l -p hello
+npm start -- create -c devnet -l -p hello
 ```
 
 To use ledger with custom derivation account and/or change:
 
 ```
-npm start -- create -c devnet -v HezRVdwZmKpdKbksxFytKnHTQVztiTmL3GHdNadMFYui -l -lda 0 -p hello
+npm start -- create -c devnet -l -lda 0 -p hello
 
-npm start -- create -c devnet -v HezRVdwZmKpdKbksxFytKnHTQVztiTmL3GHdNadMFYui -l -lda 0 -ldc 1 -p hello
+npm start -- create -c devnet -l -lda 0 -ldc 1 -p hello
 ```
 
 To use hot wallet :
 
 ```
-npm start -- create -c devnet -v HezRVdwZmKpdKbksxFytKnHTQVztiTmL3GHdNadMFYui -w keys/key.json -p hello
+npm start -- create -c devnet -w keys/key.json -p hello
 ```
 
 ---
@@ -48,27 +48,27 @@ npm start -- create -c devnet -v HezRVdwZmKpdKbksxFytKnHTQVztiTmL3GHdNadMFYui -w
 ### Execute a multisig transaction
 
 ```
-npm start -- execute -c <CLUSTER> -v <VAULT_ADDRESS> -w <WALLET_SECRET_KEY_FILEPATH> -m <MESSAGE_SECRET_KEY_FILEPATH> -t <TX_ID> -u <RPC_URL>
+npm start -- execute -c <CLUSTER: [mainnet|devnet]> -w <WALLET_SECRET_KEY_FILEPATH> -t <TX_ID>
 ```
 
 To use ledger with default derivation account and change:
 
 ```
-npm start -- execute -c devnet -v HezRVdwZmKpdKbksxFytKnHTQVztiTmL3GHdNadMFYui -l -m keys/message.json -t GSC8r7Qsi9pc698fckaQgzHufG6LqVq3vZijyu5KsXLh -u https://wormhole-v2-testnet-api.certus.one/
+npm start -- execute -c devnet -l -m keys/message.json -t GSC8r7Qsi9pc698fckaQgzHufG6LqVq3vZijyu5KsXLh
 ```
 
 To use ledger with custom derivation account and/or change:
 
 ```
-npm start -- execute -c devnet -v HezRVdwZmKpdKbksxFytKnHTQVztiTmL3GHdNadMFYui -l -lda 0 -m keys/message.json -t GSC8r7Qsi9pc698fckaQgzHufG6LqVq3vZijyu5KsXLh -u https://wormhole-v2-testnet-api.certus.one/
+npm start -- execute -c devnet -l -lda 0 -m keys/message.json -t GSC8r7Qsi9pc698fckaQgzHufG6LqVq3vZijyu5KsXLh
 
-npm start -- execute -c devnet -v HezRVdwZmKpdKbksxFytKnHTQVztiTmL3GHdNadMFYui -l -lda 0 -ldc 1 -m keys/message.json -t GSC8r7Qsi9pc698fckaQgzHufG6LqVq3vZijyu5KsXLh -u https://wormhole-v2-testnet-api.certus.one/
+npm start -- execute -c devnet -l -lda 0 -ldc 1 -m keys/message.json -t GSC8r7Qsi9pc698fckaQgzHufG6LqVq3vZijyu5KsXLh
 ```
 
 Example:
 
 ```
-npm start -- execute -c devnet -v HezRVdwZmKpdKbksxFytKnHTQVztiTmL3GHdNadMFYui -w keys/key.json -m keys/message.json -t GSC8r7Qsi9pc698fckaQgzHufG6LqVq3vZijyu5KsXLh -u https://wormhole-v2-testnet-api.certus.one/
+npm start -- execute -c devnet -w keys/key.json -m keys/message.json -t GSC8r7Qsi9pc698fckaQgzHufG6LqVq3vZijyu5KsXLh
 ```
 
 https://github.com/LedgerHQ/ledger-live/wiki/LLC:derivation

--- a/third_party/pyth/multisig-wh-message-builder/src/index.ts
+++ b/third_party/pyth/multisig-wh-message-builder/src/index.ts
@@ -351,9 +351,6 @@ async function createTx(
   const msAccount = await squad.getMultisig(vault);
 
   console.log("Creating new transaction...");
-  if (ledger) {
-    console.log("Please approve the transaction on your ledger device...");
-  }
   const newTx = await squad.createTransaction(
     msAccount.publicKey,
     msAccount.authorityIndex
@@ -383,9 +380,6 @@ async function addInstructionsToTx(
     console.log(
       `Adding instruction ${i + 1}/${instructions.length} to transaction...`
     );
-    if (ledger) {
-      console.log("Please approve the transaction on your ledger device...");
-    }
     await squad.addInstruction(
       txKey,
       instructions[i].instruction,
@@ -396,13 +390,9 @@ async function addInstructionsToTx(
   }
 
   console.log("Activating transaction...");
-  if (ledger)
-    console.log("Please approve the transaction on your ledger device...");
   await squad.activateTransaction(txKey);
   console.log("Transaction created.");
   console.log("Approving transaction...");
-  if (ledger)
-    console.log("Please approve the transaction on your ledger device...");
   await squad.approveTransaction(txKey);
   console.log("Transaction approved.");
   console.log(
@@ -619,8 +609,6 @@ async function executeMultisigTx(
   executeTx.add(executeIx);
 
   console.log("Sending transaction...");
-  if (ledger)
-    console.log("Please approve the transaction on your ledger device...");
   const signature = await provider.sendAndConfirm(executeTx);
 
   console.log(

--- a/third_party/pyth/multisig-wh-message-builder/src/index.ts
+++ b/third_party/pyth/multisig-wh-message-builder/src/index.ts
@@ -81,7 +81,6 @@ program
     await createWormholeMsgMultisigTx(
       options.cluster,
       squad,
-      options.ledger,
       CONFIG[cluster].vault,
       options.payload
     );
@@ -132,7 +131,6 @@ program
     const attesterProgramId = new PublicKey(options.attester);
     const txKey = await createTx(
       squad,
-      options.ledger,
       vaultPubkey
     );
 
@@ -160,7 +158,6 @@ program
     await addInstructionsToTx(
       options.cluster,
       squad,
-      options.ledger,
       msAccount.publicKey,
       txKey,
       squadIxs
@@ -199,8 +196,6 @@ program
       cluster,
       squad,
       CONFIG[cluster].vault,
-      options.ledger,
-      options.wallet,
       new PublicKey(options.txPda),
       CONFIG[cluster].wormholeRpcEndpoint
     );
@@ -237,7 +232,6 @@ program
     await changeThreshold(
       options.cluster,
       squad,
-      options.ledger,
       CONFIG[cluster].vault,
       options.threshold
     );
@@ -274,7 +268,6 @@ program
     await addMember(
       options.cluster,
       squad,
-      options.ledger,
       CONFIG[cluster].vault,
       new PublicKey(options.member)
     );
@@ -311,7 +304,6 @@ program
     await removeMember(
       options.cluster,
       squad,
-      options.ledger,
       CONFIG[cluster].vault,
       new PublicKey(options.member)
     );
@@ -351,7 +343,6 @@ async function getSquadsClient(
 
 async function createTx(
   squad: Squads,
-  ledger: boolean,
   vault: PublicKey
 ): Promise<PublicKey> {
   const msAccount = await squad.getMultisig(vault);
@@ -377,7 +368,6 @@ type SquadInstruction = {
 async function addInstructionsToTx(
   cluster: Cluster,
   squad: Squads,
-  ledger: boolean,
   vault: PublicKey,
   txKey: PublicKey,
   instructions: SquadInstruction[]
@@ -493,7 +483,6 @@ async function getWormholeMessageIx(
 async function createWormholeMsgMultisigTx(
   cluster: Cluster,
   squad: Squads,
-  ledger: boolean,
   vault: PublicKey,
   payload: string
 ) {
@@ -504,7 +493,7 @@ async function createWormholeMsgMultisigTx(
   );
   console.log(`Emitter Address: ${emitter.toBase58()}`);
 
-  const txKey = await createTx(squad, ledger, vault);
+  const txKey = await createTx(squad, vault);
 
   const [messagePDA, messagePdaBump] = getIxAuthorityPDA(
     txKey,
@@ -536,7 +525,6 @@ async function createWormholeMsgMultisigTx(
   await addInstructionsToTx(
     cluster,
     squad,
-    ledger,
     msAccount.publicKey,
     txKey,
     squadIxs
@@ -547,8 +535,6 @@ async function executeMultisigTx(
   cluster: string,
   squad: Squads,
   vault: PublicKey,
-  ledger: boolean,
-  walletPath: string,
   txPDA: PublicKey,
   rpcUrl: string
 ) {
@@ -645,12 +631,11 @@ async function executeMultisigTx(
 async function changeThreshold(
   cluster: Cluster,
   squad: Squads,
-  ledger: boolean,
   vault: PublicKey,
   threshold: number
 ) {
   const msAccount = await squad.getMultisig(vault);
-  const txKey = await createTx(squad, ledger, vault);
+  const txKey = await createTx(squad, vault);
   const ix = await squad.buildChangeThresholdMember(
     msAccount.publicKey,
     msAccount.externalAuthority,
@@ -661,7 +646,6 @@ async function changeThreshold(
   await addInstructionsToTx(
     cluster,
     squad,
-    ledger,
     msAccount.publicKey,
     txKey,
     squadIxs
@@ -671,12 +655,11 @@ async function changeThreshold(
 async function addMember(
   cluster: Cluster,
   squad: Squads,
-  ledger: boolean,
   vault: PublicKey,
   member: PublicKey
 ) {
   const msAccount = await squad.getMultisig(vault);
-  const txKey = await createTx(squad, ledger, vault);
+  const txKey = await createTx(squad, vault);
   const ix = await squad.buildAddMember(
     msAccount.publicKey,
     msAccount.externalAuthority,
@@ -687,7 +670,6 @@ async function addMember(
   await addInstructionsToTx(
     cluster,
     squad,
-    ledger,
     msAccount.publicKey,
     txKey,
     squadIxs
@@ -697,12 +679,11 @@ async function addMember(
 async function removeMember(
   cluster: Cluster,
   squad: Squads,
-  ledger: boolean,
   vault: PublicKey,
   member: PublicKey
 ) {
   const msAccount = await squad.getMultisig(vault);
-  const txKey = await createTx(squad, ledger, vault);
+  const txKey = await createTx(squad, vault);
   const ix = await squad.buildRemoveMember(
     msAccount.publicKey,
     msAccount.externalAuthority,
@@ -713,7 +694,6 @@ async function removeMember(
   await addInstructionsToTx(
     cluster,
     squad,
-    ledger,
     msAccount.publicKey,
     txKey,
     squadIxs

--- a/third_party/pyth/multisig-wh-message-builder/src/wallet.ts
+++ b/third_party/pyth/multisig-wh-message-builder/src/wallet.ts
@@ -34,6 +34,7 @@ export class LedgerNodeWallet implements Wallet {
   }
 
   async signTransaction(transaction: Transaction): Promise<Transaction> {
+    console.log("Please approve the transaction on your ledger device...");
     const transport = this._transport;
     const publicKey = this.publicKey;
 


### PR DESCRIPTION
Refactor the cli specifically to require less arguments (vault and rpc is hard-coded).

It also refactors the code a little.

This code can be divided into multiple files later.