### PR TITLE
Pin rust version for formatting CI checks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.69
+          toolchain: nightly-2023-03-01
           components: rustfmt, clippy
           default: true
       - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: 1.69
           components: rustfmt, clippy
+          default: true
       - uses: pre-commit/action@v2.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,20 +21,20 @@ repos:
       - id: cargo-fmt-remote-executor
         name: Cargo format for remote executor
         language: "rust"
-        entry: cargo +nightly fmt --manifest-path ./governance/remote_executor/Cargo.toml --all -- --config-path rustfmt.toml
+        entry: cargo fmt --manifest-path ./governance/remote_executor/Cargo.toml --all -- --config-path rustfmt.toml
         pass_filenames: false
         files: governance/remote_executor
       - id: cargo-clippy-remote-executor
         name: Cargo clippy for remote executor
         language: "rust"
-        entry: cargo +nightly clippy --manifest-path ./governance/remote_executor/Cargo.toml --tests --fix --allow-dirty --allow-staged -- -D warnings
+        entry: cargo clippy --manifest-path ./governance/remote_executor/Cargo.toml --tests --fix --allow-dirty --allow-staged -- -D warnings
         pass_filenames: false
         files: governance/remote_executor
       # Hooks for the attester
       - id: cargo-fmt-attester
         name: Cargo format for attester
         language: "rust"
-        entry: cargo +nightly fmt --manifest-path ./wormhole_attester/Cargo.toml --all -- --config-path rustfmt.toml
+        entry: cargo fmt --manifest-path ./wormhole_attester/Cargo.toml --all -- --config-path rustfmt.toml
         pass_filenames: false
         files: wormhole_attester
       - id: cargo-clippy-attester
@@ -49,18 +49,18 @@ repos:
       - id: cargo-fmt-cosmwasm
         name: Cargo format for cosmwasm contract
         language: "rust"
-        entry: cargo +nightly fmt --manifest-path ./target_chains/cosmwasm/Cargo.toml --all -- --config-path rustfmt.toml
+        entry: cargo fmt --manifest-path ./target_chains/cosmwasm/Cargo.toml --all -- --config-path rustfmt.toml
         pass_filenames: false
         files: target_chains/cosmwasm
       - id: cargo-clippy-cosmwasm
         name: Cargo clippy for cosmwasm contract
         language: "rust"
-        entry: cargo +nightly clippy --manifest-path ./target_chains/cosmwasm/Cargo.toml --tests --fix --allow-dirty --allow-staged -- -D warnings
+        entry: cargo clippy --manifest-path ./target_chains/cosmwasm/Cargo.toml --tests --fix --allow-dirty --allow-staged -- -D warnings
         pass_filenames: false
         files: target_chains/cosmwasm
       - id: cargo-fmt-price-service
         name: Cargo format for Rust Price Service
         language: "rust"
-        entry: cargo +nightly fmt --manifest-path ./price_service/server-rust/Cargo.toml --all -- --config-path rustfmt.toml
+        entry: cargo fmt --manifest-path ./price_service/server-rust/Cargo.toml --all -- --config-path rustfmt.toml
         pass_filenames: false
         files: price_service/server-rust


### PR DESCRIPTION
The current nightly version of rust has a bug in rustc, which is causing our CI checks to fail. This happens periodically, so i'd like to pin the rust version used to something specific.

One downside of this approach is that it doesn't pin the version used on your local machine, so you can still get pre-commit differences between your local build and CI. We could fix that by pinning the toolchain using a toolchain file instead https://rust-lang.github.io/rustup/overrides.html?highlight=rust-toolchain#the-toolchain-file .

definitely open to the toolchain file approach if that seems better to you. It's a little more configuration work, but it standardizes everything everywhere.