### PR TITLE
[price_service] Let callers specify VAA encoding

### DIFF
--- a/price_service/server/package.json
+++ b/price_service/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-service-server",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Webservice for retrieving prices from the Pyth oracle.",
   "private": "true",
   "main": "index.js",

--- a/price_service/server/src/encoding.ts
+++ b/price_service/server/src/encoding.ts
@@ -1,0 +1,46 @@
+// Utilities for encoding VAAs for specific target chains
+
+// List of all possible target chains. Note that "default" is an option because we need at least one chain
+// with a base64 encoding (which is the old default behavior of all API methods).
+export type TargetChain = "evm" | "cosmos" | "aptos" | "sui" | "default";
+export const validTargetChains = ["evm", "cosmos", "aptos", "sui", "default"];
+export const defaultTargetChain: TargetChain = "default";
+
+// Possible encodings of the binary VAA data as a string.
+// "0x" is the same as "hex" with a leading "0x" prepended to the hex string.
+export type VaaEncoding = "base64" | "hex" | "0x";
+export const defaultVaaEncoding: VaaEncoding = "base64";
+export const chainToEncoding: Record<TargetChain, VaaEncoding> = {
+  evm: "0x",
+  cosmos: "base64",
+  aptos: "base64",
+  sui: "base64",
+  default: "base64",
+};
+
+// Given a VAA represented as either a string in base64 or a Buffer, encode it as a string
+// appropriate for the given targetChain.
+export function encodeVaaForChain(
+  vaa: string | Buffer,
+  targetChain: TargetChain
+): string {
+  const encoding = chainToEncoding[targetChain];
+
+  let vaaBuffer: Buffer;
+  if (typeof vaa === "string") {
+    if (encoding === defaultVaaEncoding) {
+      return vaa;
+    } else {
+      vaaBuffer = Buffer.from(vaa, defaultVaaEncoding as BufferEncoding);
+    }
+  } else {
+    vaaBuffer = vaa;
+  }
+
+  switch (encoding) {
+    case "0x":
+      return "0x" + vaaBuffer.toString("hex");
+    default:
+      return vaaBuffer.toString(encoding);
+  }
+}

--- a/price_service/server/src/encoding.ts
+++ b/price_service/server/src/encoding.ts
@@ -2,8 +2,8 @@
 
 // List of all possible target chains. Note that "default" is an option because we need at least one chain
 // with a base64 encoding (which is the old default behavior of all API methods).
-export type TargetChain = "evm" | "cosmos" | "aptos" | "sui" | "default";
-export const validTargetChains = ["evm", "cosmos", "aptos", "sui", "default"];
+export type TargetChain = "evm" | "cosmos" | "aptos" | "default";
+export const validTargetChains = ["evm", "cosmos", "aptos", "default"];
 export const defaultTargetChain: TargetChain = "default";
 
 // Possible encodings of the binary VAA data as a string.
@@ -13,8 +13,9 @@ export const defaultVaaEncoding: VaaEncoding = "base64";
 export const chainToEncoding: Record<TargetChain, VaaEncoding> = {
   evm: "0x",
   cosmos: "base64",
+  // TODO: I think aptos actually wants a number[] for this data... need to decide how to
+  // handle that case.
   aptos: "base64",
-  sui: "base64",
   default: "base64",
 };
 

--- a/price_service/server/src/helpers.ts
+++ b/price_service/server/src/helpers.ts
@@ -34,6 +34,8 @@ export function removeLeading0x(s: string): string {
   return s;
 }
 
+// Helper for treating T | undefined as an optional value. This lets you pick a
+// default if value is undefined.
 export function getOrElse<T>(value: T | undefined, defaultValue: T): T {
   if (value === undefined) {
     return defaultValue;

--- a/price_service/server/src/helpers.ts
+++ b/price_service/server/src/helpers.ts
@@ -33,3 +33,11 @@ export function removeLeading0x(s: string): string {
 
   return s;
 }
+
+export function getOrElse<T>(value: T | undefined, defaultValue: T): T {
+  if (value === undefined) {
+    return defaultValue;
+  } else {
+    return value;
+  }
+}

--- a/price_service/server/src/rest.ts
+++ b/price_service/server/src/rest.ts
@@ -17,50 +17,22 @@ import { PromClient } from "./promClient";
 import { retry } from "ts-retry-promise";
 import { parseVaa } from "@certusone/wormhole-sdk";
 import { getOrElse } from "./helpers";
+import {
+  TargetChain,
+  validTargetChains,
+  defaultTargetChain,
+  VaaEncoding,
+  encodeVaaForChain,
+} from "./encoding";
 
 const MORGAN_LOG_FORMAT =
   ':remote-addr - :remote-user ":method :url HTTP/:http-version"' +
   ' :status :res[content-length] :response-time ms ":referrer" ":user-agent"';
 
-export type TargetChain = "evm" | "cosmos" | "aptos" | "sui" | "default";
-export const validTargetChains = ["evm", "cosmos", "aptos", "sui", "default"];
-export const defaultTargetChain: TargetChain = "default";
-export const targetChainArgString = `encoding=<${validTargetChains.join("|")}>`;
-
-export type VaaEncoding = "base64" | "hex" | "0x";
-export const defaultVaaEncoding: VaaEncoding = "base64";
-export const chainToEncoding: Record<TargetChain, VaaEncoding> = {
-  evm: "0x",
-  cosmos: "base64",
-  aptos: "base64",
-  sui: "base64",
-  default: "base64",
-};
-
-function encodeVaaForChain(
-  vaa: string | Buffer,
-  targetChain: TargetChain
-): string {
-  const encoding = chainToEncoding[targetChain];
-
-  let vaaBuffer: Buffer;
-  if (typeof vaa === "string") {
-    if (encoding === defaultVaaEncoding) {
-      return vaa;
-    } else {
-      vaaBuffer = Buffer.from(vaa, defaultVaaEncoding as BufferEncoding);
-    }
-  } else {
-    vaaBuffer = vaa;
-  }
-
-  switch (encoding) {
-    case "0x":
-      return "0x" + vaaBuffer.toString("hex");
-    default:
-      return vaaBuffer.toString(encoding);
-  }
-}
+// GET argument string to represent the options for target_chain
+export const targetChainArgString = `target_chain=<${validTargetChains.join(
+  "|"
+)}>`;
 
 export class RestException extends Error {
   statusCode: number;

--- a/price_service/server/src/rest.ts
+++ b/price_service/server/src/rest.ts
@@ -277,7 +277,10 @@ export class RestAPI {
           throw RestException.PriceFeedIdNotFound([priceFeedId]);
         }
 
-        let vaaConfig = await this.getVaaWithDbLookup(priceFeedId, publishTime);
+        const vaaConfig = await this.getVaaWithDbLookup(
+          priceFeedId,
+          publishTime
+        );
         if (vaaConfig === undefined) {
           throw RestException.VaaNotFound();
         } else {


### PR DESCRIPTION
We get a lot of questions about how to convert the base64 VAAs into hex and whatnot. This PR adds an "encoding" parameter to all of the endpoints that return a VAA which lets you pick the thing you want. 

Note that I added a "0x" option which is hex, but with a 0x prepended. The EVM APIs seem to need this in various places.

**UPDATE**

I changed my mind about how this should work. The encoding parameter is itself hard for people to figure out, so I replaced it with a `target_chain` argument which is self-explanatory. The server will map the target chains to the desired encoding.