### PR TITLE
[xc-admin] Refactor wormhole messages as classes

### DIFF
--- a/xc-admin/packages/xc-admin-common/src/__tests__/GovernancePayload.test.ts
+++ b/xc-admin/packages/xc-admin-common/src/__tests__/GovernancePayload.test.ts
@@ -1,7 +1,6 @@
 import { ChainName } from "@certusone/wormhole-sdk";
 import { PACKET_DATA_SIZE, PublicKey, SystemProgram } from "@solana/web3.js";
-import { ActionName, decodeHeader, encodeHeader } from "..";
-import { ExecutePostedVaa } from "../governance_payload/ExecutePostedVaa";
+import { ActionName, decodeHeader, encodeHeader, ExecutePostedVaa } from "..";
 
 test("GovernancePayload ser/de", (done) => {
   jest.setTimeout(60000);

--- a/xc-admin/packages/xc-admin-common/src/__tests__/GovernancePayload.test.ts
+++ b/xc-admin/packages/xc-admin-common/src/__tests__/GovernancePayload.test.ts
@@ -1,17 +1,7 @@
 import { ChainName } from "@certusone/wormhole-sdk";
-import {
-  PACKET_DATA_SIZE,
-  PublicKey,
-  SystemProgram,
-  TransactionInstruction,
-} from "@solana/web3.js";
-import {
-  ActionName,
-  decodeExecutePostedVaa,
-  decodeHeader,
-  encodeHeader,
-} from "..";
-import { encodeExecutePostedVaa } from "../governance_payload/ExecutePostedVaa";
+import { PACKET_DATA_SIZE, PublicKey, SystemProgram } from "@solana/web3.js";
+import { ActionName, decodeHeader, encodeHeader } from "..";
+import { ExecutePostedVaa } from "../governance_payload/ExecutePostedVaa";
 
 test("GovernancePayload ser/de", (done) => {
   jest.setTimeout(60000);
@@ -75,32 +65,25 @@ test("GovernancePayload ser/de", (done) => {
   ).toThrow("Invalid header, action doesn't match module");
 
   // Decode executePostVaa with empty instructions
-  let expectedExecuteVaaArgs = {
-    targetChainId: "pythnet" as ChainName,
-    instructions: [] as TransactionInstruction[],
-  };
-  buffer = encodeExecutePostedVaa(expectedExecuteVaaArgs);
+  let expectedExecutePostedVaa = new ExecutePostedVaa("pythnet", []);
+  buffer = expectedExecutePostedVaa.encode();
   expect(
     buffer.equals(Buffer.from([80, 84, 71, 77, 0, 0, 0, 26, 0, 0, 0, 0]))
   ).toBeTruthy();
-  let executePostedVaaArgs = decodeExecutePostedVaa(buffer);
+  let executePostedVaaArgs = ExecutePostedVaa.decode(buffer);
   expect(executePostedVaaArgs?.targetChainId).toBe("pythnet");
   expect(executePostedVaaArgs?.instructions.length).toBe(0);
 
   // Decode executePostVaa with one system instruction
-  expectedExecuteVaaArgs = {
-    targetChainId: "pythnet" as ChainName,
-    instructions: [
-      SystemProgram.transfer({
-        fromPubkey: new PublicKey(
-          "AWQ18oKzd187aM2oMB4YirBcdgX1FgWfukmqEX91BRES"
-        ),
-        toPubkey: new PublicKey("J25GT2knN8V2Wvg9jNrYBuj9SZdsLnU6bK7WCGrL7daj"),
-        lamports: 890880,
-      }),
-    ] as TransactionInstruction[],
-  };
-  buffer = encodeExecutePostedVaa(expectedExecuteVaaArgs);
+  expectedExecutePostedVaa = new ExecutePostedVaa("pythnet", [
+    SystemProgram.transfer({
+      fromPubkey: new PublicKey("AWQ18oKzd187aM2oMB4YirBcdgX1FgWfukmqEX91BRES"),
+      toPubkey: new PublicKey("J25GT2knN8V2Wvg9jNrYBuj9SZdsLnU6bK7WCGrL7daj"),
+      lamports: 890880,
+    }),
+  ]);
+
+  buffer = expectedExecutePostedVaa.encode();
   expect(
     buffer.equals(
       Buffer.from([
@@ -115,7 +98,7 @@ test("GovernancePayload ser/de", (done) => {
       ])
     )
   ).toBeTruthy();
-  executePostedVaaArgs = decodeExecutePostedVaa(buffer);
+  executePostedVaaArgs = ExecutePostedVaa.decode(buffer);
   expect(executePostedVaaArgs?.targetChainId).toBe("pythnet");
   expect(executePostedVaaArgs?.instructions.length).toBe(1);
   expect(

--- a/xc-admin/packages/xc-admin-common/src/__tests__/WormholeMultisigInstruction.test.ts
+++ b/xc-admin/packages/xc-admin-common/src/__tests__/WormholeMultisigInstruction.test.ts
@@ -15,8 +15,8 @@ import {
   MultisigInstructionProgram,
   MultisigParser,
   WORMHOLE_ADDRESS,
+  ExecutePostedVaa,
 } from "..";
-import { ExecutePostedVaa } from "../governance_payload/ExecutePostedVaa";
 import { WormholeMultisigInstruction } from "../multisig_transaction/WormholeMultisigInstruction";
 
 test("Wormhole multisig instruction parse: send message without governance payload", (done) => {

--- a/xc-admin/packages/xc-admin-common/src/__tests__/WormholeMultisigInstruction.test.ts
+++ b/xc-admin/packages/xc-admin-common/src/__tests__/WormholeMultisigInstruction.test.ts
@@ -1,4 +1,3 @@
-import { ChainName } from "@certusone/wormhole-sdk";
 import { createWormholeProgramInterface } from "@certusone/wormhole-sdk/lib/cjs/solana/wormhole";
 import { AnchorProvider, Wallet } from "@project-serum/anchor";
 import {
@@ -17,10 +16,7 @@ import {
   MultisigParser,
   WORMHOLE_ADDRESS,
 } from "..";
-import {
-  encodeExecutePostedVaa,
-  ExecutePostedVaaArgs,
-} from "../governance_payload/ExecutePostedVaa";
+import { ExecutePostedVaa } from "../governance_payload/ExecutePostedVaa";
 import { WormholeMultisigInstruction } from "../multisig_transaction/WormholeMultisigInstruction";
 
 test("Wormhole multisig instruction parse: send message without governance payload", (done) => {
@@ -184,19 +180,16 @@ test("Wormhole multisig instruction parse: send message with governance payload"
   );
   const parser = MultisigParser.fromCluster(cluster);
 
-  const executePostedVaaArgs: ExecutePostedVaaArgs = {
-    targetChainId: "pythnet" as ChainName,
-    instructions: [
-      SystemProgram.transfer({
-        fromPubkey: PublicKey.unique(),
-        toPubkey: PublicKey.unique(),
-        lamports: 890880,
-      }),
-    ],
-  };
+  const executePostedVaa: ExecutePostedVaa = new ExecutePostedVaa("pythnet", [
+    SystemProgram.transfer({
+      fromPubkey: PublicKey.unique(),
+      toPubkey: PublicKey.unique(),
+      lamports: 890880,
+    }),
+  ]);
 
   wormholeProgram.methods
-    .postMessage(0, encodeExecutePostedVaa(executePostedVaaArgs), 0)
+    .postMessage(0, executePostedVaa.encode(), 0)
     .accounts({
       bridge: PublicKey.unique(),
       message: PublicKey.unique(),
@@ -319,45 +312,47 @@ test("Wormhole multisig instruction parse: send message with governance payload"
 
         expect(parsedInstruction.args.nonce).toBe(0);
         expect(
-          parsedInstruction.args.payload.equals(
-            encodeExecutePostedVaa(executePostedVaaArgs)
-          )
+          parsedInstruction.args.payload.equals(executePostedVaa.encode())
         );
         expect(parsedInstruction.args.consistencyLevel).toBe(0);
 
-        expect(parsedInstruction.args.governanceName).toBe("ExecutePostedVaa");
-
-        expect(parsedInstruction.args.governanceArgs.targetChainId).toBe(
-          "pythnet"
-        );
-
-        (
-          parsedInstruction.args.governanceArgs
-            .instructions as TransactionInstruction[]
-        ).forEach((instruction, i) => {
-          expect(
-            instruction.programId.equals(
-              executePostedVaaArgs.instructions[i].programId
-            )
+        if (
+          parsedInstruction.args.governanceAction instanceof ExecutePostedVaa
+        ) {
+          expect(parsedInstruction.args.governanceAction.targetChainId).toBe(
+            "pythnet"
           );
-          expect(
-            instruction.data.equals(executePostedVaaArgs.instructions[i].data)
-          );
-          instruction.keys.forEach((account, j) => {
+
+          (
+            parsedInstruction.args.governanceAction
+              .instructions as TransactionInstruction[]
+          ).forEach((instruction, i) => {
             expect(
-              account.pubkey.equals(
-                executePostedVaaArgs.instructions[i].keys[j].pubkey
+              instruction.programId.equals(
+                executePostedVaa.instructions[i].programId
               )
-            ).toBeTruthy();
-            expect(account.isSigner).toBe(
-              executePostedVaaArgs.instructions[i].keys[j].isSigner
             );
-            expect(account.isWritable).toBe(
-              executePostedVaaArgs.instructions[i].keys[j].isWritable
+            expect(
+              instruction.data.equals(executePostedVaa.instructions[i].data)
             );
+            instruction.keys.forEach((account, j) => {
+              expect(
+                account.pubkey.equals(
+                  executePostedVaa.instructions[i].keys[j].pubkey
+                )
+              ).toBeTruthy();
+              expect(account.isSigner).toBe(
+                executePostedVaa.instructions[i].keys[j].isSigner
+              );
+              expect(account.isWritable).toBe(
+                executePostedVaa.instructions[i].keys[j].isWritable
+              );
+            });
           });
-        });
-        done();
+          done();
+        } else {
+          done("Not instance of ExecutePostedVaa");
+        }
       } else {
         done("Not instance of WormholeInstruction");
       }

--- a/xc-admin/packages/xc-admin-common/src/governance_payload/ExecutePostedVaa.ts
+++ b/xc-admin/packages/xc-admin-common/src/governance_payload/ExecutePostedVaa.ts
@@ -1,6 +1,11 @@
 import { ChainId, ChainName } from "@certusone/wormhole-sdk";
 import * as BufferLayout from "@solana/buffer-layout";
-import { encodeHeader, governanceHeaderLayout, verifyHeader } from ".";
+import {
+  encodeHeader,
+  governanceHeaderLayout,
+  PythGovernanceAction,
+  verifyHeader,
+} from ".";
 import { Layout } from "@solana/buffer-layout";
 import {
   AccountMeta,
@@ -72,7 +77,7 @@ export const executePostedVaaLayout: BufferLayout.Structure<
   new Vector<InstructionData>(instructionDataLayout, "instructions"),
 ]);
 
-export class ExecutePostedVaa {
+export class ExecutePostedVaa implements PythGovernanceAction {
   readonly targetChainId: ChainName;
   readonly instructions: TransactionInstruction[];
 

--- a/xc-admin/packages/xc-admin-common/src/governance_payload/index.ts
+++ b/xc-admin/packages/xc-admin-common/src/governance_payload/index.ts
@@ -9,7 +9,7 @@ import { ExecutePostedVaa } from "./ExecutePostedVaa";
 
 export interface PythGovernanceAction {}
 
-class PythUnknownGovernanceAction {
+class UnknownGovernanceAction {
   readonly data: Buffer;
 
   constructor(data: Buffer) {
@@ -147,7 +147,7 @@ export function decodeGovernancePayload(data: Buffer): PythGovernanceAction {
     case "ExecutePostedVaa":
       return ExecutePostedVaa.decode(data);
     default:
-      return new PythUnknownGovernanceAction(data);
+      return new UnknownGovernanceAction(data);
   }
 }
 

--- a/xc-admin/packages/xc-admin-common/src/governance_payload/index.ts
+++ b/xc-admin/packages/xc-admin-common/src/governance_payload/index.ts
@@ -5,10 +5,17 @@ import {
   toChainName,
 } from "@certusone/wormhole-sdk";
 import * as BufferLayout from "@solana/buffer-layout";
-import {
-  decodeExecutePostedVaa,
-  ExecutePostedVaaArgs,
-} from "./ExecutePostedVaa";
+import { ExecutePostedVaa } from "./ExecutePostedVaa";
+
+export interface PythGovernanceAction {}
+
+class PythUnknownGovernanceAction {
+  readonly data: Buffer;
+
+  constructor(data: Buffer) {
+    this.data = data;
+  }
+}
 
 export const ExecutorAction = {
   ExecutePostedVaa: 0,
@@ -134,17 +141,12 @@ export function verifyHeader(
   return governanceHeader;
 }
 
-export function decodeGovernancePayload(data: Buffer): {
-  name: string;
-  args: ExecutePostedVaaArgs;
-} {
+export function decodeGovernancePayload(data: Buffer): PythGovernanceAction {
   const header = decodeHeader(data);
   switch (header.action) {
     case "ExecutePostedVaa":
-      return { name: "ExecutePostedVaa", args: decodeExecutePostedVaa(data) };
+      return ExecutePostedVaa.decode(data);
     default:
-      throw "Not supported";
+      return new PythUnknownGovernanceAction(data);
   }
 }
-
-export { decodeExecutePostedVaa } from "./ExecutePostedVaa";

--- a/xc-admin/packages/xc-admin-common/src/governance_payload/index.ts
+++ b/xc-admin/packages/xc-admin-common/src/governance_payload/index.ts
@@ -150,3 +150,5 @@ export function decodeGovernancePayload(data: Buffer): PythGovernanceAction {
       return new PythUnknownGovernanceAction(data);
   }
 }
+
+export { ExecutePostedVaa } from "./ExecutePostedVaa";

--- a/xc-admin/packages/xc-admin-common/src/governance_payload/index.ts
+++ b/xc-admin/packages/xc-admin-common/src/governance_payload/index.ts
@@ -7,14 +7,9 @@ import {
 import * as BufferLayout from "@solana/buffer-layout";
 import { ExecutePostedVaa } from "./ExecutePostedVaa";
 
-export interface PythGovernanceAction {}
-
-class UnknownGovernanceAction {
-  readonly data: Buffer;
-
-  constructor(data: Buffer) {
-    this.data = data;
-  }
+export interface PythGovernanceAction {
+  readonly targetChainId: ChainName;
+  encode(): Buffer;
 }
 
 export const ExecutorAction = {
@@ -147,7 +142,7 @@ export function decodeGovernancePayload(data: Buffer): PythGovernanceAction {
     case "ExecutePostedVaa":
       return ExecutePostedVaa.decode(data);
     default:
-      return new UnknownGovernanceAction(data);
+      throw "Not supported";
   }
 }
 

--- a/xc-admin/packages/xc-admin-common/src/multisig_transaction/WormholeMultisigInstruction.ts
+++ b/xc-admin/packages/xc-admin-common/src/multisig_transaction/WormholeMultisigInstruction.ts
@@ -3,7 +3,10 @@ import { WormholeInstructionCoder } from "@certusone/wormhole-sdk/lib/cjs/solana
 import { getPythClusterApiUrl } from "@pythnetwork/client/lib/cluster";
 import { Connection, TransactionInstruction } from "@solana/web3.js";
 import { MultisigInstruction, MultisigInstructionProgram } from ".";
-import { decodeGovernancePayload } from "../governance_payload";
+import {
+  decodeGovernancePayload,
+  PythGovernanceAction,
+} from "../governance_payload";
 import { AnchorAccounts, resolveAccountNames } from "./anchor";
 
 export class WormholeMultisigInstruction implements MultisigInstruction {
@@ -47,12 +50,12 @@ export class WormholeMultisigInstruction implements MultisigInstruction {
 
       if (result.name === "postMessage") {
         try {
-          const decoded = decodeGovernancePayload(result.args.payload);
-          result.args.governanceName = decoded.name;
-          result.args.governanceArgs = decoded.args;
+          const decoded: PythGovernanceAction = decodeGovernancePayload(
+            result.args.payload
+          );
+          result.args.governanceAction = decoded;
         } catch {
-          result.args.governanceName = "Unrecognized governance message";
-          result.args.governanceArgs = {};
+          result.args.governanceAction = {};
         }
       }
       return result;

--- a/xc-admin/packages/xc-admin-common/src/propose.ts
+++ b/xc-admin/packages/xc-admin-common/src/propose.ts
@@ -152,7 +152,9 @@ export async function wrapAsRemoteInstruction(
     provider
   );
 
-  const buffer = new ExecutePostedVaa("pythnet", [instruction]);
+  const buffer: Buffer = new ExecutePostedVaa("pythnet", [
+    instruction,
+  ]).encode();
 
   const accounts = getPostMessageAccounts(
     wormholeAddress,

--- a/xc-admin/packages/xc-admin-common/src/propose.ts
+++ b/xc-admin/packages/xc-admin-common/src/propose.ts
@@ -10,7 +10,7 @@ import {
   createWormholeProgramInterface,
   getPostMessageAccounts,
 } from "@certusone/wormhole-sdk/lib/cjs/solana/wormhole";
-import { encodeExecutePostedVaa } from "./governance_payload/ExecutePostedVaa";
+import { ExecutePostedVaa } from "./governance_payload/ExecutePostedVaa";
 
 type SquadInstruction = {
   instruction: TransactionInstruction;
@@ -152,10 +152,7 @@ export async function wrapAsRemoteInstruction(
     provider
   );
 
-  const buffer = encodeExecutePostedVaa({
-    targetChainId: "pythnet",
-    instructions: [instruction],
-  });
+  const buffer = new ExecutePostedVaa("pythnet", [instruction]);
 
   const accounts = getPostMessageAccounts(
     wormholeAddress,


### PR DESCRIPTION
Because it enables using instanceof like with `MultisigInstruction`
Each type of governanceAction will have it's own class with :
`encode() : Buffer`
`decode(data : Buffer) : Self | undefined` 