### PR TITLE
[xc-admin] frontend update permissions bugfix

### DIFF
--- a/governance/xc-admin/packages/xc-admin-frontend/components/tabs/UpdatePermissions.tsx
+++ b/governance/xc-admin/packages/xc-admin-frontend/components/tabs/UpdatePermissions.tsx
@@ -228,6 +228,12 @@ const UpdatePermissions = () => {
           new: newPubkey,
         },
       })
+    } else {
+      // delete account from pubkeyChanges if it exists
+      if (pubkeyChanges && pubkeyChanges[account]) {
+        delete pubkeyChanges[account]
+      }
+      setPubkeyChanges(pubkeyChanges)
     }
   }
 

--- a/governance/xc-admin/packages/xc-admin-frontend/components/tabs/UpdatePermissions.tsx
+++ b/governance/xc-admin/packages/xc-admin-frontend/components/tabs/UpdatePermissions.tsx
@@ -118,7 +118,6 @@ const UpdatePermissions = () => {
     useState<Program<PythOracle>>()
 
   useEffect(() => {
-    console.log(rawConfig)
     if (rawConfig.permissionAccount) {
       const masterAuthority =
         rawConfig.permissionAccount.masterAuthority.toBase58()

--- a/governance/xc-admin/packages/xc-admin-frontend/components/tabs/UpdatePermissions.tsx
+++ b/governance/xc-admin/packages/xc-admin-frontend/components/tabs/UpdatePermissions.tsx
@@ -118,6 +118,7 @@ const UpdatePermissions = () => {
     useState<Program<PythOracle>>()
 
   useEffect(() => {
+    console.log(rawConfig)
     if (rawConfig.permissionAccount) {
       const masterAuthority =
         rawConfig.permissionAccount.masterAuthority.toBase58()
@@ -139,6 +140,8 @@ const UpdatePermissions = () => {
           pubkey: securityAuthority,
         },
       ])
+    } else {
+      setData([...DEFAULT_DATA])
     }
   }, [rawConfig])
 


### PR DESCRIPTION
- fix bug where setting new pubkey and reverting the change doesnt reflect properly
- fix bug where switching to cluster with permissionAccount and switching back doesnt show default value
