### PR TITLE
RFC : Add parser

### DIFF
--- a/third_party/pyth/multisig-wh-message-builder/package-lock.json
+++ b/third_party/pyth/multisig-wh-message-builder/package-lock.json
@@ -13,6 +13,7 @@
         "@ledgerhq/hw-transport": "^6.27.2",
         "@ledgerhq/hw-transport-node-hid": "^6.27.2",
         "@project-serum/anchor": "^0.25.0",
+        "@pythnetwork/client": "^2.9.0",
         "@solana/web3.js": "^1.53.0",
         "@sqds/mesh": "^1.0.6",
         "@types/lodash": "^4.14.186",
@@ -670,6 +671,78 @@
       "dependencies": {
         "@types/long": "^4.0.2",
         "@types/node": "^18.0.3"
+      }
+    },
+    "node_modules/@coral-xyz/anchor": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.26.0.tgz",
+      "integrity": "sha512-PxRl+wu5YyptWiR9F2MBHOLLibm87Z4IMUBPreX+DYBtPM+xggvcPi0KAN7+kIL4IrIhXI8ma5V0MCXxSN1pHg==",
+      "peer": true,
+      "dependencies": {
+        "@coral-xyz/borsh": "^0.26.0",
+        "@solana/web3.js": "^1.68.0",
+        "base64-js": "^1.5.1",
+        "bn.js": "^5.1.2",
+        "bs58": "^4.0.1",
+        "buffer-layout": "^1.2.2",
+        "camelcase": "^6.3.0",
+        "cross-fetch": "^3.1.5",
+        "crypto-hash": "^1.3.0",
+        "eventemitter3": "^4.0.7",
+        "js-sha256": "^0.9.0",
+        "pako": "^2.0.3",
+        "snake-case": "^3.0.4",
+        "superstruct": "^0.15.4",
+        "toml": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=11"
+      }
+    },
+    "node_modules/@coral-xyz/anchor/node_modules/base-x": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@coral-xyz/anchor/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "peer": true,
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@coral-xyz/anchor/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@coral-xyz/borsh": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.26.0.tgz",
+      "integrity": "sha512-uCZ0xus0CszQPHYfWAqKS5swS1UxvePu83oOF+TWpUkedsNlg6p2p4azxZNSSqwXb9uXMFgxhuMBX9r3Xoi0vQ==",
+      "peer": true,
+      "dependencies": {
+        "bn.js": "^5.1.2",
+        "buffer-layout": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.68.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -2149,6 +2222,18 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "node_modules/@pythnetwork/client": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/client/-/client-2.9.0.tgz",
+      "integrity": "sha512-2CyDmTwPWW+JCQgRKUpwMR/31oiLWH6I3GA0h2ZXIcbt/hWxcr5TXyKlWuyi+l+jh73WWh88gq8NXLoIgRcvkA==",
+      "dependencies": {
+        "buffer": "^6.0.1"
+      },
+      "peerDependencies": {
+        "@coral-xyz/anchor": "^0.26.0",
+        "@solana/web3.js": "^1.30.2"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.35",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.35.tgz",
@@ -2201,15 +2286,16 @@
       }
     },
     "node_modules/@solana/web3.js": {
-      "version": "1.56.2",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.56.2.tgz",
-      "integrity": "sha512-ByWfNA8H/1EB4g0749uhkQ0zZZAQealzRmmT3UMIv3xe0DeHwnrzQUavBtAlHNMrKqLHu8kd+XtPci6zreMjjA==",
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.73.0.tgz",
+      "integrity": "sha512-YrgX3Py7ylh8NYkbanoINUPCj//bWUjYZ5/WPy9nQ9SK3Cl7QWCR+NmbDjmC/fTspZGR+VO9LTQslM++jr5PRw==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@noble/ed25519": "^1.7.0",
         "@noble/hashes": "^1.1.2",
         "@noble/secp256k1": "^1.6.3",
         "@solana/buffer-layout": "^4.0.0",
+        "agentkeepalive": "^4.2.1",
         "bigint-buffer": "^1.1.5",
         "bn.js": "^5.0.0",
         "borsh": "^0.7.0",
@@ -2217,7 +2303,6 @@
         "buffer": "6.0.1",
         "fast-stable-stringify": "^1.0.0",
         "jayson": "^3.4.4",
-        "js-sha3": "^0.8.0",
         "node-fetch": "2",
         "rpc-websockets": "^7.5.0",
         "superstruct": "^0.14.2"
@@ -2820,6 +2905,19 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
       "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
+      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -3775,6 +3873,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
+    "node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "1.0.3",
@@ -4786,6 +4892,14 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/ieee754": {
@@ -8316,6 +8430,65 @@
         "@types/node": "^18.0.3"
       }
     },
