### PR TITLE
[pyth-cosmwasm] sec review update

### DIFF
--- a/target_chains/cosmwasm/contracts/pyth/src/contract.rs
+++ b/target_chains/cosmwasm/contracts/pyth/src/contract.rs
@@ -384,9 +384,9 @@ fn process_batch_attestation(
     for price_attestation in batch_attestation.price_attestations.iter() {
         let price_feed = create_price_feed_from_price_attestation(price_attestation);
 
-        let attestation_time = Timestamp::from_seconds(price_attestation.attestation_time as u64);
+        let publish_time = Timestamp::from_seconds(price_attestation.publish_time as u64);
 
-        if update_price_feed_if_new(deps, env, price_feed, attestation_time)? {
+        if update_price_feed_if_new(deps, env, price_feed, publish_time)? {
             new_attestations_cnt += 1;
         }
     }
@@ -441,7 +441,7 @@ fn update_price_feed_if_new(
     deps: &mut DepsMut,
     env: &Env,
     price_feed: PriceFeed,
-    attestation_time: Timestamp,
+    publish_time: Timestamp,
 ) -> StdResult<bool> {
     let mut is_new_price = true;
     price_info(deps.storage).update(
@@ -450,14 +450,14 @@ fn update_price_feed_if_new(
             match maybe_price_info {
                 Some(price_info) => {
                     // This check ensures that a price won't be updated with the same or older
-                    // message. Attestation_time is guaranteed increasing in
+                    // message. Publish_TIme is guaranteed increasing in
                     // solana
-                    if price_info.attestation_time < attestation_time {
+                    if price_info.publish_time < publish_time {
                         Ok(PriceInfo {
                             arrival_time: env.block.time,
                             arrival_block: env.block.height,
                             price_feed,
-                            attestation_time,
+                            publish_time,
                         })
                     } else {
                         is_new_price = false;
@@ -468,7 +468,7 @@ fn update_price_feed_if_new(
                     arrival_time: env.block.time,
                     arrival_block: env.block.height,
                     price_feed,
-                    attestation_time,
+                    publish_time,
                 }),
             }
         },
@@ -693,19 +693,19 @@ mod test {
         }])
     }
 
-    /// Updates the price feed with the given attestation time stamp and
+    /// Updates the price feed with the given publish time stamp and
     /// returns the update status (true means updated, false means ignored)
     fn do_update_price_feed(
         deps: &mut DepsMut,
         env: &Env,
         price_feed: PriceFeed,
-        attestation_time_seconds: u64,
+        publish_time_seconds: u64,
     ) -> bool {
         update_price_feed_if_new(
             deps,
             env,
             price_feed,
-            Timestamp::from_seconds(attestation_time_seconds),
+            Timestamp::from_seconds(publish_time_seconds),
         )
         .unwrap()
     }

--- a/target_chains/cosmwasm/contracts/pyth/src/contract.rs
+++ b/target_chains/cosmwasm/contracts/pyth/src/contract.rs
@@ -93,12 +93,11 @@ pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Respons
 pub fn instantiate(
     deps: DepsMut,
     _env: Env,
-    info: MessageInfo,
+    _info: MessageInfo,
     msg: InstantiateMsg,
 ) -> StdResult<Response> {
     // Save general wormhole and pyth info
     let state = ConfigInfo {
-        owner:                      info.sender,
         wormhole_contract:          deps.api.addr_validate(msg.wormhole_contract.as_ref())?,
         data_sources:               msg.data_sources.iter().cloned().collect(),
         chain_id:                   msg.chain_id,
@@ -656,7 +655,6 @@ mod test {
 
     fn create_zero_config_info() -> ConfigInfo {
         ConfigInfo {
-            owner:                      Addr::unchecked(String::default()),
             wormhole_contract:          Addr::unchecked(String::default()),
             data_sources:               HashSet::default(),
             governance_source:          PythDataSource {

--- a/target_chains/cosmwasm/contracts/pyth/src/state.rs
+++ b/target_chains/cosmwasm/contracts/pyth/src/state.rs
@@ -41,7 +41,7 @@ pub struct PythDataSource {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct ConfigInfo {
-    pub owner:                      Addr,
+    // TODO: ASK do we need to update config key?
     pub wormhole_contract:          Addr,
     pub data_sources:               HashSet<PythDataSource>,
     pub governance_source:          PythDataSource,

--- a/target_chains/cosmwasm/contracts/pyth/src/state.rs
+++ b/target_chains/cosmwasm/contracts/pyth/src/state.rs
@@ -29,7 +29,7 @@ use {
 };
 
 pub static CONFIG_KEY: &[u8] = b"config";
-pub static PRICE_INFO_KEY: &[u8] = b"price_info_v4";
+pub static PRICE_INFO_KEY: &[u8] = b"price_info_v5";
 
 /// A `PythDataSource` identifies a specific contract (given by its Wormhole `emitter`) on
 /// a specific blockchain (given by `chain_id`).
@@ -68,10 +68,10 @@ pub struct ConfigInfo {
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct PriceInfo {
-    pub arrival_time:     Timestamp,
-    pub arrival_block:    u64,
-    pub attestation_time: Timestamp,
-    pub price_feed:       PriceFeed,
+    pub arrival_time:  Timestamp,
+    pub arrival_block: u64,
+    pub publish_time:  Timestamp,
+    pub price_feed:    PriceFeed,
 }
 
 pub fn config(storage: &mut dyn Storage) -> Singleton<ConfigInfo> {


### PR DESCRIPTION
address the feedback for the initial sec review

following in particular:

1) all other chain contracts compare publish_time while this one checks for the [attestation time](https://github.com/pyth-network/pyth-crosschain/blob/fc08ec277e0c148883535515b7026fc90afd7571/target_chains/cosmwasm/contracts/pyth/src/contract.rs#L422) before updating. I don't see much impact to this except in the case of an asset that isn't trading anymore, it would be an extra storage call. Might make sense to make it uniform with the other contracts however. 
2) the owner field in the state doesn't seem to be used anywhere,