### PR TITLE
[xc-admin] Add expired proposal status

### DIFF
--- a/governance/xc_admin/packages/xc_admin_frontend/components/tabs/Proposals.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/tabs/Proposals.tsx
@@ -34,7 +34,7 @@ import Spinner from '../common/Spinner'
 import Loadbar from '../loaders/Loadbar'
 
 // check if a string is a pubkey
-const isPubkey = (str: string) => {
+const isPubkey = (str: string): boolean => {
   try {
     new PublicKey(str)
     return true
@@ -44,9 +44,9 @@ const isPubkey = (str: string) => {
 }
 
 const getProposalStatus = (
-  proposal: TransactionAccount,
+  proposal: TransactionAccount | undefined,
   multisig: MultisigAccount | undefined
-) => {
+): string => {
   if (multisig && proposal) {
     const onChainStatus = Object.keys(proposal.status)[0]
     return proposal.transactionIndex <= multisig.msChangeIndex &&

--- a/governance/xc_admin/packages/xc_admin_frontend/components/tabs/Proposals.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/tabs/Proposals.tsx
@@ -1095,8 +1095,7 @@ const Proposals = () => {
                 <div className="mt-3">
                   <Loadbar theme="light" />
                 </div>
-              ) : priceFeedMultisigProposals.length > 0 &&
-                priceFeedMultisigAccount ? (
+              ) : priceFeedMultisigProposals.length > 0 ? (
                 <>
                   <div className="pb-4">
                     <h4 className="h4">
@@ -1110,7 +1109,7 @@ const Proposals = () => {
                         proposal={proposal}
                         verified={allProposalsVerifiedArr[idx]}
                         setCurrentProposalPubkey={setCurrentProposalPubkey}
-                        msChangeIndex={priceFeedMultisigAccount.msChangeIndex}
+                        multisig={priceFeedMultisigAccount}
                       />
                     ))}
                   </div>


### PR DESCRIPTION
When the members of the multisig get updated, all previous proposals that haven't been finalized expire.
This is also a way of getting rid of all draft proposals easily.
Example of expired proposals : https://xc-admin-frontend-git-xc-admin-add-expired-status-pyth-web.vercel.app/?tab=proposals