### PR TITLE
[eth] Use latestPriceInfoPublishTime when possible

### DIFF
--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -195,16 +195,16 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
             index += attestationSize;
 
             // Store the attestation
-            PythInternalStructs.PriceInfo memory latestPrice = latestPriceInfo(priceId);
+            uint64 latestPublishTime = latestPriceInfoPublishTime(priceId);
 
             bool fresh = false;
-            if(info.price.publishTime > latestPrice.price.publishTime) {
+            if(info.price.publishTime > latestPublishTime) {
                 freshPrices += 1;
                 fresh = true;
                 setLatestPriceInfo(priceId, info);
             }
 
-            emit PriceFeedUpdate(priceId, fresh, vm.emitterChainId, vm.sequence, latestPrice.price.publishTime,
+            emit PriceFeedUpdate(priceId, fresh, vm.emitterChainId, vm.sequence, latestPublishTime,
                 info.price.publishTime, info.price.price, info.price.conf);
         }
 
@@ -230,8 +230,7 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
     }
 
     function priceFeedExists(bytes32 id) public override view returns (bool) {
-        PythInternalStructs.PriceInfo memory info = latestPriceInfo(id);
-        return (info.price.publishTime != 0);
+        return (latestPriceInfoPublishTime(id) != 0);
     }
 
     function getValidTimePeriod() public override view returns (uint) {

--- a/ethereum/contracts/pyth/PythGetters.sol
+++ b/ethereum/contracts/pyth/PythGetters.sol
@@ -27,6 +27,10 @@ contract PythGetters is PythState {
         return _state.latestPriceInfo[priceId];
     }
 
+    function latestPriceInfoPublishTime(bytes32 priceId) public view returns (uint64) {
+        return _state.latestPriceInfo[priceId].price.publishTime;
+    }
+
     function hashDataSource(PythInternalStructs.DataSource memory ds) public pure returns (bytes32) {
         return keccak256(abi.encodePacked(ds.chainId, ds.emitterAddress));
     }


### PR DESCRIPTION
When updating the price we only need to know the publish time of the cached price and don't need to read the whole memory. This change adds a method to get the publish time directly and uses it all the places that is possible within the code base here. We can use it in `updatePriceFeedsIfNecessary` too, but since it's in the sdk right now we cannot change it. Will do that later when we move the sdk inside this repo.

Snapshot difference:
```
testBenchmarkGetUpdateFee() (gas: 22 (0.016%)) 
testBenchmarkUpdatePriceFeedsFresh() (gas: -6822 (-1.740%)) 
testBenchmarkUpdatePriceFeedsIfNecessaryFresh() (gas: -7878 (-1.891%)) 
testBenchmarkUpdatePriceFeedsIfNecessaryNotFresh() (gas: -4834 (-2.388%)) 
testBenchmarkUpdatePriceFeedsNotFresh() (gas: -14822 (-4.056%)) 
```