### PR TITLE
[xc-pusher] Fix docker compose (testnet)

### DIFF
--- a/price_pusher/config.evm.testnet.sample.json
+++ b/price_pusher/config.evm.testnet.sample.json
@@ -1,6 +1,6 @@
 {
   "endpoint": "https://endpoints.omniatech.io/v1/fantom/testnet/public",
-  "pyth-contract-address": "0xff1a0f4744e8582DF1aE09D5611b887B6a12925CZ",
+  "pyth-contract-address": "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C",
   "price-service-endpoint": "https://xc-testnet.pyth.network",
   "mnemonic-file": "./mnemonic",
   "price-config-file": "./price-config.testnet.sample.yaml"

--- a/price_pusher/docker-compose.testnet.sample.yaml
+++ b/price_pusher/docker-compose.testnet.sample.yaml
@@ -58,23 +58,25 @@ services:
     restart: always
     command:
       - "--"
-      - "injective"
-      # you can choose to provide all the options here or a path to the config file
-      # we are providing a path to the config file
-      - "--config"
-      - "/command_config"
+      - "evm"
+      - "--endpoint"
+      # Replace this with RPC endpoint URL for the EVM network.
+      - "https://endpoints.omniatech.io/v1/fantom/testnet/public"
+      - "--mnemonic-file"
+      - "/mnemonic"
+      - "--pyth-contract-address"
+      - "0xff1a0f4744e8582DF1aE09D5611b887B6a12925CZ"
+      - "--price-service-endpoint"
+      - "http://price-service:4200"
+      - "--price-config-file"
+      - "/price_config"
     configs:
-      - command_config
       - mnemonic
       - price_config
     depends_on:
       price-service:
         condition: service_healthy
 configs:
-  command_config:
-    # Replace this with the path to the configuration file. You need to update the paths defined in
-    # the config file
-    file: ./config.injective.testnet.sample.json
   mnemonic:
     file: ./mnemonic # Replace this with the path to the mnemonic file
   price_config:

--- a/price_pusher/docker-compose.testnet.sample.yaml
+++ b/price_pusher/docker-compose.testnet.sample.yaml
@@ -65,7 +65,7 @@ services:
       - "--mnemonic-file"
       - "/mnemonic"
       - "--pyth-contract-address"
-      - "0xff1a0f4744e8582DF1aE09D5611b887B6a12925CZ"
+      - "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C"
       - "--price-service-endpoint"
       - "http://price-service:4200"
       - "--price-config-file"


### PR DESCRIPTION
This docker compose was crashing. The bug was really hard to find.

Basically the pusher fails if the argument `--config` doesn't end in `.json`
In this docker compose it was running with `--config /command_config`.
I'm reverting this docker compose to look like the one for mainnet.
