### PR TITLE
[cosmwasm] Release setup

### DIFF
--- a/.github/workflows/publish-pyth-sdk-cw.yml
+++ b/.github/workflows/publish-pyth-sdk-cw.yml
@@ -1,0 +1,19 @@
+name: Publish Pyth SDK for Cosmwasm to crates.io
+
+on:
+  release:
+    types:
+      - created
+jobs:
+  publish-pyth-sdk-cw:
+    name: Publish Pyth SDK CW
+    if: ${{ startsWith(github.ref, 'refs/tags/pyth-sdk-cw-v') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        working-directory: "target_chains/cosmwasm/pyth-sdk-cw"

--- a/target_chains/cosmwasm/contracts/README.md
+++ b/target_chains/cosmwasm/contracts/README.md
@@ -1,40 +1,11 @@
 # Pyth Cosmwasm
 
-This crate includes the actual contract and exposes utilities to interact with the contract on the CosmWasm ecosystem.
-It also includes an [example contract](../examples/cw-contract/) demonstrating how to read price feeds from on-chain CosmWasm applications.
+This crate includes the actual contract for the CosmWasm ecosystem.
 
-## Installation
+## Integration
 
-Add this crate to the dependencies section of your CosmWasm contract's `Cargo.toml` file:
-
-```
-[dependencies]
-pyth-cosmwasm = { git="https://github.com/pyth-network/pyth-crosschain", tag="pyth-cosmwasm-v0.1.0", features=["library"] }
-```
-
-## Usage
-
-Simply import the structs exposed by the crate and use them while interacting with the pyth contract. For example:
-
-```rust
-// to query Pyth contract
-use pyth_cosmwasm::msg::{
-    PriceFeedResponse,
-};
-
-... {
-    let price_feed_response: PriceFeedResponse =
-    deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
-        contract_addr: state.pyth_contract_addr.into_string(),
-        msg:           to_binary(&PythQueryMsg::PriceFeed {
-            id: state.price_feed_id,
-        })?,
-    }))?;
-
-    let price_feed = price_feed_response.price_feed;
-}
-....
-```
+You can use `pyth-sdk-cw` which has been published to crates.io to integrate with the Pyth contract.
+The sdk exposes data structures and testing utilities for ease of use. Please look into this [pyth-sdk-cw](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/cosmwasm/pyth-sdk-cw)
 
 ## Off-Chain Queries
 

--- a/target_chains/cosmwasm/examples/cw-contract/Cargo.toml
+++ b/target_chains/cosmwasm/examples/cw-contract/Cargo.toml
@@ -34,5 +34,5 @@ cosmwasm-storage = { version = "1.0.0" }
 cw-storage-plus = "0.13.4"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-pyth-sdk-cw = { path="../../pyth-sdk-cw"}
+pyth-sdk-cw = "0.1.0"
 cosmwasm-schema = "1.1.9"

--- a/target_chains/cosmwasm/pyth-sdk-cw/README.md
+++ b/target_chains/cosmwasm/pyth-sdk-cw/README.md
@@ -1,0 +1,49 @@
+# Pyth SDK CW
+
+This crate exposes utilities to interact with the contract on the CosmWasm ecosystem.
+You can also look at the [example contract](../examples/cw-contract/) which demonstrates how to read price feeds from on-chain CosmWasm applications.
+
+## Installation
+
+Add this crate to the dependencies section of your CosmWasm contract's `Cargo.toml` file:
+
+```
+[dependencies]
+pyth-sdk-cw = "0.1.0"
+```
+
+## Usage
+
+Simply import the structs exposed by the crate and use them while interacting with the pyth contract. For example:
+
+```rust
+// to query Pyth contract
+use pyth_sdk_cw::{
+    PriceFeedResponse,
+    query_price_feed,
+};
+
+... {
+    let price_feed_response: PriceFeedResponse = query_price_feed(&deps.querier, state.pyth_contract_addr, state.price_feed_id)?;
+    let price_feed = price_feed_response.price_feed;
+}
+....
+```
+
+## Contracts and Price Feeds
+
+Pyth is currently available on the following cosmwasm chains:
+
+### Testnet
+
+| Network   | Contract address                             |
+| --------- | -------------------------------------------- |
+| Injective | `inj1z60tg0tekdzcasenhuuwq3htjcd5slmgf7gpez` |
+
+Available price feeds on these networks can be find below:
+
+### Price Feeds
+
+| Network           | Available Price Feeds                                                                                                                |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Injective Testnet | [https://pyth.network/developers/price-feed-ids#injective-testnet](https://pyth.network/developers/price-feed-ids#injective-testnet) |

--- a/target_chains/cosmwasm/pyth-sdk-cw/src/testing.rs
+++ b/target_chains/cosmwasm/pyth-sdk-cw/src/testing.rs
@@ -53,8 +53,10 @@ impl MockPyth {
         self.feeds.insert(feed.id, feed);
     }
 
-    /// TODO: Update this with example contracts -> Handler for processing query messages. See the tests in `contract.rs` for how to use this
-    /// handler within your tests.
+    /// Handler for processing query messages.
+    /// See the tests in `contract.rs`
+    /// `https://github.com/pyth-network/pyth-crosschain/blob/main/target_chains/cosmwasm/examples/cw-contract/src/contract.rs#L13`
+    /// for how to use this handler within your tests.
     pub fn handle_wasm_query(&self, msg: &Binary) -> QuerierResult {
         let query_msg = from_binary::<QueryMsg>(msg);
         match query_msg {


### PR DESCRIPTION
### Completed
- [x] init package
- [x] move all the data structures to the package and consume them in the contract 
- [x] add MockPyth to facilitate testing for pyth contract consumers
- [x] query helper function added
- [x] generated schema - no diff
- [x] update contract to consume pyth-sdk-cw instead of pyth-cosmwasm.
- [x] setup release pipeline