### PR TITLE
[eth] Update accumulator deserialization

### DIFF
--- a/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
@@ -159,7 +159,11 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
                         revert PythErrors.InvalidUpdateData();
 
                     // This field is not used
-                    // uint32 storageIndex = UnsafeBytesLib.toUint32(encodedPayload, payloadoffset);
+                    // uint64 slot = UnsafeBytesLib.toUint64(encodedPayload, payloadoffset);
+                    payloadoffset += 8;
+
+                    // This field is not used
+                    // uint32 ringSize = UnsafeBytesLib.toUint32(encodedPayload, payloadoffset);
                     payloadoffset += 4;
 
                     digest = bytes20(

--- a/target_chains/ethereum/contracts/forge-test/utils/PythTestUtils.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/utils/PythTestUtils.t.sol
@@ -124,7 +124,8 @@ abstract contract PythTestUtils is Test, WormholeTestUtils {
         bytes memory wormholePayload = abi.encodePacked(
             uint32(0x41555756), // PythAccumulator.ACCUMULATOR_WORMHOLE_MAGIC
             uint8(PythAccumulator.UpdateType.WormholeMerkle),
-            uint32(0), // Storage index, not used in target networks
+            uint64(0), // Slot, not used in target networks
+            uint32(0), // Ring size, not used in target networks
             rootDigest
         );
 


### PR DESCRIPTION
We have changed the WormholeMerkle vaa payload slightly for hermes. This PR updates the eth implementation to address that too.