### PR TITLE
[price-service] Hotfix leading 0x problem

### DIFF
--- a/price-service/package-lock.json
+++ b/price-service/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-price-service",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-price-service",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@certusone/wormhole-sdk": "^0.9.9",

--- a/price-service/package.json
+++ b/price-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-price-service",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Pyth Price Service",
   "main": "index.js",
   "scripts": {

--- a/price-service/src/rest.ts
+++ b/price-service/src/rest.ts
@@ -130,7 +130,7 @@ export class RestAPI {
       "/api/latest_vaas",
       validate(latestVaasInputSchema),
       (req: Request, res: Response) => {
-        const priceIds = req.query.ids as string[];
+        const priceIds = (req.query.ids as string[]).map(removeLeading0x);
 
         // Multiple price ids might share same vaa, we use sequence number as
         // key of a vaa and deduplicate using a map of seqnum to vaa bytes.
@@ -138,11 +138,7 @@ export class RestAPI {
 
         const notFoundIds: string[] = [];
 
-        for (let id of priceIds) {
-          if (id.startsWith("0x")) {
-            id = id.substring(2);
-          }
-
+        for (const id of priceIds) {
           const latestPriceInfo = this.priceFeedVaaInfo.getLatestPriceInfo(id);
 
           if (latestPriceInfo === undefined) {
@@ -181,7 +177,7 @@ export class RestAPI {
       "/api/get_vaa",
       validate(getVaaInputSchema),
       asyncWrapper(async (req: Request, res: Response) => {
-        const priceFeedId = req.query.id as string;
+        const priceFeedId = removeLeading0x(req.query.id as string);
         const publishTime = Number(req.query.publish_time as string);
 
         if (
@@ -275,7 +271,7 @@ export class RestAPI {
       "/api/latest_price_feeds",
       validate(latestPriceFeedsInputSchema),
       (req: Request, res: Response) => {
-        const priceIds = req.query.ids as string[];
+        const priceIds = (req.query.ids as string[]).map(removeLeading0x);
         // verbose is optional, default to false
         const verbose = req.query.verbose === "true";
         // binary is optional, default to false
@@ -285,11 +281,7 @@ export class RestAPI {
 
         const notFoundIds: string[] = [];
 
-        for (let id of priceIds) {
-          if (id.startsWith("0x")) {
-            id = id.substring(2);
-          }
-
+        for (const id of priceIds) {
           const latestPriceInfo = this.priceFeedVaaInfo.getLatestPriceInfo(id);
 
           if (latestPriceInfo === undefined) {


### PR DESCRIPTION
`get_vaa` method says a price feed does not exist if it has leading 0x. This PR fixes that and also cleans up some other 0x usages.