### PR TITLE
[eth] Add CI for Foundry tests

### DIFF
--- a/.github/workflows/ethereum-contract.yml
+++ b/.github/workflows/ethereum-contract.yml
@@ -18,6 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Build XC-governance sdk
+        run: npm ci
+        working-directory: third_party/pyth/xc-governance-sdk-js
+
       - name: Install contract npm dependencies
         run: npm ci
 

--- a/.github/workflows/ethereum-contract.yml
+++ b/.github/workflows/ethereum-contract.yml
@@ -1,0 +1,29 @@
+on:
+  pull_request:
+    # paths: [ethereum/**]
+  push:
+    branches:
+      - main
+    # paths: [ethereum/**]
+
+name: Ethereum Contract
+
+jobs:
+  check:
+    name: Foundry tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run tests
+        run: forge test -vvv
+
+      - name: Run snapshot
+        run: NO_COLOR=1 forge snapshot --match-contract GasBenchmark >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ethereum-contract.yml
+++ b/.github/workflows/ethereum-contract.yml
@@ -1,10 +1,14 @@
 on:
   pull_request:
-    # paths: [ethereum/**]
+    paths: 
+    - ethereum/**
+    - third_party/pyth/xc-governance-sdk-js/**
   push:
     branches:
       - main
-    # paths: [ethereum/**]
+    paths: 
+    - ethereum/**
+    - third_party/pyth/xc-governance-sdk-js/**
 
 name: Ethereum Contract
 
@@ -18,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build XC-governance sdk
+      - name: Install XC-governance sdk dependencies
         run: npm ci
         working-directory: third_party/pyth/xc-governance-sdk-js
 

--- a/.github/workflows/ethereum-contract.yml
+++ b/.github/workflows/ethereum-contract.yml
@@ -12,15 +12,22 @@ jobs:
   check:
     name: Foundry tests
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ethereum/
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: recursive
+
+      - name: Install contract npm dependencies
+        run: npm ci
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
+      
+      - name: Install Forge dependencies
+        run: npm run install-forge-deps
 
       - name: Run tests
         run: forge test -vvv


### PR DESCRIPTION
Add Foundry tests for the ethereum contract to the CI. They will be executed once a file within related directories change. Please see [this](https://github.com/pyth-network/pyth-crosschain/actions/runs/3539336678) as a successful output.