### PR TITLE
[price service] Return VAA without prepending publish time

### DIFF
--- a/price_service/server/package.json
+++ b/price_service/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pythnetwork/price-service-server",
-  "version": "2.3.5",
-  "description": "Pyth price pervice server",
+  "version": "3.0.0",
+  "description": "Webservice for retrieving prices from the Pyth oracle.",
   "main": "index.js",
   "scripts": {
     "format": "prettier --write \"src/**/*.ts\"",

--- a/price_service/server/src/__tests__/rest.test.ts
+++ b/price_service/server/src/__tests__/rest.test.ts
@@ -246,13 +246,9 @@ describe("Get VAA endpoint and Get VAA CCIP", () => {
       .query({
         data: "0x" + id + pubTime16AsHex64Bit,
       });
-    const pubTime20AsHex64Bit = "0000000000000014";
     expect(ccipResp.status).toBe(StatusCodes.OK);
     expect(ccipResp.body).toEqual({
-      data:
-        "0x" +
-        pubTime20AsHex64Bit +
-        Buffer.from("abcd20", "base64").toString("hex"),
+      data: "0x" + Buffer.from("abcd20", "base64").toString("hex"),
     });
   });
 
@@ -372,10 +368,7 @@ describe("Get VAA endpoint and Get VAA CCIP", () => {
       });
     expect(ccipResp.status).toBe(StatusCodes.OK);
     expect(ccipResp.body).toEqual({
-      data:
-        "0x" +
-        pubTime5AsHex64Bit +
-        Buffer.from(`pythnet${id}5`, "base64").toString("hex"),
+      data: "0x" + Buffer.from(`pythnet${id}5`, "base64").toString("hex"),
     });
 
     dbApp.close();

--- a/price_service/server/src/rest.ts
+++ b/price_service/server/src/rest.ts
@@ -239,13 +239,7 @@ export class RestAPI {
             .status(StatusCodes.BAD_GATEWAY)
             .json({ "message:": "VAA not found." });
         } else {
-          const pubTimeBuffer = Buffer.alloc(8);
-          pubTimeBuffer.writeBigInt64BE(BigInt(vaa.publishTime));
-
-          const resData =
-            "0x" +
-            pubTimeBuffer.toString("hex") +
-            Buffer.from(vaa.vaa, "base64").toString("hex");
+          const resData = "0x" + Buffer.from(vaa.vaa, "base64").toString("hex");
 
           res.json({
             data: resData,


### PR DESCRIPTION
SNX wants to be able to pass the result payload directly to the `parseAndVerify` function. I think that's a simpler interface for our users, and we don't really need the publishTime here (I think?) so do it.