### PR TITLE
[message-buffer 10/X] - Message Buffer Admin IXs & variable length

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,13 +71,13 @@ repos:
         language: "rust"
         entry: cargo +nightly fmt --manifest-path ./message_buffer/Cargo.toml --all -- --config-path rustfmt.toml
         pass_filenames: false
-        files: accumulator_updater
+        files: message_buffer
       - id: cargo-clippy-message-buffer
         name: Cargo clippy for message buffer contract
         language: "rust"
         entry: cargo +nightly clippy --manifest-path ./message_buffer/Cargo.toml --tests --fix --allow-dirty --allow-staged -- -D warnings
         pass_filenames: false
-        files: accumulator_updater
+        files: message_buffer
       # Hooks for solana receiver contract
       - id: cargo-fmt-solana-receiver
         name: Cargo format for solana target chain contract

--- a/message_buffer/programs/message_buffer/src/instructions/create_buffer.rs
+++ b/message_buffer/programs/message_buffer/src/instructions/create_buffer.rs
@@ -1,18 +1,22 @@
-use std::mem;
-use anchor_lang::solana_program::message::MessageHeader;
 use {
     crate::{
+        instructions::is_uninitialized_account,
         state::*,
         MessageBufferError,
         MESSAGE,
     },
     anchor_lang::{
         prelude::*,
+        solana_program::message::MessageHeader,
         system_program::{
             self,
+            Allocate,
+            Assign,
             CreateAccount,
+            Transfer,
         },
     },
+    std::mem,
 };
 
 pub fn create_buffer<'info>(
@@ -26,7 +30,11 @@ pub fn create_buffer<'info>(
         .first()
         .ok_or(MessageBufferError::MessageBufferNotProvided)?;
 
-    require_gte!(target_size, MessageBuffer::HEADER_LEN as u32, MessageBufferError::MessageBufferTooSmall);
+    require_gte!(
+        target_size,
+        MessageBuffer::HEADER_LEN as u32,
+        MessageBufferError::MessageBufferTooSmall
+    );
     if is_uninitialized_account(buffer_account) {
         let (pda, bump) = Pubkey::find_program_address(
             &[
@@ -47,15 +55,13 @@ pub fn create_buffer<'info>(
         CreateBuffer::create_account(
             buffer_account,
             target_size as usize,
-            &ctx.accounts.authority,
+            &ctx.accounts.admin,
             &[signer_seeds.as_slice()],
             &ctx.accounts.system_program,
         )?;
 
-        let loader = AccountLoader::<MessageBuffer>::try_from_unchecked(
-            &crate::ID,
-            buffer_account,
-        )?;
+        let loader =
+            AccountLoader::<MessageBuffer>::try_from_unchecked(&crate::ID, buffer_account)?;
         {
             let mut accumulator_input = loader.load_init()?;
             *accumulator_input = MessageBuffer::new(bump);
@@ -66,52 +72,73 @@ pub fn create_buffer<'info>(
     Ok(())
 }
 
-pub fn is_uninitialized_account(ai: &AccountInfo) -> bool {
-    ai.data_is_empty() && ai.owner == &system_program::ID
-}
 
 #[derive(Accounts)]
 pub struct CreateBuffer<'info> {
     #[account(
     seeds = [b"message".as_ref(), b"whitelist".as_ref()],
     bump = whitelist.bump,
-    has_one = authority,
+    has_one = admin,
     )]
     pub whitelist: Account<'info, Whitelist>,
 
     // Also pays for account creation
     #[account(mut)]
-    pub authority: Signer<'info>,
+    pub admin: Signer<'info>,
 
-    pub system_program:     Program<'info, System>,
-
+    pub system_program: Program<'info, System>,
     // remaining_accounts:  - [AccumulatorInput PDA]
 }
 
 
 impl<'info> CreateBuffer<'info> {
-    // FIXME: need to handle the case where someone transfers lamports to this account before it is created.
+    /// Manually invoke transfer, allocate & assign ixs to create an account
+    /// to handle situation where an account already has lamports
+    /// since system_program::create_account will fail in this case
     fn create_account<'a>(
-        account_info: &AccountInfo<'a>,
+        new_account_info: &AccountInfo<'a>,
         space: usize,
         payer: &Signer<'a>,
         seeds: &[&[&[u8]]],
         system_program: &AccountInfo<'a>,
     ) -> Result<()> {
-        let lamports = Rent::get()?.minimum_balance(space);
-        system_program::create_account(
+        let target_rent = Rent::get()?.minimum_balance(space);
+        if new_account_info.lamports() < target_rent {
+            system_program::transfer(
+                CpiContext::new_with_signer(
+                    system_program.to_account_info(),
+                    Transfer {
+                        from: payer.to_account_info(),
+                        to:   new_account_info.to_account_info(),
+                    },
+                    seeds,
+                ),
+                target_rent - new_account_info.lamports(),
+            )?;
+        };
+
+        system_program::allocate(
             CpiContext::new_with_signer(
                 system_program.to_account_info(),
-                CreateAccount {
-                    from: payer.to_account_info(),
-                    to:   account_info.to_account_info(),
+                Allocate {
+                    account_to_allocate: new_account_info.to_account_info(),
                 },
                 seeds,
             ),
-            lamports,
             space.try_into().unwrap(),
+        )?;
+
+        system_program::assign(
+            CpiContext::new_with_signer(
+                system_program.to_account_info(),
+                Assign {
+                    account_to_assign: new_account_info.to_account_info(),
+                },
+                seeds,
+            ),
             &crate::ID,
         )?;
+
         Ok(())
     }
 }

--- a/message_buffer/programs/message_buffer/src/instructions/create_buffer.rs
+++ b/message_buffer/programs/message_buffer/src/instructions/create_buffer.rs
@@ -7,16 +7,13 @@ use {
     },
     anchor_lang::{
         prelude::*,
-        solana_program::message::MessageHeader,
         system_program::{
             self,
             Allocate,
             Assign,
-            CreateAccount,
             Transfer,
         },
     },
-    std::mem,
 };
 
 pub fn create_buffer<'info>(

