### PR TITLE
[xc-admin] Introduce the new UPGRADE_OPS_KEY

### DIFF
--- a/governance/xc_admin/packages/xc_admin_common/src/deterministic_oracle_accounts.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/deterministic_oracle_accounts.ts
@@ -9,7 +9,7 @@ import {
   SystemProgram,
   TransactionInstruction,
 } from "@solana/web3.js";
-import { OPS_KEY } from "./multisig";
+import { PRICE_FEED_OPS_KEY } from "./multisig";
 
 /**
  * Get seed for deterministic creation of a price/product account
@@ -58,7 +58,7 @@ export async function findDetermisticAccountAddress(
 ): Promise<[PublicKey, string]> {
   const seed: string = getSeed(type, symbol);
   const address: PublicKey = await PublicKey.createWithSeed(
-    OPS_KEY,
+    PRICE_FEED_OPS_KEY,
     seed,
     getPythProgramKeyForCluster(cluster)
   );

--- a/governance/xc_admin/packages/xc_admin_common/src/multisig.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/multisig.ts
@@ -1,4 +1,4 @@
-import { PublicKey } from "@solana/web3.js";
+import { Cluster, PublicKey } from "@solana/web3.js";
 import Squads, {
   DEFAULT_MULTISIG_PROGRAM_ID,
   getIxPDA,
@@ -9,11 +9,51 @@ import BN from "bn.js";
 import lodash from "lodash";
 
 /**
+ * Address of the upgrade multisig
+ */
+export const UPGRADE_MULTISIG: Record<Cluster | "localnet", PublicKey> = {
+  "mainnet-beta": new PublicKey("FVQyHcooAtThJ83XFrNnv74BcinbRH3bRmfFamAHBfuj"),
+  testnet: new PublicKey("FVQyHcooAtThJ83XFrNnv74BcinbRH3bRmfFamAHBfuj"),
+  devnet: new PublicKey("6baWtW1zTUVMSJHJQVxDUXWzqrQeYBr6mu31j3bTKwY3"),
+  localnet: new PublicKey("FVQyHcooAtThJ83XFrNnv74BcinbRH3bRmfFamAHBfuj"),
+};
+
+/**
+ * Address of the price feed multisig
+ */
+export const PRICE_FEED_MULTISIG: Record<Cluster | "localnet", PublicKey> = {
+  "mainnet-beta": new PublicKey("92hQkq8kBgCUcF9yWN8URZB9RTmA4mZpDGtbiAWA74Z8"),
+  testnet: new PublicKey("92hQkq8kBgCUcF9yWN8URZB9RTmA4mZpDGtbiAWA74Z8"),
+  devnet: new PublicKey("92hQkq8kBgCUcF9yWN8URZB9RTmA4mZpDGtbiAWA74Z8"),
+  localnet: new PublicKey("92hQkq8kBgCUcF9yWN8URZB9RTmA4mZpDGtbiAWA74Z8"),
+};
+
+/**
  * Address of the ops key (same on all networks)
  */
