### PR TITLE
[Xc admin] upd permissions remote

### DIFF
--- a/governance/xc-admin/packages/xc-admin-frontend/components/ClusterSwitch.tsx
+++ b/governance/xc-admin/packages/xc-admin-frontend/components/ClusterSwitch.tsx
@@ -50,10 +50,10 @@ const ClusterSwitch = ({ light }: { light?: boolean | null }) => {
       name: 'devnet',
     },
     // hide pythtest as its broken
-    // {
-    //   value: 'pythtest',
-    //   name: 'pythtest',
-    // },
+    {
+      value: 'pythtest',
+      name: 'pythtest',
+    },
   ]
 
   return (

--- a/governance/xc-admin/packages/xc-admin-frontend/components/tabs/MinPublishers.tsx
+++ b/governance/xc-admin/packages/xc-admin-frontend/components/tabs/MinPublishers.tsx
@@ -18,7 +18,10 @@ import toast from 'react-hot-toast'
 import { getMultisigCluster, proposeInstructions } from 'xc-admin-common'
 import { ClusterContext } from '../../contexts/ClusterContext'
 import { usePythContext } from '../../contexts/PythContext'
-import { SECURITY_MULTISIG, useMultisig } from '../../hooks/useMultisig'
+import {
+  SECURITY_MULTISIG,
+  useMultisig,
+} from '../../hooks/useMultisig'
 import { capitalizeFirstLetter } from '../../utils/capitalizeFirstLetter'
 import ClusterSwitch from '../ClusterSwitch'
 import Modal from '../common/Modal'

--- a/governance/xc-admin/packages/xc-admin-frontend/components/tabs/MinPublishers.tsx
+++ b/governance/xc-admin/packages/xc-admin-frontend/components/tabs/MinPublishers.tsx
@@ -18,10 +18,7 @@ import toast from 'react-hot-toast'
 import { getMultisigCluster, proposeInstructions } from 'xc-admin-common'
 import { ClusterContext } from '../../contexts/ClusterContext'
 import { usePythContext } from '../../contexts/PythContext'
-import {
-  SECURITY_MULTISIG,
-  useMultisig,
-} from '../../hooks/useMultisig'
+import { SECURITY_MULTISIG, useMultisig } from '../../hooks/useMultisig'
 import { capitalizeFirstLetter } from '../../utils/capitalizeFirstLetter'
 import ClusterSwitch from '../ClusterSwitch'
 import Modal from '../common/Modal'

--- a/governance/xc-admin/packages/xc-admin-frontend/components/tabs/UpdatePermissions.tsx
+++ b/governance/xc-admin/packages/xc-admin-frontend/components/tabs/UpdatePermissions.tsx
@@ -443,6 +443,3 @@ const UpdatePermissions = () => {
 }
 
 export default UpdatePermissions
-function isRemote(cluster: string): boolean {
-  throw new Error('Function not implemented.')
-}

--- a/governance/xc-admin/packages/xc-admin-frontend/components/tabs/UpdatePermissions.tsx
+++ b/governance/xc-admin/packages/xc-admin-frontend/components/tabs/UpdatePermissions.tsx
@@ -20,6 +20,9 @@ import {
   proposeInstructions,
   getMultisigCluster,
   BPF_UPGRADABLE_LOADER,
+  isRemoteCluster,
+  WORMHOLE_ADDRESS,
+  mapKey,
 } from 'xc-admin-common'
 import { ClusterContext } from '../../contexts/ClusterContext'
 import { usePythContext } from '../../contexts/PythContext'
@@ -238,11 +241,16 @@ const UpdatePermissions = () => {
   }
 
   const handleSendProposalButtonClick = () => {
-    if (pythProgramClient && finalPubkeyChanges) {
+    if (pythProgramClient && finalPubkeyChanges && squads) {
       const programDataAccount = PublicKey.findProgramAddressSync(
         [pythProgramClient?.programId.toBuffer()],
         BPF_UPGRADABLE_LOADER
       )[0]
+      const multisigAuthority = squads.getAuthorityPDA(
+        UPGRADE_MULTISIG[getMultisigCluster(cluster)],
+        1
+      )
+
       pythProgramClient?.methods
         .updPermissions(
           new PublicKey(finalPubkeyChanges['Master Authority'].new),
@@ -250,22 +258,22 @@ const UpdatePermissions = () => {
           new PublicKey(finalPubkeyChanges['Security Authority'].new)
         )
         .accounts({
-          upgradeAuthority: squads?.getAuthorityPDA(
-            UPGRADE_MULTISIG[getMultisigCluster(cluster)],
-            1
-          ),
+          upgradeAuthority: isRemoteCluster(cluster)
+            ? mapKey(multisigAuthority)
+            : multisigAuthority,
           programDataAccount,
         })
         .instruction()
         .then(async (instruction) => {
-          if (!isMultisigLoading && squads) {
+          if (!isMultisigLoading) {
             setIsSendProposalButtonLoading(true)
             try {
               const proposalPubkey = await proposeInstructions(
                 squads,
                 UPGRADE_MULTISIG[getMultisigCluster(cluster)],
                 [instruction],
-                false
+                isRemoteCluster(cluster),
+                WORMHOLE_ADDRESS[getMultisigCluster(cluster)]
               )
               toast.success(
                 `Proposal sent! 🚀 Proposal Pubkey: ${proposalPubkey}`
@@ -435,3 +443,6 @@ const UpdatePermissions = () => {
 }
 
 export default UpdatePermissions
+function isRemote(cluster: string): boolean {
+  throw new Error('Function not implemented.')
+}


### PR DESCRIPTION
This enables upd_permission for pythtest

TODO: Move multisigAuthority, isRemote, WORMHOLE_ADDRESS[getMultisigCluster(cluster)] and UPGRADE_MULTISIG[getMultisigCluster(cluster)] to the multisig hook? The remote, not-remote logic will be used in all tabs.
WDYT @cctdaniel 