+    "@coral-xyz/anchor": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.26.0.tgz",
+      "integrity": "sha512-PxRl+wu5YyptWiR9F2MBHOLLibm87Z4IMUBPreX+DYBtPM+xggvcPi0KAN7+kIL4IrIhXI8ma5V0MCXxSN1pHg==",
+      "peer": true,
+      "requires": {
+        "@coral-xyz/borsh": "^0.26.0",
+        "@solana/web3.js": "^1.68.0",
+        "base64-js": "^1.5.1",
+        "bn.js": "^5.1.2",
+        "bs58": "^4.0.1",
+        "buffer-layout": "^1.2.2",
+        "camelcase": "^6.3.0",
+        "cross-fetch": "^3.1.5",
+        "crypto-hash": "^1.3.0",
+        "eventemitter3": "^4.0.7",
+        "js-sha256": "^0.9.0",
+        "pako": "^2.0.3",
+        "snake-case": "^3.0.4",
+        "superstruct": "^0.15.4",
+        "toml": "^3.0.0"
+      },
+      "dependencies": {
+        "base-x": {
+          "version": "3.0.9",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+          "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+          "peer": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "bs58": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+          "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+          "peer": true,
+          "requires": {
+            "base-x": "^3.0.2"
+          }
+        },
+        "camelcase": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+          "peer": true
+        }
+      }
+    },
+    "@coral-xyz/borsh": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.26.0.tgz",
+      "integrity": "sha512-uCZ0xus0CszQPHYfWAqKS5swS1UxvePu83oOF+TWpUkedsNlg6p2p4azxZNSSqwXb9uXMFgxhuMBX9r3Xoi0vQ==",
+      "peer": true,
+      "requires": {
+        "bn.js": "^5.1.2",
+        "buffer-layout": "^1.2.0"
+      }
+    },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -9330,6 +9503,14 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "@pythnetwork/client": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/client/-/client-2.9.0.tgz",
+      "integrity": "sha512-2CyDmTwPWW+JCQgRKUpwMR/31oiLWH6I3GA0h2ZXIcbt/hWxcr5TXyKlWuyi+l+jh73WWh88gq8NXLoIgRcvkA==",
+      "requires": {
+        "buffer": "^6.0.1"
+      }
+    },
     "@sinclair/typebox": {
       "version": "0.24.35",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.35.tgz",
@@ -9376,15 +9557,16 @@
       }
     },
     "@solana/web3.js": {
-      "version": "1.56.2",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.56.2.tgz",
-      "integrity": "sha512-ByWfNA8H/1EB4g0749uhkQ0zZZAQealzRmmT3UMIv3xe0DeHwnrzQUavBtAlHNMrKqLHu8kd+XtPci6zreMjjA==",
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.73.0.tgz",
+      "integrity": "sha512-YrgX3Py7ylh8NYkbanoINUPCj//bWUjYZ5/WPy9nQ9SK3Cl7QWCR+NmbDjmC/fTspZGR+VO9LTQslM++jr5PRw==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@noble/ed25519": "^1.7.0",
         "@noble/hashes": "^1.1.2",
         "@noble/secp256k1": "^1.6.3",
         "@solana/buffer-layout": "^4.0.0",
+        "agentkeepalive": "^4.2.1",
         "bigint-buffer": "^1.1.5",
         "bn.js": "^5.0.0",
         "borsh": "^0.7.0",
@@ -9392,7 +9574,6 @@
         "buffer": "6.0.1",
         "fast-stable-stringify": "^1.0.0",
         "jayson": "^3.4.4",
-        "js-sha3": "^0.8.0",
         "node-fetch": "2",
         "rpc-websockets": "^7.5.0",
         "superstruct": "^0.14.2"
@@ -9866,6 +10047,16 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
       "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
+    },
+    "agentkeepalive": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
+      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
+      "requires": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      }
     },
     "ajv": {
       "version": "6.12.6",
@@ -10620,6 +10811,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
     },
     "detect-libc": {
       "version": "1.0.3",
@@ -11393,6 +11589,14 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
+    },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "requires": {
+        "ms": "^2.0.0"
+      }
     },
     "ieee754": {
       "version": "1.2.1",

--- a/third_party/pyth/multisig-wh-message-builder/package.json
+++ b/third_party/pyth/multisig-wh-message-builder/package.json
@@ -40,6 +40,7 @@
     "@ledgerhq/hw-transport": "^6.27.2",
     "@ledgerhq/hw-transport-node-hid": "^6.27.2",
     "@project-serum/anchor": "^0.25.0",
+    "@pythnetwork/client": "^2.9.0",
     "@solana/web3.js": "^1.53.0",
     "@sqds/mesh": "^1.0.6",
     "@types/lodash": "^4.14.186",

--- a/third_party/pyth/multisig-wh-message-builder/src/index.ts
+++ b/third_party/pyth/multisig-wh-message-builder/src/index.ts
@@ -28,6 +28,7 @@ import {
   WormholeTools,
   parse,
 } from "./wormhole";
+import { getPythProgramKeyForCluster } from "@pythnetwork/client";
 
 setDefaultWasm("node");
 
@@ -51,6 +52,7 @@ type Config = {
   wormholeClusterName: WormholeNetwork;
   wormholeRpcEndpoint: string;
   vault: PublicKey;
+  pythOracleSolana: PublicKey;
 };
 
 export const CONFIG: Record<Cluster, Config> = {
@@ -58,16 +60,21 @@ export const CONFIG: Record<Cluster, Config> = {
     wormholeClusterName: "TESTNET",
     vault: new PublicKey("6baWtW1zTUVMSJHJQVxDUXWzqrQeYBr6mu31j3bTKwY3"),
     wormholeRpcEndpoint: "https://wormhole-v2-testnet-api.certus.one",
+    pythOracleSolana: getPythProgramKeyForCluster("devnet"),
   },
   mainnet: {
     wormholeClusterName: "MAINNET",
     vault: new PublicKey("FVQyHcooAtThJ83XFrNnv74BcinbRH3bRmfFamAHBfuj"),
     wormholeRpcEndpoint: "https://wormhole-v2-mainnet-api.certus.one",
+    pythOracleSolana: getPythProgramKeyForCluster("mainnet-beta"),
   },
   localdevnet: {
     wormholeClusterName: "DEVNET",
     vault: new PublicKey("DFkA5ubJSETKiFnniAsm8qRXUa7RrnnE7U9awTzbcrJF"),
     wormholeRpcEndpoint: "http://guardian:7071",
+    pythOracleSolana: new PublicKey(
+      "gMYYig2utAxVoXnM9UhtTWrt8e7x2SVBZqsWZJeT5Gw"
+    ),
   },
 };
 

--- a/third_party/pyth/multisig-wh-message-builder/src/parser.ts
+++ b/third_party/pyth/multisig-wh-message-builder/src/parser.ts
@@ -1,0 +1,118 @@
+import { ChainId, CHAIN_ID_SOLANA } from "@certusone/wormhole-sdk";
+import {
+  AccountMeta,
+  PublicKey,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import { pythOracleCoder, pythIdl } from "@pythnetwork/client";
+import { Cluster, CONFIG } from ".";
+import { Idl } from "@project-serum/anchor";
+
+/// A summary of a proposal instruction :
+/// For two proposals A and B in the multisig the set of all the summarized instructions of A and all the summarized instructions of B should have null intersection
+type Summary = {
+  targetChain: ChainId;
+  component: OracleProgram;
+};
+type OracleProgram = {
+  oracleAction:
+    | UpdatePriceFeed
+    | "updatePermissions"
+    | UpdateProductAccount
+    | undefined;
+};
+
+type UpdatePriceFeed = {
+  priceAccount: PublicKey;
+};
+
+type UpdateProductAccount = {
+  productAccount: PublicKey;
+};
+
+type NamedAccounts = Record<string, AccountMeta>;
+
+export function parseProposalInstruction(
+  cluster: Cluster,
+  instruction: TransactionInstruction
+) {
+  switch (instruction.programId.toBase58()) {
+    case CONFIG[cluster].pythOracleSolana.toBase58():
+      const deserializedInstruction = pythOracleCoder().instruction.decode(
+        instruction.data
+      );
+      if (deserializedInstruction) {
+        const namedAccounts = resolveAccountNames(
+          pythIdl as unknown as Idl,
+          deserializedInstruction.name,
+          instruction
+        );
+        const summary: Summary = summarizeOracleInstruction(
+          deserializedInstruction.name,
+          namedAccounts
+        );
+        return { ...deserializedInstruction, namedAccounts, summary };
+      } else {
+        return null;
+      }
+
+    default:
+      return null;
+  }
+}
+
+export function resolveAccountNames(
+  idl: Idl,
+  name: string,
+  instruction: TransactionInstruction
+): NamedAccounts {
+  const ix = idl.instructions.find((ix) => ix.name == name);
+  if (!ix) {
+    throw Error("Instruction name not found");
+  }
+  let namedAccounts: NamedAccounts = {};
+  ix.accounts.map((account, idx) => {
+    if (idx < instruction.keys.length) {
+      namedAccounts[account.name] = instruction.keys[idx];
+    }
+  });
+  return namedAccounts;
+}
+
+export function summarizeOracleInstruction(
+  name: string,
+  namedAccounts: NamedAccounts
+): Summary {
+  switch (name) {
+    case "addProduct":
+    case "updProduct":
+    case "delProduct":
+      return {
+        targetChain: CHAIN_ID_SOLANA,
+        component: {
+          oracleAction: { productAccount: namedAccounts.productAccount.pubkey },
+        },
+      };
+    case "addPrice":
+    case "addPublisher":
+    case "delPublisher":
+    case "setMinPub":
+    case "delPrice":
+      return {
+        targetChain: CHAIN_ID_SOLANA,
+        component: {
+          oracleAction: { priceAccount: namedAccounts.priceAccount.pubkey },
+        },
+      };
+    case "updPermissions":
+      return {
+        targetChain: CHAIN_ID_SOLANA,
+        component: { oracleAction: "updatePermissions" },
+      };
+    default:
+      return {
+        targetChain: CHAIN_ID_SOLANA,
+        component: { oracleAction: undefined },
+      };
+  }
+}


### PR DESCRIPTION
I want some feedback on this. 
The goal is parsing the multisig proposals. This is achieved by parsing the instructions of the proposal one by one. 
Two representations of the instruction are useful :
- A detailed one for the UI (caveat : solana instructions and pythnet remote-instructions will be represented differently than cross-chain governance messages)
- A "summary" (not sure about the word) that will be used to detect conflicts between two proposals. If two instructions have the same summary then they are in conflict with one another. 

I made summary some sort of nested object, but I'm thinking of turning it into a string.