### PR TITLE
[multisig-cli] Refactor check that multisig vault already exists

### DIFF
--- a/third_party/pyth/multisig-wh-message-builder/src/index.ts
+++ b/third_party/pyth/multisig-wh-message-builder/src/index.ts
@@ -9,7 +9,7 @@ import {
   SystemProgram,
   TransactionInstruction,
 } from "@solana/web3.js";
-import Squads from "@sqds/mesh";
+import Squads, { DEFAULT_MULTISIG_PROGRAM_ID, getMsPDA } from "@sqds/mesh";
 import { getIxAuthorityPDA } from "@sqds/mesh";
 import { InstructionAccount } from "@sqds/mesh/lib/types";
 import bs58 from "bs58";
@@ -125,7 +125,7 @@ program
       cluster == "localdevnet" ? options.solanaRpc : undefined
     );
 
-    let vaultAddr = CONFIG[cluster].vault;
+    let vaultAddr = getMsPDA(createKeyAddr, DEFAULT_MULTISIG_PROGRAM_ID)[0];
     console.log("Creating new vault at", vaultAddr.toString());
 
     try {

--- a/third_party/pyth/multisig-wh-message-builder/src/index.ts
+++ b/third_party/pyth/multisig-wh-message-builder/src/index.ts
@@ -28,6 +28,11 @@ import {
   WormholeTools,
   parse,
 } from "./wormhole";
+import { fetchData } from "@project-serum/anchor/dist/cjs/utils/registry";
+
+const BPF_UPGRADABLE_LOADER = new PublicKey(
+  "BPFLoaderUpgradeab1e11111111111111111111111"
+);
 
 setDefaultWasm("node");
 
@@ -581,6 +586,43 @@ program
     );
   });
 
+program
+  .command("take-upgrade-authority")
+  .description("Transfer authority of a program to the multisig")
+  .option("-p --program-id <address>", "program id to transfer to the multisig")
+  .option("-c, --cluster <network>", "solana cluster to use", "devnet")
+  .option("-l, --ledger", "use ledger")
+  .option(
+    "-lda, --ledger-derivation-account <number>",
+    "ledger derivation account to use"
+  )
+  .option(
+    "-ldc, --ledger-derivation-change <number>",
+    "ledger derivation change to use"
+  )
+  .option(
+    "-w, --wallet <filepath>",
+    "multisig wallet secret key filepath",
+    "keys/key.json"
+  )
+  .action(async (options) => {
+    const cluster: Cluster = options.cluster;
+    const squad = await getSquadsClient(
+      cluster,
+      options.ledger,
+      options.ledgerDerivationAccount,
+      options.ledgerDerivationChange,
+      options.wallet
+    );
+
+    await takeUpgradeAuthority(
+      cluster,
+      squad,
+      CONFIG[cluster].vault,
+      new PublicKey(options.programId)
+    );
+  });
+
 // TODO: add subcommand for creating governance messages in the right format
 
 program.parse();
@@ -1051,6 +1093,48 @@ async function removeMember(
   );
 
   const squadIxs: SquadInstruction[] = [{ instruction: ix }];
