### PR TITLE
[Xc admin] init price

### DIFF
--- a/governance/xc-admin/packages/xc-admin-cli/src/index.ts
+++ b/governance/xc-admin/packages/xc-admin-cli/src/index.ts
@@ -174,6 +174,7 @@ mutlisigCommand(
   "Init price (useful for changing the exponent), only to be used on unused price feeds"
 )
   .requiredOption("-p, --price <pubkey>", "Price account to modify")
+  .requiredOption("-e, --exponent <number>", "New exponent")
   .action(async (options: any) => {
     const wallet = new NodeWallet(
       Keypair.fromSecretKey(
@@ -183,7 +184,7 @@ mutlisigCommand(
     const cluster: PythCluster = options.cluster;
     const vault: PublicKey = new PublicKey(options.vault);
     const priceAccount: PublicKey = new PublicKey(options.price);
-
+    const exponent = options.exponent;
     const squad = SquadsMesh.endpoint(getPythClusterApiUrl(cluster), wallet);
 
     const msAccount = await squad.getMultisig(vault);
@@ -201,7 +202,7 @@ mutlisigCommand(
       getPythProgramKeyForCluster(cluster),
       provider
     )
-      .methods.initPrice(-10, 1)
+      .methods.initPrice(exponent, 1)
       .accounts({ fundingAccount: vaultAuthority, priceAccount })
       .instruction();
     await proposeInstructions(squad, vault, [proposalInstruction], false);

--- a/governance/xc-admin/packages/xc-admin-cli/src/index.ts
+++ b/governance/xc-admin/packages/xc-admin-cli/src/index.ts
@@ -208,7 +208,7 @@ mutlisigCommand(
     await proposeInstructions(squad, vault, [proposalInstruction], false);
   });
 
-  program
+program
   .command("parse-transaction")
   .description("Parse a transaction sitting in the multisig")
   .requiredOption("-c, --cluster <network>", "solana cluster to use")
@@ -234,5 +234,5 @@ mutlisigCommand(
     );
     console.log(JSON.stringify(parsed, null, 2));
   });
-  
+
 program.parse();


### PR DESCRIPTION
As said on Slack. I don't like that needing to encode instructions in a JSON and then proposing so this is the equivalent of init-price from program-admin but direct to multisig.
Program-admin should definitely have it though for the non-multisig networks.

BTW this seems like something that doesn't happen very often so I think I CLI works well.
