### PR TITLE
[price-service-client] Pin axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20706,19 +20706,11 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
       "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/axios-retry": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.4.0.tgz",
-      "integrity": "sha512-VdgaP+gHH4iQYCCNUWF2pcqeciVOdGrBBAYUfTY+wPcO5Ltvp/37MLFNCmJKo7Gj3SHvCSdL8ouI1qLYJN3liA==",
-      "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "is-retry-allowed": "^2.2.0"
       }
     },
     "node_modules/axobject-query": {
@@ -27908,6 +27900,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -28237,6 +28230,7 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -49373,8 +49367,8 @@
       "dependencies": {
         "@pythnetwork/price-service-sdk": "*",
         "@types/ws": "^8.5.3",
-        "axios": "^1.1.0",
-        "axios-retry": "^3.4.0",
+        "axios": "=1.1.0",
+        "axios-retry": "~3.3.0",
         "isomorphic-ws": "^4.0.1",
         "ts-log": "^2.2.4",
         "ws": "^8.6.0"
@@ -49397,6 +49391,25 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "price_service/client/js/node_modules/axios": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.0.tgz",
+      "integrity": "sha512-hsJgcqz4JY7f+HZ4cWTrPZ6tZNCNFPTRx1MjRqu/hbpgpHdSCUpLVuplc+jE/h7dOvyANtw/ERA3HC2Rz/QoMg==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "price_service/client/js/node_modules/axios-retry": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.3.1.tgz",
+      "integrity": "sha512-RohAUQTDxBSWLFEnoIG/6bvmy8l3TfpkclgStjl5MDCMBDgapAWCmr1r/9harQfWC8bzLC8job6UcL1A1Yc+/Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "price_service/client/js/node_modules/yargs": {
@@ -58951,8 +58964,8 @@
         "@types/yargs": "^17.0.10",
         "@typescript-eslint/eslint-plugin": "^5.21.0",
         "@typescript-eslint/parser": "^5.21.0",
-        "axios": "^1.1.0",
-        "axios-retry": "^3.4.0",
+        "axios": "=1.1.0",
+        "axios-retry": "~3.3.0",
         "eslint": "^8.14.0",
         "isomorphic-ws": "^4.0.1",
         "jest": "^29.4.0",
@@ -58968,6 +58981,25 @@
           "version": "8.5.4",
           "requires": {
             "@types/node": "*"
+          }
+        },
+        "axios": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.0.tgz",
+          "integrity": "sha512-hsJgcqz4JY7f+HZ4cWTrPZ6tZNCNFPTRx1MjRqu/hbpgpHdSCUpLVuplc+jE/h7dOvyANtw/ERA3HC2Rz/QoMg==",
+          "requires": {
+            "follow-redirects": "^1.15.0",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+          }
+        },
+        "axios-retry": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.3.1.tgz",
+          "integrity": "sha512-RohAUQTDxBSWLFEnoIG/6bvmy8l3TfpkclgStjl5MDCMBDgapAWCmr1r/9harQfWC8bzLC8job6UcL1A1Yc+/Q==",
+          "requires": {
+            "@babel/runtime": "^7.15.4",
+            "is-retry-allowed": "^2.2.0"
           }
         },
         "yargs": {
@@ -68773,19 +68805,11 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
       "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "dev": true,
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
-      }
-    },
-    "axios-retry": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.4.0.tgz",
-      "integrity": "sha512-VdgaP+gHH4iQYCCNUWF2pcqeciVOdGrBBAYUfTY+wPcO5Ltvp/37MLFNCmJKo7Gj3SHvCSdL8ouI1qLYJN3liA==",
-      "requires": {
-        "@babel/runtime": "^7.15.4",
-        "is-retry-allowed": "^2.2.0"
       }
     },
     "axobject-query": {

--- a/price_service/client/js/package.json
+++ b/price_service/client/js/package.json
@@ -50,8 +50,8 @@
   "dependencies": {
     "@pythnetwork/price-service-sdk": "*",
     "@types/ws": "^8.5.3",
-    "axios": "^1.1.0",
-    "axios-retry": "^3.4.0",
+    "axios": "=1.1.0",
+    "axios-retry": "~3.3.0",
     "isomorphic-ws": "^4.0.1",
     "ts-log": "^2.2.4",
     "ws": "^8.6.0"


### PR DESCRIPTION
Turns out `"axios": "^1.1.0"` is not enough since it ends up resolving to `1.3.4`....

I needed to pin to 1.1.0  (`"axios": "=1.1.0"`) to solve the problem. I also had to downgrade `axios-retry` to be compatible.

reference : https://github.com/axios/axios/issues/5082
