### PR TITLE
[multisig-cli] Add support for json

### DIFF
--- a/third_party/pyth/multisig-wh-message-builder/src/index.ts
+++ b/third_party/pyth/multisig-wh-message-builder/src/index.ts
@@ -165,7 +165,8 @@ program
     "multisig wallet secret key filepath",
     "keys/key.json"
   )
-  .option("-p, --payload <hex-string>", "payload to sign", "0xdeadbeef")
+  .option("-f, --file <filepath>", "Path to a json file with instructions")
+  .option("-p, --payload <hex-string>", "VAA payload")
   .option("-s, --skip-duplicate-check", "Skip checking duplicates")
   .action(async (options) => {
     const cluster: Cluster = options.cluster;
@@ -176,50 +177,110 @@ program
       options.ledgerDerivationChange,
       options.wallet
     );
-    const wormholeTools = await loadWormholeTools(cluster, squad.connection);
 
-    if (!options.skipDuplicateCheck) {
-      const activeProposals = await getActiveProposals(
-        squad,
-        CONFIG[cluster].vault
-      );
-      const activeInstructions = await getManyProposalsInstructions(
-        squad,
-        activeProposals
-      );
+    if (options.payload) {
+      const wormholeTools = await loadWormholeTools(cluster, squad.connection);
 
-      const msAccount = await squad.getMultisig(CONFIG[cluster].vault);
-      const emitter = squad.getAuthorityPDA(
-        msAccount.publicKey,
-        msAccount.authorityIndex
-      );
+      if (!options.skipDuplicateCheck) {
+        const activeProposals = await getActiveProposals(
+          squad,
+          CONFIG[cluster].vault
+        );
+        const activeInstructions = await getManyProposalsInstructions(
+          squad,
+          activeProposals
+        );
 
-      for (let i = 0; i < activeProposals.length; i++) {
-        if (
-          hasWormholePayload(
-            squad,
-            emitter,
-            activeProposals[i].publicKey,
-            options.payload,
-            activeInstructions[i],
-            wormholeTools
-          )
-        ) {
-          console.log(
-            `❌ Skipping, payload ${options.payload} matches instructions at ${activeProposals[i].publicKey}`
-          );
-          return;
+        const msAccount = await squad.getMultisig(CONFIG[cluster].vault);
+        const emitter = squad.getAuthorityPDA(
+          msAccount.publicKey,
+          msAccount.authorityIndex
+        );
+
+        for (let i = 0; i < activeProposals.length; i++) {
+          if (
+            hasWormholePayload(
+              squad,
+              emitter,
+              activeProposals[i].publicKey,
+              options.payload,
+              activeInstructions[i],
+              wormholeTools
+            )
+          ) {
+            console.log(
+              `❌ Skipping, payload ${options.payload} matches instructions at ${activeProposals[i].publicKey}`
+            );
+            return;
+          }
         }
       }
+
+      await createWormholeMsgMultisigTx(
+        options.cluster,
+        squad,
+        CONFIG[cluster].vault,
+        options.payload,
+        wormholeTools
+      );
     }
 
-    await createWormholeMsgMultisigTx(
-      options.cluster,
-      squad,
-      CONFIG[cluster].vault,
-      options.payload,
-      wormholeTools
-    );
+    if (options.file) {
+      const inputInstructions = JSON.parse(
+        fs.readFileSync(options.file).toString()
+      );
+      const instructions: SquadInstruction[] = inputInstructions.map(
+        (ix: any): SquadInstruction => {
+          return {
+            instruction: new TransactionInstruction({
+              programId: new PublicKey(ix.program_id),
+              keys: ix.accounts.map((acc: any) => {
+                return {
+                  pubkey: new PublicKey(acc.pubkey),
+                  isSigner: acc.is_signer,
+                  isWritable: acc.is_writable,
+                };
+              }),
+              data: Buffer.from(ix.data, "hex"),
+            }),
+          };
+        }
+      );
+
+      if (!options.skipDuplicateCheck) {
+        const activeProposals = await getActiveProposals(
+          squad,
+          CONFIG[cluster].vault
+        );
+        const activeInstructions = await getManyProposalsInstructions(
+          squad,
+          activeProposals
+        );
+
+        for (let i = 0; i < activeProposals.length; i++) {
+          if (
+            areEqualOnChainInstructions(
+              instructions.map((ix) => ix.instruction),
+              activeInstructions[i]
+            )
+          ) {
+            console.log(
+              `❌ Skipping, payload ${options.payload} matches instructions at ${activeProposals[i].publicKey}`
+            );
+            return;
+          }
+        }
+      }
+
+      const txKey = await createTx(squad, CONFIG[cluster].vault);
+      await addInstructionsToTx(
+        cluster,
+        squad,
+        CONFIG[cluster].vault,
+        txKey,
+        instructions
+      );
+    }
   });
 
 program
@@ -728,6 +789,24 @@ async function createWormholeMsgMultisigTx(
     txKey,
     squadIxs
   );
+}
+
+function areEqualOnChainInstructions(
+  instructions: TransactionInstruction[],
+  onChainInstructions: InstructionAccount[]
+): boolean {
+  if (instructions.length != onChainInstructions.length) {
+    console.debug(
+      `Proposals have a different number of instructions ${instructions.length} vs ${onChainInstructions.length}`
+    );
+    return false;
+  } else {
+    return lodash
+      .range(0, instructions.length)
+      .every((i) =>
+        isEqualOnChainInstruction(instructions[i], onChainInstructions[i])
+      );
+  }
 }
 
 function hasWormholePayload(

--- a/third_party/pyth/multisig-wh-message-builder/src/index.ts
+++ b/third_party/pyth/multisig-wh-message-builder/src/index.ts
@@ -231,25 +231,8 @@ program
     }
 
     if (options.file) {
-      const inputInstructions = JSON.parse(
-        fs.readFileSync(options.file).toString()
-      );
-      const instructions: SquadInstruction[] = inputInstructions.map(
-        (ix: any): SquadInstruction => {
-          return {
-            instruction: new TransactionInstruction({
-              programId: new PublicKey(ix.program_id),
-              keys: ix.accounts.map((acc: any) => {
-                return {
-                  pubkey: new PublicKey(acc.pubkey),
-                  isSigner: acc.is_signer,
-                  isWritable: acc.is_writable,
-                };
-              }),
-              data: Buffer.from(ix.data, "hex"),
-            }),
-          };
-        }
+      const instructions: SquadInstruction[] = loadInstructionsFromJson(
+        options.file
       );
 
       if (!options.skipDuplicateCheck) {
@@ -357,25 +340,8 @@ program
     }
 
     if (options.file) {
-      const inputInstructions = JSON.parse(
-        fs.readFileSync(options.file).toString()
-      );
-      const instructions: SquadInstruction[] = inputInstructions.map(
-        (ix: any): SquadInstruction => {
-          return {
-            instruction: new TransactionInstruction({
-              programId: new PublicKey(ix.program_id),
-              keys: ix.accounts.map((acc: any) => {
-                return {
-                  pubkey: new PublicKey(acc.pubkey),
-                  isSigner: acc.is_signer,
-                  isWritable: acc.is_writable,
-                };
-              }),
-              data: Buffer.from(ix.data, "hex"),
-            }),
-          };
-        }
+      const instructions: SquadInstruction[] = loadInstructionsFromJson(
+        options.file
       );
 
       if (
@@ -1108,4 +1074,26 @@ async function removeMember(
     txKey,
     squadIxs
   );
+}
+
+function loadInstructionsFromJson(path: string): SquadInstruction[] {
+  const inputInstructions = JSON.parse(fs.readFileSync(path).toString());
+  const instructions: SquadInstruction[] = inputInstructions.map(
+    (ix: any): SquadInstruction => {
+      return {
+        instruction: new TransactionInstruction({
+          programId: new PublicKey(ix.program_id),
+          keys: ix.accounts.map((acc: any) => {
+            return {
+              pubkey: new PublicKey(acc.pubkey),
+              isSigner: acc.is_signer,
+              isWritable: acc.is_writable,
+            };
+          }),
+          data: Buffer.from(ix.data, "hex"),
+        }),
+      };
+    }
+  );
+  return instructions;
 }

--- a/third_party/pyth/multisig-wh-message-builder/src/index.ts
+++ b/third_party/pyth/multisig-wh-message-builder/src/index.ts
@@ -270,7 +270,7 @@ program
             )
           ) {
             console.log(
-              `❌ Skipping, payload ${options.payload} matches instructions at ${activeProposals[i].publicKey}`
+              `❌ Skipping, instructions from ${options.file} match instructions at ${activeProposals[i].publicKey}`
             );
             return;
           }
@@ -290,7 +290,7 @@ program
 
 program
   .command("verify")
-  .description("Verify given proposals matches a payload")
+  .description("Verify given proposal matches a payload")
   .option("-c, --cluster <network>", "solana cluster to use", "devnet")
   .option("-l, --ledger", "use ledger")
   .option(


### PR DESCRIPTION
We need `create` and `verify` to be compatible with program-admin generated json.
This PR adds the `--file` to `create` and `verify`. Only one of `--payload` or `--file` can be provided. 
When `--file` is provided the tool will parse the path provided and try to create a proposal with the instruction in that file.

Welcome to ideas to make it more understandable. I find payload/file somehow confusing.