### PR TITLE
[hermes] add get price feed ids + refactor

### DIFF
--- a/hermes/src/network/rpc.rs
+++ b/hermes/src/network/rpc.rs
@@ -43,6 +43,7 @@ pub async fn spawn(rpc_addr: String, store: Store) -> Result<()> {
         .route("/api/latest_vaas", get(rest::latest_vaas))
         .route("/api/get_vaa", get(rest::get_vaa))
         .route("/api/get_vaa_ccip", get(rest::get_vaa_ccip))
+        .route("/api/price_feed_ids", get(rest::price_feed_ids))
         .with_state(state.clone());
 
     // Listen in the background for new VAA's from the Wormhole RPC.

--- a/hermes/src/store.rs
+++ b/hermes/src/store.rs
@@ -81,4 +81,8 @@ impl Store {
             request_time,
         )
     }
+
+    pub fn get_price_feed_ids(&self) -> Vec<PriceIdentifier> {
+        proof::batch_vaa::get_price_feed_ids(self.state.clone())
+    }
 }

--- a/hermes/src/store/proof/batch_vaa.rs
+++ b/hermes/src/store/proof/batch_vaa.rs
@@ -82,7 +82,6 @@ pub fn get_price_feeds_with_update_data(
                 vaas.insert(price_info.vaa_bytes);
             }
             None => {
-                log::info!("No price feed found for price id: {:?}", price_id);
                 return Err(anyhow!("No price feed found for price id: {:?}", price_id));
             }
         }
@@ -96,6 +95,18 @@ pub fn get_price_feeds_with_update_data(
     })
 }
 
+
+pub fn get_price_feed_ids(state: State) -> Vec<PriceIdentifier> {
+    let mut price_ids = Vec::new();
+    for key in state.keys() {
+        let maybe_32_bytes: Result<[u8; 32], _> = ((*key).clone()).try_into();
+        if let Ok(bytes) = maybe_32_bytes {
+            let price_id = PriceIdentifier::new(bytes);
+            price_ids.push(price_id);
+        }
+    }
+    price_ids
+}
 
 /// Convert a PriceAttestation to a PriceFeed.
 ///

--- a/hermes/src/store/storage.rs
+++ b/hermes/src/store/storage.rs
@@ -9,6 +9,7 @@ use {
         Deref,
         DerefMut,
     },
+    pyth_sdk::PriceIdentifier,
 };
 
 pub mod local_cache;
@@ -18,13 +19,9 @@ pub enum StorageData {
     BatchVaa(PriceInfo),
 }
 
-#[derive(Clone, PartialEq, Eq, Debug, Hash, Deref, DerefMut)]
-pub struct Key(Vec<u8>);
-
-impl Key {
-    pub fn new(key: Vec<u8>) -> Self {
-        Self(key)
-    }
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
+pub enum Key {
+    BatchVaa(PriceIdentifier),
 }
 
 /// This trait defines the interface for update data storage

--- a/hermes/src/store/storage.rs
+++ b/hermes/src/store/storage.rs
@@ -37,4 +37,5 @@ impl Key {
 pub trait Storage: Sync + Send {
     fn insert(&self, key: Key, time: UnixTimestamp, value: StorageData) -> Result<()>;
     fn get(&self, key: Key, request_time: RequestTime) -> Result<Option<StorageData>>;
+    fn keys(&self) -> Vec<Key>;
 }

--- a/hermes/src/store/storage/local_cache.rs
+++ b/hermes/src/store/storage/local_cache.rs
@@ -99,4 +99,8 @@ impl Storage for LocalCache {
             None => Ok(None),
         }
     }
+
+    fn keys(&self) -> Vec<Key> {
+        self.cache.iter().map(|entry| entry.key().clone()).collect()
+    }
 }


### PR DESCRIPTION
This change touches many of our abstractions and I like to know your opinion on how we can do it better. Essentially we won't have a single way (across accumulation ways) to say what are the price ids and the solution seems to be taking the union of all accumulation states. The reason is that the prices are derived from the accumulations not the other way. 

This PR also adds a CcipUpdateNotFound error to handle the special status code situation.