### PR TITLE
[evm] Make comment match the function below

### DIFF
--- a/target_chains/ethereum/sdk/solidity/MockPyth.sol
+++ b/target_chains/ethereum/sdk/solidity/MockPyth.sol
@@ -33,7 +33,7 @@ contract MockPyth is AbstractPyth {
     }
 
     // Takes an array of encoded price feeds and stores them.
-    // You can create this data either by calling createPriceFeedData or
+    // You can create this data either by calling createPriceFeedUpdateData or
     // by using web3.js or ethers abi utilities.
     function updatePriceFeeds(
         bytes[] calldata updateData

--- a/target_chains/sui/contracts/sources/pyth.move
+++ b/target_chains/sui/contracts/sources/pyth.move
@@ -963,7 +963,7 @@ module pyth::pyth_tests{
         price_info_object_1 = vector::pop_back(&mut price_info_object_vec);
 
         vector::destroy_empty(price_info_object_vec);
-        
+
         let current_price_info = price_info::get_price_info_from_price_info_object(&price_info_object_1);
         let current_price_feed = price_info::get_price_feed(&current_price_info);
         let current_price = price_feed::get_price(current_price_feed);


### PR DESCRIPTION
The function alluded in this comment, that can be used to create mock pyth payloads was erroneously mentioned.