--- a/message_buffer/programs/message_buffer/src/instructions/create_buffer.rs
+++ b/message_buffer/programs/message_buffer/src/instructions/create_buffer.rs
@@ -1,0 +1,117 @@
+use std::mem;
+use anchor_lang::solana_program::message::MessageHeader;
+use {
+    crate::{
+        state::*,
+        AccumulatorUpdaterError,
+        MESSAGE,
+    },
+    anchor_lang::{
+        prelude::*,
+        system_program::{
+            self,
+            CreateAccount,
+        },
+    },
+};
+
+pub fn create_buffer<'info>(
+    ctx: Context<'_, '_, '_, 'info, CreateBuffer<'info>>,
+    allowed_program_auth: Pubkey,
+    base_account_key: Pubkey,
+    target_size: u32,
+) -> Result<()> {
+    let buffer_account = ctx
+        .remaining_accounts
+        .first()
+        .ok_or(AccumulatorUpdaterError::MessageBufferNotProvided)?;
+
+    require_gte!(target_size, BufferHeader::HEADER_LEN as u32, AccumulatorUpdaterError::MessageBufferTooSmall);
+    if is_uninitialized_account(buffer_account) {
+        let (pda, bump) = Pubkey::find_program_address(
+            &[
+                allowed_program_auth.as_ref(),
+                MESSAGE.as_bytes(),
+                base_account_key.as_ref(),
+            ],
+            &crate::ID,
+        );
+        require_keys_eq!(buffer_account.key(), pda);
+        let signer_seeds = [
+            allowed_program_auth.as_ref(),
+            MESSAGE.as_bytes(),
+            base_account_key.as_ref(),
+            &[bump],
+        ];
+
+        CreateBuffer::create_account(
+            buffer_account,
+            target_size as usize,
+            &ctx.accounts.authority,
+            &[signer_seeds.as_slice()],
+            &ctx.accounts.system_program,
+        )?;
+
+        let loader = AccountLoader::<BufferHeader>::try_from_unchecked(
+            &crate::ID,
+            buffer_account,
+        )?;
+        {
+            let mut accumulator_input = loader.load_init()?;
+            *accumulator_input = BufferHeader::new(bump);
+        }
+        loader.exit(&crate::ID)?;
+    }
+
+    Ok(())
+}
+
+pub fn is_uninitialized_account(ai: &AccountInfo) -> bool {
+    ai.data_is_empty() && ai.owner == &system_program::ID
+}
+
+#[derive(Accounts)]
+pub struct CreateBuffer<'info> {
+    #[account(
+    seeds = [b"message".as_ref(), b"whitelist".as_ref()],
+    bump = whitelist.bump,
+    has_one = authority,
+    )]
+    pub whitelist: Account<'info, Whitelist>,
+
+    // Also pays for account creation
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    pub system_program:     Program<'info, System>,
+
+    // remaining_accounts:  - [AccumulatorInput PDA]
+}
+
+
+impl<'info> CreateBuffer<'info> {
+    // FIXME: need to handle the case where someone transfers lamports to this account before it is created.
+    fn create_account<'a>(
+        account_info: &AccountInfo<'a>,
+        space: usize,
+        payer: &Signer<'a>,
+        seeds: &[&[&[u8]]],
+        system_program: &AccountInfo<'a>,
+    ) -> Result<()> {
+        let lamports = Rent::get()?.minimum_balance(space);
+        system_program::create_account(
+            CpiContext::new_with_signer(
+                system_program.to_account_info(),
+                CreateAccount {
+                    from: payer.to_account_info(),
+                    to:   account_info.to_account_info(),
+                },
+                seeds,
+            ),
+            lamports,
+            space.try_into().unwrap(),
+            &crate::ID,
+        )?;
+        Ok(())
+    }
+}

--- a/message_buffer/programs/message_buffer/src/instructions/create_buffer.rs
+++ b/message_buffer/programs/message_buffer/src/instructions/create_buffer.rs
@@ -3,7 +3,7 @@ use anchor_lang::solana_program::message::MessageHeader;
 use {
     crate::{
         state::*,
-        AccumulatorUpdaterError,
+        MessageBufferError,
         MESSAGE,
     },
     anchor_lang::{
@@ -24,9 +24,9 @@ pub fn create_buffer<'info>(
     let buffer_account = ctx
         .remaining_accounts
         .first()
-        .ok_or(AccumulatorUpdaterError::MessageBufferNotProvided)?;
+        .ok_or(MessageBufferError::MessageBufferNotProvided)?;
 
-    require_gte!(target_size, BufferHeader::HEADER_LEN as u32, AccumulatorUpdaterError::MessageBufferTooSmall);
+    require_gte!(target_size, MessageBuffer::HEADER_LEN as u32, MessageBufferError::MessageBufferTooSmall);
     if is_uninitialized_account(buffer_account) {
         let (pda, bump) = Pubkey::find_program_address(
             &[
@@ -52,13 +52,13 @@ pub fn create_buffer<'info>(
             &ctx.accounts.system_program,
         )?;
 
-        let loader = AccountLoader::<BufferHeader>::try_from_unchecked(
+        let loader = AccountLoader::<MessageBuffer>::try_from_unchecked(
             &crate::ID,
             buffer_account,
         )?;
         {
             let mut accumulator_input = loader.load_init()?;
-            *accumulator_input = BufferHeader::new(bump);
+            *accumulator_input = MessageBuffer::new(bump);
         }
         loader.exit(&crate::ID)?;
     }

--- a/message_buffer/programs/message_buffer/src/instructions/delete_buffer.rs
+++ b/message_buffer/programs/message_buffer/src/instructions/delete_buffer.rs
@@ -4,15 +4,7 @@ use {
         MessageBufferError,
         MESSAGE,
     },
-    anchor_lang::{
-        prelude::*,
-        solana_program::message::MessageHeader,
-        system_program::{
-            self,
-            CreateAccount,
-        },
-    },
-    std::mem,
+    anchor_lang::prelude::*,
 };
 
 pub fn delete_buffer<'info>(

--- a/message_buffer/programs/message_buffer/src/instructions/delete_buffer.rs
+++ b/message_buffer/programs/message_buffer/src/instructions/delete_buffer.rs
@@ -19,6 +19,10 @@ pub fn delete_buffer<'info>(
         .first()
         .ok_or(MessageBufferError::MessageBufferNotProvided)?;
 
+    ctx.accounts
+        .whitelist
+        .is_allowed_program_auth(&allowed_program_auth)?;
+
     verify_message_buffer(message_buffer_account_info)?;
 
     let expected_key = Pubkey::create_program_address(
@@ -31,7 +35,12 @@ pub fn delete_buffer<'info>(
         &crate::ID,
     )
     .map_err(|_| MessageBufferError::InvalidPDA)?;
-    require_keys_eq!(message_buffer_account_info.key(), expected_key);
+
+    require_keys_eq!(
+        message_buffer_account_info.key(),
+        expected_key,
+        MessageBufferError::InvalidPDA
+    );
     let loader = AccountLoader::<MessageBuffer>::try_from_unchecked(
         &crate::ID,
         message_buffer_account_info,
@@ -52,7 +61,5 @@ pub struct DeleteBuffer<'info> {
     // Also the recipient of the lamports from closing the buffer account
     #[account(mut)]
     pub admin: Signer<'info>,
-
-    pub system_program: Program<'info, System>,
     // remaining_account:  - [AccumulatorInput PDA]
 }

--- a/message_buffer/programs/message_buffer/src/instructions/delete_buffer.rs
+++ b/message_buffer/programs/message_buffer/src/instructions/delete_buffer.rs
@@ -1,0 +1,88 @@
+use {
+    crate::{
+        state::*,
+        MessageBufferError,
+        MESSAGE,
+    },
+    anchor_lang::{
+        prelude::*,
+        solana_program::message::MessageHeader,
+        system_program::{
+            self,
+            CreateAccount,
+        },
+    },
+    std::mem,
+};
+
+pub fn delete_buffer<'info>(
+    ctx: Context<'_, '_, '_, 'info, DeleteBuffer<'info>>,
+    allowed_program_auth: Pubkey,
+    base_account_key: Pubkey,
+    bump: u8,
+) -> Result<()> {
+    let buffer_account = ctx
+        .remaining_accounts
+        .first()
+        .ok_or(MessageBufferError::MessageBufferNotProvided)?;
+
+    let expected_key = Pubkey::create_program_address(
+        &[
+            allowed_program_auth.as_ref(),
+            MESSAGE.as_bytes(),
+            base_account_key.as_ref(),
+            &[bump],
+        ],
+        &crate::ID,
+    )
+    .map_err(|_| MessageBufferError::InvalidPDA)?;
+    require_keys_eq!(buffer_account.key(), expected_key);
+    let loader = AccountLoader::<MessageBuffer>::try_from_unchecked(&crate::ID, buffer_account)?;
+    loader.close(ctx.accounts.authority.to_account_info())?;
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct DeleteBuffer<'info> {
+    #[account(
+        seeds = [b"message".as_ref(), b"whitelist".as_ref()],
+        bump = whitelist.bump,
+        has_one = authority,
+    )]
+    pub whitelist: Account<'info, Whitelist>,
+
+    // Also the recipient of the lamports from closing the buffer account
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
+    // remaining_account:  - [AccumulatorInput PDA]
+}
+
+
+impl<'info> DeleteBuffer<'info> {
+    // FIXME: need to handle the case where someone transfers lamports to this account before it is created.
+    fn create_account<'a>(
+        account_info: &AccountInfo<'a>,
+        space: usize,
+        payer: &Signer<'a>,
+        seeds: &[&[&[u8]]],
+        system_program: &AccountInfo<'a>,
+    ) -> Result<()> {
+        let lamports = Rent::get()?.minimum_balance(space);
+        system_program::create_account(
+            CpiContext::new_with_signer(
+                system_program.to_account_info(),
+                CreateAccount {
+                    from: payer.to_account_info(),
+                    to:   account_info.to_account_info(),
+                },
+                seeds,
+            ),
+            lamports,
+            space.try_into().unwrap(),
+            &crate::ID,
+        )?;
+        Ok(())
+    }
+}

