### PR TITLE
[wormhole-attester] Increase accuracy and improve logging

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -11,7 +11,10 @@ namespace = os.environ.get("TILT_NAMESPACE", "development")
 load("ext://namespace", "namespace_create", "namespace_inject")
 load("ext://secret", "secret_yaml_generic")
 
-default_registry(image_registry, single_name="development")
+namespace_create(namespace)
+
+if image_registry:
+    default_registry(image_registry, single_name="development")
 
 allow_k8s_contexts(k8s_context())
 

--- a/third_party/pyth/p2w_autoattest.py
+++ b/third_party/pyth/p2w_autoattest.py
@@ -114,11 +114,11 @@ mapping_reload_interval_mins: 1 # Very fast for testing purposes
 min_rpc_interval_ms: 0 # RIP RPC
 max_batch_jobs: 1000 # Where we're going there's no oomkiller
 default_attestation_conditions:
-  min_interval_secs: 10
+  min_interval_ms: 10000
 symbol_groups:
   - group_name: fast_interval_rate_limited
     conditions:
-      min_interval_secs: 1
+      min_interval_ms: 1000
       rate_limit_interval_secs: 2
     symbols:
 """
@@ -144,7 +144,7 @@ symbol_groups:
     cfg_yaml += f"""
   - group_name: longer_interval_sensitive_changes
     conditions:
-      min_interval_secs: 3
+      min_interval_ms: 3000
       price_changed_bps: 300
     symbols:
 """

--- a/wormhole_attester/Cargo.lock
+++ b/wormhole_attester/Cargo.lock
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-wormhole-attester-client"
-version = "4.1.0"
+version = "5.0.0"
 dependencies = [
  "borsh",
  "clap 3.1.18",

--- a/wormhole_attester/client/Cargo.toml
+++ b/wormhole_attester/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-wormhole-attester-client"
-version = "4.1.0"
+version = "5.0.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/wormhole_attester/client/src/attestation_cfg.rs
+++ b/wormhole_attester/client/src/attestation_cfg.rs
@@ -314,8 +314,8 @@ pub const fn default_min_rpc_interval_ms() -> u64 {
     150
 }
 
-pub const fn default_min_interval_secs() -> u64 {
-    60
+pub const fn default_min_interval_ms() -> u64 {
+    60_000
 }
 
 pub const fn default_rate_limit_interval_secs() -> u32 {
@@ -335,8 +335,8 @@ pub struct AttestationConditions {
     /// Lower bound on attestation rate. Attestation is triggered
     /// unconditionally whenever the specified interval elapses since
     /// last attestation.
-    #[serde(default = "default_min_interval_secs")]
-    pub min_interval_secs: u64,
+    #[serde(default = "default_min_interval_ms")]
+    pub min_interval_ms: u64,
 
     /// Upper bound on attestation rate. Attesting the same batch
     /// before this many seconds pass fails the tx. This limit is
@@ -370,7 +370,7 @@ impl AttestationConditions {
         // Bug trap for new fields that also need to be included in
         // the returned expression
         let AttestationConditions {
-            min_interval_secs: _min_interval_secs,
+            min_interval_ms: _min_interval_ms,
             max_batch_jobs: _max_batch_jobs,
             price_changed_bps,
             publish_time_min_delta_secs,
@@ -384,7 +384,7 @@ impl AttestationConditions {
 impl Default for AttestationConditions {
     fn default() -> Self {
         Self {
-            min_interval_secs:           default_min_interval_secs(),
+            min_interval_ms:             default_min_interval_ms(),
             max_batch_jobs:              default_max_batch_jobs(),
             price_changed_bps:           None,
             publish_time_min_delta_secs: None,
@@ -471,7 +471,7 @@ mod tests {
         let fastbois = SymbolGroupConfig {
             group_name: "fast bois".to_owned(),
             conditions: Some(AttestationConditions {
-                min_interval_secs: 5,
+                min_interval_ms: 5,
                 ..Default::default()
             }),
             symbols:    vec![
@@ -489,7 +489,7 @@ mod tests {
         let slowbois = SymbolGroupConfig {
             group_name: "slow bois".to_owned(),
             conditions: Some(AttestationConditions {
-                min_interval_secs: 200,
+                min_interval_ms: 200,
                 ..Default::default()
             }),
             symbols:    vec![
@@ -541,7 +541,7 @@ mod tests {
         let eth_dup_price_key = Pubkey::new_unique();
 
         let attestation_conditions_1 = AttestationConditions {
-            min_interval_secs: 5,
+            min_interval_ms: 5,
             ..Default::default()
         };
 
@@ -584,7 +584,7 @@ mod tests {
         };
 
         let default_attestation_conditions = AttestationConditions {
-            min_interval_secs: 1,
+            min_interval_ms: 1,
             ..Default::default()
         };
 

--- a/wormhole_attester/client/src/batch_state.rs
+++ b/wormhole_attester/client/src/batch_state.rs
@@ -50,11 +50,11 @@ impl<'a> BatchState {
 
         // min interval
         if self.last_job_finished_at.elapsed()
-            > Duration::from_secs(self.conditions.min_interval_secs)
+            > Duration::from_millis(self.conditions.min_interval_ms)
         {
             ret = Some(format!(
                 "minimum interval of {}s elapsed since last state change",
-                self.conditions.min_interval_secs
+                self.conditions.min_interval_ms
             ));
         }
 


### PR DESCRIPTION
- Tiltfile: TILT_DOCKER_REGISTRY def behavior, re-add namespace_create
  This helped me with k8s setup details that caused me issues locally:
    * The unspecified registry would make tilt fail to start by default
    * In minikube/k3s/<your development cluster> use cases, recreating the cluster may confuse Tilt because it doesn't create the desired namespace by default. It looks like tilt is starting but short after all services show that it cannot find the namespace.
-  wormhole_attester/client v5.0.0: accuracy and logging opimisations
    
    * [BREAKING CHANGE] min_interval_secs switches to milliseconds under
      min_interval_ms
    * attestation jobs no longer use preflight checks - this includes a
    custom variant of send_and_confirm_transaction(), see util.rs for details
    * attestation error logging no longer pretty-prints the error
      structs ({:#?} became {:?})
