### PR TITLE
[crank-pythnet-relayer] Don't throw error if all VAAs were relayed

### DIFF
--- a/governance/xc_admin/packages/crank_pythnet_relayer/src/index.ts
+++ b/governance/xc_admin/packages/crank_pythnet_relayer/src/index.ts
@@ -171,11 +171,13 @@ async function run() {
           .rpc({ skipPreflight: true });
       }
     } else if (response.code == 5) {
-      throw new Error(
-        `Wormhole API failure :${wormholeApi}/v1/signed_vaa/1/${EMITTER.toBuffer().toString(
+      console.log(`All VAAs have been relayed`);
+      console.log(
+        `${wormholeApi}/v1/signed_vaa/1/${EMITTER.toBuffer().toString(
           "hex"
         )}/${lastSequenceNumber}`
       );
+      break;
     } else {
       throw new Error("Could not connect to wormhole api");
     }


### PR DESCRIPTION
Right now it fails when all the VAAs have already been relayed, I want it to succeed instead