--- a/message_buffer/programs/message_buffer/src/instructions/delete_buffer.rs
+++ b/message_buffer/programs/message_buffer/src/instructions/delete_buffer.rs
@@ -38,7 +38,7 @@ pub fn delete_buffer<'info>(
     .map_err(|_| MessageBufferError::InvalidPDA)?;
     require_keys_eq!(buffer_account.key(), expected_key);
     let loader = AccountLoader::<MessageBuffer>::try_from_unchecked(&crate::ID, buffer_account)?;
-    loader.close(ctx.accounts.authority.to_account_info())?;
+    loader.close(ctx.accounts.admin.to_account_info())?;
     Ok(())
 }
 
@@ -47,42 +47,14 @@ pub struct DeleteBuffer<'info> {
     #[account(
         seeds = [b"message".as_ref(), b"whitelist".as_ref()],
         bump = whitelist.bump,
-        has_one = authority,
+        has_one = admin,
     )]
     pub whitelist: Account<'info, Whitelist>,
 
     // Also the recipient of the lamports from closing the buffer account
     #[account(mut)]
-    pub authority: Signer<'info>,
+    pub admin: Signer<'info>,
 
     pub system_program: Program<'info, System>,
     // remaining_account:  - [AccumulatorInput PDA]
-}
-
-
-impl<'info> DeleteBuffer<'info> {
-    // FIXME: need to handle the case where someone transfers lamports to this account before it is created.
-    fn create_account<'a>(
-        account_info: &AccountInfo<'a>,
-        space: usize,
-        payer: &Signer<'a>,
-        seeds: &[&[&[u8]]],
-        system_program: &AccountInfo<'a>,
-    ) -> Result<()> {
-        let lamports = Rent::get()?.minimum_balance(space);
-        system_program::create_account(
-            CpiContext::new_with_signer(
-                system_program.to_account_info(),
-                CreateAccount {
-                    from: payer.to_account_info(),
-                    to:   account_info.to_account_info(),
-                },
-                seeds,
-            ),
-            lamports,
-            space.try_into().unwrap(),
-            &crate::ID,
-        )?;
-        Ok(())
-    }
 }

--- a/message_buffer/programs/message_buffer/src/instructions/mod.rs
+++ b/message_buffer/programs/message_buffer/src/instructions/mod.rs
@@ -1,3 +1,12 @@
 pub use put_all::*;
 
 mod put_all;
+mod create_buffer;
+mod resize_buffer;
+mod delete_buffer;
+
+// String constants for deriving PDAs.
+// An authorized program's message buffer will have PDA seeds [authorized_program_pda, MESSAGE, base_account_key],
+// where authorized_program_pda is the
+pub const MESSAGE: &str = "message";
+pub const FUND: &str = "fund";

--- a/message_buffer/programs/message_buffer/src/instructions/mod.rs
+++ b/message_buffer/programs/message_buffer/src/instructions/mod.rs
@@ -1,15 +1,56 @@
-pub use put_all::*;
-pub use create_buffer::*;
-pub use resize_buffer::*;
-pub use delete_buffer::*;
+use {
+    crate::{
+        state::MessageBuffer,
+        MessageBufferError,
+    },
+    anchor_lang::{
+        prelude::*,
+        system_program,
+        Discriminator,
+    },
+};
+pub use {
+    create_buffer::*,
+    delete_buffer::*,
+    put_all::*,
+    resize_buffer::*,
+};
 
-mod put_all;
+
 mod create_buffer;
-mod resize_buffer;
 mod delete_buffer;
+mod put_all;
+mod resize_buffer;
 
 // String constants for deriving PDAs.
 // An authorized program's message buffer will have PDA seeds [authorized_program_pda, MESSAGE, base_account_key],
 // where authorized_program_pda is the
 pub const MESSAGE: &str = "message";
 pub const FUND: &str = "fund";
+
+
+pub fn is_uninitialized_account(ai: &AccountInfo) -> bool {
+    ai.data_is_empty() && ai.owner == &system_program::ID
+}
+
+/// Verify message buffer account is initialized and has the correct discriminator.
+///
+/// Note: manually checking because using anchor's `AccountLoader.load()`
+/// will panic since the `AccountInfo.data_len()` will not match the
+/// size of the `MessageBuffer` since the `MessageBuffer` struct does not
+/// include the messages.
+pub fn verify_message_buffer(message_buffer_account_info: &AccountInfo) -> Result<()> {
+    if is_uninitialized_account(message_buffer_account_info) {
+        return err!(MessageBufferError::MessageBufferUninitialized);
+    }
+    let data = message_buffer_account_info.try_borrow_data()?;
+    if data.len() < MessageBuffer::discriminator().len() {
+        return Err(ErrorCode::AccountDiscriminatorNotFound.into());
+    }
+
+    let disc_bytes = &data[0..8];
+    if disc_bytes != &MessageBuffer::discriminator() {
+        return Err(ErrorCode::AccountDiscriminatorMismatch.into());
+    }
+    Ok(())
+}

