### PR TITLE
Update example to use APT pricefeed

### DIFF
--- a/aptos/examples/mint_nft/Move.toml
+++ b/aptos/examples/mint_nft/Move.toml
@@ -11,7 +11,7 @@ Pyth = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "
 [addresses]
 # These are testnet addresses https://docs.pyth.network/consume-data/aptos#addresses
 aptos_framework = "0x1"
-mint_nft = "_"
+mint_nft = "0x19f8503273cdb5aa93ffe4539277684615242127aa2e65ef91424136a316c9c7"
 pyth = "0x7e783b349d3e89cf5931af376ebeadbfab855b3fa239b7ada8f5a92fbea6b387"
 deployer = "0xb31e712b26fd295357355f6845e77c888298636609e93bc9b05f0f604049f434"
 wormhole = "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"

--- a/aptos/examples/mint_nft/README.md
+++ b/aptos/examples/mint_nft/README.md
@@ -1,5 +1,7 @@
 # Example Full-Stack App: 1$ Mint
 
+The example contract is deployed at : `0x19f8503273cdb5aa93ffe4539277684615242127aa2e65ef91424136a316c9c7`
+
 The goal of this contract is managing an NFT mint where the mint is paid in native currency but the cost of one NFT is always 1$.
 This example is intended to be run on Aptos testnet because it depends on Pyth and Wormhole existing onchain.
 
@@ -12,13 +14,13 @@ Both combined contain the key pieces of code needed to make an Aptos fullstack a
 
 - Use `aptos init` with rest_url : `https://testnet.aptoslabs.com/` and faucet `https://faucet.testnet.aptoslabs.com`  to generate a new keypair.
 - Use a faucet to airdrop testnet APT to your newly created account by calling `aptos account fund-with-faucet --account default`. If this doesn't work, I have had success importing my private key from `.aptos/config.yaml` into Petra and clicking the airdrop button. Otherwise send APT from another account.
-- Get your account address from `.aptos/config.yaml` and replace `mint_nft="_"` by `mint_nft="<ADDRESS>"` in `Move.toml`
+- Get your account address from `.aptos/config.yaml` and replace `mint_nft="0x19f8503273cdb5aa93ffe4539277684615242127aa2e65ef91424136a316c9c7"` by `mint_nft="<ADDRESS>"` in `Move.toml`
 - `aptos move compile`
 - `aptos move publish` 
 
 ### How to run the webapp :
 
-- In `app/src/App.tsx` replace `const MINT_NFT_MODULE = "_"` by `const MINT_NFT_MODULE = "<ADDRESS>"` the address of your module from above.
+- In `app/src/App.tsx` replace `const MINT_NFT_MODULE = "0x19f8503273cdb5aa93ffe4539277684615242127aa2e65ef91424136a316c9c7"` by `const MINT_NFT_MODULE = "<ADDRESS>"` the address of your module from above.
 - `npm install`
 - `npm run start`
 - Go to `http://localhost:3000/` in your browser and use Petra wallet to transact with the app.

--- a/aptos/examples/mint_nft/README.md
+++ b/aptos/examples/mint_nft/README.md
@@ -1,6 +1,6 @@
-# Example Full-Stack App: 100$ USD Mint
+# Example Full-Stack App: 1$ Mint
 
-The goal of this contract is managing an NFT mint where the mint is paid in native currency but the cost of one NFT is always 100$.
+The goal of this contract is managing an NFT mint where the mint is paid in native currency but the cost of one NFT is always 1$.
 This example is intended to be run on Aptos testnet because it depends on Pyth and Wormhole existing onchain.
 
 ### Important files : 

--- a/aptos/examples/mint_nft/app/src/App.tsx
+++ b/aptos/examples/mint_nft/app/src/App.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import logo from "./logo.svg";
 import "./App.css";
 import { Price, PriceFeed } from "@pythnetwork/pyth-common-js";
-import { AptosClient } from "aptos";
 import { AptosPriceServiceConnection } from "@pythnetwork/pyth-aptos-js";
 
 // Please read https://docs.pyth.network/consume-data before building on Pyth
@@ -16,8 +15,8 @@ const testnetConnection = new AptosPriceServiceConnection(
 ); // Price service client used to retrieve the offchain VAAs to update the onchain price
 
 // Price id : this is not an aptos account but instead an opaque identifier for each price https://pyth.network/developers/price-feed-ids/#pyth-cross-chain-testnet
-const ETH_USD_TESTNET_PRICE_ID =
-  "0xca80ba6dc32e08d06f1aa886011eed1d77c77be9eb761cc10d72b7d0a2fd57a6";
+const APT_USD_TESTNET_PRICE_ID =
+  "0x44a93dddd8effa54ea51076c4e851b6cbbfd938e82eb90197de38fe8876bb66e";
 
 // Aptos modules : These are testnet addresses https://docs.pyth.network/consume-data/aptos#addresses
 const MINT_NFT_MODULE = "_";
