### PR TITLE
wormhole_attester client: Change "not enough data" HTTP code to 503

### DIFF
--- a/wormhole_attester/Cargo.lock
+++ b/wormhole_attester/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-wormhole-attester-client"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "borsh",
  "clap 3.1.18",

--- a/wormhole_attester/client/Cargo.toml
+++ b/wormhole_attester/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-wormhole-attester-client"
-version = "4.0.0"
+version = "4.1.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/wormhole_attester/client/src/util.rs
+++ b/wormhole_attester/client/src/util.rs
@@ -142,15 +142,15 @@ async fn healthcheck_handler() -> Result<impl Reply, Rejection> {
             );
             Ok(reply::with_status(msg, StatusCode::OK))
         }
-        // Unhealthy - 503 Service Unavailable
+        // Unhealthy - 500 Internal Server Error
         Some(false) => {
             let msg = format!(
                 "unhealthy, all of {} latest attestations returned error",
                 hc_state.max_window_size
             );
-            Ok(reply::with_status(msg, StatusCode::SERVICE_UNAVAILABLE))
+            Ok(reply::with_status(msg, StatusCode::INTERNAL_SERVER_ERROR))
         }
-        // No data - 307 Temporary Redirect
+        // No data - 503 Service Unavailable
         None => {
             let msg = if hc_state.enable {
                 format!(
@@ -161,7 +161,7 @@ async fn healthcheck_handler() -> Result<impl Reply, Rejection> {
             } else {
                 "Healthcheck disabled (enable_healthcheck is false)".to_string()
             };
-            Ok(reply::with_status(msg, StatusCode::TEMPORARY_REDIRECT))
+            Ok(reply::with_status(msg, StatusCode::SERVICE_UNAVAILABLE))
         }
     }
 }


### PR DESCRIPTION
Previously, we used 307 Internal Redirect to tell k8s that we're still waiting for the healthcheck window to fill up. Unfortunately, k8s assumes 3XX as a success, which wrongly tells it that the service is ready. Changing to 503 causes the expected probe failure to appear when the healthcheck state is not yet determined.

This change is a hotfix for attester client 4.0.0 and bumps the version to 4.1.0