### PR TITLE
[refactor] Improve typescript codebase

### DIFF
--- a/.github/workflows/lerna.yaml
+++ b/.github/workflows/lerna.yaml
@@ -1,4 +1,4 @@
-name: Lerna build & test
+name: JS/TS checks
 on:
   pull_request:
   push:
@@ -14,7 +14,9 @@ jobs:
           cache: "npm"
       - name: Install deps
         run: npm ci
-      - name: Run lerna build
+      - name: Build
         run: npx lerna run build
-      - name: Run lerna tests
+      - name: Test
         run: npx lerna run test
+      - name: Lint
+        run: npx lerna run lint

--- a/governance/multisig_wh_message_builder/.eslintrc.js
+++ b/governance/multisig_wh_message_builder/.eslintrc.js
@@ -3,5 +3,7 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint"],
   extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
-  rules: {},
+  rules: {
+    "@typescript-eslint/no-explicit-any": "off",
+  },
 };

--- a/governance/multisig_wh_message_builder/src/index.ts
+++ b/governance/multisig_wh_message_builder/src/index.ts
@@ -106,17 +106,19 @@ program
     "http://localhost:8899"
   )
   .action(async (options: any) => {
-    let cluster: Cluster = options.cluster;
-    let createKeyAddr: PublicKey = new PublicKey(options.createKey);
-    let extAuthorityAddr: PublicKey = new PublicKey(options.externalAuthority);
+    const cluster: Cluster = options.cluster;
+    const createKeyAddr: PublicKey = new PublicKey(options.createKey);
+    const extAuthorityAddr: PublicKey = new PublicKey(
+      options.externalAuthority
+    );
 
-    let threshold: number = parseInt(options.threshold, 10);
+    const threshold: number = parseInt(options.threshold, 10);
 
-    let initialMembers = options.initialMembers
+    const initialMembers = options.initialMembers
       .split(",")
       .map((m: string) => new PublicKey(m));
 
-    let mesh = await getSquadsClient(
+    const mesh = await getSquadsClient(
       cluster,
       options.ledger,
       options.ledgerDerivationAccount,
@@ -125,11 +127,11 @@ program
       cluster == "localdevnet" ? options.solanaRpc : undefined
     );
 
-    let vaultAddr = getMsPDA(createKeyAddr, DEFAULT_MULTISIG_PROGRAM_ID)[0];
+    const vaultAddr = getMsPDA(createKeyAddr, DEFAULT_MULTISIG_PROGRAM_ID)[0];
     console.log("Creating new vault at", vaultAddr.toString());
 
     try {
-      let _multisig = await mesh.getMultisig(vaultAddr);
+      await mesh.getMultisig(vaultAddr);
 
       // NOTE(2022-12-08): If this check prevents you from iterating dev
       // work in tilt, restart solana-devnet.
@@ -137,7 +139,9 @@ program
         "Reached an existing vault under the address, refusing to create."
       );
       process.exit(17); // EEXIST
-    } catch (e: any) {}
+    } catch (e: any) {
+      undefined;
+    }
     console.log("No existing vault found, creating...");
     await mesh.createMultisig(
       extAuthorityAddr,
@@ -309,7 +313,7 @@ program
 
     const wormholeTools = await loadWormholeTools(cluster, squad.connection);
 
-    let onChainInstructions = await getProposalInstructions(
+    const onChainInstructions = await getProposalInstructions(
       squad,
       await squad.getTransaction(new PublicKey(options.txPda))
     );
@@ -692,7 +696,7 @@ async function setIsActiveIx(
   attesterProgramId: PublicKey,
   isActive: boolean
 ): Promise<TransactionInstruction> {
-  const [configKey, _bump] = PublicKey.findProgramAddressSync(
+  const [configKey] = PublicKey.findProgramAddressSync(
     [Buffer.from("pyth2wormhole-config-v3")],
     attesterProgramId
   );

--- a/governance/multisig_wh_message_builder/src/multisig.ts
+++ b/governance/multisig_wh_message_builder/src/multisig.ts
@@ -11,13 +11,13 @@ import lodash from "lodash";
 export async function getActiveProposals(
   squad: Squads,
   vault: PublicKey,
-  offset: number = 1
+  offset = 1
 ): Promise<TransactionAccount[]> {
   const msAccount = await squad.getMultisig(vault);
-  let txKeys = lodash
+  const txKeys = lodash
     .range(offset, msAccount.transactionIndex + 1)
     .map((i) => getTxPDA(vault, new BN(i), DEFAULT_MULTISIG_PROGRAM_ID)[0]);
-  let msTransactions = await squad.getTransactions(txKeys);
+  const msTransactions = await squad.getTransactions(txKeys);
   return msTransactions
     .filter(
       (x: TransactionAccount | null): x is TransactionAccount => x != null
@@ -29,10 +29,10 @@ export async function getManyProposalsInstructions(
   squad: Squads,
   txAccounts: TransactionAccount[]
 ): Promise<InstructionAccount[][]> {
-  let allIxsKeys = [];
-  let ownerTransaction = [];
-  for (let [index, txAccount] of txAccounts.entries()) {
-    let ixKeys = lodash
+  const allIxsKeys = [];
+  const ownerTransaction = [];
+  for (const [index, txAccount] of txAccounts.entries()) {
+    const ixKeys = lodash
       .range(1, txAccount.instructionIndex + 1)
       .map(
         (i) =>
@@ -42,14 +42,14 @@ export async function getManyProposalsInstructions(
             DEFAULT_MULTISIG_PROGRAM_ID
           )[0]
       );
-    for (let ixKey of ixKeys) {
+    for (const ixKey of ixKeys) {
       allIxsKeys.push(ixKey);
       ownerTransaction.push(index);
     }
   }
 
-  let allTxIxsAcccounts = await squad.getInstructions(allIxsKeys);
-  let ixAccountsByTx: InstructionAccount[][] = Array.from(
+  const allTxIxsAcccounts = await squad.getInstructions(allIxsKeys);
+  const ixAccountsByTx: InstructionAccount[][] = Array.from(
     Array(txAccounts.length),
     () => []
   );
@@ -67,13 +67,13 @@ export async function getProposalInstructions(
   squad: Squads,
   txAccount: TransactionAccount
 ): Promise<InstructionAccount[]> {
-  let ixKeys = lodash
+  const ixKeys = lodash
     .range(1, txAccount.instructionIndex + 1)
     .map(
       (i) =>
         getIxPDA(txAccount.publicKey, new BN(i), DEFAULT_MULTISIG_PROGRAM_ID)[0]
     );
-  let txIxs = await squad.getInstructions(ixKeys);
+  const txIxs = await squad.getInstructions(ixKeys);
   return txIxs.filter(
     (x: InstructionAccount | null): x is InstructionAccount => x != null
   );

--- a/governance/multisig_wh_message_builder/src/util.ts
+++ b/governance/multisig_wh_message_builder/src/util.ts
@@ -88,7 +88,6 @@ async function send(
         p2 | P2_MORE,
         buffer
       );
-      // @ts-ignore -- TransportStatusError is a constructor Function, not a Class
       if (response.length !== 2)
         throw TransportStatusError(StatusCodes.INCORRECT_DATA);
 

--- a/governance/multisig_wh_message_builder/tsconfig.json
+++ b/governance/multisig_wh_message_builder/tsconfig.json
@@ -1,19 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "**/__tests__/*"],
   "compilerOptions": {
-    "declaration": true,
-    "composite": true,
-    "declarationMap": true,
-    "incremental": true,
-    "target": "es2016",
-    "module": "commonjs",
-    "outDir": "lib",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "noErrorTruncation": true,
-    "rootDir": "src/"
-  },
-  "include": ["src/**/*.ts"]
+    "rootDir": "src/",
+    "outDir": "./lib",
+    "skipLibCheck": true
+  }
 }

--- a/governance/xc_admin/packages/crank_executor/tsconfig.json
+++ b/governance/xc_admin/packages/crank_executor/tsconfig.json
@@ -1,20 +1,10 @@
 {
+  "extends": "../../../../tsconfig.base.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "**/__tests__/*"],
   "compilerOptions": {
-    "declaration": true,
-    "composite": true,
-    "declarationMap": true,
-    "incremental": true,
-    "target": "es2016",
-    "module": "commonjs",
-    "outDir": "lib",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "noErrorTruncation": true,
-    "rootDir": "src/"
-  },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/__tests__/"]
+    "rootDir": "src/",
+    "outDir": "./lib",
+    "skipLibCheck": true
+  }
 }

--- a/governance/xc_admin/packages/crank_pythnet_relayer/tsconfig.json
+++ b/governance/xc_admin/packages/crank_pythnet_relayer/tsconfig.json
@@ -1,16 +1,10 @@
 {
+  "extends": "../../../../tsconfig.base.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "**/__tests__/*"],
   "compilerOptions": {
-    "declaration": true,
-    "target": "es2016",
-    "module": "commonjs",
-    "outDir": "lib",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "noErrorTruncation": true
-  },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/__tests__/"]
+    "rootDir": "src/",
+    "outDir": "./lib",
+    "skipLibCheck": true
+  }
 }

--- a/governance/xc_admin/packages/xc_admin_cli/tsconfig.json
+++ b/governance/xc_admin/packages/xc_admin_cli/tsconfig.json
@@ -1,20 +1,10 @@
 {
+  "extends": "../../../../tsconfig.base.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "**/__tests__/*"],
   "compilerOptions": {
-    "declaration": true,
-    "composite": true,
-    "declarationMap": true,
-    "incremental": true,
-    "target": "es2016",
-    "module": "commonjs",
-    "outDir": "lib",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "noErrorTruncation": true,
-    "rootDir": "src/"
-  },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/__tests__/"]
+    "rootDir": "src/",
+    "outDir": "./lib",
+    "skipLibCheck": true
+  }
 }

--- a/governance/xc_admin/packages/xc_admin_common/tsconfig.json
+++ b/governance/xc_admin/packages/xc_admin_common/tsconfig.json
@@ -1,20 +1,10 @@
 {
+  "extends": "../../../../tsconfig.base.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "**/__tests__/*"],
   "compilerOptions": {
-    "declaration": true,
-    "composite": true,
-    "declarationMap": true,
-    "incremental": true,
-    "target": "es2016",
-    "module": "commonjs",
-    "outDir": "lib",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "noErrorTruncation": true,
-    "rootDir": "src/"
-  },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/__tests__/"]
+    "rootDir": "src/",
+    "outDir": "./lib",
+    "skipLibCheck": true
+  }
 }

--- a/governance/xc_governance_sdk_js/src/instructions.ts
+++ b/governance/xc_governance_sdk_js/src/instructions.ts
@@ -66,7 +66,7 @@ export class DataSource implements Serializable {
 }
 
 // Magic is `PTGM` encoded as a 4 byte data: Pyth Governance Message
-const MAGIC: number = 0x5054474d;
+const MAGIC = 0x5054474d;
 
 export abstract class Instruction implements Serializable {
   constructor(

--- a/governance/xc_governance_sdk_js/tsconfig.json
+++ b/governance/xc_governance_sdk_js/tsconfig.json
@@ -1,19 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "**/__tests__/*"],
   "compilerOptions": {
-    "declaration": true,
-    "composite": true,
-    "declarationMap": true,
-    "incremental": true,
-    "target": "es2016",
-    "module": "commonjs",
-    "outDir": "lib",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "noErrorTruncation": true,
-    "rootDir": "src/"
-  },
-  "include": ["src/**/*.ts"]
+    "rootDir": "src/",
+    "outDir": "./lib",
+    "skipLibCheck": true
+  }
 }

--- a/price_service/sdk/js/tsconfig.json
+++ b/price_service/sdk/js/tsconfig.json
@@ -1,15 +1,9 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "commonjs",
-    "declaration": true,
-    "composite": true,
-    "declarationMap": true,
-    "incremental": true,
-    "outDir": "./lib",
-    "strict": true,
-    "rootDir": "src/"
-  },
+  "extends": "../../../tsconfig.base.json",
   "include": ["src"],
-  "exclude": ["node_modules", "**/__tests__/*"]
+  "exclude": ["node_modules", "**/__tests__/*"],
+  "compilerOptions": {
+    "rootDir": "src/",
+    "outDir": "./lib"
+  }
 }

--- a/price_service/server/tsconfig.json
+++ b/price_service/server/tsconfig.json
@@ -1,26 +1,10 @@
 {
-  "compilerOptions": {
-    "outDir": "lib",
-    "target": "esnext",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "lib": ["es2019"],
-    "skipLibCheck": true,
-    "allowJs": true,
-    "alwaysStrict": true,
-    "strict": true,
-    "declaration": true,
-    "composite": true,
-    "declarationMap": true,
-    "incremental": true,
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "downlevelIteration": true,
-    "esModuleInterop": true,
-    "rootDir": "src/"
-  },
+  "extends": "../../tsconfig.base.json",
   "include": ["src"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/__tests__/*"],
+  "compilerOptions": {
+    "rootDir": "src/",
+    "outDir": "./lib",
+    "skipLibCheck": true
+  }
 }

--- a/third_party/pyth/p2w-relay/tsconfig.json
+++ b/third_party/pyth/p2w-relay/tsconfig.json
@@ -1,25 +1,10 @@
 {
-  "compilerOptions": {
-    "outDir": "lib",
-    "target": "esnext",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "declaration": true,
-    "composite": true,
-    "declarationMap": true,
-    "incremental": true,
-    "lib": ["es2019"],
-    "skipLibCheck": true,
-    "allowJs": true,
-    "alwaysStrict": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "downlevelIteration": true,
-    "rootDir": "src/"
-  },
+  "extends": "../../../tsconfig.base.json",
   "include": ["src"],
-  "exclude": ["node_modules", "**/__tests__/*"]
+  "exclude": ["node_modules", "**/__tests__/*"],
+  "compilerOptions": {
+    "rootDir": "src/",
+    "outDir": "./lib",
+    "skipLibCheck": true
+  }
 }

--- a/tilt_devnet/docker_images/Dockerfile.lerna
+++ b/tilt_devnet/docker_images/Dockerfile.lerna
@@ -14,6 +14,7 @@ RUN find . -type f ! -name 'package*.json' -delete
 RUN find . -type d -empty -delete
 
 COPY ./lerna.json ./
+COPY ./tsconfig.base.json ./
 
 FROM node:18.13.0@sha256:d9061fd0205c20cd47f70bdc879a7a84fb472b822d3ad3158aeef40698d2ce36 as lerna
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "commonjs",
+    "declaration": true,
+    "composite": true,
+    "declarationMap": true,
+    "incremental": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  }
+}

--- a/wormhole_attester/sdk/js/src/index.ts
+++ b/wormhole_attester/sdk/js/src/index.ts
@@ -164,7 +164,7 @@ export function parseBatchPriceAttestation(
   const attestationSize = bytes.readUint16BE(offset);
   offset += 2;
 
-  let priceAttestations: PriceAttestation[] = [];
+  const priceAttestations: PriceAttestation[] = [];
 
   for (let i = 0; i < batchLen; i += 1) {
     priceAttestations.push(

--- a/wormhole_attester/sdk/js/tsconfig.json
+++ b/wormhole_attester/sdk/js/tsconfig.json
@@ -1,21 +1,9 @@
 {
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "**/__tests__/*"],
   "compilerOptions": {
-    "target": "esnext",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "declaration": true,
-    "composite": true,
-    "declarationMap": true,
-    "incremental": true,
-    "outDir": "./lib",
-    "strict": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "downlevelIteration": true,
-    "allowJs": true,
-    "rootDir": "src/"
-  },
-  "types": [],
-  "include": ["src", "types"],
-  "exclude": ["node_modules", "**/__tests__/*"]
+    "rootDir": "src/",
+    "outDir": "./lib"
+  }
 }


### PR DESCRIPTION
This PR:
- Adds a base tsconfig to avoid redundancy
- Fixes lint errors and add lint check to the CI

I created this based on Guillermo suggestion on the PR that added lerna for all the packages.

Notes:
- I did not add `skipLibCheck` to the base as it can have unwanted side-effects for us. We can consider adding it later.
- The paths in TS config file are relative to the config file that defines them and not the project. So I needed to define them everywhere.
