### PR TITLE
[attester] Remove while true and wait instead

### DIFF
--- a/solana/pyth2wormhole/Cargo.lock
+++ b/solana/pyth2wormhole/Cargo.lock
@@ -2710,7 +2710,7 @@ dependencies = [
 
 [[package]]
 name = "pyth2wormhole-client"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "borsh",
  "clap 3.1.18",

--- a/solana/pyth2wormhole/client/Cargo.toml
+++ b/solana/pyth2wormhole/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth2wormhole-client"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/third_party/pyth/p2w_autoattest.py
+++ b/third_party/pyth/p2w_autoattest.py
@@ -248,8 +248,7 @@ while True:
     )
 
     # Wait for an unexpected process exit
-    while p2w_client_process.poll() is None:
-        pass
+    retcode = p2w_client_process.wait()
 
     # Yell if the supposedly non-stop attestation process exits
-    logging.warn(f"pyth2wormhole-client stopped unexpectedly with code {p2w_client_process.retcode}")
+    logging.warn(f"pyth2wormhole-client stopped unexpectedly with code {retcode}")


### PR DESCRIPTION
In the last change that I removed additional logs this loop became empty and I forgot to replace it with a better command. This empty while true was causing a high cpu usage for our attester and I verified it locally. Thanks @drozdziak1 for catching it. 