### PR TITLE
[eth] Add parsePriceFeedUpdates method

### DIFF
--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -273,8 +273,193 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
         uint64 minPublishTime,
         uint64 maxPublishTime
     ) external payable override returns (PythStructs.PriceFeed[] memory priceFeeds) {
-        // TODO: To be implemented soon.
-        revert("unimplemented");
+        unchecked {
+            {
+                uint requiredFee = getUpdateFee(updateData);
+                require(msg.value >= requiredFee, "insufficient paid fee amount");
+            }
+
+            priceFeeds = new PythStructs.PriceFeed[](priceIds.length);
+
+            for(uint i = 0; i < updateData.length; i++) {
+                IWormhole.VM memory vm;
+
+                {
+                    bool valid;
+                    string memory reason;
+                    (vm, valid, reason) = wormhole().parseAndVerifyVM(updateData[i]);
+                    require(valid, reason);
+                }
+
+                require(verifyPythVM(vm), "invalid data source chain/emitter ID");
+
+
+                bytes memory encoded = vm.payload;    
+                uint index = 0;
+
+                // Check header
+                {
+                    uint32 magic = UnsafeBytesLib.toUint32(encoded, index);
+                    index += 4;
+                    require(magic == 0x50325748, "invalid magic value");
+
+                    uint16 versionMajor = UnsafeBytesLib.toUint16(encoded, index);
+                    index += 2;
+                    require(versionMajor == 3, "invalid version major, expected 3");
+
+                    uint16 versionMinor = UnsafeBytesLib.toUint16(encoded, index);
+                    index += 2;
+                    require(versionMinor >= 0, "invalid version minor, expected 0 or more");
+
+                    uint16 hdrSize = UnsafeBytesLib.toUint16(encoded, index);
+                    index += 2;
+
+                    // NOTE(2022-04-19): Currently, only payloadId comes after
+                    // hdrSize. Future extra header fields must be read using a
+                    // separate offset to respect hdrSize, i.e.:
+                    //
+                    // uint hdrIndex = 0;
+                    // bpa.header.payloadId = UnsafeBytesLib.toUint8(encoded, index + hdrIndex);
+                    // hdrIndex += 1;
+                    //
+                    // bpa.header.someNewField = UnsafeBytesLib.toUint32(encoded, index + hdrIndex);
+                    // hdrIndex += 4;
+                    //
+                    // // Skip remaining unknown header bytes
+                    // index += bpa.header.hdrSize;
+
+                    uint8 payloadId = UnsafeBytesLib.toUint8(encoded, index);
+
+                    // Skip remaining unknown header bytes
+                    index += hdrSize;
+
+                    // Payload ID of 2 required for batch headerBa
+                    require(payloadId == 2, "invalid payload ID, expected 2 for BatchPriceAttestation");
+                }
+
+                // Parse the number of attestations
+                uint16 nAttestations = UnsafeBytesLib.toUint16(encoded, index);
+                index += 2;
+
+                // Parse the attestation size
+                uint16 attestationSize = UnsafeBytesLib.toUint16(encoded, index);
+                index += 2;
+
+                // Given the message is valid the arithmetic below should not overflow, and
+                // even if it overflows then the require would fail.
+                require(encoded.length == (index + (attestationSize * nAttestations)), "invalid BatchPriceAttestation size");
+
+                bytes32 priceId;
+
+                // Deserialize each attestation
+                for (uint j=0; j < nAttestations; j++) {
+                    // NOTE: We don't advance the global index immediately.
+                    // attestationIndex is an attestation-local offset used
+                    // for readability and easier debugging.
+                    uint attestationIndex = 0;
+
+                    // Unused bytes32 product id
+                    attestationIndex += 32;
+
+                    priceId = UnsafeBytesLib.toBytes32(encoded, index + attestationIndex);
+
+                    // Check whether the caller requested for this data.
+                    uint k = 0;
+                    for(; k < priceIds.length; k++) {
+                        if (priceIds[k] == priceId) {
+                            break;
+                        }
+                    }
+
+                    // If priceFeed[k].id != 0 then it means that there was a valid
+                    // update for priceIds[k] and we don't need to process this one.
+                    if (k == priceIds.length || priceFeeds[k].id != 0) {
+                        index += attestationSize;
+                        continue;
+                    }
+
+                    priceFeeds[k].id = priceId;
+                    attestationIndex += 32;
+
+                    priceFeeds[k].price.price = int64(UnsafeBytesLib.toUint64(encoded, index + attestationIndex));
+                    attestationIndex += 8;
+
+                    priceFeeds[k].price.conf = UnsafeBytesLib.toUint64(encoded, index + attestationIndex);
+                    attestationIndex += 8;
+
+                    priceFeeds[k].price.expo = int32(UnsafeBytesLib.toUint32(encoded, index + attestationIndex));
+                    priceFeeds[k].emaPrice.expo = priceFeeds[k].price.expo;
+                    attestationIndex += 4;
+
+                    priceFeeds[k].emaPrice.price = int64(UnsafeBytesLib.toUint64(encoded, index + attestationIndex));
+                    attestationIndex += 8;
+
+                    priceFeeds[k].emaPrice.conf = UnsafeBytesLib.toUint64(encoded, index + attestationIndex);
+                    attestationIndex += 8;
+
+                    {
+                        // Status is an enum (encoded as uint8) with the following values:
+                        // 0 = UNKNOWN: The price feed is not currently updating for an unknown reason.
+                        // 1 = TRADING: The price feed is updating as expected.
+                        // 2 = HALTED: The price feed is not currently updating because trading in the product has been halted.
+                        // 3 = AUCTION: The price feed is not currently updating because an auction is setting the price.
+                        uint8 status = UnsafeBytesLib.toUint8(encoded, index + attestationIndex);
+                        attestationIndex += 1;
+
+                        // Unused uint32 numPublishers
+                        attestationIndex += 4;
+
+                        // Unused uint32 numPublishers
+                        attestationIndex += 4;
+
+                        // Unused uint64 attestationTime
+                        attestationIndex += 8;
+
+                        priceFeeds[k].price.publishTime = UnsafeBytesLib.toUint64(encoded, index + attestationIndex);
+                        priceFeeds[k].emaPrice.publishTime = priceFeeds[k].price.publishTime;
+                        attestationIndex += 8;
+
+                        if (status == 1) { // status == TRADING
+                            attestationIndex += 24;
+                        } else {
+                            // If status is not trading then the latest available price is
+                            // the previous price info that are passed here.
+
+                            // Previous publish time
+                            priceFeeds[k].price.publishTime = UnsafeBytesLib.toUint64(encoded, index + attestationIndex);
+                            priceFeeds[k].emaPrice.publishTime = priceFeeds[k].price.publishTime;
+                            attestationIndex += 8;
+
+                            // Previous price
+                            priceFeeds[k].price.price = int64(UnsafeBytesLib.toUint64(encoded, index + attestationIndex));
+                            attestationIndex += 8;
+
+                            // Previous confidence
+                            priceFeeds[k].price.conf = UnsafeBytesLib.toUint64(encoded, index + attestationIndex);
+                            attestationIndex += 8;
+                        }
+                    }
+
+                    // Check the publish time of the price is within the given range
+                    // if it is not, then set the id to 0 to indicate that this price id
+                    // still does not have a valid price feed. This will allow other updates
+                    // for this price id to be processed.
+                    if (priceFeeds[k].price.publishTime < minPublishTime ||
+                        priceFeeds[k].price.publishTime > maxPublishTime) {
+                            priceFeeds[k].id = 0;
+                        }
+
+                    require(attestationIndex <= attestationSize, "INTERNAL: Consumed more than `attestationSize` bytes");
+
+                    index += attestationSize;
+                }
+            }
+
+            for (uint k = 0; k < priceIds.length; k++) {
+                require(priceFeeds[k].id != 0,
+                    "1 or more price feeds are not found in the updateData or they are out of the given time range");
+            }
+        }
     }
 
     function queryPriceFeed(bytes32 id) public view override returns (PythStructs.PriceFeed memory priceFeed){

--- a/ethereum/forge-test/GasBenchmark.t.sol
+++ b/ethereum/forge-test/GasBenchmark.t.sol
@@ -86,8 +86,7 @@ contract GasBenchmark is Test, WormholeTestUtils, PythTestUtils {
 
     function generateUpdateDataAndFee(PythStructs.Price[] memory prices) internal returns (bytes[] memory updateData, uint updateFee) {
         bytes memory vaa = generatePriceFeedUpdateVAA(
-            priceIds,
-            prices,
+            pricesToPriceAttestations(priceIds, prices),
             sequence,
             NUM_GUARDIAN_SIGNERS
         );
@@ -120,6 +119,29 @@ contract GasBenchmark is Test, WormholeTestUtils, PythTestUtils {
         vm.expectRevert(bytes("no prices in the submitted batch have fresh prices, so this update will have no effect"));
 
         pyth.updatePriceFeedsIfNecessary{value: cachedPricesUpdateFee}(cachedPricesUpdateData, priceIds, cachedPricesPublishTimes);
+    }
+
+    function testBenchmarkParsePriceFeedUpdatesForOnePriceFeed() public {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = priceIds[0];
+
+        pyth.parsePriceFeedUpdates{value: freshPricesUpdateFee}(freshPricesUpdateData, ids, 0, 50);
+    }
+
+    function testBenchmarkParsePriceFeedUpdatesForTwoPriceFeed() public {
+        bytes32[] memory ids = new bytes32[](2);
+        ids[0] = priceIds[0];
+        ids[1] = priceIds[1];
+
+        pyth.parsePriceFeedUpdates{value: freshPricesUpdateFee}(freshPricesUpdateData, ids, 0, 50);
+    }
+
+    function testBenchmarkParsePriceFeedUpdatesForOnePriceFeedNotWithinRange() public {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = priceIds[0];
+
+        vm.expectRevert(bytes("1 or more price feeds are not found in the updateData or they are out of the given time range"));
+        pyth.parsePriceFeedUpdates{value: freshPricesUpdateFee}(freshPricesUpdateData, ids, 50, 100);
     }
 
     function testBenchmarkGetPrice() public {

--- a/ethereum/forge-test/Pyth.t.sol
+++ b/ethereum/forge-test/Pyth.t.sol
@@ -1,0 +1,444 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "forge-std/Test.sol";
+
+import "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
+import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
+import "./utils/WormholeTestUtils.t.sol";
+import "./utils/PythTestUtils.t.sol";
+import "./utils/RandTestUtils.t.sol";
+
+contract PythTest is Test, WormholeTestUtils, PythTestUtils, RandTestUtils {
+    IPyth public pyth;
+
+    // -1 is equal to 0x111111 which is the biggest uint if converted back
+    uint64 constant MAX_UINT64 = uint64(int64(-1));
+    
+    function setUp() public {
+        pyth = IPyth(setUpPyth(setUpWormhole(1)));
+    }
+
+    function generateRandomPriceAttestations(
+        uint length
+    ) internal returns (
+        bytes32[] memory priceIds,
+        PriceAttestation[] memory attestations
+    ) {
+        attestations = new PriceAttestation[](length);
+        priceIds = new bytes32[](length);
+
+        for(uint i = 0; i < length; i++) {
+            attestations[i].productId = getRandBytes32();
+            attestations[i].priceId = bytes32(i+1); // price ids should be non-zero and unique
+            attestations[i].price = getRandInt64();
+            attestations[i].conf = getRandUint64();
+            attestations[i].expo = getRandInt32();
+            attestations[i].emaPrice = getRandInt64();
+            attestations[i].emaConf = getRandUint64();
+            attestations[i].status = PriceAttestationStatus(getRandUint() % 2);
+            attestations[i].numPublishers = getRandUint32();
+            attestations[i].maxNumPublishers = getRandUint32();
+            attestations[i].attestationTime = getRandUint64();
+            attestations[i].publishTime = getRandUint64();
+            attestations[i].prevPublishTime = getRandUint64();
+            attestations[i].price = getRandInt64();
+            attestations[i].conf = getRandUint64();
+
+            priceIds[i] = attestations[i].priceId;
+        }
+    }
+
+    // This method divides attestations into a couple of batches and creates
+    // updateData for them. It returns the updateData and the updateFee
+    function createBatchedUpdateDataFromAttestations(
+        PriceAttestation[] memory attestations
+    ) internal returns (bytes[] memory updateData, uint updateFee) {
+        uint batchSize = 1 + getRandUint() % attestations.length;
+        uint numBatches = (attestations.length + batchSize - 1) / batchSize;
+
+        updateData = new bytes[](numBatches);
+
+        for(uint i = 0; i < attestations.length; i += batchSize) {
+            uint len = batchSize;
+            if(attestations.length - i < len) {
+                len = attestations.length - i;
+            }
+    
+            PriceAttestation[] memory batchAttestations = new PriceAttestation[](len);
+            for(uint j = i; j < i+len; j++) {
+                batchAttestations[j-i] = attestations[j];
+            }   
+
+            updateData[i / batchSize] = generatePriceFeedUpdateVAA(
+                batchAttestations,
+                0,
+                1
+            );
+        }
+
+        updateFee = pyth.getUpdateFee(updateData);
+    }
+
+    /// Testing parsePriceFeedUpdates method.
+    function testParsePriceFeedUpdatesWorksWithTradingStatus(uint seed) public {
+        setRandSeed(seed);
+        uint numAttestations = 1 + getRandUint() % 10;
+        (bytes32[] memory priceIds, PriceAttestation[] memory attestations) =
+            generateRandomPriceAttestations(numAttestations);
+
+        for(uint i = 0; i < numAttestations; i++) {
+            attestations[i].status = PriceAttestationStatus.Trading;
+        }
+
+        (bytes[] memory updateData, uint updateFee) = 
+            createBatchedUpdateDataFromAttestations(attestations);
+        PythStructs.PriceFeed[] memory priceFeeds =
+            pyth.parsePriceFeedUpdates{value: updateFee}(
+                updateData,
+                priceIds,
+                0,
+                MAX_UINT64
+            );
+
+        for(uint i = 0; i < numAttestations; i++) {
+            assertEq(priceFeeds[i].id, priceIds[i]);
+            assertEq(priceFeeds[i].price.price, attestations[i].price);
+            assertEq(priceFeeds[i].price.conf, attestations[i].conf);
+            assertEq(priceFeeds[i].price.expo, attestations[i].expo);
+            assertEq(priceFeeds[i].price.publishTime, attestations[i].publishTime);
+            assertEq(priceFeeds[i].emaPrice.price, attestations[i].emaPrice);
+            assertEq(priceFeeds[i].emaPrice.conf, attestations[i].emaConf);
+            assertEq(priceFeeds[i].emaPrice.expo, attestations[i].expo);
+            assertEq(priceFeeds[i].emaPrice.publishTime, attestations[i].publishTime);
+        }
+    }
+
+    function testParsePriceFeedUpdatesWorksWithUnknownStatus(uint seed) public {
+        setRandSeed(seed);
+        uint numAttestations = 1 + getRandUint() % 10;
+        (bytes32[] memory priceIds, PriceAttestation[] memory attestations) =
+            generateRandomPriceAttestations(numAttestations);
+
+        for(uint i = 0; i < numAttestations; i++) {
+            attestations[i].status = PriceAttestationStatus.Unknown;
+        }
+
+        (bytes[] memory updateData, uint updateFee) = 
+            createBatchedUpdateDataFromAttestations(attestations);
+        PythStructs.PriceFeed[] memory priceFeeds =
+            pyth.parsePriceFeedUpdates{value: updateFee}(
+                updateData,
+                priceIds,
+                0,
+                MAX_UINT64
+            );
+
+        for(uint i = 0; i < numAttestations; i++) {
+            assertEq(priceFeeds[i].id, priceIds[i]);
+            assertEq(priceFeeds[i].price.price, attestations[i].prevPrice);
+            assertEq(priceFeeds[i].price.conf, attestations[i].prevConf);
+            assertEq(priceFeeds[i].price.expo, attestations[i].expo);
+            assertEq(priceFeeds[i].price.publishTime, attestations[i].prevPublishTime);
+            assertEq(priceFeeds[i].emaPrice.price, attestations[i].emaPrice);
+            assertEq(priceFeeds[i].emaPrice.conf, attestations[i].emaConf);
+            assertEq(priceFeeds[i].emaPrice.expo, attestations[i].expo);
+            assertEq(priceFeeds[i].emaPrice.publishTime, attestations[i].prevPublishTime);
+        }
+    }
+
+    function testParsePriceFeedUpdatesWorksWithRandomDistinctUpdatesInput(uint seed) public {
+        setRandSeed(seed);
+        uint numAttestations = 1 + getRandUint() % 30;
+        (bytes32[] memory priceIds, PriceAttestation[] memory attestations) =
+            generateRandomPriceAttestations(numAttestations);
+
+        (bytes[] memory updateData, uint updateFee) = 
+            createBatchedUpdateDataFromAttestations(attestations);
+
+        // Shuffle the attestations
+        for (uint i = 1; i < numAttestations; i++) {
+            uint swapWith = getRandUint() % (i+1);
+            (attestations[i], attestations[swapWith]) = (attestations[swapWith], attestations[i]);
+            (priceIds[i], priceIds[swapWith]) = (priceIds[swapWith], priceIds[i]);
+        }
+
+        // Select only first numSelectedAttestations. numSelectedAttestations will be in [0, numAttestations]
+        uint numSelectedAttestations = getRandUint() % (numAttestations + 1);
+
+        PriceAttestation[] memory selectedAttestations = new PriceAttestation[](numSelectedAttestations);
+        bytes32[] memory selectedPriceIds = new bytes32[](numSelectedAttestations);
+
+        for (uint i = 0; i < numSelectedAttestations; i++) {
+            selectedAttestations[i] = attestations[i];
+            selectedPriceIds[i] = priceIds[i];
+        }
+
+        // Only parse selected attestations 
+        PythStructs.PriceFeed[] memory priceFeeds =
+            pyth.parsePriceFeedUpdates{value: updateFee}(
+                updateData,
+                selectedPriceIds,
+                0,
+                MAX_UINT64
+            );
+
+        for(uint i = 0; i < numSelectedAttestations; i++) {
+            assertEq(priceFeeds[i].id, selectedPriceIds[i]);
+            assertEq(priceFeeds[i].price.expo, selectedAttestations[i].expo);
+            assertEq(priceFeeds[i].emaPrice.price, selectedAttestations[i].emaPrice);
+            assertEq(priceFeeds[i].emaPrice.conf, selectedAttestations[i].emaConf);
+            assertEq(priceFeeds[i].emaPrice.expo, selectedAttestations[i].expo);
+
+            if (selectedAttestations[i].status == PriceAttestationStatus.Trading) {
+                assertEq(priceFeeds[i].price.price, selectedAttestations[i].price);
+                assertEq(priceFeeds[i].price.conf, selectedAttestations[i].conf);
+                assertEq(priceFeeds[i].price.publishTime, selectedAttestations[i].publishTime);
+                assertEq(priceFeeds[i].emaPrice.publishTime, selectedAttestations[i].publishTime);
+            } else {
+                assertEq(priceFeeds[i].price.price, selectedAttestations[i].prevPrice);
+                assertEq(priceFeeds[i].price.conf, selectedAttestations[i].prevConf);
+                assertEq(priceFeeds[i].price.publishTime, selectedAttestations[i].prevPublishTime);
+                assertEq(priceFeeds[i].emaPrice.publishTime, selectedAttestations[i].prevPublishTime);
+            }
+        }
+    }
+
+    function testParsePriceFeedUpdatesWorksWithOverlappingWithinTimeRangeUpdates() public {
+        PriceAttestation[] memory attestations = new PriceAttestation[](2);
+
+        attestations[0].priceId = bytes32(uint(1));
+        attestations[0].status = PriceAttestationStatus.Trading;
+        attestations[0].price = 1000;
+        attestations[0].publishTime = 10;
+
+        attestations[1].priceId = bytes32(uint(1));
+        attestations[1].status = PriceAttestationStatus.Trading;
+        attestations[1].price = 2000;
+        attestations[1].publishTime = 20;
+        
+        (bytes[] memory updateData, uint updateFee) = 
+            createBatchedUpdateDataFromAttestations(attestations);
+
+        bytes32[] memory priceIds = new bytes32[](1);
+        priceIds[0] = bytes32(uint(1));
+
+        PythStructs.PriceFeed[] memory priceFeeds =
+            pyth.parsePriceFeedUpdates{value: updateFee}(
+                updateData,
+                priceIds,
+                0,
+                20
+            );
+        
+        assertEq(priceFeeds.length, 1);
+        assertEq(priceFeeds[0].id, bytes32(uint(1)));
+        
+        assertTrue(
+            (priceFeeds[0].price.price == 1000 && priceFeeds[0].price.publishTime == 10) ||
+            (priceFeeds[0].price.price == 2000 && priceFeeds[0].price.publishTime == 20)
+        );
+    }
+
+    function testParsePriceFeedUpdatesWorksWithOverlappingMixedTimeRangeUpdates() public {
+        PriceAttestation[] memory attestations = new PriceAttestation[](2);
+
+        attestations[0].priceId = bytes32(uint(1));
+        attestations[0].status = PriceAttestationStatus.Trading;
+        attestations[0].price = 1000;
+        attestations[0].publishTime = 10;
+
+        attestations[1].priceId = bytes32(uint(1));
+        attestations[1].status = PriceAttestationStatus.Trading;
+        attestations[1].price = 2000;
+        attestations[1].publishTime = 20;
+        
+        (bytes[] memory updateData, uint updateFee) = 
+            createBatchedUpdateDataFromAttestations(attestations);
+
+        bytes32[] memory priceIds = new bytes32[](1);
+        priceIds[0] = bytes32(uint(1));
+
+        PythStructs.PriceFeed[] memory priceFeeds =
+            pyth.parsePriceFeedUpdates{value: updateFee}(
+                updateData,
+                priceIds,
+                5,
+                15
+            );
+        
+        assertEq(priceFeeds.length, 1);
+        assertEq(priceFeeds[0].id, bytes32(uint(1)));
+        assertEq(priceFeeds[0].price.price, 1000);
+        assertEq(priceFeeds[0].price.publishTime, 10);
+
+        priceFeeds =
+            pyth.parsePriceFeedUpdates{value: updateFee}(
+                updateData,
+                priceIds,
+                15,
+                25
+            );
+        
+        assertEq(priceFeeds.length, 1);
+        assertEq(priceFeeds[0].id, bytes32(uint(1)));
+        assertEq(priceFeeds[0].price.price, 2000);
+        assertEq(priceFeeds[0].price.publishTime, 20);
+    }
+
+    function testParsePriceFeedUpdatesRevertsIfUpdateFeeIsNotPaid() public {
+        uint numAttestations = 10;
+        (bytes32[] memory priceIds, PriceAttestation[] memory attestations) =
+            generateRandomPriceAttestations(numAttestations);
+
+        (bytes[] memory updateData, uint updateFee) = 
+            createBatchedUpdateDataFromAttestations(attestations);
+
+        // Since attestations are not empty the fee should be at least 1        
+        assertGe(updateFee, 1);
+
+        vm.expectRevert(bytes("insufficient paid fee amount"));
+
+        pyth.parsePriceFeedUpdates{value: updateFee-1}(
+            updateData,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+    }
+
+    function testParsePriceFeedUpdatesRevertsIfUpdateVAAIsInavlid(uint seed) public {
+        setRandSeed(seed);
+        uint numAttestations = 1 + getRandUint() % 10;
+        (bytes32[] memory priceIds, PriceAttestation[] memory attestations) =
+            generateRandomPriceAttestations(numAttestations);
+
+        (bytes[] memory updateData, uint updateFee) = 
+            createBatchedUpdateDataFromAttestations(attestations);
+        
+        uint mutPos = getRandUint() % updateData[0].length;
+        
+        // mutate the random position by 1 bit
+        updateData[0][mutPos] = bytes1(uint8(updateData[0][mutPos])^1);
+
+        // It might revert due to different wormhole errors
+        vm.expectRevert();
+        pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+    }
+
+    function testParsePriceFeedUpdatesRevertsIfUpdateSourceChainIsInavlid() public {
+        uint numAttestations = 10;
+        (bytes32[] memory priceIds, PriceAttestation[] memory attestations) =
+            generateRandomPriceAttestations(numAttestations);
+
+        bytes[] memory updateData = new bytes[](1);
+        updateData[0] = generateVaa(
+            uint32(block.timestamp),
+            SOURCE_EMITTER_CHAIN_ID + 1,
+            SOURCE_EMITTER_ADDRESS,
+            1, // Sequence
+            generatePriceFeedUpdatePayload(attestations),
+            1 // Num signers
+        );
+
+        uint updateFee = pyth.getUpdateFee(updateData);
+        
+        vm.expectRevert(bytes("invalid data source chain/emitter ID"));
+        pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+    }
+
+    function testParsePriceFeedUpdatesRevertsIfUpdateSourceAddressIsInavlid() public {
+        uint numAttestations = 10;
+        (bytes32[] memory priceIds, PriceAttestation[] memory attestations) =
+            generateRandomPriceAttestations(numAttestations);
+
+        bytes[] memory updateData = new bytes[](1);
+        updateData[0] = generateVaa(
+            uint32(block.timestamp),
+            SOURCE_EMITTER_CHAIN_ID,
+            0x00000000000000000000000000000000000000000000000000000000000000aa, // Random wrong source address
+            1, // Sequence
+            generatePriceFeedUpdatePayload(attestations),
+            1 // Num signers
+        );
+
+        uint updateFee = pyth.getUpdateFee(updateData);
+        
+        vm.expectRevert(bytes("invalid data source chain/emitter ID"));
+        pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+    }
+
+
+    function testParsePriceFeedUpdatesRevertsIfPriceIdNotIncluded() public {
+        PriceAttestation[] memory attestations = new PriceAttestation[](1);
+
+        attestations[0].priceId = bytes32(uint(1));
+        attestations[0].status = PriceAttestationStatus.Trading;
+        attestations[0].price = 1000;
+        attestations[0].publishTime = 10;
+
+
+        (bytes[] memory updateData, uint updateFee) = 
+            createBatchedUpdateDataFromAttestations(attestations);
+        
+        bytes32[] memory priceIds = new bytes32[](1);
+        priceIds[0] = bytes32(uint(2));
+
+        vm.expectRevert(bytes("1 or more price feeds are not found in the updateData or they are out of the given time range"));
+        pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+    }
+
+    function testParsePriceFeedUpdateRevertsIfPricesOutOfTimeRange() public {
+        uint numAttestations = 10;
+        (bytes32[] memory priceIds, PriceAttestation[] memory attestations) =
+            generateRandomPriceAttestations(numAttestations);
+
+        for(uint i = 0; i < numAttestations; i++) {
+            // Set status to Trading so publishTime is used
+            attestations[i].status = PriceAttestationStatus.Trading;
+            attestations[i].publishTime = uint64(100 + getRandUint() % 101); // All between [100, 200]
+        }
+
+        (bytes[] memory updateData, uint updateFee) = 
+            createBatchedUpdateDataFromAttestations(attestations);
+
+        // Request for parse within the given time range should work
+        pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            100,
+            200
+        );
+        
+        // Request for parse after the time range should revert.
+        vm.expectRevert(bytes("1 or more price feeds are not found in the updateData or they are out of the given time range"));
+        pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            300,
+            MAX_UINT64
+        );
+    }
+}

--- a/ethereum/forge-test/utils/RandTestUtils.t.sol
+++ b/ethereum/forge-test/utils/RandTestUtils.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "forge-std/Test.sol";
+
+contract RandTestUtils is Test {
+    uint randSeed;
+
+    function setRandSeed(uint seed) internal {
+        randSeed = seed;
+    }
+
+    function getRandBytes32() internal returns (bytes32) {
+        unchecked { randSeed++; }
+        return keccak256(abi.encode(randSeed));
+    }
+    
+    function getRandUint() internal returns (uint) {
+        return uint(getRandBytes32());
+    }
+
+    function getRandUint64() internal returns (uint64) {
+        return uint64(getRandUint());
+    }
+
+    function getRandInt64() internal returns (int64) {
+        return int64(getRandUint64());
+    }
+
+    function getRandUint32() internal returns (uint32) {
+        return uint32(getRandUint());
+    }
+
+    function getRandInt32() internal returns (int32) {
+        return int32(getRandUint32());
+    }
+}


### PR DESCRIPTION
Adds the implementation and tests and benchmarks for it (on Foundry). The tests that take an input are fuzzy and run a couple of times (256 by default).

There is a corner case when updateData contains multiple updates for the same ID. The code will chose any (the first one) within the given time range and we do not guarantee anything else. It was not clear to me whether earliest is better or the oldest. 

This change is divided in two commits, first the implementation with duplicate code. The second commit tries to reduce the redundancy a little bit without sacrificing much gas. The difference is which is acceptable:

```
testBenchmarkParsePriceFeedUpdatesForTwoPriceFeed() (gas: 67 (0.021%)) 
testBenchmarkParsePriceFeedUpdatesForOnePriceFeedNotWithinRange() (gas: 73 (0.023%)) 
testBenchmarkParsePriceFeedUpdatesForOnePriceFeed() (gas: 73 (0.024%)) 
testBenchmarkUpdatePriceFeedsIfNecessaryFresh() (gas: 269 (0.071%)) 
testBenchmarkUpdatePriceFeedsFresh() (gas: 269 (0.076%)) 
testBenchmarkUpdatePriceFeedsNotFresh() (gas: 269 (0.086%)) 
```
