### PR TITLE
[price-service] Make gap metrics more accurate

### DIFF
--- a/third_party/pyth/price-service/package-lock.json
+++ b/third_party/pyth/price-service/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-price-service",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-price-service",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@certusone/wormhole-sdk": "^0.1.4",

--- a/third_party/pyth/price-service/package.json
+++ b/third_party/pyth/price-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-price-service",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Pyth Price Service",
   "main": "index.js",
   "scripts": {

--- a/third_party/pyth/price-service/src/listen.ts
+++ b/third_party/pyth/price-service/src/listen.ts
@@ -155,6 +155,28 @@ export class Listener implements PriceStore {
     }
   }
 
+  isNewPriceInfo(
+    cachedInfo: PriceInfo | undefined,
+    observedInfo: PriceInfo
+  ): boolean {
+    if (cachedInfo == undefined) {
+      return true;
+    }
+
+    if (cachedInfo.attestationTime < observedInfo.attestationTime) {
+      return true;
+    }
+
+    if (
+      cachedInfo.attestationTime == observedInfo.attestationTime &&
+      cachedInfo.seqNum < observedInfo.seqNum
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
   async processVaa(vaa: Buffer) {
     const { parse_vaa } = await importCoreWasm();
 
@@ -184,55 +206,31 @@ export class Listener implements PriceStore {
       return;
     }
 
-    const isAnyPriceNew = batchAttestation.priceAttestations.some(
-      (priceAttestation) => {
-        const key = priceAttestation.priceId;
-        const lastAttestationTime =
-          this.priceFeedVaaMap.get(key)?.attestationTime;
-        return (
-          lastAttestationTime === undefined ||
-          lastAttestationTime < priceAttestation.attestationTime
-        );
-      }
-    );
-
-    if (!isAnyPriceNew) {
-      return;
-    }
-
     for (const priceAttestation of batchAttestation.priceAttestations) {
       const key = priceAttestation.priceId;
 
-      const lastAttestationTime =
-        this.priceFeedVaaMap.get(key)?.attestationTime;
+      const priceFeed = priceAttestationToPriceFeed(priceAttestation);
+      const priceInfo = {
+        seqNum: parsedVaa.sequence,
+        vaa,
+        publishTime: priceAttestation.publishTime,
+        attestationTime: priceAttestation.attestationTime,
+        priceFeed,
+        emitterChainId: parsedVaa.emitter_chain,
+        priceServiceReceiveTime: Math.floor(new Date().getTime() / 1000),
+      };
 
-      if (
-        lastAttestationTime === undefined ||
-        lastAttestationTime < priceAttestation.attestationTime
-      ) {
-        const priceFeed = priceAttestationToPriceFeed(priceAttestation);
-        const priceInfo = {
-          seqNum: parsedVaa.sequence,
-          vaa,
-          publishTime: priceAttestation.publishTime,
-          attestationTime: priceAttestation.attestationTime,
-          priceFeed,
-          emitterChainId: parsedVaa.emitter_chain,
-          priceServiceReceiveTime: Math.floor(new Date().getTime() / 1000),
-        };
+      const cachedPriceInfo = this.priceFeedVaaMap.get(key);
+
+      if (this.isNewPriceInfo(cachedPriceInfo, priceInfo)) {
         this.priceFeedVaaMap.set(key, priceInfo);
 
-        if (lastAttestationTime !== undefined) {
+        if (cachedPriceInfo !== undefined) {
           this.promClient?.addPriceUpdatesAttestationTimeGap(
-            priceAttestation.attestationTime - lastAttestationTime
+            priceAttestation.attestationTime - cachedPriceInfo.attestationTime
           );
-        }
-
-        const lastPublishTime = this.priceFeedVaaMap.get(key)?.publishTime;
-
-        if (lastPublishTime !== undefined) {
           this.promClient?.addPriceUpdatesPublishTimeGap(
-            priceAttestation.publishTime - lastPublishTime
+            priceAttestation.publishTime - cachedPriceInfo.publishTime
           );
         }
 

--- a/third_party/pyth/price-service/src/listen.ts
+++ b/third_party/pyth/price-service/src/listen.ts
@@ -159,7 +159,7 @@ export class Listener implements PriceStore {
     cachedInfo: PriceInfo | undefined,
     observedInfo: PriceInfo
   ): boolean {
-    if (cachedInfo == undefined) {
+    if (cachedInfo === undefined) {
       return true;
     }
 
@@ -168,7 +168,7 @@ export class Listener implements PriceStore {
     }
 
     if (
-      cachedInfo.attestationTime == observedInfo.attestationTime &&
+      cachedInfo.attestationTime === observedInfo.attestationTime &&
       cachedInfo.seqNum < observedInfo.seqNum
     ) {
       return true;


### PR DESCRIPTION
This PR aims to make the gap metric more accurate. It might slightly improve the latency of prices as described below.

The problem is that multiple attesters might attest the same price that results in the same batch information but on different VAAs. This PR will use sequence number to store the most recent one. As in one second there are multiple slots, doing so will allow price service to pick a slightly more recent price to serve (if such a thing happens).

Why is it important for metrics? Because we often compare the trens of the attestation gap metric with the vaa received metrics. After doing this change, the trend difference of these two will show how many out of order VAAs we do have and is a useful information. 

Why sequence number alone is not used? Because we might have multiple sources of data (Pythnet/Solana) and each have their own increasing sequence number. Using sequence number alone will make the switch between them difficult. The current solution will have no impact on switch.