### PR TITLE
[cosmos] Misc code cleanup

### DIFF
--- a/cosmwasm/contracts/pyth/src/contract.rs
+++ b/cosmwasm/contracts/pyth/src/contract.rs
@@ -86,7 +86,7 @@ pub fn instantiate(
         wormhole_contract:          deps.api.addr_validate(msg.wormhole_contract.as_ref())?,
         data_sources:               msg.data_sources.iter().cloned().collect(),
         chain_id:                   msg.chain_id,
-        governance_source:          msg.governance_data_source.clone(),
+        governance_source:          msg.governance_source.clone(),
         governance_source_index:    msg.governance_source_index,
         governance_sequence_number: msg.governance_sequence_number,
         valid_time_period:          Duration::from_secs(msg.valid_time_period_secs as u64),

--- a/cosmwasm/contracts/pyth/src/governance.rs
+++ b/cosmwasm/contracts/pyth/src/governance.rs
@@ -1,11 +1,5 @@
 use {
-    crate::{
-        governance::GovernanceAction::{
-            RequestGovernanceDataSourceTransfer,
-            SetValidPeriod,
-        },
-        state::PythDataSource,
-    },
+    crate::state::PythDataSource,
     byteorder::{
         BigEndian,
         ReadBytesExt,
@@ -132,11 +126,11 @@ impl GovernanceInstruction {
             }
             4 => {
                 let valid_seconds = bytes.read_u64::<BigEndian>()?;
-                Ok(SetValidPeriod { valid_seconds })
+                Ok(GovernanceAction::SetValidPeriod { valid_seconds })
             }
             5 => {
                 let governance_data_source_index = bytes.read_u32::<BigEndian>()?;
-                Ok(RequestGovernanceDataSourceTransfer {
+                Ok(GovernanceAction::RequestGovernanceDataSourceTransfer {
                     governance_data_source_index,
                 })
             }

--- a/cosmwasm/contracts/pyth/src/governance.rs
+++ b/cosmwasm/contracts/pyth/src/governance.rs
@@ -118,8 +118,8 @@ impl GovernanceInstruction {
                     bytes.read_exact(&mut emitter_address)?;
 
                     data_sources.push(PythDataSource {
-                        emitter:            Binary::from(&emitter_address),
-                        pyth_emitter_chain: chain_id,
+                        emitter: Binary::from(&emitter_address),
+                        chain_id,
                     });
                 }
 
@@ -172,7 +172,7 @@ impl GovernanceInstruction {
                 buf.write_u16::<BigEndian>(self.target_chain_id)?;
                 buf.write_u8(u8::try_from(data_sources.len())?)?;
                 for data_source in data_sources {
-                    buf.write_u16::<BigEndian>(data_source.pyth_emitter_chain)?;
+                    buf.write_u16::<BigEndian>(data_source.chain_id)?;
 
                     // The message format expects emitter addresses to be 32 bytes.
                     // However, we don't maintain this invariant in the rust code (and we violate it in the tests).

--- a/cosmwasm/contracts/pyth/src/msg.rs
+++ b/cosmwasm/contracts/pyth/src/msg.rs
@@ -23,7 +23,7 @@ pub struct InstantiateMsg {
     pub wormhole_contract: HumanAddr,
     pub data_sources:      Vec<PythDataSource>,
 
-    pub governance_data_source:     PythDataSource,
+    pub governance_source:          PythDataSource,
     pub governance_source_index:    u32,
     pub governance_sequence_number: u64,
 

--- a/cosmwasm/contracts/pyth/src/msg.rs
+++ b/cosmwasm/contracts/pyth/src/msg.rs
@@ -2,7 +2,7 @@ use {
     crate::state::PythDataSource,
     cosmwasm_std::{
         Binary,
-        Uint128,
+        Coin,
     },
     pyth_sdk_cw::{
         PriceFeed,
@@ -17,7 +17,7 @@ use {
 
 type HumanAddr = String;
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct InstantiateMsg {
     pub wormhole_contract: HumanAddr,
@@ -30,8 +30,7 @@ pub struct InstantiateMsg {
     pub chain_id:               u16,
     pub valid_time_period_secs: u16,
 
-    pub fee:       Uint128,
-    pub fee_denom: String,
+    pub fee: Coin,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]

--- a/cosmwasm/contracts/pyth/src/msg.rs
+++ b/cosmwasm/contracts/pyth/src/msg.rs
@@ -1,4 +1,5 @@
 use {
+    crate::state::PythDataSource,
     cosmwasm_std::{
         Binary,
         Uint128,
@@ -19,16 +20,15 @@ type HumanAddr = String;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct InstantiateMsg {
-    pub wormhole_contract:          HumanAddr,
-    // TODO: this should support multiple emitters
-    pub pyth_emitter:               Binary,
-    pub pyth_emitter_chain:         u16,
-    pub governance_emitter:         Binary,
-    pub governance_emitter_chain:   u16,
+    pub wormhole_contract: HumanAddr,
+    pub data_sources:      Vec<PythDataSource>,
+
+    pub governance_data_source:     PythDataSource,
     pub governance_source_index:    u32,
     pub governance_sequence_number: u64,
-    pub chain_id:                   u16,
-    pub valid_time_period_secs:     u16,
+
+    pub chain_id:               u16,
+    pub valid_time_period_secs: u16,
 
     pub fee:       Uint128,
     pub fee_denom: String,
@@ -38,7 +38,7 @@ pub struct InstantiateMsg {
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
     // TODO: add UpdatePriceFeeds if necessary
-    UpdatePriceFeeds { data: Binary },
+    UpdatePriceFeeds { data: Vec<Binary> },
     ExecuteGovernanceInstruction { data: Binary },
 }
 

--- a/cosmwasm/contracts/pyth/src/state.rs
+++ b/cosmwasm/contracts/pyth/src/state.rs
@@ -33,8 +33,8 @@ pub static PRICE_INFO_KEY: &[u8] = b"price_info_v3";
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, JsonSchema)]
 pub struct PythDataSource {
-    pub emitter:            Binary,
-    pub pyth_emitter_chain: u16,
+    pub emitter:  Binary,
+    pub chain_id: u16,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]

--- a/cosmwasm/contracts/pyth/src/state.rs
+++ b/cosmwasm/contracts/pyth/src/state.rs
@@ -2,9 +2,9 @@ use {
     cosmwasm_std::{
         Addr,
         Binary,
+        Coin,
         Storage,
         Timestamp,
-        Uint128,
     },
     cosmwasm_storage::{
         bucket,
@@ -37,7 +37,7 @@ pub struct PythDataSource {
     pub chain_id: u16,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct ConfigInfo {
     pub owner:                      Addr,
     pub wormhole_contract:          Addr,
@@ -60,8 +60,7 @@ pub struct ConfigInfo {
     pub valid_time_period:          Duration,
 
     // The fee to pay, denominated in fee_denom (typically, the chain's native token)
-    pub fee:       Uint128,
-    pub fee_denom: String,
+    pub fee: Coin,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq, JsonSchema)]

--- a/cosmwasm/tools/deploy.js
+++ b/cosmwasm/tools/deploy.js
@@ -189,8 +189,10 @@ addresses["pyth_cosmwasm.wasm"] = await instantiate(
     governance_sequence_number: 0,
     chain_id: 3,
     valid_time_period_secs: 60,
-    fee: "1",
-    fee_denom: "uluna",
+    fee: {
+      amount: "1",
+      denom: "uluna",
+    },
   },
   "pyth"
 );

--- a/cosmwasm/tools/deploy.js
+++ b/cosmwasm/tools/deploy.js
@@ -173,13 +173,18 @@ addresses["pyth_cosmwasm.wasm"] = await instantiate(
   "pyth_cosmwasm.wasm",
   {
     wormhole_contract: addresses["wormhole.wasm"],
-    pyth_emitter: Buffer.from(pythEmitterAddress, "hex").toString("base64"),
-    pyth_emitter_chain: pythChain,
-    governance_emitter: Buffer.from(
-      pythGovernanceEmitterAddress,
-      "hex"
-    ).toString("base64"),
-    governance_emitter_chain: pythChain,
+    data_sources: [
+      {
+        emitter: Buffer.from(pythEmitterAddress, "hex").toString("base64"),
+        chain_id: pythChain,
+      },
+    ],
+    governance_source: {
+      emitter: Buffer.from(pythGovernanceEmitterAddress, "hex").toString(
+        "base64"
+      ),
+      chain_id: pythChain,
+    },
     governance_source_index: 0,
     governance_sequence_number: 0,
     chain_id: 3,


### PR DESCRIPTION
Clean up a few miscellaneous issues from earlier PRs. Main changes are:

* Use PythDataSource consistently across initialization messages and configs
* Use Coin in the config and initialization message instead of separate fee/denom parameters

I suggest reading `msg.rs` and `state.rs` first to get the main changes before looking at `contract.rs` (which is mostly mechanical)..