### PR TITLE
[price-service] Fine-tune metrics

### DIFF
--- a/prometheus_config.yaml
+++ b/prometheus_config.yaml
@@ -3,3 +3,7 @@ scrape_configs:
     scrape_interval: 5s
     static_configs:
       - targets: ["p2w-attest:3000"]
+  - job_name: price_service
+    scrape_interval: 5s
+    static_configs:
+      - targets: ["pyth-price-service:8081"]

--- a/third_party/pyth/price-service/package-lock.json
+++ b/third_party/pyth/price-service/package-lock.json
@@ -25,6 +25,7 @@
         "express-validation": "^4.0.1",
         "http-status-codes": "^2.2.0",
         "joi": "^17.6.0",
+        "lru-cache": "^7.14.1",
         "morgan": "^1.10.0",
         "prom-client": "^14.0.1",
         "response-time": "^2.3.2",
@@ -56,7 +57,7 @@
       "dependencies": {
         "@certusone/wormhole-sdk": "0.2.1",
         "@improbable-eng/grpc-web-node-http-transport": "^0.14.1",
-        "@pythnetwork/pyth-sdk-js": "^1.0.0"
+        "@pythnetwork/pyth-sdk-js": "^1.1.0"
       },
       "devDependencies": {
         "@openzeppelin/contracts": "^4.2.0",
@@ -6455,6 +6456,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/jest-snapshot/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jest-snapshot/node_modules/semver": {
       "version": "7.3.7",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
@@ -6996,15 +7009,11 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+      "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -8317,6 +8326,18 @@
         }
       }
     },
+    "node_modules/superagent/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/superagent/node_modules/mime": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -8616,6 +8637,18 @@
         "esbuild": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ts-jest/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
@@ -10532,7 +10565,7 @@
         "@certusone/wormhole-sdk": "0.2.1",
         "@improbable-eng/grpc-web-node-http-transport": "^0.14.1",
         "@openzeppelin/contracts": "^4.2.0",
-        "@pythnetwork/pyth-sdk-js": "^1.0.0",
+        "@pythnetwork/pyth-sdk-js": "^1.1.0",
         "@typechain/ethers-v5": "^7.1.2",
         "@types/long": "^4.0.1",
         "@types/node": "^16.6.1",
@@ -13857,6 +13890,15 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
         "semver": {
           "version": "7.3.7",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
@@ -14272,13 +14314,9 @@
       }
     },
     "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
