### PR TITLE
[FEAT] Allow any contract to update the cache in test

### DIFF
--- a/aptos/contracts/sources/pyth.move
+++ b/aptos/contracts/sources/pyth.move
@@ -482,7 +482,7 @@ module pyth::pyth_test {
 
     /// Allow anyone to update the cache with given updates. For testing purpose only.
     #[test_only]
-    public fun update_cache_test(updates: vector<PriceUpdate>) {
+    public fun update_cache_for_test(updates: vector<PriceUpdate>) {
         pyth::update_cache(updates);
     }
     

--- a/aptos/contracts/sources/pyth.move
+++ b/aptos/contracts/sources/pyth.move
@@ -179,6 +179,12 @@ module pyth::pyth {
         update_cache(batch_price_attestation::destroy(batch_price_attestation::deserialize(vaa::destroy(vaa))));
     }
 
+    /// Allow anyone to update the cache with given updates. For testing purpose only.
+    #[test_only]
+    public fun update_cache_test(updates: vector<PriceUpdate>) {
+        update_cache(updates);
+    }
+
     /// Update the cache with given price updates, if they are newer than the ones currently cached.
     public(friend) fun update_cache(updates: vector<PriceInfo>) {
         while (!vector::is_empty(&updates)) {

--- a/aptos/contracts/sources/pyth.move
+++ b/aptos/contracts/sources/pyth.move
@@ -179,12 +179,6 @@ module pyth::pyth {
         update_cache(batch_price_attestation::destroy(batch_price_attestation::deserialize(vaa::destroy(vaa))));
     }
 
-    /// Allow anyone to update the cache with given updates. For testing purpose only.
-    #[test_only]
-    public fun update_cache_test(updates: vector<PriceUpdate>) {
-        update_cache(updates);
-    }
-
     /// Update the cache with given price updates, if they are newer than the ones currently cached.
     public(friend) fun update_cache(updates: vector<PriceInfo>) {
         while (!vector::is_empty(&updates)) {
@@ -486,6 +480,12 @@ module pyth::pyth_test {
     /// - payload corresponding to the batch price attestation of the prices returned by get_mock_price_infos()
     const TEST_VAAS: vector<vector<u8>> = vector[x"0100000000010036eb563b80a24f4253bee6150eb8924e4bdf6e4fa1dfc759a6664d2e865b4b134651a7b021b7f1ce3bd078070b688b6f2e37ce2de0d9b48e6a78684561e49d5201527e4f9b00000001001171f8dcb863d176e2c420ad6610cf687359612b6fb392e0642b0ca6b1f186aa3b0000000000000001005032574800030000000102000400951436e0be37536be96f0896366089506a59763d036728332d3e3038047851aea7c6c75c89f14810ec1c54c03ab8f1864a4c4032791f05747f560faec380a695d1000000000000049a0000000000000008fffffffb00000000000005dc0000000000000003000000000100000001000000006329c0eb000000006329c0e9000000006329c0e400000000000006150000000000000007215258d81468614f6b7e194c5d145609394f67b041e93e6695dcc616faadd0603b9551a68d01d954d6387aff4df1529027ffb2fee413082e509feb29cc4904fe000000000000041a0000000000000003fffffffb00000000000005cb0000000000000003010000000100000001000000006329c0eb000000006329c0e9000000006329c0e4000000000000048600000000000000078ac9cf3ab299af710d735163726fdae0db8465280502eb9f801f74b3c1bd190333832fad6e36eb05a8972fe5f219b27b5b2bb2230a79ce79beb4c5c5e7ecc76d00000000000003f20000000000000002fffffffb00000000000005e70000000000000003010000000100000001000000006329c0eb000000006329c0e9000000006329c0e40000000000000685000000000000000861db714e9ff987b6fedf00d01f9fea6db7c30632d6fc83b7bc9459d7192bc44a21a28b4c6619968bd8c20e95b0aaed7df2187fd310275347e0376a2cd7427db800000000000006cb0000000000000001fffffffb00000000000005e40000000000000003010000000100000001000000006329c0eb000000006329c0e9000000006329c0e400000000000007970000000000000001"];
 
+    /// Allow anyone to update the cache with given updates. For testing purpose only.
+    #[test_only]
+    public fun update_cache_test(updates: vector<PriceUpdate>) {
+        pyth::update_cache(updates);
+    }
+    
     #[test(aptos_framework = @aptos_framework)]
     fun test_get_update_fee(aptos_framework: &signer) {
         let single_update_fee = 50;


### PR DESCRIPTION
This to enabling DeFi developers to easily mock the price when writing the integration tests between the protocol and oracle.