### PR TITLE
[xc-admin] Add support for arbitrary wormhole payloads

### DIFF
--- a/governance/xc_admin/packages/xc_admin_cli/src/index.ts
+++ b/governance/xc_admin/packages/xc_admin_cli/src/index.ts
@@ -26,6 +26,7 @@ import {
   mapKey,
   MultisigParser,
   PROGRAM_AUTHORITY_ESCROW,
+  proposeArbitraryPayload,
   proposeInstructions,
   WORMHOLE_ADDRESS,
 } from "xc_admin_common";
@@ -400,6 +401,36 @@ multisigCommand("propose-sol-transfer", "Propose sol transfer")
       [proposalInstruction],
       isRemote,
       WORMHOLE_ADDRESS[getMultisigCluster(cluster)]
+    );
+  });
+
+multisigCommand("propose-arbitrary-payload", "Propose arbitrary payload")
+  .option("-p, --payload <hex-string>", "Wormhole VAA payload")
+  .action(async (options: any) => {
+    const wallet = await loadHotWalletOrLedger(
+      options.wallet,
+      options.ledgerDerivationAccount,
+      options.ledgerDerivationChange
+    );
+
+    const cluster: PythCluster = options.cluster;
+    const vault: PublicKey = new PublicKey(options.vault);
+
+    const squad = SquadsMesh.endpoint(
+      getPythClusterApiUrl(getMultisigCluster(cluster)),
+      wallet
+    );
+
+    let payload = options.payload;
+    if (payload.startsWith("0x")) {
+      payload = payload.substring(2);
+    }
+
+    await proposeArbitraryPayload(
+      squad,
+      vault,
+      Buffer.from(payload, "hex"),
+      WORMHOLE_ADDRESS[cluster]!
     );
   });
 

--- a/governance/xc_admin/packages/xc_admin_cli/src/index.ts
+++ b/governance/xc_admin/packages/xc_admin_cli/src/index.ts
@@ -65,7 +65,10 @@ const multisigCommand = (name: string, description: string) =>
       "-w, --wallet <filepath>",
       'path to the operations key or "ledger"'
     )
-    .requiredOption("-v, --vault <pubkey>", "multisig address")
+    .requiredOption(
+      "-v, --vault <pubkey>",
+      "multisig address, all the addresses can be found in xc_admin_common/src/multisig.ts"
+    )
     .option(
       "-lda, --ledger-derivation-account <number>",
       "ledger derivation account to use"

--- a/governance/xc_admin/packages/xc_admin_cli/src/index.ts
+++ b/governance/xc_admin/packages/xc_admin_cli/src/index.ts
@@ -416,10 +416,7 @@ multisigCommand("propose-arbitrary-payload", "Propose arbitrary payload")
     const cluster: PythCluster = options.cluster;
     const vault: PublicKey = new PublicKey(options.vault);
 
-    const squad = SquadsMesh.endpoint(
-      getPythClusterApiUrl(getMultisigCluster(cluster)),
-      wallet
-    );
+    const squad = SquadsMesh.endpoint(getPythClusterApiUrl(cluster), wallet);
 
     let payload = options.payload;
     if (payload.startsWith("0x")) {


### PR DESCRIPTION
Add support for arbitrary wormhole payloads to `xc_admin_cli`
Remove feature from `multisig_wh_message_builder` since we're deprecating it.