### PR TITLE
[cosmwasm] Update to use cosmwasm release

### DIFF
--- a/target_chains/cosmwasm/contracts/README.md
+++ b/target_chains/cosmwasm/contracts/README.md
@@ -9,7 +9,7 @@ Add this crate to the dependencies section of your CosmWasm contract's `Cargo.to
 
 ```
 [dependencies]
-pyth-cosmwasm = { git="https://github.com/pyth-network/pyth-crosschain", rev="5d0acc1", features=["library"] }
+pyth-cosmwasm = { git="https://github.com/pyth-network/pyth-crosschain", tag="pyth-cosmwasm-v0.1.0", features=["library"] }
 ```
 
 ## Usage

--- a/target_chains/cosmwasm/examples/cw-contract/Cargo.lock
+++ b/target_chains/cosmwasm/examples/cw-contract/Cargo.lock
@@ -633,7 +633,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "p2w-sdk"
 version = "0.1.1"
-source = "git+https://github.com/pyth-network/pyth-crosschain?rev=5d0acc1#5d0acc1a76165c16c9bdd90cd010533b2a86be3c"
+source = "git+https://github.com/pyth-network/pyth-crosschain?tag=pyth-cosmwasm-v0.1.0#16b7977179483d2a52d970a85bac707525068db5"
 dependencies = [
  "hex",
  "pyth-sdk 0.5.0",
@@ -681,10 +681,11 @@ dependencies = [
 [[package]]
 name = "pyth-cosmwasm"
 version = "0.1.0"
-source = "git+https://github.com/pyth-network/pyth-crosschain?rev=5d0acc1#5d0acc1a76165c16c9bdd90cd010533b2a86be3c"
+source = "git+https://github.com/pyth-network/pyth-crosschain?tag=pyth-cosmwasm-v0.1.0#16b7977179483d2a52d970a85bac707525068db5"
 dependencies = [
  "bigint",
  "byteorder",
+ "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
  "generic-array",

--- a/target_chains/cosmwasm/examples/cw-contract/Cargo.toml
+++ b/target_chains/cosmwasm/examples/cw-contract/Cargo.toml
@@ -34,5 +34,5 @@ cosmwasm-storage = { version = "1.0.0" }
 cw-storage-plus = "0.13.4"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-pyth-cosmwasm = { git="https://github.com/pyth-network/pyth-crosschain", rev="5d0acc1" }
+pyth-cosmwasm = { git="https://github.com/pyth-network/pyth-crosschain", tag="pyth-cosmwasm-v0.1.0", features=["library"] }
 cosmwasm-schema = "1.1.9"


### PR DESCRIPTION
https://github.com/pyth-network/pyth-crosschain/releases/tag/pyth-cosmwasm-v0.1.0