### PR TITLE
Bump wormhole rust crates to v2.14.8, remove rent adjustment

### DIFF
--- a/target_chains/cosmwasm/Cargo.lock
+++ b/target_chains/cosmwasm/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 [[package]]
 name = "cw20-wrapped-2"
 version = "0.1.0"
-source = "git+https://github.com/wormhole-foundation/wormhole?tag=v2.8.9#e47f9e481ef84d4dea7a94c9eafbf3b180892466"
+source = "git+https://github.com/wormhole-foundation/wormhole?tag=v2.14.8#7e982cb03264cf1cccfbb5d947c00d6ad3e2f8f1"
 dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-wormhole-attester-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "hex",
  "pyth-sdk 0.5.0",
@@ -2129,7 +2129,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "wormhole-bridge-terra-2"
 version = "0.1.0"
-source = "git+https://github.com/wormhole-foundation/wormhole?tag=v2.8.9#e47f9e481ef84d4dea7a94c9eafbf3b180892466"
+source = "git+https://github.com/wormhole-foundation/wormhole?tag=v2.14.8#7e982cb03264cf1cccfbb5d947c00d6ad3e2f8f1"
 dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",

--- a/target_chains/cosmwasm/Cargo.toml
+++ b/target_chains/cosmwasm/Cargo.toml
@@ -12,3 +12,6 @@ codegen-units = 1
 panic = 'abort'
 incremental = false
 overflow-checks = true
+
+[patch.crates-io]
+cw20-wrapped-2 = { git = "https://github.com/wormhole-foundation/wormhole", tag = "v2.14.8"}

--- a/target_chains/cosmwasm/contracts/pyth/Cargo.toml
+++ b/target_chains/cosmwasm/contracts/pyth/Cargo.toml
@@ -20,7 +20,7 @@ schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 serde_derive = { version = "1.0.103"}
 terraswap = "2.4.0"
-wormhole-bridge-terra-2 = { git = "https://github.com/wormhole-foundation/wormhole", tag = "v2.8.9", features = ["library"] }
+wormhole-bridge-terra-2 = { git = "https://github.com/wormhole-foundation/wormhole", tag = "v2.14.8", features = ["library"] }
 thiserror = { version = "1.0.20" }
 k256 = { version = "0.9.4", default-features = false, features = ["ecdsa"] }
 sha3 = { version = "0.9.1", default-features = false }

--- a/tilt_devnet/docker_images/Dockerfile.solana
+++ b/tilt_devnet/docker_images/Dockerfile.solana
@@ -31,7 +31,7 @@ RUN cargo init --lib /tmp/decoy-crate && \
 
 WORKDIR /usr/src/bridge
 
-ARG WORMHOLE_REV=2.14.7
+ARG WORMHOLE_REV=2.14.8
 ADD https://github.com/wormhole-foundation/wormhole/archive/refs/tags/v${WORMHOLE_REV}.tar.gz .
 RUN tar -xvf v${WORMHOLE_REV}.tar.gz
 RUN mv wormhole-${WORMHOLE_REV} wormhole

--- a/wormhole_attester/Cargo.lock
+++ b/wormhole_attester/Cargo.lock
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-wormhole-attester-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "hex",
  "pyth-sdk 0.5.0",
