### PR TITLE
[price-service] Hotfix a serde problem

### DIFF
--- a/price-service/package-lock.json
+++ b/price-service/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-price-service",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-price-service",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@certusone/wormhole-sdk": "^0.9.9",

--- a/price-service/package.json
+++ b/price-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-price-service",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Pyth Price Service",
   "main": "index.js",
   "scripts": {

--- a/price-service/src/__tests__/rest.test.ts
+++ b/price-service/src/__tests__/rest.test.ts
@@ -42,7 +42,7 @@ function dummyPriceInfoPair(
       priceFeed: dummyPriceFeed(id),
       publishTime: 0,
       attestationTime: 0,
-      seqNum: BigInt(seqNum),
+      seqNum,
       vaa: Buffer.from(vaa, "hex"),
       emitterChainId: 0,
       priceServiceReceiveTime: 0,

--- a/price-service/src/listen.ts
+++ b/price-service/src/listen.ts
@@ -23,7 +23,7 @@ import { PromClient } from "./promClient";
 
 export type PriceInfo = {
   vaa: Buffer;
-  seqNum: bigint;
+  seqNum: number;
   publishTime: TimestampInSec;
   attestationTime: TimestampInSec;
   priceFeed: PriceFeed;
@@ -284,7 +284,7 @@ export class Listener implements PriceStore {
 
       const priceFeed = priceAttestationToPriceFeed(priceAttestation);
       const priceInfo = {
-        seqNum: parsedVaa.sequence,
+        seqNum: Number(parsedVaa.sequence),
         vaa,
         publishTime: priceAttestation.publishTime,
         attestationTime: priceAttestation.attestationTime,

--- a/price-service/src/rest.ts
+++ b/price-service/src/rest.ts
@@ -134,7 +134,7 @@ export class RestAPI {
 
         // Multiple price ids might share same vaa, we use sequence number as
         // key of a vaa and deduplicate using a map of seqnum to vaa bytes.
-        const vaaMap = new Map<bigint, Buffer>();
+        const vaaMap = new Map<number, Buffer>();
 
         const notFoundIds: string[] = [];
 

--- a/price-service/src/rest.ts
+++ b/price-service/src/rest.ts
@@ -44,7 +44,7 @@ export class RestException extends Error {
 function asyncWrapper(
   callback: (req: Request, res: Response, next: NextFunction) => Promise<any>
 ) {
-  return function (req: Request, res: Response, next: NextFunction) {
+  return (req: Request, res: Response, next: NextFunction) => {
     callback(req, res, next).catch(next);
   };
 }


### PR DESCRIPTION
The problem is that when `verbose` is enabled in the price service the sequence number is converted to JSON. In #495 I updated wormhole package and this got converted to bigint and apparently JSON cannot handle the conversion.

Why it was not caught? because we did not have proper testing in place. I will add proper tests for this and other untested parts in subsequent PRs.