### PR TITLE
Remove middle structs

### DIFF
--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -24,36 +24,32 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
         setPyth2WormholeEmitter(pyth2WormholeEmitter);
     }
 
-    function updatePriceBatchFromVm(bytes calldata encodedVm) private returns (PythInternalStructs.BatchPriceAttestation memory bpa) {
+    function updatePriceBatchFromVm(bytes calldata encodedVm) private {
         (IWormhole.VM memory vm, bool valid, string memory reason) = wormhole().parseAndVerifyVM(encodedVm);
 
         require(valid, reason);
         require(verifyPythVM(vm), "invalid data source chain/emitter ID");
 
-        PythInternalStructs.BatchPriceAttestation memory batch = parseBatchPriceAttestation(vm.payload);
+        PythInternalStructs.PriceAttestation[] memory attestations = parseBatchPriceAttestation(vm.payload);
 
         uint freshPrices = 0;
 
-        for (uint i = 0; i < batch.attestations.length; i++) {
-            PythInternalStructs.PriceAttestation memory attestation = batch.attestations[i];
-    
-            PythInternalStructs.PriceInfo memory newPriceInfo = createNewPriceInfo(attestation);
-            PythInternalStructs.PriceInfo memory latestPrice = latestPriceInfo(attestation.priceId);
+        for (uint i = 0; i < attestations.length; i++) {
+            PythInternalStructs.PriceInfo memory newPriceInfo = attestations[i].priceInfo;
+            PythInternalStructs.PriceInfo memory latestPrice = latestPriceInfo(attestations[i].priceId);
 
             bool fresh = false;
             if(newPriceInfo.price.publishTime > latestPrice.price.publishTime) {
                 freshPrices += 1;
                 fresh = true;
-                setLatestPriceInfo(attestation.priceId, newPriceInfo);
+                setLatestPriceInfo(attestations[i].priceId, newPriceInfo);
             }
 
-            emit PriceFeedUpdate(attestation.priceId, fresh, vm.emitterChainId, vm.sequence, latestPrice.price.publishTime,
+            emit PriceFeedUpdate(attestations[i].priceId, fresh, vm.emitterChainId, vm.sequence, latestPrice.price.publishTime,
                 newPriceInfo.price.publishTime, newPriceInfo.price.price, newPriceInfo.price.conf);
         }
 
-        emit BatchPriceFeedUpdate(vm.emitterChainId, vm.sequence, batch.attestations.length, freshPrices);
-
-        return batch;
+        emit BatchPriceFeedUpdate(vm.emitterChainId, vm.sequence, attestations.length, freshPrices);
     }
 
     function updatePriceFeeds(bytes[] calldata updateData) public override payable {
@@ -76,53 +72,28 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
         return singleUpdateFeeInWei() * updateData.length;
     }
 
-    function createNewPriceInfo(PythInternalStructs.PriceAttestation memory pa) private pure returns (PythInternalStructs.PriceInfo memory info) {
-        PythInternalStructs.PriceAttestationStatus status = PythInternalStructs.PriceAttestationStatus(pa.status);
-        if (status == PythInternalStructs.PriceAttestationStatus.TRADING) {
-            info.price.price = pa.price;
-            info.price.conf = pa.conf;
-            info.price.publishTime = pa.publishTime;
-            info.emaPrice.publishTime = pa.publishTime;
-        } else {
-            info.price.price = pa.prevPrice;
-            info.price.conf = pa.prevConf;
-            info.price.publishTime = pa.prevPublishTime;
-
-            // The EMA is last updated when the aggregate had trading status,
-            // so, we use prev_publish_time (the time when the aggregate last had trading status).
-            info.emaPrice.publishTime = pa.prevPublishTime;
-        }
-
-        info.price.expo = pa.expo;
-        info.emaPrice.price = pa.emaPrice;
-        info.emaPrice.conf = pa.emaConf;
-        info.emaPrice.expo = pa.expo;
-
-        return info;
-    }
-
     function verifyPythVM(IWormhole.VM memory vm) private view returns (bool valid) {
         return isValidDataSource(vm.emitterChainId, vm.emitterAddress); 
     }
 
-
-    function parseBatchPriceAttestation(bytes memory encoded) public pure returns (PythInternalStructs.BatchPriceAttestation memory bpa) {
+    function parseBatchPriceAttestation(bytes memory encoded) public pure
+        returns (PythInternalStructs.PriceAttestation[] memory attestations) {
         uint index = 0;
 
         // Check header
-        bpa.header.magic = encoded.toUint32(index);
+        uint32 magic = encoded.toUint32(index);
         index += 4;
-        require(bpa.header.magic == 0x50325748, "invalid magic value");
+        require(magic == 0x50325748, "invalid magic value");
 
-        bpa.header.versionMajor = encoded.toUint16(index);
+        uint16 versionMajor = encoded.toUint16(index);
         index += 2;
-        require(bpa.header.versionMajor == 3, "invalid version major, expected 3");
+        require(versionMajor == 3, "invalid version major, expected 3");
 
-        bpa.header.versionMinor = encoded.toUint16(index);
+        uint16 versionMinor = encoded.toUint16(index);
         index += 2;
-        require(bpa.header.versionMinor >= 0, "invalid version minor, expected 0 or more");
+        require(versionMinor >= 0, "invalid version minor, expected 0 or more");
 
-        bpa.header.hdrSize = encoded.toUint16(index);
+        uint16 hdrSize = encoded.toUint16(index);
         index += 2;
 
         // NOTE(2022-04-19): Currently, only payloadId comes after
@@ -139,82 +110,102 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
         // // Skip remaining unknown header bytes
         // index += bpa.header.hdrSize;
 
-        bpa.header.payloadId = encoded.toUint8(index);
+        uint8 payloadId = encoded.toUint8(index);
 
         // Skip remaining unknown header bytes
-        index += bpa.header.hdrSize;
+        index += hdrSize;
 
         // Payload ID of 2 required for batch headerBa
-        require(bpa.header.payloadId == 2, "invalid payload ID, expected 2 for BatchPriceAttestation");
+        require(payloadId == 2, "invalid payload ID, expected 2 for BatchPriceAttestation");
 
         // Parse the number of attestations
-        bpa.nAttestations = encoded.toUint16(index);
+        uint16 nAttestations = encoded.toUint16(index);
         index += 2;
 
         // Parse the attestation size
-        bpa.attestationSize = encoded.toUint16(index);
+        uint16 attestationSize = encoded.toUint16(index);
         index += 2;
-        require(encoded.length == (index + (bpa.attestationSize * bpa.nAttestations)), "invalid BatchPriceAttestation size");
+        require(encoded.length == (index + (attestationSize * nAttestations)), "invalid BatchPriceAttestation size");
 
-        bpa.attestations = new PythInternalStructs.PriceAttestation[](bpa.nAttestations);
+        attestations = new PythInternalStructs.PriceAttestation[](nAttestations);
 
         // Deserialize each attestation
-        for (uint j=0; j < bpa.nAttestations; j++) {
+        for (uint j=0; j < nAttestations; j++) {
             // NOTE: We don't advance the global index immediately.
             // attestationIndex is an attestation-local offset used
             // for readability and easier debugging.
             uint attestationIndex = 0;
 
-            // Attestation
-            bpa.attestations[j].productId = encoded.toBytes32(index + attestationIndex);
+            // Unused bytes32 product id
             attestationIndex += 32;
 
-            bpa.attestations[j].priceId = encoded.toBytes32(index + attestationIndex);
+            attestations[j].priceId = encoded.toBytes32(index + attestationIndex);
             attestationIndex += 32;
 
-            bpa.attestations[j].price = int64(encoded.toUint64(index + attestationIndex));
+            attestations[j].priceInfo.price.price = int64(encoded.toUint64(index + attestationIndex));
             attestationIndex += 8;
 
-            bpa.attestations[j].conf = encoded.toUint64(index + attestationIndex);
+            attestations[j].priceInfo.price.conf = encoded.toUint64(index + attestationIndex);
             attestationIndex += 8;
 
-            bpa.attestations[j].expo = int32(encoded.toUint32(index + attestationIndex));
+            attestations[j].priceInfo.price.expo = int32(encoded.toUint32(index + attestationIndex));
+            attestations[j].priceInfo.emaPrice.expo = attestations[j].priceInfo.price.expo;
             attestationIndex += 4;
 
-            bpa.attestations[j].emaPrice = int64(encoded.toUint64(index + attestationIndex));
+            attestations[j].priceInfo.emaPrice.price = int64(encoded.toUint64(index + attestationIndex));
             attestationIndex += 8;
 
-            bpa.attestations[j].emaConf = encoded.toUint64(index + attestationIndex);
+            attestations[j].priceInfo.emaPrice.conf = encoded.toUint64(index + attestationIndex);
             attestationIndex += 8;
 
-            bpa.attestations[j].status = encoded.toUint8(index + attestationIndex);
+            // Status is an enum (encoded as uint8) with the following values:
+            // 0 = UNKNOWN: The price feed is not currently updating for an unknown reason.
+            // 1 = TRADING: The price feed is updating as expected.
+            // 2 = HALTED: The price feed is not currently updating because trading in the product has been halted.
+            // 3 = AUCTION: The price feed is not currently updating because an auction is setting the price.
+            uint8 status = encoded.toUint8(index + attestationIndex);
             attestationIndex += 1;
 
-            bpa.attestations[j].numPublishers = encoded.toUint32(index + attestationIndex);
+            // Unused uint32 numPublishers
             attestationIndex += 4;
 
-            bpa.attestations[j].maxNumPublishers = encoded.toUint32(index + attestationIndex);
+            // Unused uint32 numPublishers
             attestationIndex += 4;
 
-            bpa.attestations[j].attestationTime = encoded.toUint64(index + attestationIndex);
+            // Unused uint64 attestationTime
             attestationIndex += 8;
 
-            bpa.attestations[j].publishTime = encoded.toUint64(index + attestationIndex);
+            attestations[j].priceInfo.price.publishTime = encoded.toUint64(index + attestationIndex);
+            attestations[j].priceInfo.emaPrice.publishTime = attestations[j].priceInfo.price.publishTime;
             attestationIndex += 8;
 
-            bpa.attestations[j].prevPublishTime = encoded.toUint64(index + attestationIndex);
-            attestationIndex += 8;
+            if (status == 1) { // status == TRADING
+                attestationIndex += 24;
+            } else {
+                // If status is not trading then the latest available price is
+                // the previous price info that are passed here.
 
-            bpa.attestations[j].prevPrice = int64(encoded.toUint64(index + attestationIndex));
-            attestationIndex += 8;
+                // Previous publish time
+                attestations[j].priceInfo.price.publishTime = encoded.toUint64(index + attestationIndex);
+                attestationIndex += 8;
 
-            bpa.attestations[j].prevConf = encoded.toUint64(index + attestationIndex);
-            attestationIndex += 8;
+                // Previous price
+                attestations[j].priceInfo.price.price = int64(encoded.toUint64(index + attestationIndex));
+                attestationIndex += 8;
 
-            require(attestationIndex <= bpa.attestationSize, "INTERNAL: Consumed more than `attestationSize` bytes");
+                // Previous confidence
+                attestations[j].priceInfo.price.conf = encoded.toUint64(index + attestationIndex);
+                attestationIndex += 8;
+
+                // The EMA is last updated when the aggregate had trading status,
+                // so, we use previous publish time here too.
+                attestations[j].priceInfo.emaPrice.publishTime = attestations[j].priceInfo.price.publishTime;
+            }
+
+            require(attestationIndex <= attestationSize, "INTERNAL: Consumed more than `attestationSize` bytes");
 
             // Respect specified attestation size for forward-compat
-            index += bpa.attestationSize;
+            index += attestationSize;
         }
     }
 

--- a/ethereum/contracts/pyth/PythInternalStructs.sol
+++ b/ethereum/contracts/pyth/PythInternalStructs.sol
@@ -9,11 +9,6 @@ import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
 contract PythInternalStructs {
     using BytesLib for bytes;
 
-    struct PriceAttestation {
-        PriceInfo priceInfo;
-        bytes32 priceId;
-    }
-
     struct InternalPrice {
         int64 price;
         uint64 conf;

--- a/ethereum/contracts/pyth/PythInternalStructs.sol
+++ b/ethereum/contracts/pyth/PythInternalStructs.sol
@@ -9,38 +9,9 @@ import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
 contract PythInternalStructs {
     using BytesLib for bytes;
 
-    struct BatchPriceAttestation {
-        Header header;
-
-        uint16 nAttestations;
-        uint16 attestationSize;
-        PriceAttestation[] attestations;
-    }
-
-    struct Header {
-        uint32 magic;
-        uint16 versionMajor;
-        uint16 versionMinor;
-        uint16 hdrSize;
-        uint8 payloadId;
-    }
-
     struct PriceAttestation {
-        bytes32 productId;
+        PriceInfo priceInfo;
         bytes32 priceId;
-        int64 price;
-        uint64 conf;
-        int32 expo;
-        int64 emaPrice;
-        uint64 emaConf;
-        uint8 status;
-        uint32 numPublishers;
-        uint32 maxNumPublishers;
-        uint64 attestationTime;
-        uint64 publishTime;
-        uint64 prevPublishTime;
-        int64 prevPrice;
-        uint64 prevConf;
     }
 
     struct InternalPrice {
@@ -61,18 +32,5 @@ contract PythInternalStructs {
     struct DataSource {
         uint16 chainId;
         bytes32 emitterAddress;
-    }
-
-    /* PriceAttestationStatus represents the availability status of a price feed passed down in attestation.
-        UNKNOWN: The price feed is not currently updating for an unknown reason.
-        TRADING: The price feed is updating as expected.
-        HALTED: The price feed is not currently updating because trading in the product has been halted.
-        AUCTION: The price feed is not currently updating because an auction is setting the price.
-    */
-    enum PriceAttestationStatus {
-        UNKNOWN,
-        TRADING,
-        HALTED,
-        AUCTION
     }
 }

--- a/ethereum/forge-test/utils/PythTestUtils.t.sol
+++ b/ethereum/forge-test/utils/PythTestUtils.t.sol
@@ -80,7 +80,7 @@ abstract contract PythTestUtils is Test, WormholeTestUtils {
             // Breaking this in two encodePackes because of the limited EVM stack.
             attestations = abi.encodePacked(
                 attestations,
-                uint8(PythInternalStructs.PriceAttestationStatus.TRADING),
+                uint8(1), // status = 1 = Trading
                 uint32(5), // Number of publishers. This field is not used.
                 uint32(10), // Maximum number of publishers. This field is not used.
                 uint64(prices[i].publishTime), // Attestation time. This field is not used.

--- a/ethereum/test/pyth.js
+++ b/ethereum/test/pyth.js
@@ -284,10 +284,6 @@ contract("Pyth", function () {
     }
 
     it("should parse batch price attestation correctly", async function () {
-        const magic = 0x50325748;
-        const versionMajor = 3;
-        const versionMinor = 0;
-
         let attestationTime = 1647273460; // re-used for publishTime
         let publishTime = 1647273465; // re-used for publishTime
         let priceVal = 1337;
@@ -298,45 +294,27 @@ contract("Pyth", function () {
         );
         let parsed = await this.pythProxy.parseBatchPriceAttestation(rawBatch);
 
-        // Check the header
-        assert.equal(parsed.header.magic, magic);
-        assert.equal(parsed.header.versionMajor, versionMajor);
-        assert.equal(parsed.header.versionMinor, versionMinor);
-        assert.equal(parsed.header.payloadId, 2);
+        assert.equal(parsed.length, RAW_BATCH_ATTESTATION_COUNT);
 
-        assert.equal(parsed.nAttestations, RAW_BATCH_ATTESTATION_COUNT);
-        assert.equal(parsed.attestationSize, RAW_PRICE_ATTESTATION_SIZE);
-
-        assert.equal(parsed.attestations.length, parsed.nAttestations);
-
-        for (var i = 0; i < parsed.attestations.length; ++i) {
-            const prodId =
-                "0x" + (i + 1).toString(16).padStart(2, "0").repeat(32);
+        for (var i = 0; i < parsed.length; ++i) {
             const priceByte = 255 - ((i + 1) % 256);
             const priceId =
                 "0x" + priceByte.toString(16).padStart(2, "0").repeat(32);
 
-            assert.equal(parsed.attestations[i].productId, prodId);
-            assert.equal(parsed.attestations[i].priceId, priceId);
-            assert.equal(parsed.attestations[i].price, priceVal);
-            assert.equal(parsed.attestations[i].conf, 101);
-            assert.equal(parsed.attestations[i].expo, -3);
-            assert.equal(parsed.attestations[i].emaPrice, -42);
-            assert.equal(parsed.attestations[i].emaConf, 42);
-            assert.equal(parsed.attestations[i].status, 1);
-            assert.equal(parsed.attestations[i].numPublishers, 123212);
-            assert.equal(parsed.attestations[i].maxNumPublishers, 321232);
-            assert.equal(
-                parsed.attestations[i].attestationTime,
-                attestationTime
-            );
-            assert.equal(parsed.attestations[i].publishTime, publishTime);
-            assert.equal(parsed.attestations[i].prevPublishTime, 0xdeadbabe);
-            assert.equal(parsed.attestations[i].prevPrice, 0xdeadfacebeef);
-            assert.equal(parsed.attestations[i].prevConf, 0xbadbadbeef);
+            assert.equal(parsed[i].priceId, priceId);
+            assert.equal(parsed[i].priceInfo.price.price, priceVal);
+            assert.equal(parsed[i].priceInfo.price.conf, 101);
+            assert.equal(parsed[i].priceInfo.price.expo, -3);
+            assert.equal(parsed[i].priceInfo.emaPrice.expo, -3);
+
+            assert.equal(parsed[i].priceInfo.emaPrice.price, -42);
+            assert.equal(parsed[i].priceInfo.emaPrice.conf, 42);
+
+            assert.equal(parsed[i].priceInfo.emaPrice.publishTime, publishTime);
+            assert.equal(parsed[i].priceInfo.price.publishTime, publishTime);
 
             console.debug(
-                `attestation ${i + 1}/${parsed.attestations.length} parsed OK`
+                `attestation ${i + 1}/${parsed.length} parsed OK`
             );
         }
     });

--- a/ethereum/test/pyth.js
+++ b/ethereum/test/pyth.js
@@ -304,7 +304,6 @@ contract("Pyth", function () {
             price: "1337",
         });
 
-        // Then prices should be available because the valid period is now 120 seconds
         for (var i = 1; i <= RAW_BATCH_ATTESTATION_COUNT; i++) {
             const price_id =
                 "0x" +
@@ -312,15 +311,15 @@ contract("Pyth", function () {
 
             const price = await this.pythProxy.getPriceUnsafe(price_id);
             assert.equal(price.price, priceVal.toString());
-            assert.equal(price.conf, "101"); // Fixed in the fixture.
+            assert.equal(price.conf, "101"); // The value is hardcoded in the RAW_BATCH.
             assert.equal(price.publishTime, publishTime.toString());
-            assert.equal(price.expo, "-3"); // Fixed in the fixture.
+            assert.equal(price.expo, "-3"); // The value is hardcoded in the RAW_BATCH.
 
             const emaPrice = await this.pythProxy.getEmaPriceUnsafe(price_id);
             assert.equal(emaPrice.price, emaPriceVal.toString());
-            assert.equal(emaPrice.conf, "42"); // Fixed in the fixture.
+            assert.equal(emaPrice.conf, "42"); // The value is hardcoded in the RAW_BATCH.
             assert.equal(emaPrice.publishTime, publishTime.toString());
-            assert.equal(emaPrice.expo, "-3"); // Fixed in the fixture.
+            assert.equal(emaPrice.expo, "-3"); // The value is hardcoded in the RAW_BATCH.
         }
     });
 


### PR DESCRIPTION
Before converting VAA payloads to PriceInfo we convert them to PriceAttestation which is the equivalent of the payload wire format. However, this middle conversion has some costs, because (1) we copy stuff twice, and (2) we have some unused fields. 

This PR removes the middle structs and creates PriceInfo directly from the VAA payload. 

The gas improvement is not substantial, but still good (~14k gas save)

The gas snapshot difference:
```
testBenchmarkGetUpdateFee() (gas: -22 (-0.016%)) 
testBenchmarkUpdatePriceFeedsIfNecessaryNotFresh() (gas: 110 (0.054%)) 
testBenchmarkUpdatePriceFeedsIfNecessaryFresh() (gas: -22212 (-5.063%)) 
testBenchmarkUpdatePriceFeedsFresh() (gas: -22272 (-5.374%)) 
testBenchmarkUpdatePriceFeedsNotFresh() (gas: -22236 (-5.736%)) 
```