+  await addInstructionsToTx(
+    cluster,
+    squad,
+    msAccount.publicKey,
+    txKey,
+    squadIxs
+  );
+}
+
+async function takeUpgradeAuthority(
+  cluster: Cluster,
+  squad: Squads,
+  vault: PublicKey,
+  programId: PublicKey
+) {
+  const msAccount = await squad.getMultisig(vault);
+  const multiSigAuthority = squad.getAuthorityPDA(
+    msAccount.publicKey,
+    msAccount.authorityIndex
+  );
+
+  const currentUpgradeAuthority = (await fetchData(squad.connection, programId))
+    .upgradeAuthorityAddress!;
+  const programDataKey = PublicKey.findProgramAddressSync(
+    [programId.toBuffer()],
+    BPF_UPGRADABLE_LOADER
+  )[0];
+
+  // Both the current and the new authority need to sign
+  const transferIx: TransactionInstruction = {
+    keys: [
+      { isSigner: false, isWritable: true, pubkey: programDataKey },
+      { isSigner: true, isWritable: false, pubkey: currentUpgradeAuthority },
+      { isSigner: true, isWritable: false, pubkey: multiSigAuthority },
+    ],
+    programId: BPF_UPGRADABLE_LOADER,
+    data: Buffer.from([4, 0, 0, 0]),
+  };
+
+  const txKey = await createTx(squad, vault);
+
+  const squadIxs: SquadInstruction[] = [{ instruction: transferIx }];
   await addInstructionsToTx(
     cluster,
     squad,

--- a/third_party/pyth/multisig-wh-message-builder/src/index.ts
+++ b/third_party/pyth/multisig-wh-message-builder/src/index.ts
@@ -28,11 +28,6 @@ import {
   WormholeTools,
   parse,
 } from "./wormhole";
-import { fetchData } from "@project-serum/anchor/dist/cjs/utils/registry";
-
-const BPF_UPGRADABLE_LOADER = new PublicKey(
-  "BPFLoaderUpgradeab1e11111111111111111111111"
-);
 
 setDefaultWasm("node");
 
@@ -586,43 +581,6 @@ program
     );
   });
 
-program
-  .command("take-upgrade-authority")
-  .description("Transfer authority of a program to the multisig")
-  .option("-p --program-id <address>", "program id to transfer to the multisig")
-  .option("-c, --cluster <network>", "solana cluster to use", "devnet")
-  .option("-l, --ledger", "use ledger")
-  .option(
-    "-lda, --ledger-derivation-account <number>",
-    "ledger derivation account to use"
-  )
-  .option(
-    "-ldc, --ledger-derivation-change <number>",
-    "ledger derivation change to use"
-  )
-  .option(
-    "-w, --wallet <filepath>",
-    "multisig wallet secret key filepath",
-    "keys/key.json"
-  )
-  .action(async (options) => {
-    const cluster: Cluster = options.cluster;
-    const squad = await getSquadsClient(
-      cluster,
-      options.ledger,
-      options.ledgerDerivationAccount,
-      options.ledgerDerivationChange,
-      options.wallet
-    );
-
-    await takeUpgradeAuthority(
-      cluster,
-      squad,
-      CONFIG[cluster].vault,
-      new PublicKey(options.programId)
-    );
-  });
-
 // TODO: add subcommand for creating governance messages in the right format
 
 program.parse();
@@ -1093,48 +1051,6 @@ async function removeMember(
   );
 
   const squadIxs: SquadInstruction[] = [{ instruction: ix }];
-  await addInstructionsToTx(
-    cluster,
-    squad,
-    msAccount.publicKey,
-    txKey,
-    squadIxs
-  );
-}
-
-async function takeUpgradeAuthority(
-  cluster: Cluster,
-  squad: Squads,
-  vault: PublicKey,
-  programId: PublicKey
-) {
-  const msAccount = await squad.getMultisig(vault);
-  const multiSigAuthority = squad.getAuthorityPDA(
-    msAccount.publicKey,
-    msAccount.authorityIndex
-  );
-
-  const currentUpgradeAuthority = (await fetchData(squad.connection, programId))
-    .upgradeAuthorityAddress!;
-  const programDataKey = PublicKey.findProgramAddressSync(
-    [programId.toBuffer()],
-    BPF_UPGRADABLE_LOADER
-  )[0];
-
-  // Both the current and the new authority need to sign
-  const transferIx: TransactionInstruction = {
-    keys: [
-      { isSigner: false, isWritable: true, pubkey: programDataKey },
-      { isSigner: true, isWritable: false, pubkey: currentUpgradeAuthority },
-      { isSigner: true, isWritable: false, pubkey: multiSigAuthority },
-    ],
-    programId: BPF_UPGRADABLE_LOADER,
-    data: Buffer.from([4, 0, 0, 0]),
-  };
-
-  const txKey = await createTx(squad, vault);
-
-  const squadIxs: SquadInstruction[] = [{ instruction: transferIx }];
   await addInstructionsToTx(
     cluster,
     squad,


### PR DESCRIPTION
Fixes the check that checks if a vault already exists at the address when trying to create a new vault.