-      }
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+      "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA=="
     },
     "make-dir": {
       "version": "3.1.0",
@@ -15251,6 +15289,15 @@
             "ms": "2.1.2"
           }
         },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
         "mime": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -15467,6 +15514,15 @@
         "yargs-parser": "^20.x"
       },
       "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
         "semver": {
           "version": "7.3.7",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",

--- a/third_party/pyth/price-service/package.json
+++ b/third_party/pyth/price-service/package.json
@@ -44,6 +44,7 @@
     "express-validation": "^4.0.1",
     "http-status-codes": "^2.2.0",
     "joi": "^17.6.0",
+    "lru-cache": "^7.14.1",
     "morgan": "^1.10.0",
     "prom-client": "^14.0.1",
     "response-time": "^2.3.2",

--- a/third_party/pyth/price-service/src/__tests__/rest.test.ts
+++ b/third_party/pyth/price-service/src/__tests__/rest.test.ts
@@ -41,7 +41,7 @@ function dummyPriceInfoPair(
       priceFeed: dummyPriceFeed(id),
       attestationTime: 0,
       seqNum,
-      vaaBytes: Buffer.from(vaa, "hex").toString("binary"),
+      vaa: Buffer.from(vaa, "hex"),
       emitterChainId: 0,
       priceServiceReceiveTime: 0,
     },

--- a/third_party/pyth/price-service/src/__tests__/rest.test.ts
+++ b/third_party/pyth/price-service/src/__tests__/rest.test.ts
@@ -39,6 +39,7 @@ function dummyPriceInfoPair(
     id,
     {
       priceFeed: dummyPriceFeed(id),
+      publishTime: 0,
       attestationTime: 0,
       seqNum,
       vaa: Buffer.from(vaa, "hex"),

--- a/third_party/pyth/price-service/src/__tests__/ws.test.ts
+++ b/third_party/pyth/price-service/src/__tests__/ws.test.ts
@@ -43,7 +43,7 @@ function dummyPriceInfo(
     attestationTime: dummyPriceMetadataValue.attestation_time,
     emitterChainId: dummyPriceMetadataValue.emitter_chain,
     priceFeed: dummyPriceFeed(id),
-    vaaBytes: Buffer.from(vaa, "hex").toString("binary"),
+    vaa: Buffer.from(vaa, "hex"),
     priceServiceReceiveTime: dummyPriceMetadataValue.price_service_receive_time,
   };
 }

--- a/third_party/pyth/price-service/src/__tests__/ws.test.ts
+++ b/third_party/pyth/price-service/src/__tests__/ws.test.ts
@@ -40,6 +40,7 @@ function dummyPriceInfo(
 ): PriceInfo {
   return {
     seqNum: dummyPriceMetadataValue.sequence_number,
+    publishTime: 0,
     attestationTime: dummyPriceMetadataValue.attestation_time,
     emitterChainId: dummyPriceMetadataValue.emitter_chain,
     priceFeed: dummyPriceFeed(id),

--- a/third_party/pyth/price-service/src/promClient.ts
+++ b/third_party/pyth/price-service/src/promClient.ts
@@ -35,11 +35,6 @@ export class PromClient {
     help: "Summary of attestation time gaps between price updates",
     buckets: [1, 3, 5, 10, 15, 30, 60, 120],
   });
-  private apiResponseTimeSummary = new client.Summary({
-    name: `${SERVICE_PREFIX}api_response_time_ms`,
-    help: "Response time of a VAA",
-    labelNames: ["path", "status"],
-  });
   private webSocketInteractionCounter = new client.Counter({
     name: `${SERVICE_PREFIX}websocket_interaction`,
     help: "number of Web Socket interactions",
@@ -64,7 +59,6 @@ export class PromClient {
     this.register.registerMetric(this.receivedVaaCounter);
     this.register.registerMetric(this.priceUpdatesPublishTimeGapHistogram);
     this.register.registerMetric(this.priceUpdatesAttestationTimeGapHistogram);
-    this.register.registerMetric(this.apiResponseTimeSummary);
     this.register.registerMetric(this.webSocketInteractionCounter);
     // End registering metric
 
@@ -82,16 +76,6 @@ export class PromClient {
 
   addPriceUpdatesAttestationTimeGap(gap: DurationInSec) {
     this.priceUpdatesAttestationTimeGapHistogram.observe(gap);
-  }
-
-  addResponseTime(path: string, status: number, duration: DurationInMs) {
-    this.apiResponseTimeSummary.observe(
-      {
-        path,
-        status,
-      },
-      duration
-    );
   }
 
   addWebSocketInteraction(

--- a/third_party/pyth/price-service/src/promClient.ts
+++ b/third_party/pyth/price-service/src/promClient.ts
@@ -27,9 +27,14 @@ export class PromClient {
     name: `${SERVICE_PREFIX}vaas_received`,
     help: "number of Pyth VAAs received",
   });
-  private priceUpdatesGapHistogram = new client.Histogram({
-    name: `${SERVICE_PREFIX}price_updates_gap_seconds`,
-    help: "Summary of gaps between price updates",
+  private priceUpdatesPublishTimeGapHistogram = new client.Histogram({
+    name: `${SERVICE_PREFIX}price_updates_publish_time_gap_seconds`,
+    help: "Summary of publish time gaps between price updates",
+    buckets: [1, 3, 5, 10, 15, 30, 60, 120],
+  });
+  private priceUpdatesAttestationTimeGapHistogram = new client.Histogram({
+    name: `${SERVICE_PREFIX}price_updates_attestation_time_gap_seconds`,
+    help: "Summary of attestation time gaps between price updates",
     buckets: [1, 3, 5, 10, 15, 30, 60, 120],
   });
   private apiResponseTimeSummary = new client.Summary({
@@ -59,7 +64,8 @@ export class PromClient {
     });
     // Register each metric
     this.register.registerMetric(this.receivedVaaCounter);
-    this.register.registerMetric(this.priceUpdatesGapHistogram);
+    this.register.registerMetric(this.priceUpdatesPublishTimeGapHistogram);
+    this.register.registerMetric(this.priceUpdatesAttestationTimeGapHistogram);
     this.register.registerMetric(this.apiResponseTimeSummary);
     this.register.registerMetric(this.webSocketInteractionCounter);
     // End registering metric
@@ -72,8 +78,12 @@ export class PromClient {
     this.receivedVaaCounter.inc();
   }
 
-  addPriceUpdatesGap(gap: DurationInSec) {
-    this.priceUpdatesGapHistogram.observe(gap);
+  addPriceUpdatesPublishTimeGap(gap: DurationInSec) {
+    this.priceUpdatesPublishTimeGapHistogram.observe(gap);
+  }
+
+  addPriceUpdatesAttestationTimeGap(gap: DurationInSec) {
+    this.priceUpdatesAttestationTimeGapHistogram.observe(gap);
   }
 
   // We have multiple paths and for the time being it is not important for us

--- a/third_party/pyth/price-service/src/promClient.ts
+++ b/third_party/pyth/price-service/src/promClient.ts
@@ -1,4 +1,3 @@
-import { stat } from "fs";
 import http = require("http");
 import client = require("prom-client");
 import { DurationInMs, DurationInSec } from "./helpers";
@@ -20,7 +19,6 @@ type WebSocketInteractionType =
 
 export class PromClient {
   private register = new client.Registry();
-  private collectDefaultMetrics = client.collectDefaultMetrics;
 
   // Actual metrics
   private receivedVaaCounter = new client.Counter({
@@ -40,7 +38,7 @@ export class PromClient {
   private apiResponseTimeSummary = new client.Summary({
     name: `${SERVICE_PREFIX}api_response_time_ms`,
     help: "Response time of a VAA",
-    labelNames: ["status"],
+    labelNames: ["path", "status"],
   });
   private webSocketInteractionCounter = new client.Counter({
     name: `${SERVICE_PREFIX}websocket_interaction`,
@@ -86,11 +84,10 @@ export class PromClient {
     this.priceUpdatesAttestationTimeGapHistogram.observe(gap);
   }
 
-  // We have multiple paths and for the time being it is not important for us
-  // to capture it. We might consider capturing it in the future.
-  addResponseTime(_path: string, status: number, duration: DurationInMs) {
+  addResponseTime(path: string, status: number, duration: DurationInMs) {
     this.apiResponseTimeSummary.observe(
       {
+        path,
         status,
       },
       duration

--- a/third_party/pyth/price-service/src/rest.ts
+++ b/third_party/pyth/price-service/src/rest.ts
@@ -88,7 +88,7 @@ export class RestAPI {
 
         // Multiple price ids might share same vaa, we use sequence number as
         // key of a vaa and deduplicate using a map of seqnum to vaa bytes.
-        const vaaMap = new Map<number, string>();
+        const vaaMap = new Map<number, Buffer>();
 
         const notFoundIds: string[] = [];
 
@@ -104,24 +104,15 @@ export class RestAPI {
             continue;
           }
 
-          const freshness: DurationInSec =
-            new Date().getTime() / 1000 -
-            latestPriceInfo.priceFeed.getPriceUnchecked().publishTime;
-          this.promClient?.addApiRequestsPriceFreshness(
-            req.path,
-            id,
-            freshness
-          );
-
-          vaaMap.set(latestPriceInfo.seqNum, latestPriceInfo.vaaBytes);
+          vaaMap.set(latestPriceInfo.seqNum, latestPriceInfo.vaa);
         }
 
         if (notFoundIds.length > 0) {
           throw RestException.PriceFeedIdNotFound(notFoundIds);
         }
 
-        const jsonResponse = Array.from(vaaMap.values(), (vaaBytes) =>
-          Buffer.from(vaaBytes, "binary").toString("base64")
+        const jsonResponse = Array.from(vaaMap.values(), (vaa) =>
+          vaa.toString("base64")
         );
 
         res.json(jsonResponse);
@@ -162,15 +153,6 @@ export class RestAPI {
             notFoundIds.push(id);
             continue;
           }
-
-          const freshness: DurationInSec =
-            new Date().getTime() / 1000 -
-            latestPriceInfo.priceFeed.getEmaPriceUnchecked().publishTime;
-          this.promClient?.addApiRequestsPriceFreshness(
-            req.path,
-            id,
-            freshness
-          );
 
           if (verbose) {
             responseJson.push({

--- a/third_party/pyth/price-service/src/rest.ts
+++ b/third_party/pyth/price-service/src/rest.ts
@@ -63,14 +63,6 @@ export class RestAPI {
 
     app.use(morgan(MORGAN_LOG_FORMAT, { stream: winstonStream }));
 
-    app.use(
-      responseTime((req: Request, res: Response, time: DurationInMs) => {
-        if (res.statusCode !== StatusCodes.NOT_FOUND) {
-          this.promClient?.addResponseTime(req.path, res.statusCode, time);
-        }
-      })
-    );
-
     const endpoints: string[] = [];
 
     const latestVaasInputSchema: schema = {


### PR DESCRIPTION
- Remove nodejs default metrics. We don't use them.
- Remove response time metric.
- Remove freshness metric and add gap metric for attestationTime and publishTime.
  They are similar; however, freshness was measured upon user request but gap is
  measured upon receiving the next update.
- Change receivedVaa to actually represent distinct vaa received. Prior
  to this, the older vaas, or vaas with same attestation time were
  not counted in this metric. This will also improve the performance.
- Refactors the code a little. `vaaBytes` type was not string and was
  Buffer. It is fixed now.