### PR TITLE
Get price feed endpoint

### DIFF
--- a/price_service/client/js/src/PriceServiceConnection.ts
+++ b/price_service/client/js/src/PriceServiceConnection.ts
@@ -174,6 +174,11 @@ export class PriceServiceConnection {
     return [response.data.vaa, response.data.publishTime];
   }
 
+  async getPriceFeed(
+    priceId: HexString,
+    publishTIme: EpochTimeStamp
+  ): Promise<[PriceFeed, EpochTimeStamp]> {}
+
   /**
    * Fetch the list of available price feed ids.
    * This will throw an axios error if there is a network problem or the price service returns a non-ok response.

--- a/price_service/client/js/src/PriceServiceConnection.ts
+++ b/price_service/client/js/src/PriceServiceConnection.ts
@@ -174,11 +174,6 @@ export class PriceServiceConnection {
     return [response.data.vaa, response.data.publishTime];
   }
 
-  async getPriceFeed(
-    priceId: HexString,
-    publishTIme: EpochTimeStamp
-  ): Promise<[PriceFeed, EpochTimeStamp]> {}
-
   /**
    * Fetch the list of available price feed ids.
    * This will throw an axios error if there is a network problem or the price service returns a non-ok response.

--- a/price_service/server/src/listen.ts
+++ b/price_service/server/src/listen.ts
@@ -35,7 +35,7 @@ export type PriceInfo = {
 export function createPriceInfo(
   priceAttestation: PriceAttestation,
   vaa: Buffer,
-  sequence: string,
+  sequence: bigint,
   emitterChain: number
 ): PriceInfo {
   const priceFeed = priceAttestationToPriceFeed(priceAttestation);

--- a/price_service/server/src/rest.ts
+++ b/price_service/server/src/rest.ts
@@ -128,7 +128,7 @@ export class RestAPI {
     }
 
     for (const priceAttestation of batchAttestation.priceAttestations) {
-      if (priceAttestation.priceId == priceFeedId) {
+      if (priceAttestation.priceId === priceFeedId) {
         return createPriceInfo(
           priceAttestation,
           vaa,
@@ -145,7 +145,7 @@ export class RestAPI {
     priceInfo: PriceInfo,
     verbose: boolean,
     binary: boolean
-  ): Object {
+  ): object {
     return {
       ...priceInfo.priceFeed.toJson(),
       ...(verbose && {

--- a/tilt_devnet/docker_images/Dockerfile.lerna
+++ b/tilt_devnet/docker_images/Dockerfile.lerna
@@ -18,6 +18,8 @@ COPY ./tsconfig.base.json ./
 
 FROM node:18.13.0@sha256:d9061fd0205c20cd47f70bdc879a7a84fb472b822d3ad3158aeef40698d2ce36 as lerna
 
+RUN apt-get update && apt-get install -y libusb-dev
+
 # 1000 is the uid and gid of the node user
 USER 1000
 RUN mkdir -p /home/node/.npm


### PR DESCRIPTION
This PR adds an endpoint that's the equivalent of get_vaa (so price id & publish time), but that returns the parsed price feed data. All of the other methods have both vaa & price feed options except this one, so this makes the API uniform.