### PR TITLE
Update the VAA hash to use payload hash

### DIFF
--- a/third_party/pyth/price-service/package-lock.json
+++ b/third_party/pyth/price-service/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-price-service",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-price-service",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@certusone/wormhole-sdk": "^0.1.4",

--- a/third_party/pyth/price-service/package.json
+++ b/third_party/pyth/price-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-price-service",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Pyth Price Service",
   "main": "index.js",
   "scripts": {

--- a/third_party/pyth/price-service/src/listen.ts
+++ b/third_party/pyth/price-service/src/listen.ts
@@ -163,7 +163,7 @@ export class Listener implements PriceStore {
     const parsedVaa = parse_vaa(vaa);
 
     const vaaHash: VaaHash = createHash("md5")
-      .update(parsedVaa.payload)
+      .update(Buffer.from(parsedVaa.payload))
       .digest("base64");
 
     if (this.observedVaas.has(vaaHash)) {

--- a/third_party/pyth/price-service/src/listen.ts
+++ b/third_party/pyth/price-service/src/listen.ts
@@ -160,7 +160,11 @@ export class Listener implements PriceStore {
   async processVaa(vaa: Buffer) {
     const { parse_vaa } = await importCoreWasm();
 
-    const vaaHash: VaaHash = createHash("md5").update(vaa).digest("base64");
+    const parsedVaa = parse_vaa(vaa);
+
+    const vaaHash: VaaHash = createHash("md5")
+      .update(parsedVaa.payload)
+      .digest("base64");
 
     if (this.observedVaas.has(vaaHash)) {
       return;
@@ -168,8 +172,6 @@ export class Listener implements PriceStore {
 
     this.observedVaas.set(vaaHash, true);
     this.promClient?.incReceivedVaa();
-
-    const parsedVaa = parse_vaa(vaa);
 
     let batchAttestation;
 


### PR DESCRIPTION
Prior to this PR, we cached the VAAs and skipped them based on the entire VAA hash; Also we have a metric for counting distinct received VAAs. However, it seems that a VAA can have different signature sets and that will results in different hashes. 

This PR changes the hash to the hash of the VAA payload which is always unique.