### PR TITLE
[xc-admin] Decoders can't throw

### DIFF
--- a/xc-admin/packages/xc-admin-common/src/__tests__/GovernancePayload.test.ts
+++ b/xc-admin/packages/xc-admin-common/src/__tests__/GovernancePayload.test.ts
@@ -14,8 +14,8 @@ test("GovernancePayload ser/de", (done) => {
     buffer.equals(Buffer.from([80, 84, 71, 77, 0, 0, 0, 26]))
   ).toBeTruthy();
   let governanceHeader = PythGovernanceHeader.decode(buffer);
-  expect(governanceHeader.targetChainId).toBe("pythnet");
-  expect(governanceHeader.action).toBe("ExecutePostedVaa");
+  expect(governanceHeader?.targetChainId).toBe("pythnet");
+  expect(governanceHeader?.action).toBe("ExecutePostedVaa");
 
   // Valid header 2
   expectedGovernanceHeader = new PythGovernanceHeader(
@@ -37,25 +37,25 @@ test("GovernancePayload ser/de", (done) => {
   expect(governanceHeader?.action).toBe("SetFee");
 
   // Wrong magic number
-  expect(() =>
+  expect(
     PythGovernanceHeader.decode(
       Buffer.from([0, 0, 0, 0, 0, 0, 0, 26, 0, 0, 0, 0])
     )
-  ).toThrow("Wrong magic number");
+  ).toBeUndefined();
 
   // Wrong chain
-  expect(() =>
+  expect(
     PythGovernanceHeader.decode(
       Buffer.from([80, 84, 71, 77, 0, 0, 255, 255, 0, 0, 0, 0])
     )
-  ).toThrow("Chain Id not found");
+  ).toBeUndefined();
 
   // Wrong module/action combination
-  expect(() =>
+  expect(
     PythGovernanceHeader.decode(
       Buffer.from([80, 84, 71, 77, 0, 1, 0, 26, 0, 0, 0, 0])
     )
-  ).toThrow("Invalid header, action doesn't match module");
+  ).toBeUndefined();
 
   // Decode executePostVaa with empty instructions
   let expectedExecutePostedVaa = new ExecutePostedVaa("pythnet", []);

--- a/xc-admin/packages/xc-admin-common/src/__tests__/WormholeMultisigInstruction.test.ts
+++ b/xc-admin/packages/xc-admin-common/src/__tests__/WormholeMultisigInstruction.test.ts
@@ -199,9 +199,6 @@ test("Wormhole multisig instruction parse: send message with governance payload"
     .then((instruction) => {
       const parsedInstruction = parser.parseInstruction(instruction);
       if (parsedInstruction instanceof WormholeMultisigInstruction) {
-        expect(
-          parsedInstruction instanceof WormholeMultisigInstruction
-        ).toBeTruthy();
         expect(parsedInstruction.program).toBe(
           MultisigInstructionProgram.WormholeBridge
         );
@@ -313,15 +310,13 @@ test("Wormhole multisig instruction parse: send message with governance payload"
         );
         expect(parsedInstruction.args.consistencyLevel).toBe(0);
 
-        if (
-          parsedInstruction.args.governanceAction instanceof ExecutePostedVaa
-        ) {
-          expect(parsedInstruction.args.governanceAction.targetChainId).toBe(
+        if (parsedInstruction.governanceAction instanceof ExecutePostedVaa) {
+          expect(parsedInstruction.governanceAction.targetChainId).toBe(
             "pythnet"
           );
 
           (
-            parsedInstruction.args.governanceAction
+            parsedInstruction.governanceAction
               .instructions as TransactionInstruction[]
           ).forEach((instruction, i) => {
             expect(

--- a/xc-admin/packages/xc-admin-common/src/governance_payload/ExecutePostedVaa.ts
+++ b/xc-admin/packages/xc-admin-common/src/governance_payload/ExecutePostedVaa.ts
@@ -1,6 +1,10 @@
 import { ChainId, ChainName } from "@certusone/wormhole-sdk";
 import * as BufferLayout from "@solana/buffer-layout";
-import { PythGovernanceAction, PythGovernanceHeader } from ".";
+import {
+  PythGovernanceAction,
+  PythGovernanceHeader,
+  safeLayoutDecode,
+} from ".";
 import { Layout } from "@solana/buffer-layout";
 import {
   AccountMeta,
@@ -76,19 +80,14 @@ export class ExecutePostedVaa implements PythGovernanceAction {
 
   /** Decode ExecutePostedVaa */
   static decode(data: Buffer): ExecutePostedVaa | undefined {
-    let header = PythGovernanceHeader.decode(data);
-    if (!header) {
-      return undefined;
-    }
+    const header = PythGovernanceHeader.decode(data);
+    if (!header) return undefined;
 
-    let deserialized;
-    try {
-      deserialized = this.layout.decode(
-        data.subarray(PythGovernanceHeader.span)
-      );
-    } catch {
-      return undefined;
-    }
+    const deserialized = safeLayoutDecode(
+      this.layout,
+      data.subarray(PythGovernanceHeader.span)
+    );
+    if (!deserialized) return undefined;
 
     let instructions: TransactionInstruction[] = deserialized.map((ix) => {
       let programId: PublicKey = new PublicKey(ix.programId);

--- a/xc-admin/packages/xc-admin-common/src/governance_payload/ExecutePostedVaa.ts
+++ b/xc-admin/packages/xc-admin-common/src/governance_payload/ExecutePostedVaa.ts
@@ -75,11 +75,21 @@ export class ExecutePostedVaa implements PythGovernanceAction {
   }
 
   /** Decode ExecutePostedVaa */
-  static decode(data: Buffer): ExecutePostedVaa {
+  static decode(data: Buffer): ExecutePostedVaa | undefined {
     let header = PythGovernanceHeader.decode(data);
-    let deserialized = this.layout.decode(
-      data.subarray(PythGovernanceHeader.span)
-    );
+    if (!header) {
+      return undefined;
+    }
+
+    let deserialized;
+    try {
+      deserialized = this.layout.decode(
+        data.subarray(PythGovernanceHeader.span)
+      );
+    } catch {
+      return undefined;
+    }
+
     let instructions: TransactionInstruction[] = deserialized.map((ix) => {
       let programId: PublicKey = new PublicKey(ix.programId);
       let keys: AccountMeta[] = ix.accounts.map((acc) => {

--- a/xc-admin/packages/xc-admin-common/src/multisig_transaction/PythMultisigInstruction.ts
+++ b/xc-admin/packages/xc-admin-common/src/multisig_transaction/PythMultisigInstruction.ts
@@ -1,4 +1,8 @@
-import { MultisigInstruction, MultisigInstructionProgram } from ".";
+import {
+  MultisigInstruction,
+  MultisigInstructionProgram,
+  UNRECOGNIZED_INSTRUCTION,
+} from ".";
 import { AnchorAccounts, resolveAccountNames } from "./anchor";
 import { pythIdl, pythOracleCoder } from "@pythnetwork/client";
 import { TransactionInstruction } from "@solana/web3.js";
@@ -35,8 +39,8 @@ export class PythMultisigInstruction implements MultisigInstruction {
       );
     } else {
       return new PythMultisigInstruction(
-        "Unrecognized instruction",
-        {},
+        UNRECOGNIZED_INSTRUCTION,
+        { data: instruction.data },
         { named: {}, remaining: instruction.keys }
       );
     }

--- a/xc-admin/packages/xc-admin-common/src/multisig_transaction/anchor.ts
+++ b/xc-admin/packages/xc-admin-common/src/multisig_transaction/anchor.ts
@@ -15,7 +15,7 @@ export function resolveAccountNames(
 ): { named: NamedAccounts; remaining: RemainingAccounts } {
   const ix = idl.instructions.find((ix) => ix.name == name);
   if (!ix) {
-    throw Error("Instruction name not found");
+    return { named: {}, remaining: instruction.keys };
   }
   const named: NamedAccounts = {};
   const remaining: RemainingAccounts = [];

--- a/xc-admin/packages/xc-admin-common/src/multisig_transaction/index.ts
+++ b/xc-admin/packages/xc-admin-common/src/multisig_transaction/index.ts
@@ -7,6 +7,7 @@ import { WORMHOLE_ADDRESS } from "../wormhole";
 import { PythMultisigInstruction } from "./PythMultisigInstruction";
 import { WormholeMultisigInstruction } from "./WormholeMultisigInstruction";
 
+export const UNRECOGNIZED_INSTRUCTION = "unrecognizedInstruction";
 export enum MultisigInstructionProgram {
   PythOracle,
   WormholeBridge,


### PR DESCRIPTION
Try to switch to a world where nothing can throw errors.

- Update `decode` to not throw and instead return undefined
- resolveAccountName can't throw

How `undefined` are handled :
- 1. If we don't recognize the program of the instruction, it becomes `UnrecognizedProgram implements MultisigInstruction` which stores the instruction (useful to print the instruction)
- 2. If we don't recognize an instruction in `PythMultisigInstruction` or `WormholeMultisigInstruction` the name of the instruction is set to `unrecognizedInstruction` instead of for example `postMessage` or `addPrice`.
- 3. If we recognize a `postMessage` in `WormholeMultisigInstruction` but we can't deserialize the wormhole payload `wormholeMultisigInstruction.governanceAction` will be `undefined`, but the payload is stored in `wormholeMultisigInstruction.args.payload`

It think it's good to distinguish the 3 cases because the `undefined` is at a different depth. It ends up being a little bit inconsistent, but ultimately it is because we use anchor to deserialize the instructions and that part somehow breaks the types.