### PR TITLE
[eth]: Fix gas benchmark to generate useful gas snapshot

### DIFF
--- a/ethereum/README.md
+++ b/ethereum/README.md
@@ -59,17 +59,19 @@ A gas report should have a couple of tables like this:
 ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
 │ .............                                                                             ┆ .....           ┆ .....  ┆ .....  ┆ .....   ┆ ..      │
 ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-│ parseAndVerifyVM                                                                          ┆ 90292           ┆ 91262  ┆ 90292  ┆ 138792  ┆ 50      │
-├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-│ updatePriceFeeds                                                                          ┆ 187385          ┆ 206005 ┆ 187385 ┆ 1118385 ┆ 50      │
+│ updatePriceFeeds                                                                          ┆ 383169          ┆ 724277 ┆ 187385 ┆ 1065385 ┆ 2       │
 ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
 │ .............                                                                             ┆ .....           ┆ .....  ┆ .....  ┆ .....   ┆ ...     │
 ╰───────────────────────────────────────────────────────────────────────────────────────────┴─────────────────┴────────┴────────┴─────────┴─────────╯
 ```
 
-For most of the methods, the median gas usage is an indication of our desired gas usage. Because the calls that store something in the storage
-for the first time use significantly more gas.
+For most of the methods, the minimum gas usage is an indication of our desired gas usage. Because the calls that store something in the storage
+for the first time in `setUp` use significantly more gas. For example, in the above table, there are two calls to `updatePriceFeeds`. The first
+call has happend in the `setUp` method and costed over a million gas and is not intended for our Benchmark. So our desired value is the
+minimum value which is around 380k gas.
 
 If you like to optimize the contract and measure the gas optimization you can get gas snapshots using `forge snapshot` and evaluate your
 optimization with it. For more information, please refer to [Gas Snapshots documentation](https://book.getfoundry.sh/forge/gas-snapshots).
 Once you optimized the code, please share the snapshot difference (generated using `forge snapshot --diff <old-snapshot>`) in the PR too.
+This snapshot gas value also includes an initial transaction cost as well as reading from the contract storage itself. You can get the
+most accurate result by looking at the gas report or the gas shown in the call trace with `-vvvv` argument to `forge test`.

--- a/ethereum/forge-test/GasBenchmark.t.sol
+++ b/ethereum/forge-test/GasBenchmark.t.sol
@@ -127,7 +127,7 @@ contract GasBenchmark is Test, WormholeTestUtils, PythTestUtils {
         // is set to 60 seconds, the getPrice should work as expected.
         vm.warp(0);
 
-        pyth.getPrice(priceIds[getRand() % NUM_PRICES]);
+        pyth.getPrice(priceIds[0]);
     }
 
     function testBenchmarkGetUpdateFee() public view {

--- a/ethereum/forge-test/GasBenchmark.t.sol
+++ b/ethereum/forge-test/GasBenchmark.t.sol
@@ -24,7 +24,20 @@ contract GasBenchmark is Test, WormholeTestUtils, PythTestUtils {
     IPyth public pyth;
     
     bytes32[] priceIds;
-    PythStructs.Price[] prices;
+
+    // Cached prices are populated in the setUp
+    PythStructs.Price[] cachedPrices;
+    bytes[] cachedPricesUpdateData;
+    uint cachedPricesUpdateFee;
+    uint64[] cachedPricesPublishTimes;
+
+    // Fresh prices are different prices that can be used
+    // as a fresh price to update the prices
+    PythStructs.Price[] freshPrices;
+    bytes[] freshPricesUpdateData;
+    uint freshPricesUpdateFee;
+    uint64[] freshPricesPublishTimes;
+
     uint64 sequence;
     uint randSeed;
 
@@ -38,17 +51,32 @@ contract GasBenchmark is Test, WormholeTestUtils, PythTestUtils {
         }
 
         for (uint i = 0; i < NUM_PRICES; ++i) {
-            prices.push(PythStructs.Price(
+            
+            uint64 publishTime = uint64(getRand() % 10);
+    
+            cachedPrices.push(PythStructs.Price(
                 int64(uint64(getRand() % 1000)), // Price
                 uint64(getRand() % 100), // Confidence
                 -5, // Expo
-                getRand() % 10 // publishTime
+                publishTime
             ));
+            cachedPricesPublishTimes.push(publishTime);
+
+            publishTime += uint64(getRand() % 10);
+            freshPrices.push(PythStructs.Price(
+                int64(uint64(getRand() % 1000)), // Price
+                uint64(getRand() % 100), // Confidence
+                -5, // Expo
+                publishTime
+            ));
+            freshPricesPublishTimes.push(publishTime);
         }
 
         // Populate the contract with the initial prices
-        (bytes[] memory updateData, uint updateFee) = generateUpdateDataAndFee();
-        pyth.updatePriceFeeds{value: updateFee}(updateData);
+        (cachedPricesUpdateData, cachedPricesUpdateFee) = generateUpdateDataAndFee(cachedPrices);
+        pyth.updatePriceFeeds{value: cachedPricesUpdateFee}(cachedPricesUpdateData);
+
+        (freshPricesUpdateData, freshPricesUpdateFee) = generateUpdateDataAndFee(freshPrices);
     }
 
     function getRand() internal returns (uint val) {
@@ -56,15 +84,7 @@ contract GasBenchmark is Test, WormholeTestUtils, PythTestUtils {
         val = uint(keccak256(abi.encode(randSeed)));
     }
 
-    function advancePrices() internal {
-        for (uint i = 0; i < NUM_PRICES; ++i) {
-            prices[i].price = int64(uint64(getRand() % 1000));
-            prices[i].conf = uint64(getRand() % 100);
-            prices[i].publishTime += getRand() % 10;
-        }
-    }
-
-    function generateUpdateDataAndFee() internal returns (bytes[] memory updateData, uint updateFee) {
+    function generateUpdateDataAndFee(PythStructs.Price[] memory prices) internal returns (bytes[] memory updateData, uint updateFee) {
         bytes memory vaa = generatePriceFeedUpdateVAA(
             priceIds,
             prices,
@@ -81,53 +101,36 @@ contract GasBenchmark is Test, WormholeTestUtils, PythTestUtils {
     }
 
     function testBenchmarkUpdatePriceFeedsFresh() public {
-        advancePrices();
-
-        (bytes[] memory updateData, uint updateFee) = generateUpdateDataAndFee();
-        pyth.updatePriceFeeds{value: updateFee}(updateData);
+        pyth.updatePriceFeeds{value: freshPricesUpdateFee}(freshPricesUpdateData);
     }
 
     function testBenchmarkUpdatePriceFeedsNotFresh() public {
-        (bytes[] memory updateData, uint updateFee) = generateUpdateDataAndFee();
-        pyth.updatePriceFeeds{value: updateFee}(updateData);
+        pyth.updatePriceFeeds{value: cachedPricesUpdateFee}(cachedPricesUpdateData);
     }
 
     function testBenchmarkUpdatePriceFeedsIfNecessaryFresh() public {
-        advancePrices();
-
-        uint64[] memory publishTimes = new uint64[](NUM_PRICES);
-        
-        for (uint j = 0; j < NUM_PRICES; ++j) {
-            publishTimes[j] = uint64(prices[j].publishTime);
-        }
-
-        (bytes[] memory updateData, uint updateFee) = generateUpdateDataAndFee();
-
         // Since the prices have advanced, the publishTimes are newer than one in
         // the contract and hence, the call should succeed.
-        pyth.updatePriceFeedsIfNecessary{value: updateFee}(updateData, priceIds, publishTimes);
+        pyth.updatePriceFeedsIfNecessary{value: freshPricesUpdateFee}(freshPricesUpdateData, priceIds, freshPricesPublishTimes);
     }
 
     function testBenchmarkUpdatePriceFeedsIfNecessaryNotFresh() public {
-        uint64[] memory publishTimes = new uint64[](NUM_PRICES);
-        
-        for (uint j = 0; j < NUM_PRICES; ++j) {
-            publishTimes[j] = uint64(prices[j].publishTime);
-        }
-
-        (bytes[] memory updateData, uint updateFee) = generateUpdateDataAndFee();
-
         // Since the price is not advanced, the publishTimes are the same as the
         // ones in the contract.
         vm.expectRevert(bytes("no prices in the submitted batch have fresh prices, so this update will have no effect"));
 
-        pyth.updatePriceFeedsIfNecessary{value: updateFee}(updateData, priceIds, publishTimes);
+        pyth.updatePriceFeedsIfNecessary{value: cachedPricesUpdateFee}(cachedPricesUpdateData, priceIds, cachedPricesPublishTimes);
     }
 
     function testBenchmarkGetPrice() public {
-        // Set the block timestamp to the publish time, so getPrice work as expected.
-        vm.warp(prices[0].publishTime);
+        // Set the block timestamp to 0. As prices have < 10 timestamp and staleness 
+        // is set to 60 seconds, the getPrice should work as expected.
+        vm.warp(0);
 
         pyth.getPrice(priceIds[getRand() % NUM_PRICES]);
+    }
+
+    function testBenchmarkGetUpdateFee() public view {
+        pyth.getUpdateFee(freshPricesUpdateData);
     }
 }


### PR DESCRIPTION
This PR changes the benchmark test to generate gas usages that are expected and useful for our usage.

Apparently, Foundry runs all the code of a test in an imaginary transaction which is different than using hardhat/truffle. Because in hardhat/truffle, as their tests are written in JS, each contract call is a transaction. But in Foundry it's different. 

This caused problem in our benchmark because re-writing to a storage slot (other than the first write) in the same transaction costs very little (it is considered a warm access,`G_warmaccess = 100`) compared to a normal write (to a non-zero value, `G_sreset` = 2900). In addition to this, in the first write we are consuming a lot of gas as it is writing to a zero storage slot. This was the reason that fresh and non-fresh calls were not much different from each other because re-writes were really cheap. So to solve it we need to exclude the first write which is very expensive and have each subsequent call to the contract separately. Unfortunately we cannot separate contract calls with each other in a Foundry test..

Hopefully, before giving up on Foundry, I looked at their source code and saw that `setUp` is running separately. So I guessed that can fix the problem and it did!

So, I moved the first price update to the `setUp` method. It is reasonable because we can see it as populating the contract with some data. Also, I removed the benchmark iterations because with what I mentioned above, doing an operation twice will be much cheaper than before and won't be useful in the benchmark. I also moved all non-call logic (such as generating the VAA) to the test setup so they will be excluded.

I also added a benchmark test for the getUpdateFee. Currently it is not doing much, but if it gets complex, it is good that we be able to track its gas usage.

The resulting gas snapshot is listed below. It is reasonable and each benchmark test represent the gas cost of a single call (easier to track). This value also includes an initial transaction cost as well as reading from the contract storage itself. You can get the most accurate result by looking at the gas report (minimum value) or the gas shown in the call trace with `-vvvv` argument to `forge test`.

```
GasBenchmark:testBenchmarkGetPrice() (gas: 44944)
GasBenchmark:testBenchmarkGetUpdateFee() (gas: 133433)
GasBenchmark:testBenchmarkUpdatePriceFeedsFresh() (gas: 517137)
GasBenchmark:testBenchmarkUpdatePriceFeedsIfNecessaryFresh() (gas: 542821)
GasBenchmark:testBenchmarkUpdatePriceFeedsIfNecessaryNotFresh() (gas: 269028)
GasBenchmark:testBenchmarkUpdatePriceFeedsNotFresh() (gas: 454250)
PythTestUtilsTest:testGeneratePriceFeedUpdateVAAWorks() (gas: 8132042)
WormholeTestUtilsTest:testGenerateVaaWorks() (gas: 3112564)
``` 


P.S: Although the gas snapshot works correctly, but still the gas report includes `setUp` calls. So you need to look at the minimum value there.