### PR TITLE
[js] Fix JS publish workflow harder

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -16,6 +16,6 @@ jobs:
           node-version: "16"
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
-      - run: npx lerna publish from-package --no-git-tag-version --yes
+      - run: npx lerna publish from-package --no-private --no-git-tag-version --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
this is failing because it's trying to publish private packages. chatGPT says this option fixes it, so let's find out.