### PR TITLE
[xc-admin-frontend] Remove code that checks duplicated

### DIFF
--- a/governance/xc_admin/packages/xc_admin_frontend/components/tabs/UpdateProductMetadata.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/tabs/UpdateProductMetadata.tsx
@@ -167,13 +167,6 @@ const UpdateProductMetadata = () => {
       return false
     }
 
-    // check for duplicate keys in jsonParsed
-    const jsonSymbolsSet = new Set(jsonSymbols)
-    if (jsonSymbols.length !== jsonSymbolsSet.size) {
-      toast.error('Duplicate symbols in json file!')
-      return false
-    }
-
     let isValid = true
     // check that the keys of the values of json are equal to the keys of the values of data
     jsonSymbols.forEach((symbol) => {


### PR DESCRIPTION
This code doesn't do anything because JSON.parse already deletes duplicates and keeps the last appearance of the key.