### PR TITLE
[eth] Gas improvement: Optimize getPrice and getEmaPrice

### DIFF
--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -244,6 +244,7 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
     ) public view override returns (PythStructs.Price memory price) {
         PythInternalStructs.PriceInfo storage info = _state.latestPriceInfo[id];
         price.publishTime = info.publishTime;
+        price.expo = info.expo;
         price.price = info.price;
         price.conf = info.conf;
 
@@ -259,6 +260,7 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
     ) public view override returns (PythStructs.Price memory price) {
         PythInternalStructs.PriceInfo storage info = _state.latestPriceInfo[id];
         price.publishTime = info.publishTime;
+        price.expo = info.expo;
         price.price = info.emaPrice;
         price.conf = info.emaConf;
 

--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -235,6 +235,36 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
         );
     }
 
+    // This is an overwrite of the same method in AbstractPyth.sol
+    // to be more gas efficient. It cannot move to PythGetters as it
+    // is overwriting the interface. Even indirect calling of a similar
+    // method from PythGetter has some gas overhead.
+    function getPriceUnsafe(
+        bytes32 id
+    ) public view override returns (PythStructs.Price memory price) {
+        PythInternalStructs.PriceInfo storage info = _state.latestPriceInfo[id];
+        price.publishTime = info.publishTime;
+        price.price = info.price;
+        price.conf = info.conf;
+
+        require(price.publishTime != 0, "price feed for the given id is not pushed or does not exist");
+    }
+
+    // This is an overwrite of the same method in AbstractPyth.sol
+    // to be more gas efficient. It cannot move to PythGetters as it
+    // is overwriting the interface. Even indirect calling of a similar
+    // method from PythGetter has some gas overhead.
+    function getEmaPriceUnsafe(
+        bytes32 id
+    ) public view override returns (PythStructs.Price memory price) {
+        PythInternalStructs.PriceInfo storage info = _state.latestPriceInfo[id];
+        price.publishTime = info.publishTime;
+        price.price = info.emaPrice;
+        price.conf = info.emaConf;
+
+        require(price.publishTime != 0, "price feed for the given id is not pushed or does not exist");
+    }
+
     function parsePriceFeedUpdates(
         bytes[] calldata updateData,
         bytes32[] calldata priceIds,

--- a/ethereum/forge-test/GasBenchmark.t.sol
+++ b/ethereum/forge-test/GasBenchmark.t.sol
@@ -130,6 +130,15 @@ contract GasBenchmark is Test, WormholeTestUtils, PythTestUtils {
         pyth.getPrice(priceIds[0]);
     }
 
+
+    function testBenchmarkGetEmaPrice() public {
+        // Set the block timestamp to 0. As prices have < 10 timestamp and staleness 
+        // is set to 60 seconds, the getPrice should work as expected.
+        vm.warp(0);
+
+        pyth.getEmaPrice(priceIds[0]);
+    }
+
     function testBenchmarkGetUpdateFee() public view {
         pyth.getUpdateFee(freshPricesUpdateData);
     }


### PR DESCRIPTION
AbstractPyth constructs price and emaPrice by creating a complete PriceFeed but it has some gas overhead as not everything in PriceFeed is used. This will reduce our `getPrice` and `getEmaPrice` gas usage significantly.

Snapshot difference:
```
testBenchmarkGetEmaPrice() (gas: -1202 (-4.488%)) 
testBenchmarkGetPrice() (gas: -3297 (-12.341%)) 
```

p.s: above numbers have decreased a bit due to addition of `expo` field that I missed before. (for `testBenchmarkGetPrice` it is -3226)