--- a/message_buffer/programs/message_buffer/src/instructions/mod.rs
+++ b/message_buffer/programs/message_buffer/src/instructions/mod.rs
@@ -1,4 +1,7 @@
 pub use put_all::*;
+pub use create_buffer::*;
+pub use resize_buffer::*;
+pub use delete_buffer::*;
 
 mod put_all;
 mod create_buffer;

--- a/message_buffer/programs/message_buffer/src/instructions/put_all.rs
+++ b/message_buffer/programs/message_buffer/src/instructions/put_all.rs
@@ -13,10 +13,6 @@ use {
 };
 
 
-pub const MESSAGE: &str = "message";
-pub const FUND: &str = "fund";
-
-
 pub fn put_all<'info>(
     ctx: Context<'_, '_, '_, 'info, PutAll<'info>>,
     base_account_key: Pubkey,
@@ -28,50 +24,22 @@ pub fn put_all<'info>(
         .first()
         .ok_or(AccumulatorUpdaterError::MessageBufferNotProvided)?;
 
-    let loader;
+    /*
+        let loader;
 
-    {
-        let accumulator_input = &mut (if is_uninitialized_account(accumulator_input_ai) {
-            let (pda, bump) = Pubkey::find_program_address(
-                &[
-                    cpi_caller_auth.as_ref(),
-                    MESSAGE.as_bytes(),
-                    base_account_key.as_ref(),
-                ],
-                &crate::ID,
-            );
-            require_keys_eq!(accumulator_input_ai.key(), pda);
-            let signer_seeds = [
-                cpi_caller_auth.as_ref(),
-                MESSAGE.as_bytes(),
-                base_account_key.as_ref(),
-                &[bump],
-            ];
-            let fund_pda_bump = *ctx
-                .bumps
-                .get(FUND)
-                .ok_or(AccumulatorUpdaterError::FundBumpNotFound)?;
-            let fund_signer_seeds = [FUND.as_bytes(), &[fund_pda_bump]];
-            PutAll::create_account(
-                accumulator_input_ai,
-                8 + MessageBuffer::INIT_SPACE,
-                &ctx.accounts.fund,
-                &[signer_seeds.as_slice(), fund_signer_seeds.as_slice()],
-                &ctx.accounts.system_program,
-            )?;
-            loader = AccountLoader::<MessageBuffer>::try_from_unchecked(
-                &crate::ID,
-                accumulator_input_ai,
-            )?;
-            let mut accumulator_input = loader.load_init()?;
-            accumulator_input.header = BufferHeader::new(bump);
-            accumulator_input
-        } else {
-            loader = AccountLoader::<MessageBuffer>::try_from(accumulator_input_ai)?;
-            let mut accumulator_input = loader.load_mut()?;
-            accumulator_input.header.set_version();
-            accumulator_input
-        });
+    // TODO: use MessageHeader here
+    let account_data = accumulator_input_ai.try_borrow_mut_data()?;
+    let header = bytemuck::from_bytes_mut(&mut account_data.deref_mut()[8..mem::size_of::<BufferHeader>() + 8]);
+    let message_region = [mem::size_of::<BufferHeader>() + 8..];
+
+    loader = AccountLoader::<BufferHeader>::try_from(accumulator_input_ai)?;
+    let mut accumulator_input = loader.load_mut()?;
+    accumulator_input.header.set_version();
+    accumulator_input
+
+    accumulator_input_ai.data.
+
+
         // note: redundant for uninitialized code path but safer to check here.
         // compute budget cost should be minimal
         accumulator_input.validate(
@@ -81,14 +49,13 @@ pub fn put_all<'info>(
         )?;
 
 
-        let (num_msgs, num_bytes) = accumulator_input.put_all(&messages);
-        if num_msgs != messages.len() {
-            msg!("unable to fit all messages in accumulator input account. Wrote {}/{} messages and {} bytes", num_msgs, messages.len(), num_bytes);
-        }
+    let (num_msgs, num_bytes) = accumulator_input.put_all(&messages);
+    if num_msgs != messages.len() {
+        msg!("unable to fit all messages in accumulator input account. Wrote {}/{} messages and {} bytes", num_msgs, messages.len(), num_bytes);
     }
 
-
     loader.exit(&crate::ID)?;
+     */
 
     Ok(())
 }

--- a/message_buffer/programs/message_buffer/src/instructions/put_all.rs
+++ b/message_buffer/programs/message_buffer/src/instructions/put_all.rs
@@ -10,9 +10,11 @@ use {
             CreateAccount,
         },
     },
-    std::cell::RefMut,
-    std::mem,
-    std::ops::DerefMut,
+    std::{
+        cell::RefMut,
+        mem,
+        ops::DerefMut,
+    },
 };
 
 
@@ -40,7 +42,8 @@ pub fn put_all<'info>(
         base_account_key,
     )?;
 
-    header.set_version();
+    header.refresh();
+
     let (num_msgs, num_bytes) = header.put_all_in_buffer(body_bytes, &messages);
 
     if num_msgs != messages.len() {
@@ -58,16 +61,6 @@ pub fn is_uninitialized_account(ai: &AccountInfo) -> bool {
 #[derive(Accounts)]
 #[instruction( base_account_key: Pubkey)]
 pub struct PutAll<'info> {
-    /// `Fund` is a system account that holds
-    /// the lamports that will be used to fund
-    /// `AccumulatorInput` account initialization
-    #[account(
-        mut,
-        seeds = [b"fund".as_ref()],
-        owner = system_program::System::id(),
-        bump,
-    )]
-    pub fund:               SystemAccount<'info>,
     pub whitelist_verifier: WhitelistVerifier<'info>,
     pub system_program:     Program<'info, System>,
     // remaining_accounts:  - [AccumulatorInput PDA]

--- a/message_buffer/programs/message_buffer/src/instructions/put_all.rs
+++ b/message_buffer/programs/message_buffer/src/instructions/put_all.rs
@@ -28,8 +28,6 @@ pub fn put_all<'info>(
         .ok_or(AccumulatorUpdaterError::MessageBufferNotProvided)?;
 
 
-
-    // TODO: use MessageHeader here
     let account_data = &mut message_buffer_account_info.try_borrow_mut_data()?;
     let header_end_index = mem::size_of::<BufferHeader>() + 8;
     let (header_bytes, body_bytes) = account_data.split_at_mut(header_end_index);

--- a/message_buffer/programs/message_buffer/src/instructions/put_all.rs
+++ b/message_buffer/programs/message_buffer/src/instructions/put_all.rs
@@ -1,25 +1,11 @@
 use {
     crate::{
-        instructions::{
-            is_uninitialized_account,
-            verify_message_buffer,
-        },
+        instructions::verify_message_buffer,
         state::*,
         MessageBufferError,
     },
-    anchor_lang::{
-        prelude::*,
-        system_program::{
-            self,
-            CreateAccount,
-        },
-        Discriminator,
-    },
-    std::{
-        cell::RefMut,
-        mem,
-        ops::DerefMut,
-    },
+    anchor_lang::prelude::*,
+    std::mem,
 };
 
 

