### PR TITLE
[cosmos] Require governance instruction bytes to be completely consumed

### DIFF
--- a/cosmwasm/contracts/pyth/src/governance.rs
+++ b/cosmwasm/contracts/pyth/src/governance.rs
@@ -141,8 +141,10 @@ impl GovernanceInstruction {
         // interpret every field in the governance message). The logic is a little janky
         // but seems to be the simplest way to check that the reader is at EOF.
         let mut next_byte = [0_u8; 1];
-        if !bytes.read(&mut next_byte).contains(&0) {
-            Err("Governance action had an unexpectedly long payload.".to_string())?
+        let read_result = bytes.read(&mut next_byte);
+        match read_result {
+            Ok(0) => (),
+            _ => Err("Governance action had an unexpectedly long payload.".to_string())?,
         }
 
         Ok(GovernanceInstruction {

--- a/cosmwasm/contracts/pyth/src/lib.rs
+++ b/cosmwasm/contracts/pyth/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(option_result_contains)]
 #[cfg(test)]
 extern crate lazy_static;
 

--- a/cosmwasm/contracts/pyth/src/lib.rs
+++ b/cosmwasm/contracts/pyth/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(option_result_contains)]
 #[cfg(test)]
 extern crate lazy_static;
 


### PR DESCRIPTION
This check prevents us from accidentally missing a part of a governance message if we upgrade the format.