### PR TITLE
[message-buffer 17/x] separate payer from admin

### DIFF
--- a/pythnet/message_buffer/programs/message_buffer/src/instructions/create_buffer.rs
+++ b/pythnet/message_buffer/programs/message_buffer/src/instructions/create_buffer.rs
@@ -66,7 +66,7 @@ pub fn create_buffer<'info>(
         CreateBuffer::create_account(
             buffer_account,
             target_size as usize,
-            &ctx.accounts.admin,
+            &ctx.accounts.payer,
             &[signer_seeds.as_slice()],
             &ctx.accounts.system_program,
         )?;
@@ -95,9 +95,11 @@ pub struct CreateBuffer<'info> {
     )]
     pub whitelist: Account<'info, Whitelist>,
 
-    // Also pays for account creation
-    #[account(mut)]
     pub admin: Signer<'info>,
+
+    /// pays for account initialization
+    #[account(mut)]
+    pub payer: Signer<'info>,
 
     pub system_program: Program<'info, System>,
     // remaining_accounts:  - [AccumulatorInput PDA]

--- a/pythnet/message_buffer/programs/message_buffer/src/instructions/delete_buffer.rs
+++ b/pythnet/message_buffer/programs/message_buffer/src/instructions/delete_buffer.rs
@@ -25,13 +25,15 @@ pub struct DeleteBuffer<'info> {
     )]
     pub whitelist: Account<'info, Whitelist>,
 
-    // Also the recipient of the lamports from closing the buffer account
-    #[account(mut)]
     pub admin: Signer<'info>,
+
+    /// Recipient of the lamports from closing the buffer account
+    #[account(mut)]
+    pub payer: Signer<'info>,
 
     #[account(
         mut,
-        close = admin,
+        close = payer,
         seeds = [allowed_program_auth.as_ref(), MESSAGE.as_bytes(), base_account_key.as_ref()],
         bump = message_buffer.load()?.bump,
     )]

--- a/pythnet/message_buffer/programs/message_buffer/src/instructions/resize_buffer.rs
+++ b/pythnet/message_buffer/programs/message_buffer/src/instructions/resize_buffer.rs
@@ -49,9 +49,11 @@ pub struct ResizeBuffer<'info> {
     )]
     pub whitelist: Account<'info, Whitelist>,
 
-    // Also pays for account creation
-    #[account(mut)]
     pub admin: Signer<'info>,
+
+    /// Pays for any additional rent needed to increase the buffer size
+    #[account(mut)]
+    pub payer: Signer<'info>,
 
     pub system_program: Program<'info, System>,
 
@@ -64,7 +66,7 @@ pub struct ResizeBuffer<'info> {
         mut,
         realloc = target_size as usize,
         realloc::zero = false,
-        realloc::payer = admin,
+        realloc::payer = payer,
         seeds = [allowed_program_auth.as_ref(), MESSAGE.as_bytes(), base_account_key.as_ref()],
         bump = message_buffer.load()?.bump,
     )]