--- a/message_buffer/programs/message_buffer/src/instructions/put_all.rs
+++ b/message_buffer/programs/message_buffer/src/instructions/put_all.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         state::*,
-        AccumulatorUpdaterError,
+        MessageBufferError,
     },
     anchor_lang::{
         prelude::*,
@@ -27,14 +27,14 @@ pub fn put_all<'info>(
     let message_buffer_account_info = ctx
         .remaining_accounts
         .first()
-        .ok_or(AccumulatorUpdaterError::MessageBufferNotProvided)?;
+        .ok_or(MessageBufferError::MessageBufferNotProvided)?;
 
 
     let account_data = &mut message_buffer_account_info.try_borrow_mut_data()?;
-    let header_end_index = mem::size_of::<BufferHeader>() + 8;
+    let header_end_index = mem::size_of::<MessageBuffer>() + 8;
     let (header_bytes, body_bytes) = account_data.split_at_mut(header_end_index);
 
-    let header: &mut BufferHeader = bytemuck::from_bytes_mut(&mut header_bytes[8..]);
+    let header: &mut MessageBuffer = bytemuck::from_bytes_mut(&mut header_bytes[8..]);
 
     header.validate(
         message_buffer_account_info.key(),

--- a/message_buffer/programs/message_buffer/src/instructions/put_all.rs
+++ b/message_buffer/programs/message_buffer/src/instructions/put_all.rs
@@ -51,6 +51,5 @@ pub fn put_all<'info>(
 #[instruction( base_account_key: Pubkey)]
 pub struct PutAll<'info> {
     pub whitelist_verifier: WhitelistVerifier<'info>,
-    pub system_program:     Program<'info, System>,
     // remaining_accounts:  - [AccumulatorInput PDA]
 }

--- a/message_buffer/programs/message_buffer/src/instructions/resize_buffer.rs
+++ b/message_buffer/programs/message_buffer/src/instructions/resize_buffer.rs
@@ -1,0 +1,103 @@
+use {
+    crate::{
+        state::*,
+        MessageBufferError,
+        MESSAGE,
+    },
+    anchor_lang::{
+        prelude::*,
+        solana_program::{
+            entrypoint::MAX_PERMITTED_DATA_INCREASE,
+            message::MessageHeader,
+        },
+        system_program::{
+            self,
+            Allocate,
+            Assign,
+            CreateAccount,
+            Transfer,
+        },
+    },
+    std::mem,
+};
+
+pub fn resize_buffer<'info>(
+    ctx: Context<'_, '_, '_, 'info, ResizeBuffer<'info>>,
+    allowed_program_auth: Pubkey,
+    base_account_key: Pubkey,
+    buffer_bump: u8,
+    target_size: u32,
+) -> Result<()> {
+    let buffer_account = ctx
+        .remaining_accounts
+        .first()
+        .ok_or(MessageBufferError::MessageBufferNotProvided)?;
+
+    require_gte!(
+        target_size,
+        MessageBuffer::HEADER_LEN as u32,
+        MessageBufferError::MessageBufferTooSmall
+    );
+    let target_size = target_size as usize;
+    let target_size_delta = target_size.saturating_sub(buffer_account.data_len());
+    require_gte!(MAX_PERMITTED_DATA_INCREASE, target_size_delta, MessageBufferError::ReallocTooLarge);
+
+    let expected_key = Pubkey::create_program_address(
+        &[
+            allowed_program_auth.as_ref(),
+            MESSAGE.as_bytes(),
+            base_account_key.as_ref(),
+            &[buffer_bump],
+        ],
+        &crate::ID,
+    )
+    .map_err(|_| MessageBufferError::InvalidPDA)?;
+    require_keys_eq!(buffer_account.key(), expected_key);
+
+    let is_size_increase = target_size as usize > buffer_account.data_len();
+    if target_size_delta > 0 {
+
+        let target_rent = Rent::get()?.minimum_balance(target_size as usize);
+        if buffer_account.lamports() < target_rent {
+            system_program::transfer(
+                CpiContext::new(
+                    ctx.accounts.system_program.to_account_info(),
+                    Transfer {
+                        from: ctx.accounts.admin.to_account_info(),
+                        to:   buffer_account.to_account_info(),
+                    },
+                ),
+                target_rent - buffer_account.lamports(),
+            )?;
+        }
+        buffer_account.realloc(target_size, false).map_err(|_| MessageBufferError::ReallocFailed)?;
+
+    } else {
+        // TODO:
+        //      do we want to allow shrinking?
+        //      if so, do we want to transfer excess lamports?
+        buffer_account.realloc(target_size as usize, false)?;
+    }
+    Ok(())
+}
+
+#[derive(Accounts)]
+#[instruction(
+    allowed_program_auth: Pubkey, base_account_key: Pubkey,
+    buffer_bump: u8, target_size: u32
+)]
+pub struct ResizeBuffer<'info> {
+    #[account(
+        seeds = [b"message".as_ref(), b"whitelist".as_ref()],
+        bump = whitelist.bump,
+        has_one = admin,
+    )]
+    pub whitelist: Account<'info, Whitelist>,
+
+    // Also pays for account creation
+    #[account(mut)]
+    pub admin: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
+    // remaining_accounts:  - [AccumulatorInput PDA]
+}

--- a/message_buffer/programs/message_buffer/src/lib.rs
+++ b/message_buffer/programs/message_buffer/src/lib.rs
@@ -83,6 +83,14 @@ pub mod message_buffer {
     ) -> Result<()> {
         instructions::put_all(ctx, base_account_key, messages)
     }
+
+
+    pub fn create_buffer<'info>(
+        ctx: Context<'_, '_, '_, 'info, CreateBuffer<'info>>,
+        allowed_program_auth: Pubkey,
+        base_account_key: Pubkey,
+        target_size: u32,
+    ) -> Result<()> { instructions::create_buffer(ctx, allowed_program_auth, base_account_key, target_size) }
 }
 
 #[derive(Accounts)]

--- a/message_buffer/programs/message_buffer/src/lib.rs
+++ b/message_buffer/programs/message_buffer/src/lib.rs
@@ -73,7 +73,6 @@ pub mod message_buffer {
     /// any existing contents.
     ///
     /// TODO:
-    ///     - try handling re-allocation of the accumulator_input space
     ///     - handle updates ("paging/batches of messages")
     ///
     pub fn put_all<'info>(
@@ -85,12 +84,24 @@ pub mod message_buffer {
     }
 
 
+    /// Initializes the buffer account with
     pub fn create_buffer<'info>(
         ctx: Context<'_, '_, '_, 'info, CreateBuffer<'info>>,
         allowed_program_auth: Pubkey,
         base_account_key: Pubkey,
         target_size: u32,
-    ) -> Result<()> { instructions::create_buffer(ctx, allowed_program_auth, base_account_key, target_size) }
+    ) -> Result<()> {
+        instructions::create_buffer(ctx, allowed_program_auth, base_account_key, target_size)
+    }
+
+    pub fn delete_buffer<'info>(
+        ctx: Context<'_, '_, '_, 'info, DeleteBuffer<'info>>,
+        allowed_program_auth: Pubkey,
+        base_account_key: Pubkey,
+        bump: u8,
+    ) -> Result<()> {
+        instructions::delete_buffer(ctx, allowed_program_auth, base_account_key, bump)
+    }
 }
 
 #[derive(Accounts)]
