### PR TITLE
[eth]: Improve optimization runs to 10000

### DIFF
--- a/ethereum/contracts/pyth/PythState.sol
+++ b/ethereum/contracts/pyth/PythState.sol
@@ -30,8 +30,7 @@ contract PythStorage {
         // with a lower or equal sequence number will be discarded. This prevents double-execution,
         // and also makes sure that messages are executed in the right order.
         uint64 lastExecutedGovernanceSequence;
-        // Mapping of cached price information
-        // priceId => PriceInfo
+        // After a backward-incompatible change in PriceFeed this mapping got deprecated.
         mapping(bytes32 => PythDeprecatedStructs.DeprecatedPriceInfoV2) _deprecatedLatestPriceInfoV2;
         // Index of the governance data source, increased each time the governance data source
         // changes.

--- a/ethereum/foundry.toml
+++ b/ethereum/foundry.toml
@@ -1,7 +1,7 @@
 [profile.default]
 solc_version = '0.8.4'
 optimizer = true
-optimizer_runs = 1000
+optimizer_runs = 10000
 src = 'contracts'
 # We put the tests into the forge-test directory (instead of test) so that
 # truffle doesn't try to build them

--- a/ethereum/truffle-config.js
+++ b/ethereum/truffle-config.js
@@ -230,7 +230,7 @@ module.exports = {
       settings: {
         optimizer: {
           enabled: true,
-          runs: 1000,
+          runs: 10000,
         },
       },
     },


### PR DESCRIPTION
Now that the contract size is smaller we can increase the optimization runs again. This PR changes it to 10000. It changes contract size from 19.22KB to 21.16KB but saves more gas. Below is the snapshot difference:

```
testBenchmarkUpdatePriceFeedsIfNecessaryNotFresh() (gas: -24 (-0.014%)) 
testBenchmarkGetUpdateFee() (gas: -21 (-0.016%)) 
testBenchmarkGetEmaPrice() (gas: -18 (-0.071%)) 
testBenchmarkGetPrice() (gas: -30 (-0.128%)) 
testBenchmarkUpdatePriceFeedsIfNecessaryFresh() (gas: -801 (-0.212%)) 
testBenchmarkUpdatePriceFeedsFresh() (gas: -801 (-0.224%)) 
testBenchmarkParsePriceFeedUpdatesForTwoPriceFeed() (gas: -741 (-0.233%)) 
testBenchmarkUpdatePriceFeedsNotFresh() (gas: -741 (-0.235%)) 
testBenchmarkParsePriceFeedUpdatesForOnePriceFeed() (gas: -741 (-0.238%)) 
testBenchmarkParsePriceFeedUpdatesForOnePriceFeedNotWithinRange() (gas: -747 (-0.239%)) 
```

This PR also modifies a comment for a deprecated state variable.