### PR TITLE
Scaffolding for xc-admin (new crosschain admin tool)

### DIFF
--- a/xc-admin/.gitignore
+++ b/xc-admin/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/xc-admin/lerna.json
+++ b/xc-admin/lerna.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "node_modules/lerna/schemas/lerna-schema.json",
+  "useWorkspaces": true,
+  "version": "0.0.0"
+}

--- a/xc-admin/package.json
+++ b/xc-admin/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "xc-admin",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
+  "devDependencies": {
+    "lerna": "^6.3.0"
+  }
+}

--- a/xc-admin/packages/xc-admin-common/package.json
+++ b/xc-admin/packages/xc-admin-common/package.json
@@ -12,5 +12,8 @@
   },
   "bugs": {
     "url": "https://github.com/pyth-network/pyth-crosschain/issues"
+  },
+  "dependencies": {
+    "typescript": "^4.9.4"
   }
 }

--- a/xc-admin/packages/xc-admin-common/package.json
+++ b/xc-admin/packages/xc-admin-common/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "xc-admin-common",
+  "version": "0.0.0",
+  "description": "",
+  "author": "",
+  "homepage": "https://github.com/pyth-network/pyth-crosschain",
+  "license": "ISC",
+  "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pyth-network/pyth-crosschain.git"
+  },
+  "bugs": {
+    "url": "https://github.com/pyth-network/pyth-crosschain/issues"
+  }
+}

--- a/xc-admin/packages/xc-admin-common/tsconfig.json
+++ b/xc-admin/packages/xc-admin-common/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "target": "es2016",
+    "module": "commonjs",
+    "outDir": "lib",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noErrorTruncation": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Some scaffolding. I see the project as a lerna folder. With:
- a xc-admin-common package that the other packages will share
- a website package
- a cli package
- packages for relayers