### PR TITLE
wormhole-attester: port the v1.3.0 healthcheck hotfix

### DIFF
--- a/third_party/pyth/p2w_autoattest.py
+++ b/third_party/pyth/p2w_autoattest.py
@@ -187,6 +187,7 @@ first_attest_result = run_or_die(
         P2W_RPC_TIMEOUT_SECS,
     ],
     capture_output=True,
+    debug = True,
 )
 
 logging.info("p2w_autoattest ready to roll!")

--- a/third_party/pyth/p2w_autoattest.py
+++ b/third_party/pyth/p2w_autoattest.py
@@ -166,7 +166,7 @@ symbol_groups:
 
 # Set helpfully chatty logging default, filtering especially annoying
 # modules like async HTTP requests and tokio runtime logs
-os.environ["RUST_LOG"] = os.environ.get("RUST_LOG", "pyth_wormhole_attester_client,solana_client,main,pyth_sdk_solana=trace")
+os.environ["RUST_LOG"] = os.environ.get("RUST_LOG", "info")
 
 # Send the first attestation in one-shot mode for testing
 first_attest_result = run_or_die(

--- a/tilt-devnet/docker-images/Dockerfile.client
+++ b/tilt-devnet/docker-images/Dockerfile.client
@@ -9,12 +9,11 @@ RUN apt-get update && apt-get install -yq libudev-dev ncat
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && apt-get install -y nodejs
 
 ADD rust-toolchain /rust-toolchain
-ADD wormhole-attester/ /usr/src/wormhole-attester
-WORKDIR /usr/src/wormhole-attester
+WORKDIR /usr/src/bridge-client
 
 RUN --mount=type=cache,target=/root/.cache \
-    --mount=type=cache,target=/usr/local/cargo/registry,id=cargo_registry \
-    --mount=type=cache,target=/usr/src/solana/pyth2wormhole/target,id=p2w_cargo_build \
+    --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=target \
     cargo install --version =2.0.12 --locked spl-token-cli --target-dir target
 
 
@@ -26,7 +25,7 @@ ENV BRIDGE_ADDRESS="Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o"
 
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/src/solana/pyth2wormhole/target \
+    --mount=type=cache,target=target \
 	set -xe && \
     cargo install bridge_client --git https://github.com/wormhole-foundation/wormhole --tag $WORMHOLE_TAG --locked --root /usr/local --target-dir target && \
     cargo install token_bridge_client --git https://github.com/wormhole-foundation/wormhole --tag $WORMHOLE_TAG --locked --root /usr/local --target-dir target

--- a/wormhole-attester/client/src/healthcheck.rs
+++ b/wormhole-attester/client/src/healthcheck.rs
@@ -1,4 +1,5 @@
 use {
+    crate::attestation_cfg,
     std::{
         collections::VecDeque,
         sync::Arc,
@@ -7,7 +8,7 @@ use {
 };
 
 lazy_static::lazy_static! {
-    pub static ref HEALTHCHECK_STATE: Arc<Mutex<HealthCheckState>> = Arc::new(Mutex::new(HealthCheckState::new(1, false)));
+    pub static ref HEALTHCHECK_STATE: Arc<Mutex<HealthCheckState>> = Arc::new(Mutex::new(HealthCheckState::new(attestation_cfg::default_healthcheck_window_size as usize, attestation_cfg::default_enable_healthcheck())));
 }
 
 /// Helper structure for deciding service health

--- a/wormhole-attester/client/src/healthcheck.rs
+++ b/wormhole-attester/client/src/healthcheck.rs
@@ -2,13 +2,14 @@ use {
     crate::attestation_cfg,
     std::{
         collections::VecDeque,
+        convert::TryInto,
         sync::Arc,
     },
     tokio::sync::Mutex,
 };
 
 lazy_static::lazy_static! {
-    pub static ref HEALTHCHECK_STATE: Arc<Mutex<HealthCheckState>> = Arc::new(Mutex::new(HealthCheckState::new(attestation_cfg::default_healthcheck_window_size as usize, attestation_cfg::default_enable_healthcheck())));
+    pub static ref HEALTHCHECK_STATE: Arc<Mutex<HealthCheckState>> = Arc::new(Mutex::new(HealthCheckState::new(attestation_cfg::default_healthcheck_window_size().try_into().expect("could not convert window size to usize"), attestation_cfg::default_enable_healthcheck())));
 }
 
 /// Helper structure for deciding service health

--- a/wormhole-attester/client/src/main.rs
+++ b/wormhole-attester/client/src/main.rs
@@ -312,8 +312,8 @@ async fn handle_attest_daemon_mode(
         )
         .into());
     }
-    let mut hc = HEALTHCHECK_STATE.lock().await;
-    *hc = HealthCheckState::new(
+
+    *HEALTHCHECK_STATE.lock().await = HealthCheckState::new(
         attestation_cfg.healthcheck_window_size as usize,
         attestation_cfg.enable_healthcheck,
     );


### PR DESCRIPTION
This PR fixes a missing assignment to HealthCheckState's enable
flag. This would cause the attester to ignore all settings (including
defaults) and keep the enable flag set to false because we would never
bother setting it from attestation_cfg that came at runtime.

The bug is fixed and the healthcheck behavior is hardened. Currently,
the lazy_static block will explicitly initialize the global with
default values from attestation_cfg (enable is true, window size is
100). This prevents a similar human error from disabling the
healthcheck. Secondly, main.rs overwrites the default values using the
HealthCheckState::new() constructor, instead of individual struct
member assignments. This ensures that all necessary values or their
defaults are passed as the desired healthcheck state.
