### PR TITLE
Gas usage experiments

### DIFF
--- a/target_chains/ethereum/contracts/forge-test/GasUsageExperiments.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/GasUsageExperiments.t.sol
@@ -297,15 +297,9 @@ contract GasUsageExperiments is Test, WormholeTestUtils, PythTestUtils {
         return ThresholdUpdate(signature, data);
     }
 
-    function testBenchmarkUpdatePriceFeedsFresh() public {
+    function testWormholeBatchUpdate() public {
         pyth.updatePriceFeeds{value: freshPricesUpdateFee}(
             freshPricesUpdateData
-        );
-    }
-
-    function testBenchmarkUpdatePriceFeedsNotFresh() public {
-        pyth.updatePriceFeeds{value: cachedPricesUpdateFee}(
-            cachedPricesUpdateData
         );
     }
 

--- a/target_chains/ethereum/contracts/forge-test/GasUsageExperiments.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/GasUsageExperiments.t.sol
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "forge-std/Test.sol";
+
+import "../contracts/libraries/external/UnsafeBytesLib.sol";
+import "@pythnetwork/pyth-sdk-solidity/AbstractPyth.sol";
+import "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
+import "@pythnetwork/pyth-sdk-solidity/PythErrors.sol";
+import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
+import "../contracts/pyth/PythInternalStructs.sol";
+import "./utils/WormholeTestUtils.t.sol";
+import "./utils/PythTestUtils.t.sol";
+
+contract GasUsageExperiments is Test, WormholeTestUtils, PythTestUtils {
+    // 19, current mainnet number of guardians, is used to have gas estimates
+    // close to our mainnet transactions.
+    uint8 constant NUM_GUARDIANS = 19;
+    // 2/3 of the guardians should sign a message for a VAA which is 13 out of 19 guardians.
+    // It is possible to have more signers but the median seems to be 13.
+    uint8 constant NUM_GUARDIAN_SIGNERS = 13;
+
+    // We use 5 prices to form a batch of 5 prices, close to our mainnet transactions.
+    uint8 constant NUM_PRICES = 5;
+
+    PythExperimental public pyth;
+
+    bytes32[] priceIds;
+
+    // Cached prices are populated in the setUp
+    PythStructs.Price[] cachedPrices;
+    bytes[] cachedPricesUpdateData;
+    uint cachedPricesUpdateFee;
+    uint64[] cachedPricesPublishTimes;
+
+    // Fresh prices are different prices that can be used
+    // as a fresh price to update the prices
+    PythStructs.Price[] freshPrices;
+    bytes[] freshPricesUpdateData;
+    uint freshPricesUpdateFee;
+    uint64[] freshPricesPublishTimes;
+
+    uint64 sequence;
+    uint randSeed;
+
+    function setUp() public {
+        address payable wormhole = payable(setUpWormhole(NUM_GUARDIANS));
+
+        // Deploy experimental contract
+        PythExperimental implementation = new PythExperimental();
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(implementation),
+            new bytes(0)
+        );
+        pyth = PythExperimental(address(proxy));
+
+        uint16[] memory emitterChainIds = new uint16[](1);
+        emitterChainIds[0] = PythTestUtils.SOURCE_EMITTER_CHAIN_ID;
+
+        bytes32[] memory emitterAddresses = new bytes32[](1);
+        emitterAddresses[0] = PythTestUtils.SOURCE_EMITTER_ADDRESS;
+
+        pyth.initialize(wormhole, emitterChainIds, emitterAddresses);
+
+        // TBD not clear what's going on below here
+
+        priceIds = new bytes32[](NUM_PRICES);
+        priceIds[0] = bytes32(
+            0x1000000000000000000000000000000000000000000000000000000000000f00
+        );
+        for (uint i = 1; i < NUM_PRICES; ++i) {
+            priceIds[i] = bytes32(uint256(priceIds[i - 1]) + 1);
+        }
+
+        for (uint i = 0; i < NUM_PRICES; ++i) {
+            uint64 publishTime = uint64(getRand() % 10);
+
+            cachedPrices.push(
+                PythStructs.Price(
+                    int64(uint64(getRand() % 1000)), // Price
+                    uint64(getRand() % 100), // Confidence
+                    -5, // Expo
+                    publishTime
+                )
+            );
+            cachedPricesPublishTimes.push(publishTime);
+
+            publishTime += uint64(getRand() % 10);
+            freshPrices.push(
+                PythStructs.Price(
+                    int64(uint64(getRand() % 1000)), // Price
+                    uint64(getRand() % 100), // Confidence
+                    -5, // Expo
+                    publishTime
+                )
+            );
+            freshPricesPublishTimes.push(publishTime);
+        }
+
+        // Populate the contract with the initial prices
+        (
+            cachedPricesUpdateData,
+            cachedPricesUpdateFee
+        ) = generateUpdateDataAndFee(cachedPrices);
+        pyth.updatePriceFeeds{value: cachedPricesUpdateFee}(
+            cachedPricesUpdateData
+        );
+
+        (
+            freshPricesUpdateData,
+            freshPricesUpdateFee
+        ) = generateUpdateDataAndFee(freshPrices);
+    }
+
+    function getRand() internal returns (uint val) {
+        ++randSeed;
+        val = uint(keccak256(abi.encode(randSeed)));
+    }
+
+    function generateUpdateDataAndFee(
+        PythStructs.Price[] memory prices
+    ) internal returns (bytes[] memory updateData, uint updateFee) {
+        bytes memory vaa = generatePriceFeedUpdateVAA(
+            pricesToPriceAttestations(priceIds, prices),
+            sequence,
+            NUM_GUARDIAN_SIGNERS
+        );
+
+        ++sequence;
+
+        updateData = new bytes[](1);
+        updateData[0] = vaa;
+
+        // updateFee = pyth.getUpdateFee(updateData);
+        updateFee = 0;
+    }
+
+    function testBenchmarkUpdatePriceFeedsFresh() public {
+        pyth.updatePriceFeeds{value: freshPricesUpdateFee}(
+            freshPricesUpdateData
+        );
+    }
+
+    function testBenchmarkUpdatePriceFeedsNotFresh() public {
+        pyth.updatePriceFeeds{value: cachedPricesUpdateFee}(
+            cachedPricesUpdateData
+        );
+    }
+
+    /*
+    function testBenchmarkParsePriceFeedUpdatesForOnePriceFeed() public {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = priceIds[0];
+
+        pyth.parsePriceFeedUpdates{value: freshPricesUpdateFee}(
+            freshPricesUpdateData,
+            ids,
+            0,
+            50
+        );
+    }
+
+    function testBenchmarkParsePriceFeedUpdatesForTwoPriceFeed() public {
+        bytes32[] memory ids = new bytes32[](2);
+        ids[0] = priceIds[0];
+        ids[1] = priceIds[1];
+
+        pyth.parsePriceFeedUpdates{value: freshPricesUpdateFee}(
+            freshPricesUpdateData,
+            ids,
+            0,
+            50
+        );
+    }
+
+    function testBenchmarkParsePriceFeedUpdatesForOnePriceFeedNotWithinRange()
+        public
+    {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = priceIds[0];
+
+        vm.expectRevert(PythErrors.PriceFeedNotFoundWithinRange.selector);
+        pyth.parsePriceFeedUpdates{value: freshPricesUpdateFee}(
+            freshPricesUpdateData,
+            ids,
+            50,
+            100
+        );
+    }
+
+    function testBenchmarkGetPrice() public {
+        // Set the block timestamp to 0. As prices have < 10 timestamp and staleness
+        // is set to 60 seconds, the getPrice should work as expected.
+        vm.warp(0);
+
+        pyth.getPrice(priceIds[0]);
+    }
+
+    function testBenchmarkGetEmaPrice() public {
+        // Set the block timestamp to 0. As prices have < 10 timestamp and staleness
+        // is set to 60 seconds, the getPrice should work as expected.
+        vm.warp(0);
+
+        pyth.getEmaPrice(priceIds[0]);
+    }
+
+    function testBenchmarkGetUpdateFee() public view {
+        pyth.getUpdateFee(freshPricesUpdateData);
+    }
+    */
+}
+
+contract PythExperimental {
+    address payable wormholeAddr;
+    // For tracking all active emitter/chain ID pairs
+    PythInternalStructs.DataSource[] validDataSources;
+    mapping(bytes32 => bool) isValidDataSource;
+
+    function initialize(
+        address payable wormholeArg,
+        uint16[] calldata dataSourceEmitterChainIds,
+        bytes32[] calldata dataSourceEmitterAddresses
+    ) public {
+        wormholeAddr = wormholeArg;
+
+        if (
+            dataSourceEmitterChainIds.length !=
+            dataSourceEmitterAddresses.length
+        ) revert PythErrors.InvalidArgument();
+
+        for (uint i = 0; i < dataSourceEmitterChainIds.length; i++) {
+            PythInternalStructs.DataSource memory ds = PythInternalStructs
+                .DataSource(
+                    dataSourceEmitterChainIds[i],
+                    dataSourceEmitterAddresses[i]
+                );
+
+            isValidDataSource[hashDataSource(ds)] = true;
+            validDataSources.push(ds);
+        }
+    }
+
+    // Experiment 1: Minimal wormhole update. No hashing or anything is performed.
+
+    function updatePriceFeeds(bytes[] calldata updateData) public payable {
+        for (uint i = 0; i < updateData.length; ) {
+            IWormhole.VM memory vm = parseAndVerifyBatchAttestationVM(
+                updateData[i]
+            );
+
+            unchecked {
+                i++;
+            }
+        }
+    }
+
+    function parseAndVerifyBatchAttestationVM(
+        bytes calldata encodedVm
+    ) internal view returns (IWormhole.VM memory vm) {
+        {
+            bool valid;
+            (vm, valid, ) = wormhole().parseAndVerifyVM(encodedVm);
+            if (!valid) revert PythErrors.InvalidWormholeVaa();
+        }
+
+        if (!verifyPythVM(vm)) revert PythErrors.InvalidUpdateDataSource();
+    }
+
+    function verifyPythVM(
+        IWormhole.VM memory vm
+    ) private view returns (bool valid) {
+        return
+            isValidDataSource[
+                keccak256(
+                    abi.encodePacked(vm.emitterChainId, vm.emitterAddress)
+                )
+            ];
+    }
+
+    // Misc utilities
+
+    function hashDataSource(
+        PythInternalStructs.DataSource memory ds
+    ) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(ds.chainId, ds.emitterAddress));
+    }
+
+    function wormhole() public view returns (IWormhole) {
+        return IWormhole(wormholeAddr);
+    }
+}

