### PR TITLE
attester: Add an on-chain last attestation timestamp and rate limit arg

### DIFF
--- a/third_party/pyth/p2w_autoattest.py
+++ b/third_party/pyth/p2w_autoattest.py
@@ -116,9 +116,10 @@ max_batch_jobs: 1000 # Where we're going there's no oomkiller
 default_attestation_conditions:
   min_interval_secs: 10
 symbol_groups:
-  - group_name: fast_interval_only
+  - group_name: fast_interval_rate_limited
     conditions:
       min_interval_secs: 1
+      rate_limit_interval_secs: 2
     symbols:
 """
 

--- a/wormhole_attester/client/src/attestation_cfg.rs
+++ b/wormhole_attester/client/src/attestation_cfg.rs
@@ -318,6 +318,10 @@ pub const fn default_min_interval_secs() -> u64 {
     60
 }
 
+pub const fn default_rate_limit_interval_secs() -> Option<u32> {
+    Some(1)
+}
+
 pub const fn default_max_batch_jobs() -> usize {
     20
 }
@@ -340,7 +344,7 @@ pub struct AttestationConditions {
     /// redundant batch resends and tx expenses. NOTE: The client
     /// logic does not include rate limit failures in monitoring error
     /// counts.
-    #[serde(default)]
+    #[serde(default = "default_rate_limit_interval_secs")]
     pub rate_limit_interval_secs: Option<u32>,
 
     /// Limit concurrent attestation attempts per batch. This setting
@@ -384,7 +388,7 @@ impl Default for AttestationConditions {
             max_batch_jobs:              default_max_batch_jobs(),
             price_changed_bps:           None,
             publish_time_min_delta_secs: None,
-            rate_limit_interval_secs:    Some(1),
+            rate_limit_interval_secs:    default_rate_limit_interval_secs(),
         }
     }
 }

--- a/wormhole_attester/client/src/attestation_cfg.rs
+++ b/wormhole_attester/client/src/attestation_cfg.rs
@@ -66,6 +66,7 @@ pub struct AttestationConfig {
     /// Attestation conditions that will be used for any symbols included in the mapping
     /// that aren't explicitly in one of the groups below, and any groups without explicitly
     /// configured attestation conditions.
+    #[serde(default)]
     pub default_attestation_conditions: AttestationConditions,
 
     /// Groups of symbols to publish.
@@ -383,7 +384,7 @@ impl Default for AttestationConditions {
             max_batch_jobs:              default_max_batch_jobs(),
             price_changed_bps:           None,
             publish_time_min_delta_secs: None,
-            rate_limit_interval_secs:    None,
+            rate_limit_interval_secs:    Some(1),
         }
     }
 }

--- a/wormhole_attester/client/src/attestation_cfg.rs
+++ b/wormhole_attester/client/src/attestation_cfg.rs
@@ -318,8 +318,8 @@ pub const fn default_min_interval_secs() -> u64 {
     60
 }
 
-pub const fn default_rate_limit_interval_secs() -> Option<u32> {
-    Some(1)
+pub const fn default_rate_limit_interval_secs() -> u32 {
+    1
 }
 
 pub const fn default_max_batch_jobs() -> usize {
@@ -343,9 +343,9 @@ pub struct AttestationConditions {
     /// enforced on-chain, letting concurret attesters prevent
     /// redundant batch resends and tx expenses. NOTE: The client
     /// logic does not include rate limit failures in monitoring error
-    /// counts.
+    /// counts. 0 effectively disables this feature.
     #[serde(default = "default_rate_limit_interval_secs")]
-    pub rate_limit_interval_secs: Option<u32>,
+    pub rate_limit_interval_secs: u32,
 
     /// Limit concurrent attestation attempts per batch. This setting
     /// should act only as a failsafe cap on resource consumption and is

--- a/wormhole_attester/client/src/lib.rs
+++ b/wormhole_attester/client/src/lib.rs
@@ -299,8 +299,8 @@ pub fn gen_attest_tx(
     symbols: &[P2WSymbol],
     latest_blockhash: Hash,
     // Desired rate limit interval. If all of the symbols are over
-    // the limit, the tx will fail
-    rate_limit_interval_secs: Option<u32>,
+    // the limit, the tx will fail. 0 means off.
+    rate_limit_interval_secs: u32,
 ) -> Result<Transaction, ErrBoxSend> {
     let emitter_addr = P2WEmitter::key(None, &p2w_addr);
 

--- a/wormhole_attester/client/src/lib.rs
+++ b/wormhole_attester/client/src/lib.rs
@@ -298,6 +298,9 @@ pub fn gen_attest_tx(
     wh_msg_id: u64,
     symbols: &[P2WSymbol],
     latest_blockhash: Hash,
+    // Desired rate limit interval. If all of the symbols are over
+    // the limit, the tx will fail
+    rate_limit_interval_secs: Option<u32>,
 ) -> Result<Transaction, ErrBoxSend> {
     let emitter_addr = P2WEmitter::key(None, &p2w_addr);
 
@@ -390,8 +393,9 @@ pub fn gen_attest_tx(
     let ix_data = (
         pyth_wormhole_attester::instruction::Instruction::Attest,
         AttestData {
-            consistency_level:  ConsistencyLevel::Confirmed,
+            consistency_level: ConsistencyLevel::Confirmed,
             message_account_id: wh_msg_id,
+            rate_limit_interval_secs,
         },
     );
 

--- a/wormhole_attester/client/src/main.rs
+++ b/wormhole_attester/client/src/main.rs
@@ -619,7 +619,7 @@ pub struct AttestationJobArgs {
     pub payer:                    Keypair,
     pub symbols:                  Vec<P2WSymbol>,
     pub max_jobs_sema:            Arc<Semaphore>,
-    pub rate_limit_interval_secs: Option<u32>,
+    pub rate_limit_interval_secs: u32,
     pub message_q_mtx:            Arc<Mutex<P2WMessageQueue>>,
 }
 
@@ -691,7 +691,7 @@ async fn attestation_job(args: AttestationJobArgs) -> Result<(), ErrBoxSend> {
                 {
                     info!(
                         "Batch {}/{}, group {:?} OK: configured {} second rate limit interval reached, backing off",
-                        batch_no, batch_count, group_name, rate_limit_interval_secs.unwrap(),
+                        batch_no, batch_count, group_name, rate_limit_interval_secs,
                     );
                     // Note: We return early if rate limit tx
                     // error is detected. This ensures that we

--- a/wormhole_attester/client/tests/test_attest.rs
+++ b/wormhole_attester/client/tests/test_attest.rs
@@ -111,6 +111,7 @@ async fn test_happy_path() -> Result<(), p2wc::ErrBoxSend> {
         0,
         symbols.as_slice(),
         ctx.last_blockhash,
+        None,
     )?;
 
     // NOTE: 2022-09-05

--- a/wormhole_attester/client/tests/test_attest.rs
+++ b/wormhole_attester/client/tests/test_attest.rs
@@ -111,7 +111,7 @@ async fn test_happy_path() -> Result<(), p2wc::ErrBoxSend> {
         0,
         symbols.as_slice(),
         ctx.last_blockhash,
-        None,
+        0,
     )?;
 
     // NOTE: 2022-09-05

--- a/wormhole_attester/program/src/attest.rs
+++ b/wormhole_attester/program/src/attest.rs
@@ -54,6 +54,9 @@ use {
 /// correct value dynamically.
 pub const P2W_MAX_BATCH_SIZE: u16 = 5;
 
+/// Log message contents for easier detection in attester clients
+pub const RATE_LIMIT_EXCEEDED_MSG: &str = "ATTESTER ALL SYMBOLS EXCEED RATE LIMIT";
+
 #[derive(FromAccounts)]
 pub struct Attest<'b> {
     // Payer also used for wormhole
@@ -127,8 +130,16 @@ pub struct Attest<'b> {
 
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct AttestData {
-    pub consistency_level:  ConsistencyLevel,
-    pub message_account_id: u64,
+    pub consistency_level:        ConsistencyLevel,
+    pub message_account_id:       u64,
+    /// Fail the transaction if the global attestation rate of all
+    /// symbols in this batch is more frequent than the passed
+    /// interval. This is checked using the attestation time stored in
+    /// attestation state. This enables all of the clients to only
+    /// contribute attestations if their desired interval is not
+    /// already reached. If at least one symbol has been waiting
+    /// longer than this interval, we attest the whole batch.
+    pub rate_limit_interval_secs: Option<u32>,
 }
 
 pub fn attest(ctx: &ExecutionContext, accs: &mut Attest, data: AttestData) -> SoliResult<()> {
@@ -180,6 +191,10 @@ pub fn attest(ctx: &ExecutionContext, accs: &mut Attest, data: AttestData) -> So
     // Collect the validated symbols here for batch serialization
     let mut attestations = Vec::with_capacity(price_pairs.len());
 
+    let this_attestation_time = accs.clock.unix_timestamp;
+
+
+    let mut over_rate_limit = true;
     for (state, price) in price_pairs.into_iter() {
         // Pyth must own the price
         if accs.config.pyth_owner != *price.owner {
@@ -200,8 +215,6 @@ pub fn attest(ctx: &ExecutionContext, accs: &mut Attest, data: AttestData) -> So
             return Err(ProgramError::InvalidAccountData.into());
         }
 
-        let attestation_time = accs.clock.unix_timestamp;
-
         let price_data_ref = price.try_borrow_data()?;
 
         // Parse the upstream Pyth struct to extract current publish
@@ -213,6 +226,7 @@ pub fn attest(ctx: &ExecutionContext, accs: &mut Attest, data: AttestData) -> So
             })?;
 
         // Retrieve and rotate last_attested_tradind_publish_time
+
 
         // Pick the value to store for the next attestation of this
         // symbol. We use the prev_ value if the symbol is not
@@ -237,13 +251,36 @@ pub fn attest(ctx: &ExecutionContext, accs: &mut Attest, data: AttestData) -> So
         // Build an attestatioin struct for this symbol using the just decided current value
         let attestation = PriceAttestation::from_pyth_price_struct(
             Identifier::new(price.key.to_bytes()),
-            attestation_time,
+            this_attestation_time,
             current_last_attested_trading_publish_time,
             price_struct,
         );
 
         // Save the new value for the next attestation of this symbol
         state.0 .0.last_attested_trading_publish_time = new_last_attested_trading_publish_time;
+
+        // don't re-evaluate if at least one symbol was found to be under limit
+        if over_rate_limit {
+            // Evaluate rate limit
+            match data.rate_limit_interval_secs {
+                Some(interval)
+                    if (this_attestation_time - state.0 .0.last_attestation_time)
+                        >= interval as i64 =>
+                {
+                    over_rate_limit = false;
+                }
+                // Unset attestation
+                None => {
+                    over_rate_limit = false;
+                }
+                Some(_other) => {
+                    trace!("Price {:?}: over rate limit", price.key);
+                }
+            }
+        }
+
+        // Update last attestation time
+        state.0 .0.last_attestation_time = this_attestation_time;
 
         // handling of last_attested_trading_publish_time ends here
 
@@ -270,6 +307,13 @@ pub fn attest(ctx: &ExecutionContext, accs: &mut Attest, data: AttestData) -> So
 
 
         attestations.push(attestation);
+    }
+
+    // Do not proceed if none of the symbols is under rate limit
+    if over_rate_limit {
+        trace!("All symbols over limit, bailing out");
+        solana_program::msg!(RATE_LIMIT_EXCEEDED_MSG);
+        return Err(ProgramError::InvalidInstructionData.into());
     }
 
     let batch_attestation = BatchPriceAttestation {

--- a/wormhole_attester/program/src/attestation_state.rs
+++ b/wormhole_attester/program/src/attestation_state.rs
@@ -25,6 +25,8 @@ use {
 pub struct AttestationState {
     /// The last trading publish_time this attester saw
     pub last_attested_trading_publish_time: UnixTimestamp,
+    /// The last time this symbol was attested
+    pub last_attestation_time:              UnixTimestamp,
 }
 
 impl Owned for AttestationState {

--- a/wormhole_attester/program/src/error.rs
+++ b/wormhole_attester/program/src/error.rs
@@ -1,0 +1,6 @@
+/// Append-only custom error list.
+#[repr(u32)]
+pub enum AttesterCustomError {
+    /// Explicitly checked for in client code, change carefully
+    AttestRateLimitReached = 13,
+}

--- a/wormhole_attester/program/src/lib.rs
+++ b/wormhole_attester/program/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod attest;
 pub mod attestation_state;
 pub mod config;
+pub mod error;
 pub mod initialize;
 pub mod message;
 pub mod migrate;


### PR DESCRIPTION
This new value is bumped on chain with each new attestation, on a per-symbol basis. The timestamp is common for  all cranks. This enables attester cranks to rate limit their attestations of a symbol together with all other attesters. Ultimately, our tx expenses  should drop while still fulfilling our preferred attestation rates.

## Rate limiting logic in depth
The rate-limiting works by letting clients specify a desired rate limiting interval in instruction args. If all of the batch's symbols were already attested up to that amount of time ago, the TX fails and no SOL is spent. Note: this rate limit may be reached because of a different attester working in parallel with the client that sees this soft error. The rate limiting error does not contribute to metrics nor healthcheck.

## Review areas of interest
* Comments and naming - This feature is the first of its kind, affecting concurrent attester behavior. I think it's important to make sure it's easy to understand the results coming from using this new feature in the crank service. Hopefully the comments are enough and easy to understand
* New logic in `attest.rs` code path - there's new logic evaluating the rate limit on chain and updating the value afterwards. 
* New attestation job logic in `main.rs` - We use tx simulation to detect the exact rate limit error and avoid counting it in monitoring ok/error counters. This is done by returning early from a rather dense code block. Style/readability suggestions are very welcome there. 

## Testing
The mock attester in Tilt gets a 2-second rate limit using the config value on its 1-second min interval attestation group. The rate limiting code can be seen as non-error INFO level messages about the rate limit. This happens only on 50-66% of resend attempts, as expected for the fast resends on a slower rate limit.