### PR TITLE
Xc admin/change error handling

### DIFF
--- a/xc-admin/packages/xc-admin-common/src/__tests__/GovernancePayload.test.ts
+++ b/xc-admin/packages/xc-admin-common/src/__tests__/GovernancePayload.test.ts
@@ -60,22 +60,19 @@ test("GovernancePayload ser/de", (done) => {
   expect(governanceHeader?.action).toBe("SetFee");
 
   // Wrong magic number
-  governanceHeader = decodeHeader(
-    Buffer.from([0, 0, 0, 0, 0, 0, 0, 26, 0, 0, 0, 0])
-  );
-  expect(governanceHeader).toBeUndefined();
+  expect(() =>
+    decodeHeader(Buffer.from([0, 0, 0, 0, 0, 0, 0, 26, 0, 0, 0, 0]))
+  ).toThrow("Wrong magic number");
 
   // Wrong chain
-  governanceHeader = decodeHeader(
-    Buffer.from([80, 84, 71, 77, 0, 0, 255, 255, 0, 0, 0, 0])
-  );
-  expect(governanceHeader).toBeUndefined();
+  expect(() =>
+    decodeHeader(Buffer.from([80, 84, 71, 77, 0, 0, 255, 255, 0, 0, 0, 0]))
+  ).toThrow();
 
   // Wrong module/action combination
-  governanceHeader = decodeHeader(
-    Buffer.from([80, 84, 71, 77, 0, 1, 0, 26, 0, 0, 0, 0])
-  );
-  expect(governanceHeader).toBeUndefined();
+  expect(() =>
+    decodeHeader(Buffer.from([80, 84, 71, 77, 0, 1, 0, 26, 0, 0, 0, 0]))
+  ).toThrow();
 
   // Decode executePostVaa with empty instructions
   let expectedExecuteVaaArgs = {

--- a/xc-admin/packages/xc-admin-common/src/__tests__/GovernancePayload.test.ts
+++ b/xc-admin/packages/xc-admin-common/src/__tests__/GovernancePayload.test.ts
@@ -67,12 +67,12 @@ test("GovernancePayload ser/de", (done) => {
   // Wrong chain
   expect(() =>
     decodeHeader(Buffer.from([80, 84, 71, 77, 0, 0, 255, 255, 0, 0, 0, 0]))
-  ).toThrow();
+  ).toThrow("Chain Id not found");
 
   // Wrong module/action combination
   expect(() =>
     decodeHeader(Buffer.from([80, 84, 71, 77, 0, 1, 0, 26, 0, 0, 0, 0]))
-  ).toThrow();
+  ).toThrow("Invalid header, action doesn't match module");
 
   // Decode executePostVaa with empty instructions
   let expectedExecuteVaaArgs = {

--- a/xc-admin/packages/xc-admin-common/src/governance_payload/ExecutePostedVaa.ts
+++ b/xc-admin/packages/xc-admin-common/src/governance_payload/ExecutePostedVaa.ts
@@ -83,16 +83,10 @@ export type ExecutePostedVaaArgs = {
 };
 
 /** Decode ExecutePostedVaaArgs and return undefined if it failed */
-export function decodeExecutePostedVaa(
-  data: Buffer
-): ExecutePostedVaaArgs | undefined {
+export function decodeExecutePostedVaa(data: Buffer): ExecutePostedVaaArgs {
   let deserialized = executePostedVaaLayout.decode(data);
 
   let header = verifyHeader(deserialized.header);
-
-  if (!header) {
-    return undefined;
-  }
 
   let instructions: TransactionInstruction[] = deserialized.instructions.map(
     (ix) => {

--- a/xc-admin/packages/xc-admin-common/src/governance_payload/index.ts
+++ b/xc-admin/packages/xc-admin-common/src/governance_payload/index.ts
@@ -75,7 +75,7 @@ export function governanceHeaderLayout(): BufferLayout.Structure<
 }
 
 /** Decode Pyth Governance Header and return undefined if the header is invalid */
-export function decodeHeader(data: Buffer): PythGovernanceHeader | undefined {
+export function decodeHeader(data: Buffer): PythGovernanceHeader {
   let deserialized = governanceHeaderLayout().decode(data);
   return verifyHeader(deserialized);
 }
@@ -111,27 +111,23 @@ export function verifyHeader(
     action: number;
     chain: ChainId;
   }>
-) {
+): PythGovernanceHeader {
   if (deserialized.magicNumber !== MAGIC_NUMBER) {
-    return undefined;
+    throw new Error("Wrong magic number");
   }
 
   if (!toChainName(deserialized.chain)) {
-    return undefined;
+    throw new Error("Chain Id not found");
   }
 
-  try {
-    let governanceHeader: PythGovernanceHeader = {
-      targetChainId: toChainName(deserialized.chain),
-      action: toActionName({
-        actionId: deserialized.action,
-        moduleId: deserialized.module,
-      }),
-    };
-    return governanceHeader;
-  } catch {
-    return undefined;
-  }
+  let governanceHeader: PythGovernanceHeader = {
+    targetChainId: toChainName(deserialized.chain),
+    action: toActionName({
+      actionId: deserialized.action,
+      moduleId: deserialized.module,
+    }),
+  };
+  return governanceHeader;
 }
 
 export { decodeExecutePostedVaa } from "./ExecutePostedVaa";


### PR DESCRIPTION
export function `decodeHeader(data: Buffer)` was returning `GovernanceHeader | undefined`.
This made things complicated because when you called this function there were 3 outcomes :
- a) throws error
- b) returns undefined
- c) returns something

So I decided to switch to throwing errors instead of undefined.