### PR TITLE
Drozdziak1/refactor p2w autoattest py

### DIFF
--- a/third_party/pyth/p2w_autoattest.py
+++ b/third_party/pyth/p2w_autoattest.py
@@ -186,7 +186,6 @@ while True:
             "attest",
             "-f",
             P2W_ATTESTATION_CFG,
-            "-d",
             "--timeout",
             P2W_RPC_TIMEOUT_SECS,
         ]

--- a/third_party/pyth/p2w_autoattest.py
+++ b/third_party/pyth/p2w_autoattest.py
@@ -168,34 +168,6 @@ symbol_groups:
 # modules like async HTTP requests and tokio runtime logs
 os.environ["RUST_LOG"] = os.environ.get("RUST_LOG", "info")
 
-# Send the first attestation in one-shot mode for testing
-first_attest_result = run_or_die(
-    [
-        "pwhac",
-        "--commitment",
-        "confirmed",
-        "--p2w-addr",
-        P2W_SOL_ADDRESS,
-        "--rpc-url",
-        SOL_RPC_URL,
-        "--payer",
-        SOL_PAYER_KEYPAIR,
-        "attest",
-        "-f",
-        P2W_ATTESTATION_CFG,
-        "--timeout",
-        P2W_RPC_TIMEOUT_SECS,
-    ],
-    capture_output=True,
-    debug = True,
-)
-
-logging.info("p2w_autoattest ready to roll!")
-
-# Let k8s know the service is up
-readiness_thread = threading.Thread(target=readiness, daemon=True)
-readiness_thread.start()
-
 # Do not exit this script if a continuous attestation stops for
 # whatever reason (this avoids k8s restart penalty)
 while True:

--- a/wormhole-attester/Cargo.lock
+++ b/wormhole-attester/Cargo.lock
@@ -2710,7 +2710,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-wormhole-attester-client"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "borsh",
  "clap 3.1.18",

--- a/wormhole-attester/client/Cargo.toml
+++ b/wormhole-attester/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-wormhole-attester-client"
-version = "2.0.0"
+version = "3.0.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/wormhole-attester/client/src/cli.rs
+++ b/wormhole-attester/client/src/cli.rs
@@ -60,27 +60,6 @@ pub enum Action {
         #[clap(short = 'f', long = "--config", help = "Attestation YAML config")]
         attestation_cfg:           PathBuf,
         #[clap(
-            short = 'n',
-            long = "--n-retries",
-            help = "How many times to retry send_transaction() on each batch before flagging a failure. Only active outside daemon mode",
-            default_value = "5"
-        )]
-        n_retries:                 usize,
-        #[clap(
-            short = 'i',
-            long = "--retry-interval",
-            help = "How long to wait between send_transaction
-            retries. Only active outside daemon mode",
-            default_value = "5"
-        )]
-        retry_interval_secs:       u64,
-        #[clap(
-            short = 'd',
-            long = "--daemon",
-            help = "Do not stop attesting. In this mode, this program will behave more like a daemon and continuously attest the specified symbols."
-        )]
-        daemon:                    bool,
-        #[clap(
             short = 't',
             long = "--timeout",
             help = "How many seconds to wait before giving up on  tx confirmation.",


### PR DESCRIPTION
This change gets rid of non-daemon mode. The Python script still makes sense for Tilt, but removing the explicit daemon mode switch should simplify the prod command line a little.