@@ -3086,7 +3086,7 @@ dependencies = [
 [[package]]
 name = "rocksalt"
 version = "0.1.0"
-source = "git+https://github.com/wormhole-foundation/wormhole?tag=v2.8.9#e47f9e481ef84d4dea7a94c9eafbf3b180892466"
+source = "git+https://github.com/wormhole-foundation/wormhole?tag=v2.14.8#7e982cb03264cf1cccfbb5d947c00d6ad3e2f8f1"
 dependencies = [
  "byteorder",
  "proc-macro2 1.0.38",
@@ -4385,7 +4385,7 @@ dependencies = [
 [[package]]
 name = "solitaire"
 version = "0.1.0"
-source = "git+https://github.com/wormhole-foundation/wormhole?tag=v2.8.9#e47f9e481ef84d4dea7a94c9eafbf3b180892466"
+source = "git+https://github.com/wormhole-foundation/wormhole?tag=v2.14.8#7e982cb03264cf1cccfbb5d947c00d6ad3e2f8f1"
 dependencies = [
  "borsh",
  "byteorder",
@@ -5350,7 +5350,7 @@ dependencies = [
 [[package]]
 name = "wormhole-bridge-solana"
 version = "0.1.0"
-source = "git+https://github.com/wormhole-foundation/wormhole?tag=v2.8.9#e47f9e481ef84d4dea7a94c9eafbf3b180892466"
+source = "git+https://github.com/wormhole-foundation/wormhole?tag=v2.14.8#7e982cb03264cf1cccfbb5d947c00d6ad3e2f8f1"
 dependencies = [
  "borsh",
  "byteorder",

--- a/wormhole_attester/client/Cargo.toml
+++ b/wormhole_attester/client/Cargo.toml
@@ -21,7 +21,7 @@ borsh = "=0.9.3"
 clap = {version = "3.1.18", features = ["derive"]}
 env_logger = "0.8.4"
 log = "0.4.14"
-wormhole-bridge-solana = {git = "https://github.com/wormhole-foundation/wormhole", tag = "v2.8.9"}
+wormhole-bridge-solana = {git = "https://github.com/wormhole-foundation/wormhole", tag = "v2.14.8"}
 pyth-wormhole-attester = {path = "../program"}
 pyth-wormhole-attester-sdk = { path = "../sdk/rust", features=["solana"] }
 pyth-sdk-solana = "0.6.1"
@@ -32,7 +32,7 @@ solana-client = "=1.10.31"
 solana-program = "=1.10.31"
 solana-sdk = "=1.10.31"
 solana-transaction-status = "=1.10.31"
-solitaire = {git = "https://github.com/wormhole-foundation/wormhole", tag = "v2.8.9"}
+solitaire = {git = "https://github.com/wormhole-foundation/wormhole", tag = "v2.14.8"}
 tokio = {version = "1", features = ["sync", "rt-multi-thread", "time"]}
 futures = "0.3.21"
 sha3 = "0.10.6"

--- a/wormhole_attester/program/Cargo.toml
+++ b/wormhole_attester/program/Cargo.toml
@@ -15,9 +15,9 @@ trace = ["solitaire/trace", "wormhole-bridge-solana/trace"]
 no-entrypoint = []
 
 [dependencies]
-wormhole-bridge-solana = { git = "https://github.com/wormhole-foundation/wormhole", tag = "v2.8.9" }
-solitaire = { git = "https://github.com/wormhole-foundation/wormhole", tag = "v2.8.9"}
-rocksalt = { git = "https://github.com/wormhole-foundation/wormhole", tag = "v2.8.9"}
+wormhole-bridge-solana = { git = "https://github.com/wormhole-foundation/wormhole", tag = "v2.14.8" }
+solitaire = { git = "https://github.com/wormhole-foundation/wormhole", tag = "v2.14.8"}
+rocksalt = { git = "https://github.com/wormhole-foundation/wormhole", tag = "v2.14.8"}
 solana-program = "=1.10.31"
 borsh = "=0.9.3"
 pyth-client = "0.2.2"

--- a/wormhole_attester/program/src/initialize.rs
+++ b/wormhole_attester/program/src/initialize.rs
@@ -3,12 +3,6 @@ use {
         P2WConfigAccount,
         Pyth2WormholeConfig,
     },
-    solana_program::{
-        program::invoke,
-        rent::Rent,
-        system_instruction,
-        sysvar::Sysvar,
-    },
     solitaire::{
         trace,
         AccountState,
@@ -40,22 +34,6 @@ pub fn initialize(
     accs.new_config
         .create(ctx, accs.payer.info().key, CreationLamports::Exempt)?;
     accs.new_config.1 = data;
-
-    // TODO(2022-09-05): Remove this rent collection after
-    // sysvar-based rent calculation becomes mainline in Solitaire.
-    let config_balance = accs.new_config.info().lamports();
-    let config_rent_exempt = Rent::get()?.minimum_balance(accs.new_config.info().data_len());
-
-    if config_balance < config_rent_exempt {
-        let required_deposit = config_rent_exempt - config_balance;
-
-        let transfer_ix = system_instruction::transfer(
-            accs.payer.key,
-            accs.new_config.info().key,
-            required_deposit,
-        );
-        invoke(&transfer_ix, ctx.accounts)?
-    }
 
     Ok(())
 }

--- a/wormhole_attester/sdk/rust/Cargo.toml
+++ b/wormhole_attester/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-wormhole-attester-sdk"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Wormhole Contributors <contact@certus.one>"]
 edition = "2018"
 description = "Pyth to Wormhole SDK"
@@ -17,7 +17,7 @@ hex = "0.4.3"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 pyth-sdk = {version = "0.5.0"}
 pyth-sdk-solana = { version = "0.5.0", optional = true }
-solitaire = { git = "https://github.com/wormhole-foundation/wormhole", tag = "v2.8.9", optional = true}
+solitaire = { git = "https://github.com/wormhole-foundation/wormhole", tag = "v2.14.8", optional = true}
 solana-program = { version = "=1.10.31", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This change upgrades our wormhole cargo dependency to the current latest release. It introduces a fix in rent calculation logic, making Solitaire compatible with PythNet. This lets us get rid of dedicated rent adjustment logic, which we also remove in this change. Additionally, the Dockerfile.client Wormhole CLI's are bumped to match on top of Guillermo's recent version bump