### PR TITLE
[price-pusher] Add nonce for evm + refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ bigtable-writer.json
 .aptos
 tsconfig.tsbuildinfo
 *~
+*mnemonic*

--- a/package-lock.json
+++ b/package-lock.json
@@ -47819,7 +47819,7 @@
     },
     "price_pusher": {
       "name": "@pythnetwork/pyth-price-pusher",
-      "version": "3.1.0",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@injectivelabs/sdk-ts": "^1.0.457",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47819,7 +47819,7 @@
     },
     "price_pusher": {
       "name": "@pythnetwork/pyth-price-pusher",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@injectivelabs/sdk-ts": "^1.0.457",

--- a/price_pusher/README.md
+++ b/price_pusher/README.md
@@ -55,7 +55,8 @@ npm run start -- evm --endpoint wss://example-rpc.com \
     --price-config-file "path/to/price-config-file.yaml.testnet.sample.yaml" \
     --mnemonic-file "path/to/mnemonic.txt" \
     [--pushing-frequency 10] \
-    [--polling-frequency 5]
+    [--polling-frequency 5] \
+    [--override-gas-price-multiplier 1.1]
 
 # For Injective
 npm run start -- injective --grpc-endpoint https://grpc-endpoint.com \
@@ -63,7 +64,8 @@ npm run start -- injective --grpc-endpoint https://grpc-endpoint.com \
     --price-config-file "path/to/price-config-file.yaml.testnet.sample.yaml" \
     --mnemonic-file "path/to/mnemonic.txt" \
     [--pushing-frequency 10] \
-    [--polling-frequency 5]
+    [--polling-frequency 5] \
+
 
 # Or, run the price pusher docker image instead of building from the source
 docker run public.ecr.aws/pyth-network/xc-price-pusher:v<version> -- <above-arguments>
@@ -125,3 +127,13 @@ docker-compose -f docker-compose.testnet.sample.yaml up
 It will take a few minutes until all the services are up and running.
 
 [pyth price service]: https://github.com/pyth-network/pyth-crosschain/tree/main/price_service/server
+
+## Reliability
+
+You can run multiple instances of the price pusher to increase the reliability. It is better to use
+difference RPCs to get better reliability in case an RPC goes down. **If you use the same payer account
+in different pushers, then due to blockchains nonce or sequence for accounts, a transaction won't be
+pushed twiced and you won't pay additional costs most of the time.** However, there might be some race
+condiitons in the RPCs because they are often behind a load balancer than can sometimes cause rejected
+transactions land on-chain. You can reduce the chances of additional cost overhead by reducing the
+pushing frequency.

--- a/price_pusher/README.md
+++ b/price_pusher/README.md
@@ -82,11 +82,11 @@ npm run start -- {network} --help
 
 ### Example
 
-For example, to push `BTC/USD` and `BNB/USD` prices on BNB testnet, run the following command:
+For example, to push `BTC/USD` and `BNB/USD` prices on Fantom testnet, run the following command:
 
 ```sh
 npm run dev -- evm --endpoint https://endpoints.omniatech.io/v1/fantom/testnet/public \
-    --pyth-contract-address 0xd7308b14BF4008e7C7196eC35610B1427C5702EA --price-service-endpoint https://xc-testnet.pyth.network \
+    --pyth-contract-address 0xff1a0f4744e8582DF1aE09D5611b887B6a12925C --price-service-endpoint https://xc-testnet.pyth.network \
     --mnemonic-file "./mnemonic" --price-config-file "./price-config.testnet.sample.yaml"
 ```
 

--- a/price_pusher/README.md
+++ b/price_pusher/README.md
@@ -54,7 +54,7 @@ npm run start -- evm --endpoint wss://example-rpc.com \
     --price-service-endpoint https://example-pyth-price.com \
     --price-config-file "path/to/price-config-file.yaml.testnet.sample.yaml" \
     --mnemonic-file "path/to/mnemonic.txt" \
-    [--cooldown-duration 10] \
+    [--pushing-frequency 10] \
     [--polling-frequency 5]
 
 # For Injective
@@ -62,7 +62,7 @@ npm run start -- injective --grpc-endpoint https://grpc-endpoint.com \
     --pyth-contract-address inj1z60tg0... --price-service-endpoint "https://example-pyth-price.com" \
     --price-config-file "path/to/price-config-file.yaml.testnet.sample.yaml" \
     --mnemonic-file "path/to/mnemonic.txt" \
-    [--cooldown-duration 10] \
+    [--pushing-frequency 10] \
     [--polling-frequency 5]
 
 # Or, run the price pusher docker image instead of building from the source

--- a/price_pusher/config.evm.testnet.sample.json
+++ b/price_pusher/config.evm.testnet.sample.json
@@ -1,0 +1,7 @@
+{
+  "endpoint": "https://endpoints.omniatech.io/v1/fantom/testnet/public",
+  "pyth-contract-address": "0xff1a0f4744e8582DF1aE09D5611b887B6a12925CZ",
+  "price-service-endpoint": "https://xc-testnet.pyth.network",
+  "mnemonic-file": "./mnemonic",
+  "price-config-file": "./price-config.testnet.sample.yaml"
+}

--- a/price_pusher/docker-compose.testnet.sample.yaml
+++ b/price_pusher/docker-compose.testnet.sample.yaml
@@ -65,9 +65,17 @@ services:
       - "/command_config"
     configs:
       - command_config
+      - mnemonic
+      - price_config
     depends_on:
       price-service:
         condition: service_healthy
 configs:
   command_config:
-    file: ./config.injective.testnet.sample.json # Replace this with the path to the configuration file
+    # Replace this with the path to the configuration file. You need to update the paths defined in
+    # the config file
+    file: ./config.injective.testnet.sample.json
+  mnemonic:
+    file: ./mnemonic # Replace this with the path to the mnemonic file
+  price_config:
+    file: ./price-config.testnet.sample.yaml # Replace this with the path to the price configuration file

--- a/price_pusher/package.json
+++ b/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-price-pusher",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/price_pusher/package.json
+++ b/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-price-pusher",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/price_pusher/src/controller.ts
+++ b/price_pusher/src/controller.ts
@@ -4,17 +4,17 @@ import { IPricePusher, IPriceListener } from "./interface";
 import { PriceConfig, shouldUpdate } from "./price-config";
 
 export class Controller {
-  private cooldownDuration: DurationInSeconds;
+  private pushingFrequency: DurationInSeconds;
   constructor(
     private priceConfigs: PriceConfig[],
     private sourcePriceListener: IPriceListener,
     private targetPriceListener: IPriceListener,
     private targetChainPricePusher: IPricePusher,
     config: {
-      cooldownDuration: DurationInSeconds;
+      pushingFrequency: DurationInSeconds;
     }
   ) {
-    this.cooldownDuration = config.cooldownDuration;
+    this.pushingFrequency = config.pushingFrequency;
   }
 
   async start() {
@@ -25,7 +25,7 @@ export class Controller {
     // wait for the listeners to get updated. There could be a restart
     // before this run and we need to respect the cooldown duration as
     // their might be a message sent before.
-    await sleep(this.cooldownDuration * 1000);
+    await sleep(this.pushingFrequency * 1000);
 
     for (;;) {
       const pricesToPush: PriceConfig[] = [];
@@ -58,7 +58,7 @@ export class Controller {
         );
       }
 
-      await sleep(this.cooldownDuration * 1000);
+      await sleep(this.pushingFrequency * 1000);
     }
   }
 }

--- a/price_pusher/src/evm/command.ts
+++ b/price_pusher/src/evm/command.ts
@@ -46,7 +46,7 @@ export default {
     ...options.mnemonicFile,
     ...options.pythContractAddress,
     ...options.pollingFrequency,
-    ...options.cooldownDuration,
+    ...options.pushingFrequency,
   },
   handler: function (argv: any) {
     // FIXME: type checks for this
@@ -56,7 +56,7 @@ export default {
       priceServiceEndpoint,
       mnemonicFile,
       pythContractAddress,
-      cooldownDuration,
+      pushingFrequency,
       pollingFrequency,
       customGasStation,
       txSpeed,
@@ -109,7 +109,7 @@ export default {
       pythListener,
       evmListener,
       evmPusher,
-      { cooldownDuration }
+      { pushingFrequency }
     );
 
     controller.start();

--- a/price_pusher/src/evm/custom-gas-station.ts
+++ b/price_pusher/src/evm/custom-gas-station.ts
@@ -7,7 +7,7 @@ import {
   customGasChainIds,
 } from "../utils";
 
-type chainMethods = Record<CustomGasChainId, () => Promise<string>>;
+type chainMethods = Record<CustomGasChainId, () => Promise<string | undefined>>;
 
 export class CustomGasStation {
   private chain: CustomGasChainId;
@@ -25,11 +25,19 @@ export class CustomGasStation {
   }
 
   private async fetchMaticMainnetGasPrice() {
-    const res = await fetch("https://gasstation-mainnet.matic.network/v2");
-    const jsonRes = await res.json();
-    const gasPrice = jsonRes[this.speed].maxFee;
-    const gweiGasPrice = Web3.utils.toWei(gasPrice.toFixed(2), "Gwei");
-    return gweiGasPrice.toString();
+    try {
+      const res = await fetch("https://gasstation-mainnet.matic.network/v2");
+      const jsonRes = await res.json();
+      const gasPrice = jsonRes[this.speed].maxFee;
+      const gweiGasPrice = Web3.utils.toWei(gasPrice.toFixed(2), "Gwei");
+      return gweiGasPrice.toString();
+    } catch (e) {
+      console.error(
+        "Failed to fetch gas price from Matic mainnet. Returning undefined"
+      );
+      console.error(e);
+      return undefined;
+    }
   }
 }
 

--- a/price_pusher/src/injective/command.ts
+++ b/price_pusher/src/injective/command.ts
@@ -42,7 +42,14 @@ export default {
     const priceServiceConnection = new PriceServiceConnection(
       priceServiceEndpoint,
       {
-        logger: console,
+        logger: {
+          // Log only warnings and errors from the price service client
+          info: () => undefined,
+          warn: console.warn,
+          error: console.error,
+          debug: () => undefined,
+          trace: () => undefined,
+        },
       }
     );
     const mnemonic = fs.readFileSync(mnemonicFile, "utf-8").trim();

--- a/price_pusher/src/injective/command.ts
+++ b/price_pusher/src/injective/command.ts
@@ -24,7 +24,7 @@ export default {
     ...options.mnemonicFile,
     ...options.pythContractAddress,
     ...options.pollingFrequency,
-    ...options.cooldownDuration,
+    ...options.pushingFrequency,
   },
   handler: function (argv: any) {
     // FIXME: type checks for this
@@ -34,7 +34,7 @@ export default {
       priceServiceEndpoint,
       mnemonicFile,
       pythContractAddress,
-      cooldownDuration,
+      pushingFrequency,
       pollingFrequency,
     } = argv;
 
@@ -81,7 +81,7 @@ export default {
       pythListener,
       injectiveListener,
       injectivePusher,
-      { cooldownDuration }
+      { pushingFrequency }
     );
 
     controller.start();

--- a/price_pusher/src/options.ts
+++ b/price_pusher/src/options.ts
@@ -37,11 +37,11 @@ export const pollingFrequency = {
   } as Options,
 };
 
-export const cooldownDuration = {
-  "cooldown-duration": {
+export const pushingFrequency = {
+  "pushing-duration": {
     description:
-      "The amount of time (in seconds) to wait between pushing price updates. " +
-      "This value should be greater than the block time of the network, so this program confirms " +
+      "The frequency to push prices to the RPC. " +
+      "It is better that the value be greater than the block time of the network, so this program confirms " +
       "it is updated and does not push it twice.",
     type: "number",
     required: false,


### PR DESCRIPTION
This PR changes the EVM pusher to rely on the account nonce to increase reliability and cost-efficiency of the pusher.

On EVM networks nonce is the transaction index of the user transaction. it increments 1 by 1 and you cannot send two transactions with the same nonce; if there are multiple transactions with the same nonce only one gets chosen on-chain.

Sometimes our transactions do not land on chain because the gas is lower than the necessary amount to be included on-chain. By setting nonce manually we can replace the older transaction with a higher gas to increase  likelihood of the price landing on-chain without paying any extra cost. The `override-gas-price-multiplier` option with the default of 1.1 is added to handle this situation. Also we can try updating the prices on a faster frequency or even run multiple pushers with the same sender without adding any extra cost because they will be excluded (without reverting on-chain). Since we get nonce from the RPC, if the tx is landed with the RPC knowledge, then the quick update will get rejected on simulation because the RPC state is up to date.  However, in our experiments due to RPCs being behind a load-balancer and not being completely in-sync there were rare occurances of on-chain reverted transaction under extreme conditions (pushing every second). We can reduce the chances of this happening by reducing the pushing frequency.

Because of the above change and better handlings of errors, now it is safe to run multiple instances of the pusher using the same account without additional cost overhead.


In this PR there are some refactorings:
- The price service connection logger is changed to only log warning/error to reduce the log noise.
- The cooldown-duration is renamed to pushing-frequency to be more understandable. As this is a breaking change, the version is bumped to 4.0.0