### PR TITLE
[price-service] Handle WS error

### DIFF
--- a/price-service/src/ws.ts
+++ b/price-service/src/ws.ts
@@ -233,6 +233,10 @@ export class WebSocketAPI {
         this.aliveClients.add(ws);
       });
 
+      ws.on("error", (err: Error) => {
+        logger.warn(`Err with client ${this.wsId.get(ws)}: ${err}`);
+      });
+
       ws.on("close", (_code: number, _reason: Buffer) => {
         logger.info(`client ${this.wsId.get(ws)} closed the connection.`);
         this.promClient?.addWebSocketInteraction("close", "ok");


### PR DESCRIPTION
There is a low chance that ws errors happens but it is positive and has happened a couple of times with the following error:
`RangeError: Invalid WebSocket frame: RSV2 and RSV3 must be clear`

This PR logs the error and ignores it. The connection will get closed itself or if not the pinging mechanism will prune it.