@@ -31,7 +30,7 @@ function PriceText(props: { price: Price | undefined }) {
         {" "}
         <p>
           {" "}
-          Current ETH/USD price:{" "}
+          Current APT/USD price:{" "}
           <span style={{ color: "green" }}>
             {" "}
             {price.getPriceAsNumberUnchecked().toFixed(3) +
@@ -44,7 +43,7 @@ function PriceText(props: { price: Price | undefined }) {
           Current NFT price:{" "}
           <span style={{ color: "green" }}>
             {" "}
-            {(100 / price.getPriceAsNumberUnchecked()).toFixed(5)} APT{" "}
+            {(1 / price.getPriceAsNumberUnchecked()).toFixed(5)} APT{" "}
           </span>{" "}
         </p>{" "}
       </div>
@@ -68,7 +67,7 @@ function App() {
 
   // Subscribe to offchain prices. These are the prices that a typical frontend will want to show.
   testnetConnection.subscribePriceFeedUpdates(
-    [ETH_USD_TESTNET_PRICE_ID],
+    [APT_USD_TESTNET_PRICE_ID],
     (priceFeed: PriceFeed) => {
       const price = priceFeed.getPriceUnchecked(); // Fine to use unchecked (not checking for staleness) because this must be a recent price given that it comes from a websocket subscription.
       setPythOffChainPrice(price);
@@ -120,7 +119,7 @@ function App() {
 
 async function sendMintTransaction() {
   const priceFeedUpdateData = await testnetConnection.getPriceFeedsUpdateData([
-    ETH_USD_TESTNET_PRICE_ID,
+    APT_USD_TESTNET_PRICE_ID,
   ]);
   const mintTransaction = {
     type: "entry_function_payload",

--- a/aptos/examples/mint_nft/app/src/App.tsx
+++ b/aptos/examples/mint_nft/app/src/App.tsx
@@ -19,7 +19,7 @@ const APT_USD_TESTNET_PRICE_ID =
   "0x44a93dddd8effa54ea51076c4e851b6cbbfd938e82eb90197de38fe8876bb66e";
 
 // Aptos modules : These are testnet addresses https://docs.pyth.network/consume-data/aptos#addresses
-const MINT_NFT_MODULE = "_";
+const MINT_NFT_MODULE = "0x19f8503273cdb5aa93ffe4539277684615242127aa2e65ef91424136a316c9c7";
 
 /// React component that shows the offchain price and confidence interval
 function PriceText(props: { price: Price | undefined }) {

--- a/aptos/examples/mint_nft/sources/minting.move
+++ b/aptos/examples/mint_nft/sources/minting.move
@@ -16,10 +16,8 @@ module mint_nft::minting {
     use aptos_std::math64::pow;
     use aptos_token::token::{Self, TokenDataId};
 
-    // WARNING This is actually the ETH/USD while APT is not listed
     // For the entire list of price_ids head to https://pyth.network/developers/price-feed-ids/#pyth-cross-chain-testnet
-    // TODO : Update to the real APT/USD when it's out
-    const APTOS_USD_PRICE_FEED_IDENTIFIER : vector<u8> = x"ca80ba6dc32e08d06f1aa886011eed1d77c77be9eb761cc10d72b7d0a2fd57a6"; 
+    const APTOS_USD_PRICE_FEED_IDENTIFIER : vector<u8> = x"44a93dddd8effa54ea51076c4e851b6cbbfd938e82eb90197de38fe8876bb66e"; 
 
     // This event stores the receiver of the NFT and the TokenDataId of the NFT
     struct TokenMintingEvent has drop, store {
@@ -81,7 +79,7 @@ module mint_nft::minting {
         });
     }
 
-    /// Mint an edition of the Pythian NFT pay 100 USD in native APT
+    /// Mint an edition of the Pythian NFT pay 1 USD in native APT
     public entry fun mint_nft(receiver : &signer, vaas : vector<vector<u8>>) acquires CollectionTokenMinter{
         // Fetch the signer capability to mint the NFT
         let collection_token_minter = borrow_global_mut<CollectionTokenMinter>(@mint_nft); 
@@ -94,7 +92,7 @@ module mint_nft::minting {
         let price_positive = i64::get_magnitude_if_positive(&price::get_price(&price)); // This will fail if the price is negative
         let expo_magnitude = i64::get_magnitude_if_negative(&price::get_expo(&price)); // This will fail if the exponent is positive
 
-        let price_in_aptos_coin =  (100 * OCTAS_PER_APTOS * pow(10, expo_magnitude)) / price_positive; // 100 USD in AptosCoin
+        let price_in_aptos_coin =  (OCTAS_PER_APTOS * pow(10, expo_magnitude)) / price_positive; // 1 USD in APT
 
         coin::transfer<aptos_coin::AptosCoin>(receiver, @mint_nft, price_in_aptos_coin); // Pay for the NFT
     }


### PR DESCRIPTION
Update example to use APT instead of ETH now that the price feed is live.