--- a/pythnet/message_buffer/programs/message_buffer/src/lib.rs
+++ b/pythnet/message_buffer/programs/message_buffer/src/lib.rs
@@ -145,11 +145,13 @@ pub mod message_buffer {
 #[derive(Accounts)]
 pub struct Initialize<'info> {
     /// Admin that can update the whitelist and create/resize/delete buffers
+    pub admin: Signer<'info>,
+
     #[account(mut)]
-    pub admin:          Signer<'info>,
+    pub payer:          Signer<'info>,
     #[account(
         init,
-        payer = admin,
+        payer = payer,
         seeds = [MESSAGE.as_bytes(), WHITELIST.as_bytes()],
         bump,
         space = 8 + Whitelist::INIT_SPACE,

--- a/pythnet/message_buffer/programs/mock-cpi-caller/tests/cases/test_create_buffer.rs
+++ b/pythnet/message_buffer/programs/mock-cpi-caller/tests/cases/test_create_buffer.rs
@@ -50,6 +50,7 @@ async fn create_buffer_with_invalid_admin_should_fail() {
         space,
         context.whitelist(),
         invalid_admin.pubkey(),
+        context.payer.pubkey(),
         msg_buffer_pda,
     );
 
@@ -80,7 +81,7 @@ async fn create_buffer_with_invalid_size_should_fail() {
     );
     let cpi_caller_auth = MessageBufferTestContext::get_mock_cpi_auth();
     let _whitelist = context.whitelist();
-    let admin = context.default_admin();
+    let admin = context.admin();
 
     let (msg_buffer_pda, _) = find_msg_buffer_pda(cpi_caller_auth, pyth_price_acct);
     let invalid_create_buffer_ix = create_msg_buffer_ix(
@@ -89,6 +90,7 @@ async fn create_buffer_with_invalid_size_should_fail() {
         1,
         context.whitelist(),
         admin.pubkey(),
+        context.payer.pubkey(),
         msg_buffer_pda,
     );
 

--- a/pythnet/message_buffer/programs/mock-cpi-caller/tests/cases/test_initialize.rs
+++ b/pythnet/message_buffer/programs/mock-cpi-caller/tests/cases/test_initialize.rs
@@ -15,3 +15,19 @@ async fn test_initialize() {
     assert_eq!(0, allowed_programs_len);
     assert_eq!(allowed_programs, vec![]);
 }
+
+#[tokio::test]
+async fn test_initialize_with_payer_as_admin() {
+    let context = &mut MessageBufferTestContext::initialize_context(false).await;
+    let admin = &context.payer.insecure_clone();
+    let (_, whitelist_bump) = context.initialize(admin).await.unwrap();
+
+    let (whitelist_acct_bump, admin_pubkey, allowed_programs_len, allowed_programs) =
+        context.fetch_whitelist().await.unwrap();
+
+    assert_eq!(whitelist_bump, whitelist_acct_bump);
+    assert_eq!(admin.pubkey(), admin_pubkey);
+
+    assert_eq!(0, allowed_programs_len);
+    assert_eq!(allowed_programs, vec![]);
+}

--- a/pythnet/message_buffer/programs/mock-cpi-caller/tests/cases/test_initialize.rs
+++ b/pythnet/message_buffer/programs/mock-cpi-caller/tests/cases/test_initialize.rs
@@ -3,14 +3,14 @@ use super::*;
 #[tokio::test]
 async fn test_initialize() {
     let context = &mut MessageBufferTestContext::initialize_context(false).await;
-    let admin = context.payer.insecure_clone();
-    let (_, whitelist_bump) = context.initialize(admin).await.unwrap();
+    let admin = Keypair::new();
+    let (_, whitelist_bump) = context.initialize(&admin).await.unwrap();
 
     let (whitelist_acct_bump, admin_pubkey, allowed_programs_len, allowed_programs) =
         context.fetch_whitelist().await.unwrap();
 
     assert_eq!(whitelist_bump, whitelist_acct_bump);
-    assert_eq!(context.payer.pubkey(), admin_pubkey);
+    assert_eq!(admin.pubkey(), admin_pubkey);
 
     assert_eq!(0, allowed_programs_len);
     assert_eq!(allowed_programs, vec![]);

--- a/pythnet/message_buffer/programs/mock-cpi-caller/tests/cases/test_resize_buffer.rs
+++ b/pythnet/message_buffer/programs/mock-cpi-caller/tests/cases/test_resize_buffer.rs
@@ -100,7 +100,7 @@ async fn fail_resize_buffer_invalid_increase() {
     .unwrap();
 
     let whitelist = context.whitelist();
-    let admin = context.default_admin();
+    let admin = context.admin();
     let cpi_caller_auth = MessageBufferTestContext::get_mock_cpi_auth();
     let pyth_price_acct = MessageBufferTestContext::default_pyth_price_account();
     let (msg_buffer_pda, msg_buffer_bump) = MessageBufferTestContext::default_msg_buffer();
@@ -115,6 +115,7 @@ async fn fail_resize_buffer_invalid_increase() {
         target_size,
         whitelist,
         admin.pubkey(),
+        context.payer.pubkey(),
         msg_buffer_pda,
     );
 
@@ -154,6 +155,7 @@ async fn fail_resize_buffer_invalid_increase() {
         target_size,
         whitelist,
         admin.pubkey(),
+        context.payer.pubkey(),
         msg_buffer_pda,
     );
 
@@ -259,7 +261,7 @@ async fn fail_resize_initialized_buffer() {
     .unwrap();
 
     let payer = context.payer.pubkey();
-    let admin = context.default_admin();
+    let admin = context.admin();
     let pyth_price_acct = MessageBufferTestContext::default_pyth_price_account();
     let whitelist = context.whitelist();
     let cpi_caller_auth = MessageBufferTestContext::get_mock_cpi_auth();
@@ -295,6 +297,7 @@ async fn fail_resize_initialized_buffer() {
         target_size,
         whitelist,
         admin.pubkey(),
+        context.payer.pubkey(),
         msg_buffer_pda,
     );
 
@@ -317,6 +320,7 @@ async fn fail_resize_initialized_buffer() {
         target_size,
         whitelist,
         admin.pubkey(),
+        context.payer.pubkey(),
         msg_buffer_pda,
     );
 
@@ -341,7 +345,7 @@ async fn fail_resize_buffer_exceed_max_size() {
     .unwrap();
 
     let whitelist = context.whitelist();
-    let admin = context.default_admin();
+    let admin = context.admin();
     let cpi_caller_auth = MessageBufferTestContext::get_mock_cpi_auth();
     let pyth_price_acct = MessageBufferTestContext::default_pyth_price_account();
     let (msg_buffer_pda, _msg_buffer_bump) = MessageBufferTestContext::default_msg_buffer();
@@ -356,6 +360,7 @@ async fn fail_resize_buffer_exceed_max_size() {
             target_size,
             whitelist,
             admin.pubkey(),
+            context.payer.pubkey(),
             msg_buffer_pda,
         );
 
@@ -370,6 +375,7 @@ async fn fail_resize_buffer_exceed_max_size() {
         target_size,
         whitelist,
         admin.pubkey(),
+        context.payer.pubkey(),
         msg_buffer_pda,
     );
 

--- a/pythnet/message_buffer/programs/mock-cpi-caller/tests/cases/test_set_allowed_programs.rs
+++ b/pythnet/message_buffer/programs/mock-cpi-caller/tests/cases/test_set_allowed_programs.rs
@@ -3,8 +3,8 @@ use super::*;
 #[tokio::test]
 async fn test_set_allowed_programs() {
     let context = &mut MessageBufferTestContext::initialize_context(false).await;
-    let admin = context.default_admin();
-    context.initialize(admin).await.unwrap();
+    let admin = Keypair::new();
+    context.initialize(&admin).await.unwrap();
 
 
     let mock_cpi_caller_auth = MessageBufferTestContext::get_mock_cpi_auth();

--- a/pythnet/message_buffer/scripts/setup_message_buffer.ts
+++ b/pythnet/message_buffer/scripts/setup_message_buffer.ts
@@ -43,7 +43,7 @@ const messageBufferProgram = new Program(
   provider
 ) as unknown as Program<MessageBuffer>;
 
-const whitelistAdmin = payer;
+const whitelistAdmin = anchor.web3.Keypair.generate();
 
 const MESSAGE = Buffer.from("message");
 const [whitelistPubkey, whitelistBump] =
@@ -86,10 +86,8 @@ async function main() {
     ...(await provider.connection.getLatestBlockhash()),
   });
 
-  const whitelistAdminBalance = await provider.connection.getBalance(
-    whitelistAdmin.publicKey
-  );
-  console.log(`whitelistAdminBalance: ${whitelistAdminBalance}`);
+  const payerBalance = await provider.connection.getBalance(payer.publicKey);
+  console.log(`payerBalance: ${payerBalance}`);
   console.log("Airdrop complete");
   console.groupEnd();
 
@@ -103,7 +101,9 @@ async function main() {
       .initialize()
       .accounts({
         admin: whitelistAdmin.publicKey,
+        payer: payer.publicKey,
       })
+      .signers([whitelistAdmin, payer])
       .rpc();
 
     console.log(`initializeTxnSig: ${initializeTxnSig}`);

--- a/pythnet/message_buffer/scripts/setup_message_buffer.ts
+++ b/pythnet/message_buffer/scripts/setup_message_buffer.ts
@@ -43,7 +43,7 @@ const messageBufferProgram = new Program(
   provider
 ) as unknown as Program<MessageBuffer>;
 
-const whitelistAdmin = anchor.web3.Keypair.generate();
+const whitelistAdmin = payer;
 
 const MESSAGE = Buffer.from("message");
 const [whitelistPubkey, whitelistBump] =


### PR DESCRIPTION
add payer to all contexts requiring lamports for rent separate from admin

Note - this should still work in the case that `admin` & `payer` are the same 