### PR TITLE
[wormhole-attester] Fix rate_limit logic

### DIFF
--- a/wormhole_attester/Cargo.lock
+++ b/wormhole_attester/Cargo.lock
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-wormhole-attester"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "borsh",
  "pyth-client",

--- a/wormhole_attester/program/Cargo.toml
+++ b/wormhole_attester/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-wormhole-attester"
-version = "2.0.0"
+version = "2.0.1"
 description = "Pyth-over-Wormhole Solana contract"
 edition = "2018"
 

--- a/wormhole_attester/program/src/attest.rs
+++ b/wormhole_attester/program/src/attest.rs
@@ -255,20 +255,29 @@ pub fn attest(ctx: &ExecutionContext, accs: &mut Attest, data: AttestData) -> So
             price_struct,
         );
 
-        // Save the new value for the next attestation of this symbol
-        state.0 .0.last_attested_trading_publish_time = new_last_attested_trading_publish_time;
-
         // don't re-evaluate if at least one symbol was found to be under limit
         if over_rate_limit {
             // Evaluate rate limit - should be smaller than duration from last attestation
-            if this_attestation_time - state.0 .0.last_attestation_time
-                >= data.rate_limit_interval_secs as i64
+            let trading_publish_time_diff = new_last_attested_trading_publish_time
+                - state.0 .0.last_attested_trading_publish_time;
+            let attestation_publish_time_diff =
+                this_attestation_time - state.0 .0.last_attestation_time;
+
+            // We like to have the rate_limit for trading publish_time because that is the field that
+            // the users consume. However, when the price is not trading we still want to send
+            // the prices. We do not use the same frequency because that might cause two
+            // attestations within the rate_limit which is not a desired behavior.
+            if trading_publish_time_diff >= data.rate_limit_interval_secs as i64
+                || attestation_publish_time_diff >= 2 * data.rate_limit_interval_secs as i64
             {
                 over_rate_limit = false;
             } else {
                 trace!("Price {:?}: over rate limit", price.key);
             }
         }
+
+        // Save the new value for the next attestation of this symbol
+        state.0 .0.last_attested_trading_publish_time = new_last_attested_trading_publish_time;
 
         // Update last attestation time
         state.0 .0.last_attestation_time = this_attestation_time;


### PR DESCRIPTION
With the current logic, we attest every second and have different attestation times. However, users use price publish time and we need to perform the logic on the publish time. This PR fixes this issue. 

We need to deploy our contracts after this change. Since only the internal logic has changes, we don't need to touch attesters. 