### PR TITLE
[price-pusher] Bug fix on revert and crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47854,7 +47854,7 @@
     },
     "price_pusher": {
       "name": "@pythnetwork/pyth-evm-price-pusher",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@injectivelabs/sdk-ts": "^1.0.457",

--- a/price_pusher/package.json
+++ b/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-evm-price-pusher",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Pyth EVM Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/price_pusher/src/controller.ts
+++ b/price_pusher/src/controller.ts
@@ -22,6 +22,11 @@ export class Controller {
     await this.sourcePriceListener.start();
     await this.targetPriceListener.start();
 
+    // wait for the listeners to get updated. There could be a restart
+    // before this run and we need to respect the cooldown duration as
+    // their might be a message sent before.
+    await sleep(this.cooldownDuration * 1000);
+
     for (;;) {
       const pricesToPush: PriceConfig[] = [];
       const pubTimesToPush: UnixTimestamp[] = [];

--- a/price_pusher/src/evm/evm.ts
+++ b/price_pusher/src/evm/evm.ts
@@ -150,10 +150,20 @@ export class EvmPricePusher implements ChainPricePusher {
       "Pushing ",
       priceIdsWith0x.map((priceIdWith0x) => `${priceIdWith0x}`)
     );
-    const updateFee = await this.pythContract.methods
-      .getUpdateFee(priceFeedUpdateData)
-      .call();
-    console.log(`Update fee: ${updateFee}`);
+
+    let updateFee;
+
+    try {
+      updateFee = await this.pythContract.methods
+        .getUpdateFee(priceFeedUpdateData)
+        .call();
+      console.log(`Update fee: ${updateFee}`);
+    } catch (e: any) {
+      console.error(
+        "An unidentified error has occured when getting the update fee:"
+      );
+      throw e;
+    }
 
     const gasPrice = await this.customGasStation?.getCustomGasPrice();
 
@@ -168,11 +178,7 @@ export class EvmPricePusher implements ChainPricePusher {
         console.log(`Successful. Tx hash: ${hash}`);
       })
       .on("error", (err: Error, receipt?: TransactionReceipt) => {
-        if (
-          err.message.includes(
-            "VM Exception while processing transaction: revert"
-          )
-        ) {
+        if (err.message.includes("revert")) {
           // Since we are using custom error structs on solidity the rejection
           // doesn't return any information why the call has reverted. Assuming that
           // the update data is valid there is no possible rejection cause other than


### PR DESCRIPTION
This PR tries to solve a bug that was reported by one of the consumers. The bug was that the code was crashing on revert and the service didn't handle it well (it was a different message). Because of this bug there was another bug that the service was sending a transaction again and again because of the restart.

This PR updates the error handling to capture all messages containing "revert" and also waits for cooldown seconds before starting to push.

Also, some peoples reported that due to bad RPC they got error on the step that gets the `updateFee` and for some reason the error message was not caught (as this was not handled). This PR solves that too.