### PR TITLE
[accumulator-updater 5/x] Single PDA

### DIFF
--- a/accumulator_updater/programs/accumulator_updater/Cargo.toml
+++ b/accumulator_updater/programs/accumulator_updater/Cargo.toml
@@ -16,6 +16,6 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = "0.27.0"
+anchor-lang = { version = "0.27.0", features = ["init-if-needed"] }
 # needed for the new #[account(zero_copy)] in anchor 0.27.0
 bytemuck = { version = "1.4.0", features = ["derive", "min_const_generics"]}

--- a/accumulator_updater/programs/accumulator_updater/Cargo.toml
+++ b/accumulator_updater/programs/accumulator_updater/Cargo.toml
@@ -16,6 +16,6 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = { version = "0.27.0", features = ["init-if-needed"] }
+anchor-lang = { version = "0.27.0" }
 # needed for the new #[account(zero_copy)] in anchor 0.27.0
 bytemuck = { version = "1.4.0", features = ["derive", "min_const_generics"]}

--- a/accumulator_updater/programs/accumulator_updater/src/instructions/put_all.rs
+++ b/accumulator_updater/programs/accumulator_updater/src/instructions/put_all.rs
@@ -12,17 +12,19 @@ use {
     },
 };
 
+// NOte: get rid of this. not using schema.
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct InputSchemaAndData {
     pub schema: u8,
     pub data:   Vec<u8>,
 }
 
+pub const ACCUMULATOR: &[u8; 11] = b"accumulator";
 
 pub fn put_all<'info>(
     ctx: Context<'_, '_, '_, 'info, PutAll<'info>>,
     base_account_key: Pubkey,
-    values: Vec<InputSchemaAndData>,
+    values: Vec<Vec<u8>>,
 ) -> Result<()> {
     let cpi_caller = ctx.accounts.whitelist_verifier.is_allowed()?;
     let account_infos = ctx.remaining_accounts;
@@ -39,7 +41,7 @@ pub fn put_all<'info>(
             let (pda, bump) = Pubkey::find_program_address(
                 &[
                     cpi_caller.as_ref(),
-                    b"accumulator".as_ref(),
+                    ACCUMULATOR.as_ref(),
                     base_account_key.as_ref(),
                 ],
                 &crate::ID,
@@ -47,7 +49,7 @@ pub fn put_all<'info>(
             require_keys_eq!(accumulator_input_ai.key(), pda);
             let signer_seeds = &[
                 cpi_caller.as_ref(),
-                b"accumulator".as_ref(),
+                ACCUMULATOR.as_ref(),
                 base_account_key.as_ref(),
                 &[bump],
             ];
@@ -68,10 +70,12 @@ pub fn put_all<'info>(
         } else {
             loader = AccountLoader::<AccumulatorInput>::try_from(accumulator_input_ai)?;
             let mut accumulator_input = loader.load_mut()?;
-            accumulator_input.validate(accumulator_input_ai.key(), cpi_caller, base_account_key)?;
             accumulator_input.header.set_version();
             accumulator_input
         });
+        // note: redundant for uninitialized code path but safer to check here.
+        // compute budget cost should be minimal
+        accumulator_input.validate(accumulator_input_ai.key(), cpi_caller, base_account_key)?;
         accumulator_input.put_all(values)?;
     }
 

