### PR TITLE
Choose unique VAA for query time if it exists

### DIFF
--- a/price_service/server/src/listen.ts
+++ b/price_service/server/src/listen.ts
@@ -28,7 +28,7 @@ export type PriceInfo = {
   seqNum: number;
   publishTime: TimestampInSec;
   attestationTime: TimestampInSec;
-  lastAttestedPublishTime: TimestampInSec,
+  lastAttestedPublishTime: TimestampInSec;
   priceFeed: PriceFeed;
   emitterChainId: number;
   priceServiceReceiveTime: number;
@@ -98,7 +98,12 @@ export class VaaCache {
     this.cacheCleanupLoopInterval = cacheCleanupLoopInterval;
   }
 
-  set(key: VaaKey, publishTime: TimestampInSec, lastAttestedPublishTime: TimestampInSec, vaa: string): void {
+  set(
+    key: VaaKey,
+    publishTime: TimestampInSec,
+    lastAttestedPublishTime: TimestampInSec,
+    vaa: string
+  ): void {
     if (this.cache.has(key)) {
       this.cache.get(key)!.push({ publishTime, lastAttestedPublishTime, vaa });
     } else {
@@ -113,12 +118,6 @@ export class VaaCache {
       const vaaConf = this.find(this.cache.get(key)!, publishTime);
       return vaaConf;
     }
-  }
-
-  // insert elt into array. Assumes that array is sorted by publishTime first and lastAttestedPublishTime second
-  // and maintains that invariant.
-  private insert(array: VaaConfig[], elt: VaaConfig) {
-    if (array.length == 0)
   }
 
   private find(
@@ -137,7 +136,10 @@ export class VaaCache {
 
     while (left <= right) {
       const middle = Math.floor((left + right) / 2);
-      if (arr[middle].publishTime === publishTime && arr[middle]) {
+      if (
+        arr[middle].publishTime === publishTime &&
+        arr[middle].lastAttestedPublishTime < publishTime
+      ) {
         return arr[middle];
       } else if (arr[middle].publishTime < publishTime) {
         left = middle + 1;

--- a/price_service/server/src/rest.ts
+++ b/price_service/server/src/rest.ts
@@ -67,6 +67,11 @@ function asyncWrapper(
   };
 }
 
+export type VaaResponse = {
+  publishTime: number;
+  vaa: string;
+};
+
 export class RestAPI {
   private port: number;
   private priceFeedVaaInfo: PriceStore;
@@ -92,12 +97,18 @@ export class RestAPI {
   async getVaaWithDbLookup(
     priceFeedId: string,
     publishTime: TimestampInSec
-  ): Promise<VaaConfig | undefined> {
+  ): Promise<VaaResponse | undefined> {
     // Try to fetch the vaa from the local cache
-    let vaa = this.priceFeedVaaInfo.getVaa(priceFeedId, publishTime);
+    const vaaConfig = this.priceFeedVaaInfo.getVaa(priceFeedId, publishTime);
+    let vaa: VaaResponse | undefined = undefined;
 
     // if publishTime is older than cache ttl or vaa is not found, fetch from db
-    if (vaa === undefined && this.dbApiEndpoint && this.dbApiCluster) {
+    if (vaaConfig !== undefined) {
+      vaa = {
+        vaa: vaaConfig.vaa,
+        publishTime: vaaConfig.publishTime,
+      };
+    } else if (vaa === undefined && this.dbApiEndpoint && this.dbApiCluster) {
       const priceFeedWithoutLeading0x = removeLeading0x(priceFeedId);
 
       try {

--- a/wormhole_attester/sdk/js/src/index.ts
+++ b/wormhole_attester/sdk/js/src/index.ts
@@ -34,6 +34,7 @@ export type PriceAttestation = {
   prevPublishTime: UnixTimestamp;
   prevPrice: string;
   prevConf: string;
+  lastAttestedPublishTime: UnixTimestamp;
 };
 
 export type BatchPriceAttestation = {
@@ -94,6 +95,9 @@ export function parsePriceAttestation(bytes: Buffer): PriceAttestation {
   const prevConf = bytes.readBigUint64BE(offset).toString();
   offset += 8;
 
+  const lastAttestedPublishTime = Number(bytes.readBigInt64BE(offset));
+  offset += 8;
+
   return {
     productId,
     priceId,
@@ -110,6 +114,7 @@ export function parsePriceAttestation(bytes: Buffer): PriceAttestation {
     prevPublishTime,
     prevPrice,
     prevConf,
+    lastAttestedPublishTime,
   };
 }
 


### PR DESCRIPTION
The current get_vaa endpoint returns any vaa whose publishTime equals that of the query. However, there can be more than one such VAA, in which case the server picks arbitrarily. This PR changes the behavior to choose the unique VAA for that time based on lastAttestedPublishTime. 

Note that this PR is imperfect in that it only fixes the problem if the desired VAA is in the cache. If the VAA is not in the cache, we can return a different VAA (either from the cache or the database). We unfortunately can't solve that problem without changing the database schema to include lastAttestedPublishTime, which doesn't seem worthwhile right now. Let's just remember to add that column when indexing the accumulator data.