### PR TITLE
[eth] Gas improvement: Optimize events

### DIFF
--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -216,6 +216,15 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
         }
     }
 
+    function parsePriceFeedUpdates(
+        bytes[] calldata updateData,
+        bytes32[] calldata priceIds,
+        uint64 minPublishTime,
+        uint64 maxPublishTime
+    ) external payable override returns (PythStructs.PriceFeed[] memory priceFeeds) {
+        // TODO: To be implemented soon.
+    }
+
     function queryPriceFeed(bytes32 id) public view override returns (PythStructs.PriceFeed memory priceFeed){
         // Look up the latest price info for the given ID
         PythInternalStructs.PriceInfo memory info = latestPriceInfo(id);

--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -40,8 +40,6 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
 
             unchecked { i++; }
         }
-
-        emit UpdatePriceFeeds(msg.sender, updateData.length, requiredFee);
     }
 
     /// This method is deprecated, please use the `getUpdateFee(bytes[])` instead.
@@ -120,7 +118,6 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
 
             PythInternalStructs.PriceInfo memory info;
             bytes32 priceId;
-            uint freshPrices = 0;
             
             // Deserialize each attestation
             for (uint j=0; j < nAttestations; j++) {
@@ -200,19 +197,13 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
                 // Store the attestation
                 uint64 latestPublishTime = latestPriceInfoPublishTime(priceId);
 
-                bool fresh = false;
                 if(info.publishTime > latestPublishTime) {
-                    freshPrices += 1;
-                    fresh = true;
                     setLatestPriceInfo(priceId, info);
+                    emit PriceFeedUpdate(priceId, info.publishTime, info.price, info.conf);
                 }
-
-                emit PriceFeedUpdate(priceId, fresh, vm.emitterChainId, vm.sequence, latestPublishTime,
-                    info.publishTime, info.price, info.conf);
             }
 
-
-            emit BatchPriceFeedUpdate(vm.emitterChainId, vm.sequence, nAttestations, freshPrices);
+            emit BatchPriceFeedUpdate(vm.emitterChainId, vm.sequence);
         }
     }
 

--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -214,6 +214,7 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
         uint64 maxPublishTime
     ) external payable override returns (PythStructs.PriceFeed[] memory priceFeeds) {
         // TODO: To be implemented soon.
+        revert("unimplemented");
     }
 
     function queryPriceFeed(bytes32 id) public view override returns (PythStructs.PriceFeed memory priceFeed){

--- a/ethereum/forge-test/utils/PythTestUtils.t.sol
+++ b/ethereum/forge-test/utils/PythTestUtils.t.sol
@@ -6,6 +6,7 @@ import "../../contracts/pyth/PythUpgradable.sol";
 import "../../contracts/pyth/PythInternalStructs.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
+import "@pythnetwork/pyth-sdk-solidity/IPythEvents.sol";
 import "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
 
 
@@ -130,10 +131,7 @@ abstract contract PythTestUtils is Test, WormholeTestUtils {
     }
 }
 