-export const OPS_KEY = new PublicKey(
+export const PRICE_FEED_OPS_KEY = new PublicKey(
   "ACzP6RC98vcBk9oTeAwcH1o5HJvtBzU59b5nqdwc7Cxy"
 );
+
+export const UPGRADE_OPS_KEY = new PublicKey(
+  "opsLibxVY7Vz5eYMmSfX8cLFCFVYTtH6fr6MiifMpA7"
+);
+
+export function getOpsKey(vault: PublicKey): PublicKey {
+  if (
+    Object.values(PRICE_FEED_MULTISIG).some((pubkey) => {
+      return pubkey.equals(vault);
+    })
+  )
+    return PRICE_FEED_OPS_KEY;
+  else if (
+    Object.values(UPGRADE_MULTISIG).some((pubkey) => {
+      return pubkey.equals(vault);
+    })
+  )
+    return UPGRADE_OPS_KEY;
+  else throw new Error("Unrecognized multisig vault");
+}
 
 /**
  * Find all proposals for vault `vault` using Squads client `squad`

--- a/governance/xc_admin/packages/xc_admin_frontend/components/PermissionDepermissionKey.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/PermissionDepermissionKey.tsx
@@ -12,12 +12,12 @@ import {
   getMultisigCluster,
   isRemoteCluster,
   mapKey,
+  PRICE_FEED_MULTISIG,
   proposeInstructions,
   WORMHOLE_ADDRESS,
 } from 'xc_admin_common'
 import { ClusterContext } from '../contexts/ClusterContext'
 import { usePythContext } from '../contexts/PythContext'
-import { PRICE_FEED_MULTISIG } from '../hooks/useMultisig'
 import { ProductRawConfig } from '../hooks/usePyth'
 import Arrow from '../images/icons/down.inline.svg'
 import { capitalizeFirstLetter } from '../utils/capitalizeFirstLetter'

--- a/governance/xc_admin/packages/xc_admin_frontend/components/tabs/General.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/tabs/General.tsx
@@ -10,13 +10,13 @@ import {
   getMultisigCluster,
   isRemoteCluster,
   mapKey,
+  PRICE_FEED_MULTISIG,
   proposeInstructions,
   WORMHOLE_ADDRESS,
 } from 'xc_admin_common'
 import { ClusterContext } from '../../contexts/ClusterContext'
 import { useMultisigContext } from '../../contexts/MultisigContext'
 import { usePythContext } from '../../contexts/PythContext'
-import { PRICE_FEED_MULTISIG } from '../../hooks/useMultisig'
 import { capitalizeFirstLetter } from '../../utils/capitalizeFirstLetter'
 import ClusterSwitch from '../ClusterSwitch'
 import Modal from '../common/Modal'

--- a/governance/xc_admin/packages/xc_admin_frontend/components/tabs/Proposals.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/tabs/Proposals.tsx
@@ -19,6 +19,7 @@ import {
   getRemoteCluster,
   MultisigInstruction,
   MultisigParser,
+  PRICE_FEED_MULTISIG,
   PythMultisigInstruction,
   UnrecognizedProgram,
   WormholeMultisigInstruction,
@@ -27,7 +28,6 @@ import { ClusterContext } from '../../contexts/ClusterContext'
 import { useMultisigContext } from '../../contexts/MultisigContext'
 import { usePythContext } from '../../contexts/PythContext'
 import { StatusFilterContext } from '../../contexts/StatusFilterContext'
-import { PRICE_FEED_MULTISIG } from '../../hooks/useMultisig'
 import VerifiedIcon from '../../images/icons/verified.inline.svg'
 import VotedIcon from '../../images/icons/voted.inline.svg'
 import { capitalizeFirstLetter } from '../../utils/capitalizeFirstLetter'

--- a/governance/xc_admin/packages/xc_admin_frontend/components/tabs/UpdatePermissions.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/tabs/UpdatePermissions.tsx
@@ -23,11 +23,11 @@ import {
   mapKey,
   proposeInstructions,
   WORMHOLE_ADDRESS,
+  UPGRADE_MULTISIG,
 } from 'xc_admin_common'
 import { ClusterContext } from '../../contexts/ClusterContext'
 import { useMultisigContext } from '../../contexts/MultisigContext'
 import { usePythContext } from '../../contexts/PythContext'
-import { UPGRADE_MULTISIG } from '../../hooks/useMultisig'
 import CopyIcon from '../../images/icons/copy.inline.svg'
 import { capitalizeFirstLetter } from '../../utils/capitalizeFirstLetter'
 import ClusterSwitch from '../ClusterSwitch'

--- a/governance/xc_admin/packages/xc_admin_frontend/hooks/useMultisig.ts
+++ b/governance/xc_admin/packages/xc_admin_frontend/hooks/useMultisig.ts
@@ -18,26 +18,14 @@ import {
   isRemoteCluster,
   MultisigInstruction,
   MultisigParser,
+  PRICE_FEED_MULTISIG,
   PythMultisigInstruction,
   UnrecognizedProgram,
+  UPGRADE_MULTISIG,
   WormholeMultisigInstruction,
 } from 'xc_admin_common'
 import { ClusterContext } from '../contexts/ClusterContext'
 import { pythClusterApiUrls } from '../utils/pythClusterApiUrl'
-
-export const UPGRADE_MULTISIG: Record<Cluster | 'localnet', PublicKey> = {
-  'mainnet-beta': new PublicKey('FVQyHcooAtThJ83XFrNnv74BcinbRH3bRmfFamAHBfuj'),
-  testnet: new PublicKey('FVQyHcooAtThJ83XFrNnv74BcinbRH3bRmfFamAHBfuj'),
-  devnet: new PublicKey('6baWtW1zTUVMSJHJQVxDUXWzqrQeYBr6mu31j3bTKwY3'),
-  localnet: new PublicKey('FVQyHcooAtThJ83XFrNnv74BcinbRH3bRmfFamAHBfuj'),
-}
-
-export const PRICE_FEED_MULTISIG: Record<Cluster | 'localnet', PublicKey> = {
-  'mainnet-beta': new PublicKey('92hQkq8kBgCUcF9yWN8URZB9RTmA4mZpDGtbiAWA74Z8'),
-  testnet: new PublicKey('92hQkq8kBgCUcF9yWN8URZB9RTmA4mZpDGtbiAWA74Z8'),
-  devnet: new PublicKey('92hQkq8kBgCUcF9yWN8URZB9RTmA4mZpDGtbiAWA74Z8'),
-  localnet: new PublicKey('92hQkq8kBgCUcF9yWN8URZB9RTmA4mZpDGtbiAWA74Z8'),
-}
 
 interface MultisigHookData {
   isLoading: boolean
@@ -250,3 +238,4 @@ export const useMultisig = (wallet: Wallet): MultisigHookData => {
     setpriceFeedMultisigProposals,
   }
 }
+export { PRICE_FEED_MULTISIG }

--- a/governance/xc_admin/packages/xc_admin_frontend/hooks/useMultisig.ts
+++ b/governance/xc_admin/packages/xc_admin_frontend/hooks/useMultisig.ts
@@ -238,4 +238,3 @@ export const useMultisig = (wallet: Wallet): MultisigHookData => {
     setpriceFeedMultisigProposals,
   }
 }
-export { PRICE_FEED_MULTISIG }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27892,6 +27892,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -28221,6 +28222,7 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -49988,7 +49990,7 @@
     },
     "target_chains/ethereum/sdk/js": {
       "name": "@pythnetwork/pyth-evm-js",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@pythnetwork/price-service-client": "*",


### PR DESCRIPTION
I need this PR because the logic in `propose.ts` was wrong since it was hardcoded to use the price feeds ops key.
Now that the upgrade multisig has a different ops key we need to fix that.

- `OPS_KEY` becomes `PRICE_FEED_OPS_KEY` 
- `UPGRADE_OPS_KEY` introduced
- `UPGRADE_MULTISIG` and `PRICE_FEED_MULTISIG` moved to `xc-admin-common`
- `getOpsKey` gives you the right ops key for each multisig

