### PR TITLE
Fix Bug - price pusher was not pushing to mainnet

### DIFF
--- a/price_pusher/config.injective.testnet.sample.json
+++ b/price_pusher/config.injective.testnet.sample.json
@@ -3,5 +3,6 @@
   "pyth-contract-address": "inj1z60tg0tekdzcasenhuuwq3htjcd5slmgf7gpez",
   "price-service-endpoint": "https://xc-testnet.pyth.network",
   "mnemonic-file": "./mnemonic",
-  "price-config-file": "./price-config.testnet.sample.yaml"
+  "price-config-file": "./price-config.testnet.sample.yaml",
+  "network": "testnet"
 }

--- a/price_pusher/package.json
+++ b/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "4.1.2",
+  "version": "5.0.0",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/price_pusher/src/injective/command.ts
+++ b/price_pusher/src/injective/command.ts
@@ -6,6 +6,7 @@ import { InjectivePriceListener, InjectivePricePusher } from "./injective";
 import { PythPriceListener } from "../pyth-price-listener";
 import { Controller } from "../controller";
 import { Options } from "yargs";
+import { getNetworkInfo } from "@injectivelabs/networks";
 
 export default {
   command: "injective",
@@ -16,6 +17,11 @@ export default {
         "gRPC endpoint URL for injective. The pusher will periodically" +
         "poll for updates. The polling interval is configurable via the " +
         "`polling-frequency` command-line argument.",
+      type: "string",
+      required: true,
+    } as Options,
+    network: {
+      description: "testnet or mainnet",
       type: "string",
       required: true,
     } as Options,
@@ -36,7 +42,12 @@ export default {
       pythContractAddress,
       pushingFrequency,
       pollingFrequency,
+      network,
     } = argv;
+
+    if (network !== "testnet" && network !== "mainnet") {
+      throw new Error("Please specify network. One of [testnet, mainnet]");
+    }
 
     const priceConfigs = readPriceConfigFile(priceConfigFile);
     const priceServiceConnection = new PriceServiceConnection(
@@ -73,7 +84,10 @@ export default {
       priceServiceConnection,
       pythContractAddress,
       grpcEndpoint,
-      mnemonic
+      mnemonic,
+      {
+        chainId: getNetworkInfo(network).chainId,
+      }
     );
 
     const controller = new Controller(


### PR DESCRIPTION
Transactions are signed with different chainId on testnet and mainnet. 
It was using the the same for both which caused this bug. 

This PR fixes that. 