### PR TITLE
[eth] Gas improvement: Increase optimizer runs to 10000

### DIFF
--- a/ethereum/foundry.toml
+++ b/ethereum/foundry.toml
@@ -1,7 +1,7 @@
 [profile.default]
 solc_version = '0.8.4'
 optimizer = true
-optimizer_runs = 100000
+optimizer_runs = 10000
 src = 'contracts'
 # We put the tests into the forge-test directory (instead of test) so that
 # truffle doesn't try to build them

--- a/ethereum/foundry.toml
+++ b/ethereum/foundry.toml
@@ -1,7 +1,7 @@
 [profile.default]
 solc_version = '0.8.4'
 optimizer = true
-optimizer_runs = 200
+optimizer_runs = 100000
 src = 'contracts'
 # We put the tests into the forge-test directory (instead of test) so that
 # truffle doesn't try to build them

--- a/ethereum/truffle-config.js
+++ b/ethereum/truffle-config.js
@@ -230,7 +230,7 @@ module.exports = {
       settings: {
         optimizer: {
           enabled: true,
-          runs: 100000,
+          runs: 10000,
         },
       },
     },

--- a/ethereum/truffle-config.js
+++ b/ethereum/truffle-config.js
@@ -230,7 +230,7 @@ module.exports = {
       settings: {
         optimizer: {
           enabled: true,
-          runs: 200,
+          runs: 100000,
         },
       },
     },


### PR DESCRIPTION
Increasing optimizer runs will optimize the gas usage of methods more and will increase the contract size, hence the deployment cost.

After this change the standard JSON compiler output size changes from 432K to 456K.

Snapshot difference:
```
testBenchmarkGetUpdateFee() (gas: -101 (-0.076%)) 
testBenchmarkUpdatePriceFeedsIfNecessaryNotFresh() (gas: -325 (-0.184%)) 
testBenchmarkUpdatePriceFeedsNotFresh() (gas: -1291 (-0.410%)) 
testBenchmarkUpdatePriceFeedsIfNecessaryFresh() (gas: -1605 (-0.424%)) 
testBenchmarkUpdatePriceFeedsFresh() (gas: -1555 (-0.435%)) 
testBenchmarkGetPrice() (gas: -259 (-0.969%)) 
```

p.s: I read one place that `runs` is an estimate of how many times the contract is expected to be called as opposed to number of optimization passes through the code!

Update:
tests failed because they could not deploy the contract with the following warning:
```
Warning: Contract code size exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on mainnet. Consider enabling the optimizer (with a low "runs" value!), turning off revert strings, or using libraries.
```

So I changed it to 10000 (from 100,000)