### PR TITLE
[xc-admin-frontend] Stop reloading proposals when you connect a wallet

### DIFF
--- a/governance/xc_admin/packages/xc_admin_frontend/hooks/useMultisig.ts
+++ b/governance/xc_admin/packages/xc_admin_frontend/hooks/useMultisig.ts
@@ -1,8 +1,10 @@
 import { Wallet } from '@coral-xyz/anchor'
+import NodeWallet from '@coral-xyz/anchor/dist/cjs/nodewallet'
 import {
   AccountMeta,
   Cluster,
   Connection,
+  Keypair,
   PublicKey,
   Transaction,
 } from '@solana/web3.js'
@@ -97,14 +99,6 @@ export const useMultisig = (wallet: Wallet): MultisigHookData => {
     ;(async () => {
       try {
         // mock wallet to allow users to view proposals without connecting their wallet
-        const signTransaction = () =>
-          new Promise<Transaction>((resolve) => {
-            resolve(new Transaction())
-          })
-        const signAllTransactions = () =>
-          new Promise<Transaction[]>((resolve) => {
-            resolve([new Transaction()])
-          })
         const squads = wallet
           ? new SquadsMesh({
               connection,
@@ -112,11 +106,7 @@ export const useMultisig = (wallet: Wallet): MultisigHookData => {
             })
           : new SquadsMesh({
               connection,
-              wallet: {
-                signTransaction: () => signTransaction(),
-                signAllTransactions: () => signAllTransactions(),
-                publicKey: new PublicKey(0),
-              },
+              wallet: new NodeWallet(new Keypair()),
             })
         if (cancelled) return
         setUpgradeMultisigAccount(


### PR DESCRIPTION
Proposals would get refreshed when u connect disconnect your wallet. I refactored squads into `readonlySquads` and `squads` so that this behavior doesn't happen.
