### PR TITLE
Fix path to CW sdk

### DIFF
--- a/.github/workflows/publish-pyth-sdk-cw.yml
+++ b/.github/workflows/publish-pyth-sdk-cw.yml
@@ -16,4 +16,4 @@ jobs:
       - run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        working-directory: "target_chains/cosmwasm/pyth-sdk-cw"
+        working-directory: "target_chains/cosmwasm/sdk/rust"


### PR DESCRIPTION
we moved this and never fixed the publish workflow