### PR TITLE
[js-packages] Build all packages before publishing

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -16,6 +16,7 @@ jobs:
           node-version: "16"
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
+      - run: npx lerna run build --no-private
       - run: npx lerna publish from-package --no-private --no-git-tag-version --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR aims to resolve the following problem. 

The way the script currently works is it only builds the packages it aims to publish. However if your package depends on another package that's not being published, the whole thing will fail because that other package hasn't been built. 

https://github.com/pyth-network/pyth-crosschain/actions/runs/4852553452/jobs/8647678135
in this job after a bugfix to `price-service-client` publish `price-service-client` failed because we're not publishing `price-service-sdk`.

There are two solutions :
- Build all the packages at the beginning of the workflow (this PR)
- Make sure to bump all packages every time we make a new release.