-contract PythTestUtilsTest is Test, WormholeTestUtils, PythTestUtils {
-    // TODO: It is better to have a PythEvents contract that be extendable. 
-    event PriceFeedUpdate(bytes32 indexed id, bool indexed fresh, uint16 chainId, uint64 sequenceNumber, uint lastPublishTime, uint publishTime, int64 price, uint64 conf);
-
+contract PythTestUtilsTest is Test, WormholeTestUtils, PythTestUtils, IPythEvents {
     function testGeneratePriceFeedUpdateVAAWorks() public {
         IPyth pyth = IPyth(setUpPyth(setUpWormhole(
             1 // Number of guardians
@@ -163,7 +161,7 @@ contract PythTestUtilsTest is Test, WormholeTestUtils, PythTestUtils {
         uint updateFee = pyth.getUpdateFee(updateData);
 
         vm.expectEmit(true, true, false, true);
-        emit PriceFeedUpdate(priceIds[0], true, SOURCE_EMITTER_CHAIN_ID, 1, 0, 1, 100, 10);
+        emit PriceFeedUpdate(priceIds[0], 1, 100, 10);
 
         pyth.updatePriceFeeds{value: updateFee}(updateData);
     }

--- a/ethereum/package-lock.json
+++ b/ethereum/package-lock.json
@@ -13,7 +13,7 @@
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
         "@openzeppelin/contracts": "^4.5.0",
         "@openzeppelin/contracts-upgradeable": "^4.5.2",
-        "@pythnetwork/pyth-sdk-solidity": "^2.0.0",
+        "@pythnetwork/pyth-sdk-solidity": "^2.1.0",
         "@pythnetwork/xc-governance-sdk": "file:../third_party/pyth/xc-governance-sdk-js",
         "dotenv": "^10.0.0",
         "elliptic": "^6.5.2",
@@ -5641,9 +5641,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "node_modules/@pythnetwork/pyth-sdk-solidity": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-2.0.0.tgz",
-      "integrity": "sha512-ogWpnI23Ofz1D5AmglkRxr+M/up/y15CBvXuxDcdq0Q6DvW3ksfPWP0DwCV2s7xbeSKYdpr97O+4NRmDCGeDsg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-2.1.0.tgz",
+      "integrity": "sha512-jHzqw+BHaCOAYwRNCgAUhcbNZrB5f3Arly3PaYN3/Tg7/5RQ95a9FD15XvJB1DB3yymUPIkmLYMur7Sh+e1G4A=="
     },
     "node_modules/@pythnetwork/xc-governance-sdk": {
       "resolved": "../third_party/pyth/xc-governance-sdk-js",
@@ -44827,9 +44827,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@pythnetwork/pyth-sdk-solidity": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-2.0.0.tgz",
-      "integrity": "sha512-ogWpnI23Ofz1D5AmglkRxr+M/up/y15CBvXuxDcdq0Q6DvW3ksfPWP0DwCV2s7xbeSKYdpr97O+4NRmDCGeDsg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-2.1.0.tgz",
+      "integrity": "sha512-jHzqw+BHaCOAYwRNCgAUhcbNZrB5f3Arly3PaYN3/Tg7/5RQ95a9FD15XvJB1DB3yymUPIkmLYMur7Sh+e1G4A=="
     },
     "@pythnetwork/xc-governance-sdk": {
       "version": "file:../third_party/pyth/xc-governance-sdk-js",

--- a/ethereum/package.json
+++ b/ethereum/package.json
@@ -32,7 +32,7 @@
     "@certusone/wormhole-sdk-wasm": "^0.0.1",
     "@openzeppelin/contracts": "^4.5.0",
     "@openzeppelin/contracts-upgradeable": "^4.5.2",
-    "@pythnetwork/pyth-sdk-solidity": "^2.0.0",
+    "@pythnetwork/pyth-sdk-solidity": "^2.1.0",
     "@pythnetwork/xc-governance-sdk": "file:../third_party/pyth/xc-governance-sdk-js",
     "dotenv": "^10.0.0",
     "elliptic": "^6.5.2",


### PR DESCRIPTION
This PR omits unnecessary fields in the events and also removes the `UpdatePriceFeeds` events (as its information could be retrieved somehow). Also because of the new event structure it won't emit any `PriceFeedUpdate` for non-fresh updates.

snapshot difference:
```
testBenchmarkGetPrice() (gas: -13 (-0.049%)) 
testBenchmarkUpdatePriceFeedsIfNecessaryFresh() (gas: -10675 (-2.731%)) 
testBenchmarkUpdatePriceFeedsFresh() (gas: -10675 (-2.901%)) 
testBenchmarkUpdatePriceFeedsNotFresh() (gas: -18899 (-5.658%)) 
```

p.s: As the sdk is updated, `parsePriceFeedUpdates` is added to the interface. I added it with a ToDo to be addressed in a separate PR.