--- a/target_chains/ethereum/contracts/forge-test/VerificationExperiments.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/VerificationExperiments.t.sol
@@ -15,7 +15,7 @@ import "./utils/WormholeTestUtils.t.sol";
 import "./utils/PythTestUtils.t.sol";
 
 // Experiments to measure the gas usage of different ways of verifying prices in the EVM contract.
-contract GasUsageExperiments is Test, WormholeTestUtils, PythTestUtils {
+contract VerificationExperiments is Test, WormholeTestUtils, PythTestUtils {
     // 19, current mainnet number of guardians, is used to have gas estimates
     // close to our mainnet transactions.
     uint8 constant NUM_GUARDIANS = 19;


### PR DESCRIPTION
We wanted to benchmark the gas usage of different ways of verifying prices in the ethereum contract. I tried out a bunch of different things and here's what I get:

| Update Type                                   | Gas Cost |
| --------------------------------------------- | ------- |
| Native update (use tx signature of 1 price update)   | 48k     |
| Threshold update (sign 1 price update directly)                              | 54.5k   |
| Threshold update for 1 price w/ 8-deep merkle tree         | 58k     |
| WH update for 1 price w/ 8-deep merkle tree                | 201k    |
| WH batch update w/ 5 prices                    | 222k    |

The two things that I think are worth pointing out are:
1. The merkle tree doesn't add that much overhead over the native update, which represents the lower bound of what's achievable. That's good, because it means our current path will end up in a near-optimal state once everything is done.
2. We do get a minor gas improvement from the merkle tree update itself.

I think our current path is reasonable given these results, so that's good. No need to change anything.