### PR TITLE
[xc-admin] Fix bug with targetChain

### DIFF
--- a/governance/xc_admin/packages/xc_admin_frontend/components/tabs/Proposals.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/tabs/Proposals.tsx
@@ -311,7 +311,7 @@ const Proposal = ({
                   <div>Target Chain</div>
                   <div>
                     {instruction.governanceAction.targetChainId === 'pythnet' &&
-                    cluster === 'devnet'
+                    getRemoteCluster(cluster) === 'pythtest'
                       ? 'pythtest'
                       : 'pythnet'}
                   </div>


### PR DESCRIPTION
Fix targetChain to be pythtest when on the pythtest tab.