### PR TITLE
[js] Fix JS workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,14 @@ To perform a release, follow these steps:
 4. When this release is published, it will automatically trigger a CI workflow to publish the updated packages to NPM.
 
 If you have a javascript package that shouldn't be published, simply add `"private": "true"` to the `package.json` file
-and it will be excluded from the publishing workflow.
+and it will be excluded from the publishing workflow. If you are creating a new public javascript package, you should add
+the following config option to `package.json`:
+
+```
+  "publishConfig": {
+    "access": "public"
+  },
+```
 
 ### pre-commit hooks
 

--- a/price_pusher/package.json
+++ b/price_pusher/package.json
@@ -16,6 +16,9 @@
     "url": "https://github.com/pyth-network/pyth-crosschain",
     "directory": "price_pusher"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "jest src/ --passWithNoTests",
     "build": "tsc",

--- a/price_service/client/js/package.json
+++ b/price_service/client/js/package.json
@@ -16,6 +16,9 @@
     "url": "https://github.com/pyth-network/pyth-crosschain",
     "directory": "price_service/client/js"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "jest --testPathIgnorePatterns=.*.e2e.test.ts --passWithNoTests",
     "test:e2e": "jest --testPathPattern=.*.e2e.test.ts",

--- a/price_service/sdk/js/package.json
+++ b/price_service/sdk/js/package.json
@@ -13,6 +13,9 @@
     "url": "https://github.com/pyth-network/pyth-crosschain.git",
     "directory": "price_service/sdk/js"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "jest",
     "build": "tsc",

--- a/target_chains/aptos/sdk/js/package.json
+++ b/target_chains/aptos/sdk/js/package.json
@@ -16,6 +16,9 @@
     "url": "https://github.com/pyth-network/pyth-crosschain",
     "directory": "target_chains/aptos/sdk/js"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "jest --passWithNoTests",
     "build": "tsc",

--- a/target_chains/cosmwasm/sdk/js/package.json
+++ b/target_chains/cosmwasm/sdk/js/package.json
@@ -16,6 +16,9 @@
     "url": "https://github.com/pyth-network/pyth-crosschain",
     "directory": "target_chains/cosmwasm/sdk/js"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "jest --passWithNoTests",
     "build": "tsc",

--- a/target_chains/ethereum/sdk/js/package.json
+++ b/target_chains/ethereum/sdk/js/package.json
@@ -16,6 +16,9 @@
     "url": "https://github.com/pyth-network/pyth-crosschain",
     "directory": "target_chains/ethereum/sdk/js"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "jest --passWithNoTests",
     "build": "tsc",


### PR DESCRIPTION
I'm still trying to get the publish workflow to work. apparently if you don't set this option, lerna defaults to publishing the packages as non-public (which fails because we don't pay for it)