### PR TITLE
docker: add restart `on-failure`

### DIFF
--- a/price_service/server/docker-compose.mainnet.yaml
+++ b/price_service/server/docker-compose.mainnet.yaml
@@ -53,7 +53,7 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://localhost:4200/ready"
+          "http://localhost:4200/ready",
         ]
       start_period: 20s
     depends_on:

--- a/price_service/server/docker-compose.mainnet.yaml
+++ b/price_service/server/docker-compose.mainnet.yaml
@@ -2,6 +2,7 @@ services:
   spy:
     # Find latest Guardian images in https://github.com/wormhole-foundation/wormhole/pkgs/container/guardiand
     image: ghcr.io/wormhole-foundation/guardiand:v2.14.8.1
+    restart: on-failure
     command:
       - "spy"
       - "--nodeKey"
@@ -17,6 +18,7 @@ services:
   price-service:
     # Find latest price service images https://gallery.ecr.aws/pyth-network/xc-server
     image: public.ecr.aws/pyth-network/xc-server:v3.0.0
+    restart: on-failure
     # Or alternatively use a locally built image
     # image: pyth_price_server
     environment:
@@ -51,7 +53,7 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://localhost:4200/ready",
+          "http://localhost:4200/ready"
         ]
       start_period: 20s
     depends_on:

--- a/price_service/server/docker-compose.testnet.yaml
+++ b/price_service/server/docker-compose.testnet.yaml
@@ -53,7 +53,7 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://localhost:4200/ready"
+          "http://localhost:4200/ready",
         ]
       start_period: 20s
     depends_on:

--- a/price_service/server/docker-compose.testnet.yaml
+++ b/price_service/server/docker-compose.testnet.yaml
@@ -2,6 +2,7 @@ services:
   spy:
     # Find latest Guardian images in https://github.com/wormhole-foundation/wormhole/pkgs/container/guardiand
     image: ghcr.io/wormhole-foundation/guardiand:v2.14.8.1
+    restart: on-failure
     command:
       - "spy"
       - "--nodeKey"
@@ -17,6 +18,7 @@ services:
   price-service:
     # Find latest price service images https://gallery.ecr.aws/pyth-network/xc-server
     image: public.ecr.aws/pyth-network/xc-server:v3.0.0
+    restart: on-failure
     # Or alternatively use a locally built image
     # image: pyth_price_server
     environment:
@@ -51,7 +53,7 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://localhost:4200/ready",
+          "http://localhost:4200/ready"
         ]
       start_period: 20s
     depends_on:


### PR DESCRIPTION
Added restart `on-failure` to docker-compose mainnet/testnet of price feed server. Price feed server will automatically recover in case of unexpected error.