### PR TITLE
[price-service] Update Vaa key for cache/metrics

### DIFF
--- a/third_party/pyth/price-service/package-lock.json
+++ b/third_party/pyth/price-service/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-price-service",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-price-service",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@certusone/wormhole-sdk": "^0.1.4",

--- a/third_party/pyth/price-service/package.json
+++ b/third_party/pyth/price-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-price-service",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Pyth Price Service",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In #422 I used the payload as the key for VAA hash and metric count. However, there might be possible cases that this metric is not unique. This PR changes that to the tuple of `(emitter_chain_id, emitter_address, sequence)` which is guaranteed to be unique per VAA.