--- a/accumulator_updater/programs/accumulator_updater/src/instructions/put_all.rs
+++ b/accumulator_updater/programs/accumulator_updater/src/instructions/put_all.rs
@@ -26,85 +26,58 @@ pub fn put_all<'info>(
 ) -> Result<()> {
     let cpi_caller = ctx.accounts.whitelist_verifier.is_allowed()?;
     let account_infos = ctx.remaining_accounts;
-    require_eq!(account_infos.len(), values.len());
+    let accumulator_input_ai = account_infos
+        .first()
+        .ok_or(AccumulatorUpdaterError::AccumulatorInputNotProvided)?;
 
-    let rent = Rent::get()?;
-    let (mut initialized, mut updated) = (vec![], vec![]);
+    let _rent = Rent::get()?;
 
-    for (
-        ai,
-        InputSchemaAndData {
-            schema: account_schema,
-            data: account_data,
-        },
-    ) in account_infos.iter().zip(values)
+    let loader;
+
     {
-        let bump = if is_uninitialized_account(ai) {
-            let seeds = &[
-                cpi_caller.as_ref(),
-                b"accumulator".as_ref(),
-                base_account_key.as_ref(),
-                &account_schema.to_le_bytes(),
-            ];
-            let (pda, bump) = Pubkey::find_program_address(seeds, &crate::ID);
-            require_keys_eq!(ai.key(), pda);
-
-
-            //TODO: Update this with serialization logic
-            // 8 for anchor discriminator
-            let accumulator_size = 8 + AccumulatorInput::size(&account_data);
-            PutAll::create_account(
-                ai,
-                accumulator_size,
-                &ctx.accounts.payer,
+        let accumulator_input = &mut (if is_uninitialized_account(accumulator_input_ai) {
+            let (pda, bump) = Pubkey::find_program_address(
                 &[
                     cpi_caller.as_ref(),
                     b"accumulator".as_ref(),
                     base_account_key.as_ref(),
-                    &account_schema.to_le_bytes(),
-                    &[bump],
                 ],
-                &rent,
+                &crate::ID,
+            );
+            require_keys_eq!(accumulator_input_ai.key(), pda);
+            let signer_seeds = &[
+                cpi_caller.as_ref(),
+                b"accumulator".as_ref(),
+                base_account_key.as_ref(),
+                &[bump],
+            ];
+            PutAll::create_account(
+                accumulator_input_ai,
+                8 + AccumulatorInput::INIT_SPACE,
+                &ctx.accounts.payer,
+                signer_seeds,
                 &ctx.accounts.system_program,
             )?;
-            initialized.push(ai.key());
-
-            bump
-        } else {
-            let accumulator_input = <AccumulatorInput as AccountDeserialize>::try_deserialize(
-                &mut &**ai.try_borrow_mut_data()?,
+            loader = AccountLoader::<AccumulatorInput>::try_from_unchecked(
+                &crate::ID,
+                accumulator_input_ai,
             )?;
-            {
-                // TODO: allow re-sizing?
-                require_gte!(
-                    accumulator_input.data.len(),
-                    account_data.len(),
-                    AccumulatorUpdaterError::CurrentDataLengthExceeded
-                );
-
-                accumulator_input.validate(
-                    ai.key(),
-                    cpi_caller,
-                    base_account_key,
-                    account_schema,
-                )?;
-            }
-
-
-            updated.push(ai.key());
-            accumulator_input.header.bump
-        };
-
-        let accumulator_input =
-            AccumulatorInput::new(AccumulatorHeader::new(bump, account_schema), account_data);
-        accumulator_input.persist(ai)?;
+            let mut accumulator_input = loader.load_init()?;
+            accumulator_input.header = AccumulatorHeader::new(bump);
+            accumulator_input
+        } else {
+            loader = AccountLoader::<AccumulatorInput>::try_from(accumulator_input_ai)?;
+            let mut accumulator_input = loader.load_mut()?;
+            accumulator_input.validate(accumulator_input_ai.key(), cpi_caller, base_account_key)?;
+            accumulator_input.header.set_version();
+            accumulator_input
+        });
+        accumulator_input.put_all(values)?;
     }
 
-    msg!(
-        "[emit-updates]: initialized: {:?}, updated: {:?}",
-        initialized,
-        updated
-    );
+
+    loader.exit(&crate::ID)?;
+
     Ok(())
 }
 
@@ -113,6 +86,7 @@ pub fn is_uninitialized_account(ai: &AccountInfo) -> bool {
 }
 
 #[derive(Accounts)]
+#[instruction( base_account_key: Pubkey)]
 pub struct PutAll<'info> {
     #[account(mut)]
     pub payer:              Signer<'info>,
@@ -127,10 +101,9 @@ impl<'info> PutAll<'info> {
         space: usize,
         payer: &AccountInfo<'a>,
         seeds: &[&[u8]],
-        rent: &Rent,
         system_program: &AccountInfo<'a>,
     ) -> Result<()> {
-        let lamports = rent.minimum_balance(space);
+        let lamports = Rent::get()?.minimum_balance(space);
 
         system_program::create_account(
             CpiContext::new_with_signer(

--- a/accumulator_updater/programs/accumulator_updater/src/instructions/put_all.rs
+++ b/accumulator_updater/programs/accumulator_updater/src/instructions/put_all.rs
@@ -15,8 +15,6 @@ use {
 
 pub const ACCUMULATOR: &[u8; 11] = b"accumulator";
 
-/// Puts all
-///
 pub fn put_all<'info>(
     ctx: Context<'_, '_, '_, 'info, PutAll<'info>>,
     base_account_key: Pubkey,
@@ -70,9 +68,6 @@ pub fn put_all<'info>(
         // note: redundant for uninitialized code path but safer to check here.
         // compute budget cost should be minimal
         accumulator_input.validate(accumulator_input_ai.key(), cpi_caller, base_account_key)?;
-
-
-        // accumulator_input.put_all_old(messages)?;
 
 
         let (num_msgs, num_bytes) = accumulator_input.put_all(&messages);

--- a/accumulator_updater/programs/accumulator_updater/src/lib.rs
+++ b/accumulator_updater/programs/accumulator_updater/src/lib.rs
@@ -52,23 +52,25 @@ pub mod accumulator_updater {
     }
 
 
-    /// Create or update inputs for the Accumulator. Each input is written
-    /// into a separate PDA account derived with
-    /// seeds = [cpi_caller, b"accumulator", base_account_key, schema]
+    /// Insert messages/inputs for the Accumulator. All inputs derived from the
+    /// `base_account_key` will go into the same PDA. The PDA is derived with
+    /// seeds = [cpi_caller, b"accumulator", base_account_key]
     ///
-    /// The caller of this instruction must pass those PDAs
-    /// while calling this function in the same order as elements.
     ///
     ///
     /// * `base_account_key`    - Pubkey of the original account the
-    ///                         AccumulatorInput(s) are derived from
-    /// * `values`              - Vec of account_data in same respective
+    ///                           AccumulatorInput is derived from
+    /// * `messages`            - Vec of vec of bytes, each representing a message
+    ///                           to be hashed and accumulated
+    ///
+    /// TODO: need to be tolerant/handle situation where PDA size is insufficient
+    ///      to hold all messages.
     pub fn put_all<'info>(
         ctx: Context<'_, '_, '_, 'info, PutAll<'info>>,
         base_account_key: Pubkey,
-        values: Vec<Vec<u8>>,
+        messages: Vec<Vec<u8>>,
     ) -> Result<()> {
-        instructions::put_all(ctx, base_account_key, values)
+        instructions::put_all(ctx, base_account_key, messages)
     }
 }
 

--- a/accumulator_updater/programs/accumulator_updater/src/lib.rs
+++ b/accumulator_updater/programs/accumulator_updater/src/lib.rs
@@ -62,12 +62,11 @@ pub mod accumulator_updater {
     ///
     /// * `base_account_key`    - Pubkey of the original account the
     ///                         AccumulatorInput(s) are derived from
-    /// * `values`              - Vec of (schema, account_data) in same respective
-    ///                           order `ctx.remaining_accounts`
+    /// * `values`              - Vec of account_data in same respective
     pub fn put_all<'info>(
         ctx: Context<'_, '_, '_, 'info, PutAll<'info>>,
         base_account_key: Pubkey,
-        values: Vec<InputSchemaAndData>,
+        values: Vec<Vec<u8>>,
     ) -> Result<()> {
         instructions::put_all(ctx, base_account_key, values)
     }

--- a/accumulator_updater/programs/accumulator_updater/src/lib.rs
+++ b/accumulator_updater/programs/accumulator_updater/src/lib.rs
@@ -128,4 +128,6 @@ pub enum AccumulatorUpdaterError {
     CurrentDataLengthExceeded,
     #[msg("Accumulator Input not writable")]
     AccumulatorInputNotWritable,
+    #[msg("Accumulator Input not provided")]
+    AccumulatorInputNotProvided,
 }

--- a/accumulator_updater/programs/accumulator_updater/src/lib.rs
+++ b/accumulator_updater/programs/accumulator_updater/src/lib.rs
@@ -69,7 +69,8 @@ pub mod accumulator_updater {
     /// then the remaining messages will be ignored.
     ///
     /// The current implementation assumes that each invocation of this
-    /// ix is independent of any previous invocations.
+    /// ix is independent of any previous invocations. It will overwrite
+    /// any existing contents.
     ///
     /// TODO:
     ///     - try handling re-allocation of the accumulator_input space

--- a/accumulator_updater/programs/accumulator_updater/src/lib.rs
+++ b/accumulator_updater/programs/accumulator_updater/src/lib.rs
@@ -63,8 +63,18 @@ pub mod accumulator_updater {
     /// * `messages`            - Vec of vec of bytes, each representing a message
     ///                           to be hashed and accumulated
     ///
-    /// TODO: need to be tolerant/handle situation where PDA size is insufficient
-    ///      to hold all messages.
+    /// This ix will write as many of the messages up to the length
+    /// of the `accumulator_input.data`.
+    /// If `accumulator_input.data.len() < messages.map(|x| x.len()).sum()`
+    /// then the remaining messages will be ignored.
+    ///
+    /// The current implementation assumes that each invocation of this
+    /// ix is independent of any previous invocations.
+    ///
+    /// TODO:
+    ///     - try handling re-allocation of the accumulator_input space
+    ///     - handle updates ("paging/batches of messages")
+    ///
     pub fn put_all<'info>(
         ctx: Context<'_, '_, '_, 'info, PutAll<'info>>,
         base_account_key: Pubkey,

--- a/accumulator_updater/programs/accumulator_updater/src/macros.rs
+++ b/accumulator_updater/programs/accumulator_updater/src/macros.rs
@@ -5,7 +5,6 @@ macro_rules! accumulator_input_seeds {
             $cpi_caller_pid.as_ref(),
             b"accumulator".as_ref(),
             $base_account.as_ref(),
-            &$accumulator_input.header.account_schema.to_le_bytes(),
             &[$accumulator_input.header.bump],
         ]
     };

--- a/accumulator_updater/programs/accumulator_updater/src/state/accumulator_input.rs
+++ b/accumulator_updater/programs/accumulator_updater/src/state/accumulator_input.rs
@@ -1,6 +1,7 @@
 use {
     crate::{
         accumulator_input_seeds,
+        instructions::InputSchemaAndData,
         AccumulatorUpdaterError,
     },
     anchor_lang::prelude::*,
@@ -14,25 +15,80 @@ use {
 /// the CPI calling program (e.g. Pyth Oracle)
 ///
 /// TODO: implement custom serialization & set alignment
-#[account]
+#[account(zero_copy)]
+#[derive(Debug, InitSpace)]
 pub struct AccumulatorInput {
     pub header: AccumulatorHeader,
-    pub data:   Vec<u8>,
+    // 10KB - 8 (discriminator) - 2053 (header) - 11 (alignment)
+    pub data:   [u8; 8_176],
+}
+
+#[zero_copy]
+#[derive(InitSpace, Debug)]
+pub struct AccumulatorHeader {
+    pub bump:     u8,                // 1
+    pub version:  u8,                // 2
+    pub unused_0: u16,               // 2
+    pub indexes:  [InputIndex; 255], // 2048
+}
+
+#[zero_copy]
+#[derive(Debug, InitSpace)]
+pub struct InputIndex {
+    pub offset:   u32,
+    pub len:      u16,
+    pub unused_0: u16,
 }
 
 impl AccumulatorInput {
-    pub fn size(data: &Vec<u8>) -> usize {
-        AccumulatorHeader::SIZE + 4 + data.len()
+    pub const DATA_MAX_LEN: usize = (4 * 1024) - 8 - AccumulatorHeader::INIT_SPACE;
+
+    pub fn init_size(values: &Vec<InputSchemaAndData>) -> usize {
+        let mut size = AccumulatorHeader::INIT_SPACE + 4;
+        for v in values {
+            size += v.data.len();
+        }
+        size
     }
 
-    pub fn new(header: AccumulatorHeader, data: Vec<u8>) -> Self {
-        Self { header, data }
+    pub fn size(&self) -> usize {
+        AccumulatorHeader::INIT_SPACE + 4 + self.data.len()
     }
 
-    pub fn update(&mut self, new_data: Vec<u8>) {
-        self.header = AccumulatorHeader::new(self.header.bump, self.header.account_schema);
-        self.data = new_data;
+    pub fn offset(&self) -> u32 {
+        self.header
+            .indexes
+            .iter()
+            .map(|v| v.offset)
+            .max()
+            .unwrap_or_default()
     }
+
+
+    pub fn new(bump: u8) -> Self {
+        let header = AccumulatorHeader::new(bump);
+        Self {
+            header,
+            data: [0u8; 8_176],
+        }
+    }
+
+    pub fn put_all(&mut self, values: Vec<InputSchemaAndData>) -> Result<()> {
+        let mut offset = self.offset();
+        for v in values {
+            let end;
+            {
+                let input_idx = &mut self.header.indexes[v.schema as usize];
+                input_idx.len = v.data.len() as u16;
+                input_idx.offset = offset;
+                end = offset + input_idx.len as u32;
+            }
+            self.data[((offset as usize)..(end as usize))].copy_from_slice(&v.data);
+            offset = end;
+        }
+        Ok(())
+    }
+
 
     fn derive_pda(&self, cpi_caller: Pubkey, base_account: Pubkey) -> Result<Pubkey> {
         let res = Pubkey::create_program_address(
@@ -43,24 +99,9 @@ impl AccumulatorInput {
         Ok(res)
     }
 
-    pub fn validate(
-        &self,
-        key: Pubkey,
-        cpi_caller: Pubkey,
-        base_account: Pubkey,
-        account_schema: u8,
-    ) -> Result<()> {
+    pub fn validate(&self, key: Pubkey, cpi_caller: Pubkey, base_account: Pubkey) -> Result<()> {
         let expected_key = self.derive_pda(cpi_caller, base_account)?;
         require_keys_eq!(expected_key, key);
-        require_eq!(self.header.account_schema, account_schema);
-        Ok(())
-    }
-
-    pub fn persist(&self, ai: &AccountInfo) -> Result<()> {
-        AccountSerialize::try_serialize(self, &mut &mut ai.data.borrow_mut()[..]).map_err(|e| {
-            msg!("original error: {:?}", e);
-            AccumulatorUpdaterError::SerializeError
-        })?;
         Ok(())
     }
 }
@@ -68,8 +109,8 @@ impl AccumulatorInput {
 //TODO:
 // - implement custom serialization & set alignment
 // - what other fields are needed?
-#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, Default)]
-pub struct AccumulatorHeader {
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, Default, InitSpace)]
+pub struct AccumulatorHeaderOld {
     pub bump:           u8,
     pub version:        u8,
     pub account_schema: u8,
@@ -77,14 +118,72 @@ pub struct AccumulatorHeader {
 
 
 impl AccumulatorHeader {
-    pub const SIZE: usize = 1 + 1 + 1;
     pub const CURRENT_VERSION: u8 = 1;
 
-    pub fn new(bump: u8, account_schema: u8) -> Self {
+    pub fn new(bump: u8) -> Self {
         Self {
             bump,
+            unused_0: 0,
             version: Self::CURRENT_VERSION,
-            account_schema,
+            indexes: [InputIndex {
+                offset:   0,
+                unused_0: 0,
+                len:      0,
+            }; u8::MAX as usize],
         }
+    }
+
+    pub fn set_version(&mut self) {
+        self.version = Self::CURRENT_VERSION;
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        std::mem::{
+            align_of,
+            size_of,
+        },
+    };
+
+    #[test]
+    fn test_sizes_and_alignments() {
+        let (input_idx_size, input_idx_align) = (size_of::<InputIndex>(), align_of::<InputIndex>());
+
+        let (header_idx_size, header_idx_align) = (
+            size_of::<AccumulatorHeader>(),
+            align_of::<AccumulatorHeader>(),
+        );
+
+        let (input_size, input_align) = (
+            size_of::<AccumulatorInput>(),
+            align_of::<AccumulatorInput>(),
+        );
+
+        // input_idx
+        //     size: 4
+        //     align: 2
+        // header
+        //     size: 1022
+        //     align: 2
+        // input
+        //     size: 2046
+        //     align: 2
+        println!(
+            r"
+            input_idx
+                size: {input_idx_size:?}
+                align: {input_idx_align:?}
+            header
+                size: {header_idx_size:?}
+                align: {header_idx_align:?}
+            input
+                size: {input_size:?}
+                align: {input_align:?}
+        "
+        )
     }
 }

--- a/accumulator_updater/programs/accumulator_updater/src/state/accumulator_input.rs
+++ b/accumulator_updater/programs/accumulator_updater/src/state/accumulator_input.rs
@@ -155,15 +155,15 @@ mod test {
             align_of::<AccumulatorInput>(),
         );
 
-        // input_idx
-        //     size: 4
-        //     align: 2
-        // header
-        //     size: 1022
-        //     align: 2
-        // input
-        //     size: 2046
-        //     align: 2
+        //            input_idx
+        //                 size: 8
+        //                 align: 4
+        //             header
+        //                 size: 2044
+        //                 align: 4
+        //             input
+        //                 size: 10220
+        //                 align: 4
         println!(
             r"
             input_idx

--- a/accumulator_updater/programs/accumulator_updater/src/state/accumulator_input.rs
+++ b/accumulator_updater/programs/accumulator_updater/src/state/accumulator_input.rs
@@ -84,23 +84,9 @@ impl AccumulatorInput {
     // need to be made to write all the messages
     // TODO: add a end_offsets index parameter for "continuation"
     // TODO: test max size of parameters that can be passed into CPI call
-    pub fn put_all_old(&mut self, values: Vec<Vec<u8>>) -> Result<()> {
-        let mut offset = 0u16;
-
-        for (i, v) in values.into_iter().enumerate() {
-            let start = offset;
-            let end = offset + (v.len() as u16);
-            self.header.end_offsets[i] = end;
-            self.data[(start as usize)..(end as usize)].copy_from_slice(&v);
-            offset = end;
-        }
-        Ok(())
-    }
-
     pub fn put_all(&mut self, values: &Vec<Vec<u8>>) -> (usize, u16) {
         let mut offset = 0u16;
 
-        let values_len = values.len();
         for (i, v) in values.iter().enumerate() {
             let start = offset;
             let end = offset + (v.len() as u16);
@@ -112,7 +98,7 @@ impl AccumulatorInput {
             self.data[(start as usize)..(end as usize)].copy_from_slice(v);
             offset = end
         }
-        (values_len, offset)
+        (values.len(), offset)
     }
 
 

--- a/accumulator_updater/programs/accumulator_updater/src/state/accumulator_input.rs
+++ b/accumulator_updater/programs/accumulator_updater/src/state/accumulator_input.rs
@@ -23,6 +23,9 @@ pub struct AccumulatorInput {
     pub data:   [u8; 8_176],
 }
 
+//TODO:
+// - implement custom serialization & set alignment
+// - what other fields are needed?
 #[zero_copy]
 #[derive(InitSpace, Debug)]
 pub struct AccumulatorHeader {
@@ -30,6 +33,27 @@ pub struct AccumulatorHeader {
     pub version:  u8,                // 2
     pub unused_0: u16,               // 2
     pub indexes:  [InputIndex; 255], // 2048
+}
+
+impl AccumulatorHeader {
+    pub const CURRENT_VERSION: u8 = 1;
+
+    pub fn new(bump: u8) -> Self {
+        Self {
+            bump,
+            unused_0: 0,
+            version: Self::CURRENT_VERSION,
+            indexes: [InputIndex {
+                offset:   0,
+                unused_0: 0,
+                len:      0,
+            }; u8::MAX as usize],
+        }
+    }
+
+    pub fn set_version(&mut self) {
+        self.version = Self::CURRENT_VERSION;
+    }
 }
 
 #[zero_copy]
@@ -103,38 +127,6 @@ impl AccumulatorInput {
         let expected_key = self.derive_pda(cpi_caller, base_account)?;
         require_keys_eq!(expected_key, key);
         Ok(())
-    }
-}
-
-//TODO:
-// - implement custom serialization & set alignment
-// - what other fields are needed?
-#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, Default, InitSpace)]
-pub struct AccumulatorHeaderOld {
-    pub bump:           u8,
-    pub version:        u8,
-    pub account_schema: u8,
-}
-
-
-impl AccumulatorHeader {
-    pub const CURRENT_VERSION: u8 = 1;
-
-    pub fn new(bump: u8) -> Self {
-        Self {
-            bump,
-            unused_0: 0,
-            version: Self::CURRENT_VERSION,
-            indexes: [InputIndex {
-                offset:   0,
-                unused_0: 0,
-                len:      0,
-            }; u8::MAX as usize],
-        }
-    }
-
-    pub fn set_version(&mut self) {
-        self.version = Self::CURRENT_VERSION;
     }
 }
 

--- a/accumulator_updater/programs/accumulator_updater/src/state/accumulator_input.rs
+++ b/accumulator_updater/programs/accumulator_updater/src/state/accumulator_input.rs
@@ -19,8 +19,10 @@ use {
 #[derive(Debug, InitSpace)]
 pub struct AccumulatorInput {
     pub header: AccumulatorHeader,
-    // 10KB - 8 (discriminator) - 514 (header) - 11 (alignment)
-    pub data:   [u8; 8_690],
+    // 10KB - 8 (discriminator) - 514 (header)
+    // TODO: do we want to initialize this to the max size?
+    //   - will lead to more data being passed around for validators
+    pub data:   [u8; 9_718],
 }
 
 //TODO:
@@ -46,7 +48,9 @@ impl AccumulatorHeader {
     // HEADER_LEN allows for append-only forward-compatibility for the header.
     // this is the number of bytes from the beginning of the account_info.data
     // to the start of the `AccumulatorInput` data.
-    // *NOTE* this is slightly different than the `BatchPriceAttestation` header_size
+    //
+    // *NOTE* this implementation is slightly different
+    // than the `BatchPriceAttestation` header_size
     pub const HEADER_LEN: u16 = 8 + AccumulatorHeader::INIT_SPACE as u16;
 
     pub const CURRENT_VERSION: u8 = 1;
@@ -90,7 +94,7 @@ impl AccumulatorInput {
         let header = AccumulatorHeader::new(bump);
         Self {
             header,
-            data: [0u8; 8_690],
+            data: [0u8; 9_718],
         }
     }
 
@@ -184,7 +188,7 @@ mod test {
         );
         assert_eq!(header_idx_size, 514);
         assert_eq!(header_idx_align, 2);
-        assert_eq!(input_size, 8690);
+        assert_eq!(input_size, 10_232);
         assert_eq!(input_align, 2);
     }
 

--- a/accumulator_updater/programs/mock-cpi-caller/src/lib.rs
+++ b/accumulator_updater/programs/mock-cpi-caller/src/lib.rs
@@ -42,7 +42,7 @@ mod test {
     fn ix_discriminator() {
         let a = &(accumulator_updater::instruction::PutAll {
             base_account_key: anchor_lang::prelude::Pubkey::default(),
-            values:           vec![],
+            messages:         vec![],
         }
         .data()[..8]);
 

--- a/accumulator_updater/programs/mock-cpi-caller/src/message/price.rs
+++ b/accumulator_updater/programs/mock-cpi-caller/src/message/price.rs
@@ -1,30 +1,57 @@
 use {
     crate::{
-        message::AccumulatorSerializer,
+        message::{
+            AccumulatorSerializer,
+            MessageSchema,
+        },
         state::PriceAccount,
     },
     anchor_lang::prelude::*,
-    bytemuck::{
-        Pod,
-        Zeroable,
-    },
     std::io::Write,
 };
 
-// TODO: should these schemas be "external" (protobuf?)
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Pod, Zeroable)]
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
+pub struct MessageHeader {
+    pub schema:  u8,
+    pub version: u16,
+    pub size:    u32,
+}
+
+impl MessageHeader {
+    pub const CURRENT_VERSION: u8 = 2;
+
+    pub fn new(schema: MessageSchema, size: u32) -> Self {
+        Self {
+            schema: schema.to_u8(),
+            version: Self::CURRENT_VERSION as u16,
+            size,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
 pub struct CompactPriceMessage {
+    pub header:     MessageHeader,
     pub price_expo: u64,
     pub price:      u64,
     pub id:         u64,
 }
 
 
+impl CompactPriceMessage {
+    // size without header
+    pub const SIZE: usize = 24;
+}
+
 impl AccumulatorSerializer for CompactPriceMessage {
     fn accumulator_serialize(&self) -> Result<Vec<u8>> {
         let mut bytes = vec![];
+        bytes.write_all(&self.header.schema.to_be_bytes())?;
+        bytes.write_all(&self.header.version.to_be_bytes())?;
+        bytes.write_all(&self.header.size.to_be_bytes())?;
         bytes.write_all(&self.id.to_be_bytes())?;
         bytes.write_all(&self.price.to_be_bytes())?;
         bytes.write_all(&self.price_expo.to_be_bytes())?;
@@ -35,6 +62,7 @@ impl AccumulatorSerializer for CompactPriceMessage {
 impl From<&PriceAccount> for CompactPriceMessage {
     fn from(other: &PriceAccount) -> Self {
         Self {
+            header:     MessageHeader::new(MessageSchema::Compact, Self::SIZE as u32),
             id:         other.id,
             price:      other.price,
             price_expo: other.price_expo,
@@ -44,8 +72,9 @@ impl From<&PriceAccount> for CompactPriceMessage {
 
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Pod, Zeroable)]
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
 pub struct FullPriceMessage {
+    pub header:     MessageHeader,
     pub id:         u64,
     pub price:      u64,
     pub price_expo: u64,
@@ -53,9 +82,14 @@ pub struct FullPriceMessage {
     pub ema_expo:   u64,
 }
 
+impl FullPriceMessage {
+    pub const SIZE: usize = 40;
+}
+
 impl From<&PriceAccount> for FullPriceMessage {
     fn from(other: &PriceAccount) -> Self {
         Self {
+            header:     MessageHeader::new(MessageSchema::Full, Self::SIZE as u32),
             id:         other.id,
             price:      other.price,
             price_expo: other.price_expo,
@@ -68,6 +102,9 @@ impl From<&PriceAccount> for FullPriceMessage {
 impl AccumulatorSerializer for FullPriceMessage {
     fn accumulator_serialize(&self) -> Result<Vec<u8>> {
         let mut bytes = vec![];
+        bytes.write_all(&self.header.schema.to_be_bytes())?;
+        bytes.write_all(&self.header.version.to_be_bytes())?;
+        bytes.write_all(&self.header.size.to_be_bytes())?;
         bytes.write_all(&self.id.to_be_bytes())?;
         bytes.write_all(&self.price.to_be_bytes())?;
         bytes.write_all(&self.price_expo.to_be_bytes())?;

--- a/accumulator_updater/tests/accumulator_updater.ts
+++ b/accumulator_updater/tests/accumulator_updater.ts
@@ -299,13 +299,13 @@ type AccumulatorInputHeader = IdlTypes<AccumulatorUpdater>["AccumulatorHeader"];
 // accountType and accountSchema.
 function parseAccumulatorInput({
   header,
-  data,
+  messages,
 }: {
   header: AccumulatorInputHeader;
-  data: number[];
+  messages: number[];
 }): AccumulatorPriceMessage[] {
-  const messages = [];
-  let dataBuffer = Buffer.from(data);
+  const accumulatorMessages = [];
+  let dataBuffer = Buffer.from(messages);
 
   let start = 0;
   for (let i = 0; i < header.endOffsets.length; i++) {
@@ -321,16 +321,16 @@ function parseAccumulatorInput({
       parseMessageBytes(messageBytes);
     console.info(`header: ${JSON.stringify(msgHeader, null, 2)}`);
     if (msgHeader.schema == 0) {
-      messages.push(parseFullPriceMessage(msgData));
+      accumulatorMessages.push(parseFullPriceMessage(msgData));
     } else if (msgHeader.schema == 1) {
-      messages.push(parseCompactPriceMessage(msgData));
+      accumulatorMessages.push(parseCompactPriceMessage(msgData));
     } else {
       console.warn("Unknown input index: " + i);
       continue;
     }
     start = endOffset;
   }
-  return messages;
+  return accumulatorMessages;
 }
 
 type MessageHeader = {

--- a/accumulator_updater/tests/accumulator_updater.ts
+++ b/accumulator_updater/tests/accumulator_updater.ts
@@ -310,16 +310,16 @@ function parseAccumulatorInput({
 
   let dataBuffer = Buffer.from(data);
 
-  for (let i = 0; i < header.indexes.length; i++) {
-    const inputIndex = header.indexes[i];
-    if (inputIndex.len == 0) {
-      continue;
+  let start = 0;
+  for (let i = 0; i < header.endOffsets.length; i++) {
+    const endOffset = header.endOffsets[i];
+
+    if (endOffset == 0) {
+      console.log(`endOffset = 0. breaking`);
+      break;
     }
 
-    const inputData = dataBuffer.subarray(
-      inputIndex.offset,
-      inputIndex.offset + inputIndex.len
-    );
+    const inputData = dataBuffer.subarray(start, endOffset);
     if (i == 0) {
       messages.push(parseFullPriceMessage(inputData));
     } else if (i == 1) {
@@ -328,6 +328,7 @@ function parseAccumulatorInput({
       console.warn("Unknown input index: " + i);
       continue;
     }
+    start = endOffset;
   }
   return messages;
 }

--- a/accumulator_updater/tests/accumulator_updater.ts
+++ b/accumulator_updater/tests/accumulator_updater.ts
@@ -121,14 +121,7 @@ describe("accumulator_updater", () => {
       ],
       accumulatorUpdaterProgram.programId
     )[0];
-    // const accumulatorPdaMetas = accumulatorPdaKeys.map((pda) => {
-    //   return {
-    //     pubkey: pda,
-    //     isSigner: false,
-    //     isWritable: true,
-    //   };
-    //   // return pda;
-    // });
+
     const accumulatorPdaMetas = [
       {
         pubkey: accumulatorPdaKey,
@@ -192,9 +185,7 @@ describe("accumulator_updater", () => {
       );
 
     const accumulatorPriceMessages = parseAccumulatorInput(accumulatorInput);
-    // const accumulatorPriceMessages = accumulatorInputs.map((ai) => {
-    //   return parseAccumulatorInput(ai);
-    // });
+
     console.log(
       `accumulatorPriceMessages: ${JSON.stringify(
         accumulatorPriceMessages,
@@ -313,7 +304,6 @@ function parseAccumulatorInput({
   data,
 }: {
   header: AccumulatorInputHeader;
-  // data: number[]
   data: Uint8Array;
 }): AccumulatorPriceMessage[] {
   const messages = [];


### PR DESCRIPTION
### Summary
Write all schemas/messages for an account into one PDA

### Updates
- update `AccumulatorInput` and related structs to `zero_copy`
- add `InputIndex` for indexing into `AccumulatorInput.data`
### TODOs
- funding account
- realloc (need wrapper struct in increments of 10240 bytes?)
