### PR TITLE
Update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,12 @@
 **/*cache*
 **/.next
 
+# All our TS projects are in `src` and the JS build output is in `lib`
+# We should make sure that we exclude the ones that we really need in docker
+**/lib
+
+**/tsconfig.tsbuildinfo
+
 .git
 
 hermes/wormhole

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,14 @@
-target
-bin
 **/target
 **/node_modules
+**/bin
+**/build
+**/target
+**/*artifact*
+**/*cache*
+**/.next
+
+**/lib
+
+.git
+
+hermes/wormhole

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,8 +7,6 @@
 **/*cache*
 **/.next
 
-**/lib
-
 .git
 
 hermes/wormhole

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bigtable-writer.json
 tsconfig.tsbuildinfo
 *~
 *mnemonic*
+.envrc

--- a/target_chains/cosmwasm/contracts/pyth/src/contract.rs
+++ b/target_chains/cosmwasm/contracts/pyth/src/contract.rs
@@ -1111,9 +1111,7 @@ mod test {
                 expo:         302,
                 publish_time: 303,
             },
-            Price {
-                ..Default::default()
-            },
+            Default::default(),
         );
         price_feed_bucket(&mut deps.storage)
             .save(address, &dummy_price_feed)

--- a/third_party/pyth/p2w-relay/Dockerfile.pyth_relay
+++ b/third_party/pyth/p2w-relay/Dockerfile.pyth_relay
@@ -4,6 +4,7 @@ FROM lerna
 WORKDIR /home/node/
 USER 1000
 
+COPY --chown=1000:1000 target_chains/ethereum/sdk/solidity target_chains/ethereum/sdk/solidity
 COPY --chown=1000:1000 price_service/sdk/js price_service/sdk/js
 COPY --chown=1000:1000 third_party/pyth/p2w-relay third_party/pyth/p2w-relay
 COPY --chown=1000:1000 wormhole_attester/sdk/js wormhole_attester/sdk/js


### PR DESCRIPTION
The main purpose of this PR is to ignore as many things as possible for docker build to reduce the build transferred context size. Also, this PR fixes some bugs in our images to make Tilt working.