@@ -127,7 +138,7 @@ pub struct UpdateWhitelist<'info> {
 
 // TODO: rename this
 #[error_code]
-pub enum AccumulatorUpdaterError {
+pub enum MessageBufferError {
     #[msg("CPI Caller not allowed")]
     CallerNotAllowed,
     #[msg("Whitelist already contains program")]

--- a/message_buffer/programs/message_buffer/src/lib.rs
+++ b/message_buffer/programs/message_buffer/src/lib.rs
@@ -52,11 +52,10 @@ pub mod message_buffer {
     }
 
 
-    /// Insert messages/inputs for the Accumulator. All inputs derived from the
-    /// `base_account_key` will go into the same PDA. The PDA is derived with
-    /// seeds = [cpi_caller_auth, b"accumulator", base_account_key]
-    ///
-    ///
+    /// Put messages into the Accumulator. All messages put for the same
+    /// `base_account_key` go into the same buffer PDA. The PDA's address is
+    /// `[allowed_program_auth, MESSAGE, base_account_key]`, where `allowed_program_auth`
+    /// is the whitelisted pubkey who authorized this call.
     ///
     /// * `base_account_key`    - Pubkey of the original account the
     ///                           `MessageBuffer` is derived from
@@ -118,6 +117,7 @@ pub struct UpdateWhitelist<'info> {
 }
 
 
+// TODO: rename this
 #[error_code]
 pub enum AccumulatorUpdaterError {
     #[msg("CPI Caller not allowed")]
@@ -140,6 +140,8 @@ pub enum AccumulatorUpdaterError {
     CurrentDataLengthExceeded,
     #[msg("Message Buffer not provided")]
     MessageBufferNotProvided,
+    #[msg("Message Buffer is not sufficiently large")]
+    MessageBufferTooSmall,
     #[msg("Fund Bump not found")]
     FundBumpNotFound,
 }

--- a/message_buffer/programs/message_buffer/src/lib.rs
+++ b/message_buffer/programs/message_buffer/src/lib.rs
@@ -40,14 +40,11 @@ pub mod message_buffer {
         Ok(())
     }
 
-    /// Sets the new authority for the whitelist
-    pub fn update_whitelist_authority(
-        ctx: Context<UpdateWhitelist>,
-        new_authority: Pubkey,
-    ) -> Result<()> {
+    /// Sets the new admin for the whitelist
+    pub fn update_whitelist_admin(ctx: Context<UpdateWhitelist>, new_admin: Pubkey) -> Result<()> {
         let whitelist = &mut ctx.accounts.whitelist;
-        whitelist.validate_new_authority(new_authority)?;
-        whitelist.admin = new_authority;
+        whitelist.validate_new_admin(new_admin)?;
+        whitelist.admin = new_admin;
         Ok(())
     }
 

--- a/message_buffer/programs/message_buffer/src/macros.rs
+++ b/message_buffer/programs/message_buffer/src/macros.rs
@@ -5,7 +5,7 @@ macro_rules! accumulator_input_seeds {
             $cpi_caller_pid.as_ref(),
             b"message".as_ref(),
             $base_account.as_ref(),
-            &[$accumulator_input.header.bump],
+            &[$accumulator_input.bump],
         ]
     };
 }

--- a/message_buffer/programs/message_buffer/src/state/message_buffer.rs
+++ b/message_buffer/programs/message_buffer/src/state/message_buffer.rs
@@ -54,7 +54,7 @@ impl BufferHeader {
     ///
 // TODO: add a end_offsets index parameter for "continuation"
 // TODO: test max size of parameters that can be passed into CPI call
-    fn put_all_in_buffer(&mut self, destination: &mut [u8], values: &Vec<Vec<u8>>) -> (usize, u16) {
+    pub fn put_all_in_buffer(&mut self, destination: &mut [u8], values: &Vec<Vec<u8>>) -> (usize, u16) {
         let mut offset = 0u16;
 
         for (i, v) in values.iter().enumerate() {

--- a/message_buffer/programs/message_buffer/src/state/message_buffer.rs
+++ b/message_buffer/programs/message_buffer/src/state/message_buffer.rs
@@ -54,7 +54,7 @@ impl BufferHeader {
     ///
 // TODO: add a end_offsets index parameter for "continuation"
 // TODO: test max size of parameters that can be passed into CPI call
-    fn put_all_in_buffer(&mut self, destination: &mut &[u8], values: &Vec<Vec<u8>>) -> (usize, u16) {
+    fn put_all_in_buffer(&mut self, destination: &mut [u8], values: &Vec<Vec<u8>>) -> (usize, u16) {
         let mut offset = 0u16;
 
         for (i, v) in values.iter().enumerate() {
@@ -68,10 +68,10 @@ impl BufferHeader {
                 return (i, start);
             }
             let end = end.unwrap();
-            if end > self.messages.len() as u16 {
+            if end > destination.len() as u16 {
                 return (i, start);
             }
-            self.header.end_offsets[i] = end;
+            self.end_offsets[i] = end;
             destination[(start as usize)..(end as usize)].copy_from_slice(v);
             offset = end
         }

--- a/message_buffer/programs/message_buffer/src/state/message_buffer.rs
+++ b/message_buffer/programs/message_buffer/src/state/message_buffer.rs
@@ -128,10 +128,7 @@ mod test {
     use {
         super::*,
         anchor_lang::solana_program::keccak::hashv,
-        bytemuck::{
-            bytes_of,
-            bytes_of_mut,
-        },
+        bytemuck::bytes_of_mut,
         std::{
             io::Write,
             mem::{
@@ -186,7 +183,7 @@ mod test {
             .write_all(messages.as_mut_slice())
             .unwrap();
 
-        let account_data_len = account_info_data.len();
+        let _account_data_len = account_info_data.len();
 
         let destination = &mut account_info_data[(message_buffer.header_len as usize)..];
 
@@ -242,7 +239,7 @@ mod test {
             .write_all(messages.as_mut_slice())
             .unwrap();
 
-        let account_data_len = account_info_data.len();
+        let _account_data_len = account_info_data.len();
 
         let destination = &mut account_info_data[(message_buffer.header_len as usize)..];
 
@@ -298,7 +295,7 @@ mod test {
             .write_all(messages.as_mut_slice())
             .unwrap();
 
-        let account_data_len = account_info_data.len();
+        let _account_data_len = account_info_data.len();
 
         let destination = &mut account_info_data[(message_buffer.header_len as usize)..];
 

--- a/message_buffer/programs/message_buffer/src/state/whitelist.rs
+++ b/message_buffer/programs/message_buffer/src/state/whitelist.rs
@@ -10,7 +10,7 @@ use {
 #[derive(InitSpace)]
 pub struct Whitelist {
     pub bump:             u8,
-    pub authority:        Pubkey,
+    pub admin:            Pubkey,
     #[max_len(32)]
     pub allowed_programs: Vec<Pubkey>,
 }

--- a/message_buffer/programs/message_buffer/src/state/whitelist.rs
+++ b/message_buffer/programs/message_buffer/src/state/whitelist.rs
@@ -29,8 +29,8 @@ impl Whitelist {
         Ok(())
     }
 
-    pub fn validate_new_authority(&self, new_authority: Pubkey) -> Result<()> {
-        require_keys_neq!(new_authority, Pubkey::default());
+    pub fn validate_new_admin(&self, new_admin: Pubkey) -> Result<()> {
+        require_keys_neq!(new_admin, Pubkey::default());
         Ok(())
     }
 }

--- a/message_buffer/programs/message_buffer/src/state/whitelist.rs
+++ b/message_buffer/programs/message_buffer/src/state/whitelist.rs
@@ -1,5 +1,5 @@
 use {
-    crate::AccumulatorUpdaterError,
+    crate::MessageBufferError,
     anchor_lang::prelude::*,
 };
 
@@ -19,12 +19,12 @@ impl Whitelist {
     pub fn validate_programs(&self, allowed_programs: &[Pubkey]) -> Result<()> {
         require!(
             !self.allowed_programs.contains(&Pubkey::default()),
-            AccumulatorUpdaterError::InvalidAllowedProgram
+            MessageBufferError::InvalidAllowedProgram
         );
         require_gte!(
             32,
             allowed_programs.len(),
-            AccumulatorUpdaterError::MaximumAllowedProgramsExceeded
+            MessageBufferError::MaximumAllowedProgramsExceeded
         );
         Ok(())
     }
@@ -53,7 +53,7 @@ impl<'info> WhitelistVerifier<'info> {
         let whitelist = &self.whitelist;
         require!(
             whitelist.allowed_programs.contains(&auth),
-            AccumulatorUpdaterError::CallerNotAllowed
+            MessageBufferError::CallerNotAllowed
         );
         Ok(auth)
     }

--- a/message_buffer/programs/message_buffer/src/state/whitelist.rs
+++ b/message_buffer/programs/message_buffer/src/state/whitelist.rs
@@ -33,6 +33,14 @@ impl Whitelist {
         require_keys_neq!(new_admin, Pubkey::default());
         Ok(())
     }
+
+    pub fn is_allowed_program_auth(&self, auth: &Pubkey) -> Result<()> {
+        require!(
+            self.allowed_programs.contains(auth),
+            MessageBufferError::CallerNotAllowed
+        );
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
@@ -51,10 +59,7 @@ impl<'info> WhitelistVerifier<'info> {
     pub fn is_allowed(&self) -> Result<Pubkey> {
         let auth = self.cpi_caller_auth.key();
         let whitelist = &self.whitelist;
-        require!(
-            whitelist.allowed_programs.contains(&auth),
-            MessageBufferError::CallerNotAllowed
-        );
+        whitelist.is_allowed_program_auth(&auth)?;
         Ok(auth)
     }
 }

--- a/message_buffer/programs/mock-cpi-caller/src/instructions/add_price.rs
+++ b/message_buffer/programs/mock-cpi-caller/src/instructions/add_price.rs
@@ -62,10 +62,8 @@ impl<'info> AddPrice<'info> {
         inputs: Vec<Vec<u8>>,
     ) -> anchor_lang::Result<()> {
         let mut accounts = vec![
-            // AccountMeta::new(ctx.accounts.fund.key(), false),
             AccountMeta::new_readonly(ctx.accounts.accumulator_whitelist.key(), false),
             AccountMeta::new_readonly(ctx.accounts.auth.key(), true),
-            AccountMeta::new_readonly(ctx.accounts.system_program.key(), false),
         ];
         accounts.extend_from_slice(
             &ctx.remaining_accounts

--- a/message_buffer/programs/mock-cpi-caller/src/instructions/add_price.rs
+++ b/message_buffer/programs/mock-cpi-caller/src/instructions/add_price.rs
@@ -62,7 +62,7 @@ impl<'info> AddPrice<'info> {
         inputs: Vec<Vec<u8>>,
     ) -> anchor_lang::Result<()> {
         let mut accounts = vec![
-            AccountMeta::new(ctx.accounts.fund.key(), false),
+            // AccountMeta::new(ctx.accounts.fund.key(), false),
             AccountMeta::new_readonly(ctx.accounts.accumulator_whitelist.key(), false),
             AccountMeta::new_readonly(ctx.accounts.auth.key(), true),
             AccountMeta::new_readonly(ctx.accounts.system_program.key(), false),
@@ -131,8 +131,6 @@ pub struct AddPrice<'info> {
     pub pyth_price_account:     AccountLoader<'info, PriceAccount>,
     #[account(mut)]
     pub payer:                  Signer<'info>,
-    #[account(mut)]
-    pub fund:                   SystemAccount<'info>,
     /// also needed for accumulator_updater
     pub system_program:         Program<'info, System>,
     /// CHECK: whitelist
@@ -147,5 +145,5 @@ pub struct AddPrice<'info> {
     pub auth:                   SystemAccount<'info>,
     pub message_buffer_program: Program<'info, MessageBufferProgram>,
     // Remaining Accounts
-    // should all be new uninitialized accounts
+    // MessageBuffer PDA
 }

--- a/message_buffer/programs/mock-cpi-caller/src/instructions/update_price.rs
+++ b/message_buffer/programs/mock-cpi-caller/src/instructions/update_price.rs
@@ -42,8 +42,6 @@ pub struct UpdatePrice<'info> {
     bump,
     )]
     pub pyth_price_account:     AccountLoader<'info, PriceAccount>,
-    #[account(mut)]
-    pub fund:                   SystemAccount<'info>,
     /// Needed for accumulator_updater
     pub system_program:         Program<'info, System>,
     /// CHECK: whitelist
@@ -90,7 +88,6 @@ impl<'info> UpdatePrice<'info> {
         values: Vec<Vec<u8>>,
     ) -> anchor_lang::Result<()> {
         let mut accounts = vec![
-            AccountMeta::new(ctx.accounts.fund.key(), false),
             AccountMeta::new_readonly(ctx.accounts.accumulator_whitelist.key(), false),
             AccountMeta::new_readonly(ctx.accounts.auth.key(), true),
             AccountMeta::new_readonly(ctx.accounts.system_program.key(), false),

--- a/message_buffer/programs/mock-cpi-caller/src/instructions/update_price.rs
+++ b/message_buffer/programs/mock-cpi-caller/src/instructions/update_price.rs
@@ -42,8 +42,6 @@ pub struct UpdatePrice<'info> {
     bump,
     )]
     pub pyth_price_account:     AccountLoader<'info, PriceAccount>,
-    /// Needed for accumulator_updater
-    pub system_program:         Program<'info, System>,
     /// CHECK: whitelist
     pub accumulator_whitelist:  UncheckedAccount<'info>,
     #[account(
@@ -90,7 +88,6 @@ impl<'info> UpdatePrice<'info> {
         let mut accounts = vec![
             AccountMeta::new_readonly(ctx.accounts.accumulator_whitelist.key(), false),
             AccountMeta::new_readonly(ctx.accounts.auth.key(), true),
-            AccountMeta::new_readonly(ctx.accounts.system_program.key(), false),
         ];
         accounts.extend_from_slice(
             &ctx.remaining_accounts

--- a/message_buffer/tests/message_buffer.ts
+++ b/message_buffer/tests/message_buffer.ts
@@ -821,7 +821,7 @@ type MessageBufferType = {
 function deserializeMessageBufferHeader(
   messageBufferProgram: Program<MessageBuffer>,
   accountData: Buffer
-): IdlAccounts<MessageBuffer>["MessageBuffer"] {
+): IdlAccounts<MessageBuffer>["messageBuffer"] {
   return messageBufferProgram.coder.accounts.decode(
     "MessageBuffer",
     accountData

--- a/message_buffer/tests/message_buffer.ts
+++ b/message_buffer/tests/message_buffer.ts
@@ -243,9 +243,9 @@ describe("accumulator_updater", () => {
   });
 
   it("Updates the whitelist authority", async () => {
-    const newWhitelistAuthority = anchor.web3.Keypair.generate();
+    const newWhitelistAdmin = anchor.web3.Keypair.generate();
     await messageBufferProgram.methods
-      .updateWhitelistAuthority(newWhitelistAuthority.publicKey)
+      .updateWhitelistAdmin(newWhitelistAdmin.publicKey)
       .accounts({
         admin: whitelistAdmin.publicKey,
       })
@@ -255,15 +255,15 @@ describe("accumulator_updater", () => {
     let whitelist = await messageBufferProgram.account.whitelist.fetch(
       whitelistPubkey
     );
-    assert.isTrue(whitelist.admin.equals(newWhitelistAuthority.publicKey));
+    assert.isTrue(whitelist.admin.equals(newWhitelistAdmin.publicKey));
 
     // swap back to original authority
     await messageBufferProgram.methods
-      .updateWhitelistAuthority(whitelistAdmin.publicKey)
+      .updateWhitelistAdmin(whitelistAdmin.publicKey)
       .accounts({
-        admin: newWhitelistAuthority.publicKey,
+        admin: newWhitelistAdmin.publicKey,
       })
-      .signers([newWhitelistAuthority])
+      .signers([newWhitelistAdmin])
       .rpc();
 
     whitelist = await messageBufferProgram.account.whitelist.fetch(

--- a/message_buffer/tests/message_buffer.ts
+++ b/message_buffer/tests/message_buffer.ts
@@ -6,33 +6,25 @@ import {
   BorshAccountsCoder,
 } from "@coral-xyz/anchor";
 import { MessageBuffer } from "../target/types/message_buffer";
-console.log("-1");
 import { MockCpiCaller } from "../target/types/mock_cpi_caller";
 import lumina from "@lumina-dev/test";
 import { assert } from "chai";
 import { AccountMeta, ComputeBudgetProgram } from "@solana/web3.js";
 import bs58 from "bs58";
 
-console.log("0");
-
 // Enables tool that runs in local browser for easier debugging of
 // transactions in this test -  https://lumina.fyi/debug
 // lumina();
-console.log("1");
 
 const messageBufferProgram = anchor.workspace
   .MessageBuffer as Program<MessageBuffer>;
 const mockCpiProg = anchor.workspace.MockCpiCaller as Program<MockCpiCaller>;
 let whitelistAdmin = anchor.web3.Keypair.generate();
 
-console.log("1.5");
-
 const [mockCpiCallerAuth] = anchor.web3.PublicKey.findProgramAddressSync(
   [messageBufferProgram.programId.toBuffer(), Buffer.from("cpi")],
   mockCpiProg.programId
 );
-
-console.log("2");
 
 const pythPriceAccountId = new anchor.BN(1);
 const addPriceParams = {
@@ -276,7 +268,6 @@ describe("accumulator_updater", () => {
     const mockCpiCallerAddPriceTxPubkeys = await mockCpiProg.methods
       .addPrice(addPriceParams)
       .accounts({
-        // fund: fundPda,
         systemProgram: anchor.web3.SystemProgram.programId,
         auth: mockCpiCallerAuth,
         accumulatorWhitelist: whitelistPubkey,
@@ -671,7 +662,6 @@ describe("accumulator_updater", () => {
       .accounts({
         whitelist: whitelistPubkey,
         admin: whitelistAdmin.publicKey,
-        systemProgram: anchor.web3.SystemProgram.programId,
       })
       .signers([whitelistAdmin])
       .remainingAccounts([accumulatorPdaMeta2])
@@ -757,11 +747,7 @@ async function getMessageBuffer(
 ): Promise<Buffer | null> {
   let accountInfo = await connection.getAccountInfo(accountKey);
   return accountInfo ? accountInfo.data : null;
-  // return (accountInfo ?? accountInfo.data)
-  // return (await connection.getAccountInfo(accumulatorPdaKey)).data;
 }
-
-// type BufferHeader = IdlAccounts<MessageBuffer>["BufferHeader"];
 
 // Parses MessageBuffer.data into a PriceAccount or PriceOnly object based on the
 // accountType and accountSchema.

--- a/message_buffer/tests/message_buffer.ts
+++ b/message_buffer/tests/message_buffer.ts
@@ -461,17 +461,17 @@ export const getAccumulatorPdaMeta = (
   };
 };
 
+async function getMessageBuffer(connection: anchor.web3.Connection, accountKey: anchor.web3.PublicKey): Buffer {
+  (await connection.getAccountInfo(accumulatorPdaKey)).data;
+}
+
 type BufferHeader = IdlAccounts<MessageBufferType>["BufferHeader"];
 
 // Parses MessageBuffer.data into a PriceAccount or PriceOnly object based on the
 // accountType and accountSchema.
-function parseMessageBuffer({
-  header,
-  messages,
-}: {
-  header: BufferHeader;
-  messages: number[];
-}): AccumulatorPriceMessage[] {
+function parseMessageBuffer(accountData: Buffer): AccumulatorPriceMessage[] {
+  header =
+
   const accumulatorMessages = [];
   let dataBuffer = Buffer.from(messages);
 


### PR DESCRIPTION
### Summary
Add `create/resize/delete_buffer` ixs, allow for `MessageBuffer` to be variable length

### Changes
- Remove `fund`
- Rename `whitelist.authority` to `whitelist.admin` and check that admin is signer & payer for all admin ixs.
- `MessageBuffer` struct now only defines the header fields and allows for variable length for the actual messages (see `MessageBuffer::put_all_in_buffer`)