### PR TITLE
[eth] Use PythErrors everywhere

### DIFF
--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -482,10 +482,6 @@ abstract contract Pyth is PythGetters, PythSetters, AbstractPyth {
                             index,
                             attestationSize
                         );
-                    require(
-                        info.publishTime != 0,
-                        "price feed for the given id is not pushed or does not exist"
-                    );
 
                     priceFeeds[k].id = priceId;
                     priceFeeds[k].price.price = info.price;

--- a/ethereum/contracts/pyth/PythGovernanceInstructions.sol
+++ b/ethereum/contracts/pyth/PythGovernanceInstructions.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.0;
 
 import "../libraries/external/BytesLib.sol";
 import "./PythInternalStructs.sol";
+import "@pythnetwork/pyth-sdk-solidity/PythErrors.sol";
 
 /**
  * @dev `PythGovernanceInstructions` defines a set of structs and parsing functions
@@ -75,17 +76,16 @@ contract PythGovernanceInstructions {
         uint index = 0;
 
         uint32 magic = encodedInstruction.toUint32(index);
-        require(magic == MAGIC, "invalid magic for GovernanceInstruction");
+
+        if (magic != MAGIC) revert PythErrors.InvalidGovernanceMessage();
+
         index += 4;
 
         uint8 modNumber = encodedInstruction.toUint8(index);
         gi.module = GovernanceModule(modNumber);
         index += 1;
 
-        require(
-            gi.module == MODULE,
-            "invalid module for GovernanceInstruction"
-        );
+        if (gi.module != MODULE) revert PythErrors.InvalidGovernanceTarget();
 
         uint8 actionNumber = encodedInstruction.toUint8(index);
         gi.action = GovernanceAction(actionNumber);
@@ -112,10 +112,8 @@ contract PythGovernanceInstructions {
         uc.newImplementation = address(encodedPayload.toAddress(index));
         index += 20;
 
-        require(
-            encodedPayload.length == index,
-            "invalid length for UpgradeContractPayload"
-        );
+        if (encodedPayload.length != index)
+            revert PythErrors.InvalidGovernanceMessage();
     }
 
     /// @dev Parse a AuthorizeGovernanceDataSourceTransferPayload (action 2) with minimal validation
@@ -142,10 +140,8 @@ contract PythGovernanceInstructions {
         sgdsClaim.governanceDataSourceIndex = encodedPayload.toUint32(index);
         index += 4;
 
-        require(
-            encodedPayload.length == index,
-            "invalid length for RequestGovernanceDataSourceTransferPayload"
-        );
+        if (encodedPayload.length != index)
+            revert PythErrors.InvalidGovernanceMessage();
     }
 
     /// @dev Parse a SetDataSourcesPayload (action 3) with minimal validation
@@ -169,10 +165,8 @@ contract PythGovernanceInstructions {
             index += 32;
         }
 
-        require(
-            encodedPayload.length == index,
-            "invalid length for SetDataSourcesPayload"
-        );
+        if (encodedPayload.length != index)
+            revert PythErrors.InvalidGovernanceMessage();
     }
 
     /// @dev Parse a SetFeePayload (action 4) with minimal validation
@@ -189,10 +183,8 @@ contract PythGovernanceInstructions {
 
         sf.newFee = uint256(val) * uint256(10) ** uint256(expo);
 
-        require(
-            encodedPayload.length == index,
-            "invalid length for SetFeePayload"
-        );
+        if (encodedPayload.length != index)
+            revert PythErrors.InvalidGovernanceMessage();
     }
 
     /// @dev Parse a SetValidPeriodPayload (action 5) with minimal validation
@@ -204,9 +196,7 @@ contract PythGovernanceInstructions {
         svp.newValidPeriod = uint256(encodedPayload.toUint64(index));
         index += 8;
 
-        require(
-            encodedPayload.length == index,
-            "invalid length for SetValidPeriodPayload"
-        );
+        if (encodedPayload.length != index)
+            revert PythErrors.InvalidGovernanceMessage();
     }
 }

--- a/ethereum/contracts/pyth/PythUpgradable.sol
+++ b/ethereum/contracts/pyth/PythUpgradable.sol
@@ -11,6 +11,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "./PythGovernance.sol";
 import "./Pyth.sol";
+import "@pythnetwork/pyth-sdk-solidity/PythErrors.sol";
 
 contract PythUpgradable is
     Initializable,

--- a/ethereum/contracts/pyth/PythUpgradable.sol
+++ b/ethereum/contracts/pyth/PythUpgradable.sol
@@ -127,11 +127,10 @@ contract PythUpgradable is
         _upgradeToAndCallUUPS(payload.newImplementation, new bytes(0), false);
 
         // Calling a method using `this.<method>` will cause a contract call that will use
-        // the new contract.
-        require(
-            this.pythUpgradableMagic() == 0x97a6f304,
-            "the new implementation is not a Pyth contract"
-        );
+        // the new contract. This call will fail if the method does not exists or the magic
+        // is different.
+        if (this.pythUpgradableMagic() != 0x97a6f304)
+            revert PythErrors.InvalidGovernanceMessage();
 
         emit ContractUpgraded(oldImplementation, _getImplementation());
     }

--- a/ethereum/forge-test/GasBenchmark.t.sol
+++ b/ethereum/forge-test/GasBenchmark.t.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "forge-std/Test.sol";
 
 import "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
+import "@pythnetwork/pyth-sdk-solidity/PythErrors.sol";
 import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
 import "./utils/WormholeTestUtils.t.sol";
 import "./utils/PythTestUtils.t.sol";
@@ -139,11 +140,7 @@ contract GasBenchmark is Test, WormholeTestUtils, PythTestUtils {
     function testBenchmarkUpdatePriceFeedsIfNecessaryNotFresh() public {
         // Since the price is not advanced, the publishTimes are the same as the
         // ones in the contract.
-        vm.expectRevert(
-            bytes(
-                "no prices in the submitted batch have fresh prices, so this update will have no effect"
-            )
-        );
+        vm.expectRevert(PythErrors.NoFreshUpdate.selector);
 
         pyth.updatePriceFeedsIfNecessary{value: cachedPricesUpdateFee}(
             cachedPricesUpdateData,
@@ -183,11 +180,7 @@ contract GasBenchmark is Test, WormholeTestUtils, PythTestUtils {
         bytes32[] memory ids = new bytes32[](1);
         ids[0] = priceIds[0];
 
-        vm.expectRevert(
-            bytes(
-                "1 or more price feeds are not found in the updateData or they are out of the given time range"
-            )
-        );
+        vm.expectRevert(PythErrors.PriceFeedNotFoundWithinRange.selector);
         pyth.parsePriceFeedUpdates{value: freshPricesUpdateFee}(
             freshPricesUpdateData,
             ids,

--- a/ethereum/forge-test/Pyth.t.sol
+++ b/ethereum/forge-test/Pyth.t.sol
@@ -396,7 +396,7 @@ contract PythTest is Test, WormholeTestUtils, PythTestUtils, RandTestUtils {
         updateData[0][mutPos] = bytes1(uint8(updateData[0][mutPos]) ^ 1);
 
         // It might revert due to different wormhole errors
-        vm.expectRevert(PythErrors.InvalidWormholeVaa.selector);
+        vm.expectRevert();
         pyth.parsePriceFeedUpdates{value: updateFee}(
             updateData,
             priceIds,

--- a/ethereum/forge-test/Pyth.t.sol
+++ b/ethereum/forge-test/Pyth.t.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "forge-std/Test.sol";
 
 import "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
+import "@pythnetwork/pyth-sdk-solidity/PythErrors.sol";
 import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
 import "./utils/WormholeTestUtils.t.sol";
 import "./utils/PythTestUtils.t.sol";
@@ -364,7 +365,7 @@ contract PythTest is Test, WormholeTestUtils, PythTestUtils, RandTestUtils {
         // Since attestations are not empty the fee should be at least 1
         assertGe(updateFee, 1);
 
-        vm.expectRevert(bytes("insufficient paid fee amount"));
+        vm.expectRevert(PythErrors.InsufficientFee.selector);
 
         pyth.parsePriceFeedUpdates{value: updateFee - 1}(
             updateData,
@@ -395,7 +396,7 @@ contract PythTest is Test, WormholeTestUtils, PythTestUtils, RandTestUtils {
         updateData[0][mutPos] = bytes1(uint8(updateData[0][mutPos]) ^ 1);
 
         // It might revert due to different wormhole errors
-        vm.expectRevert();
+        vm.expectRevert(PythErrors.InvalidWormholeVaa.selector);
         pyth.parsePriceFeedUpdates{value: updateFee}(
             updateData,
             priceIds,
@@ -425,7 +426,7 @@ contract PythTest is Test, WormholeTestUtils, PythTestUtils, RandTestUtils {
 
         uint updateFee = pyth.getUpdateFee(updateData);
 
-        vm.expectRevert(bytes("invalid data source chain/emitter ID"));
+        vm.expectRevert(PythErrors.InvalidUpdateDataSource.selector);
         pyth.parsePriceFeedUpdates{value: updateFee}(
             updateData,
             priceIds,
@@ -455,7 +456,7 @@ contract PythTest is Test, WormholeTestUtils, PythTestUtils, RandTestUtils {
 
         uint updateFee = pyth.getUpdateFee(updateData);
 
-        vm.expectRevert(bytes("invalid data source chain/emitter ID"));
+        vm.expectRevert(PythErrors.InvalidUpdateDataSource.selector);
         pyth.parsePriceFeedUpdates{value: updateFee}(
             updateData,
             priceIds,
@@ -480,11 +481,7 @@ contract PythTest is Test, WormholeTestUtils, PythTestUtils, RandTestUtils {
         bytes32[] memory priceIds = new bytes32[](1);
         priceIds[0] = bytes32(uint(2));
 
-        vm.expectRevert(
-            bytes(
-                "1 or more price feeds are not found in the updateData or they are out of the given time range"
-            )
-        );
+        vm.expectRevert(PythErrors.PriceFeedNotFoundWithinRange.selector);
         pyth.parsePriceFeedUpdates{value: updateFee}(
             updateData,
             priceIds,
@@ -520,11 +517,7 @@ contract PythTest is Test, WormholeTestUtils, PythTestUtils, RandTestUtils {
         );
 
         // Request for parse after the time range should revert.
-        vm.expectRevert(
-            bytes(
-                "1 or more price feeds are not found in the updateData or they are out of the given time range"
-            )
-        );
+        vm.expectRevert(PythErrors.PriceFeedNotFoundWithinRange.selector);
         pyth.parsePriceFeedUpdates{value: updateFee}(
             updateData,
             priceIds,

--- a/ethereum/package-lock.json
+++ b/ethereum/package-lock.json
@@ -13,7 +13,7 @@
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
         "@openzeppelin/contracts": "^4.5.0",
         "@openzeppelin/contracts-upgradeable": "^4.5.2",
-        "@pythnetwork/pyth-sdk-solidity": "^2.1.0",
+        "@pythnetwork/pyth-sdk-solidity": "^2.2.0",
         "@pythnetwork/xc-governance-sdk": "file:../third_party/pyth/xc-governance-sdk-js",
         "dotenv": "^10.0.0",
         "elliptic": "^6.5.2",
@@ -5642,9 +5642,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "node_modules/@pythnetwork/pyth-sdk-solidity": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-2.1.0.tgz",
-      "integrity": "sha512-jHzqw+BHaCOAYwRNCgAUhcbNZrB5f3Arly3PaYN3/Tg7/5RQ95a9FD15XvJB1DB3yymUPIkmLYMur7Sh+e1G4A=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-2.2.0.tgz",
+      "integrity": "sha512-LsRMmaf9MTflGSymqOJMepFk/3R7DyxMOJfLDB5RDSieyiq+RJ5IYIYnXAFsMrqkjibOtVxARcortHtE9VWwhw=="
     },
     "node_modules/@pythnetwork/xc-governance-sdk": {
       "resolved": "../third_party/pyth/xc-governance-sdk-js",
@@ -45038,9 +45038,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@pythnetwork/pyth-sdk-solidity": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-2.1.0.tgz",
-      "integrity": "sha512-jHzqw+BHaCOAYwRNCgAUhcbNZrB5f3Arly3PaYN3/Tg7/5RQ95a9FD15XvJB1DB3yymUPIkmLYMur7Sh+e1G4A=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-2.2.0.tgz",
+      "integrity": "sha512-LsRMmaf9MTflGSymqOJMepFk/3R7DyxMOJfLDB5RDSieyiq+RJ5IYIYnXAFsMrqkjibOtVxARcortHtE9VWwhw=="
     },
     "@pythnetwork/xc-governance-sdk": {
       "version": "file:../third_party/pyth/xc-governance-sdk-js",

--- a/ethereum/package.json
+++ b/ethereum/package.json
@@ -32,7 +32,7 @@
     "@certusone/wormhole-sdk-wasm": "^0.0.1",
     "@openzeppelin/contracts": "^4.5.0",
     "@openzeppelin/contracts-upgradeable": "^4.5.2",
-    "@pythnetwork/pyth-sdk-solidity": "^2.1.0",
+    "@pythnetwork/pyth-sdk-solidity": "^2.2.0",
     "@pythnetwork/xc-governance-sdk": "file:../third_party/pyth/xc-governance-sdk-js",
     "dotenv": "^10.0.0",
     "elliptic": "^6.5.2",

--- a/ethereum/test/pyth.js
+++ b/ethereum/test/pyth.js
@@ -1105,10 +1105,10 @@ contract("Pyth", function () {
       2
     );
 
-    // Strangely this test was failing without the hard coded gas limit.
-    // It will failing randomly on a place that it shouldn't without any message due to
-    // gas limit if the value is not hard-coded.
-    // Gas value 6.7m gas is very high and close to the ganache limit.
+    // This test fails without the hard coded gas limit.
+    // Without gas limit, it fails on a random place (in wormhole sig verification) which
+    // is probably because truffle cannot estimate the gas usage correctly. So the gas is
+    // hard-coded to a high value of 6.7m gas (close to ganache limit).
     await expectRevertCustomError(
       this.pythProxy.executeGovernanceInstruction(transferBackVaaWrong, {
         gas: 6700000,
@@ -1388,7 +1388,6 @@ async function expectRevertCustomError(promise, reason) {
     expect.fail("Expected promise to throw but it didn't");
   } catch (revert) {
     if (reason) {
-      // expect(revert.message).to.include(reason);
       const reasonId = web3.utils.keccak256(reason + "()").substr(0, 10);
       expect(
         JSON.stringify(revert),


### PR DESCRIPTION
This PR uses PythErrors structs instead of error strings everywhere and updates the tests (both truffle and foundry). This change reduces contract size from 23.69KB to 20.94KB.

Notes:
- Error structs are only possible with `revert`. So I changed all `require` statements to `revert`.
- Truffle does not support error structs and I adopted a solution from [here](https://github.com/OpenZeppelin/openzeppelin-test-helpers/issues/180) and created `expectRevertCustomError`.