### PR TITLE
[Price pusher client] Fix axios bug by downgrading, bump all dependents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48092,7 +48092,7 @@
     },
     "price_pusher": {
       "name": "@pythnetwork/price-pusher",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@injectivelabs/sdk-ts": "^1.0.484",
@@ -49368,12 +49368,12 @@
     },
     "price_service/client/js": {
       "name": "@pythnetwork/price-service-client",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@pythnetwork/price-service-sdk": "*",
         "@types/ws": "^8.5.3",
-        "axios": "^1.2.5",
+        "axios": "^1.1.0",
         "axios-retry": "^3.4.0",
         "isomorphic-ws": "^4.0.1",
         "ts-log": "^2.2.4",
@@ -49455,7 +49455,7 @@
     },
     "price_service/server": {
       "name": "@pythnetwork/price-service-server",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@certusone/wormhole-sdk": "^0.9.9",
@@ -49515,7 +49515,7 @@
     },
     "target_chains/aptos/sdk/js": {
       "name": "@pythnetwork/pyth-aptos-js",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@pythnetwork/price-service-client": "*",
@@ -49606,7 +49606,7 @@
     },
     "target_chains/cosmwasm/sdk/js": {
       "name": "@pythnetwork/pyth-terra-js",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@pythnetwork/price-service-client": "*",
@@ -50004,7 +50004,7 @@
     },
     "target_chains/ethereum/sdk/js": {
       "name": "@pythnetwork/pyth-evm-js",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@pythnetwork/price-service-client": "*",
@@ -58951,7 +58951,7 @@
         "@types/yargs": "^17.0.10",
         "@typescript-eslint/eslint-plugin": "^5.21.0",
         "@typescript-eslint/parser": "^5.21.0",
-        "axios": "^1.2.5",
+        "axios": "^1.1.0",
         "axios-retry": "^3.4.0",
         "eslint": "^8.14.0",
         "isomorphic-ws": "^4.0.1",

--- a/price_pusher/package.json
+++ b/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/price_service/client/js/package.json
+++ b/price_service/client/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-service-client",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Pyth price service client",
   "author": {
     "name": "Pyth Data Association"
@@ -50,7 +50,7 @@
   "dependencies": {
     "@pythnetwork/price-service-sdk": "*",
     "@types/ws": "^8.5.3",
-    "axios": "^1.2.5",
+    "axios": "^1.1.0",
     "axios-retry": "^3.4.0",
     "isomorphic-ws": "^4.0.1",
     "ts-log": "^2.2.4",

--- a/target_chains/aptos/sdk/js/package.json
+++ b/target_chains/aptos/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-aptos-js",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Pyth Network Aptos Utilities",
   "homepage": "https://pyth.network",
   "author": {

--- a/target_chains/cosmwasm/sdk/js/package.json
+++ b/target_chains/cosmwasm/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-terra-js",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Pyth Network Terra Utils in JS",
   "homepage": "https://pyth.network",
   "author": {

--- a/target_chains/ethereum/sdk/js/package.json
+++ b/target_chains/ethereum/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-evm-js",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Pyth Network EVM Utils in JS",
   "homepage": "https://pyth.network",
   "author": {


### PR DESCRIPTION
This bug was found by Brett from telegram. Basically EvmConnection wasn't working in a React app because of some axios weirdness.
Minimal example here : 
https://github.com/guibescos/test-connection

I want to make this change and make a release ASAP.