### PR TITLE
Ethereum/parse price feed updates accumulators

### DIFF
--- a/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
@@ -478,7 +478,7 @@ abstract contract Pyth is
                         ) {
                             priceFeeds[k].id = 0;
                         } else {
-                            setPriceFeedsInfo(
+                            fillPriceFeedsInfo(
                                 priceFeeds,
                                 k,
                                 accumulatorPriceId,
@@ -582,11 +582,12 @@ abstract contract Pyth is
     }
 
     function getPriceFeedsIndex(
-        bytes32[] memory priceIds,
+        bytes32[] calldata priceIds,
         bytes32 targetPriceId
     ) private pure returns (uint index) {
         uint k = 0;
-        for (; k < priceIds.length; k++) {
+        uint len = priceIds.length;
+        for (; k < len; k++) {
             if (priceIds[k] == targetPriceId) {
                 break;
             }
@@ -594,7 +595,7 @@ abstract contract Pyth is
         return k;
     }
 
-    function setPriceFeedsInfo(
+    function fillPriceFeedsInfo(
         PythStructs.PriceFeed[] memory priceFeeds,
         uint k,
         bytes32 priceId,

--- a/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
@@ -476,7 +476,7 @@ abstract contract Pyth is
                             publishTime >= minPublishTime &&
                             publishTime <= maxPublishTime
                         ) {
-                            fillPriceFeedsInfo(
+                            fillPriceFeedFromPriceInfo(
                                 priceFeeds,
                                 k,
                                 accumulatorPriceId,
@@ -546,7 +546,7 @@ abstract contract Pyth is
                             publishTime >= minPublishTime &&
                             publishTime <= maxPublishTime
                         ) {
-                            fillPriceFeedsInfo(
+                            fillPriceFeedFromPriceInfo(
                                 priceFeeds,
                                 k,
                                 priceId,
@@ -582,7 +582,7 @@ abstract contract Pyth is
         return k;
     }
 
-    function fillPriceFeedsInfo(
+    function fillPriceFeedFromPriceInfo(
         PythStructs.PriceFeed[] memory priceFeeds,
         uint k,
         bytes32 priceId,

--- a/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
@@ -11,7 +11,6 @@ import "./PythAccumulator.sol";
 import "./PythGetters.sol";
 import "./PythSetters.sol";
 import "./PythInternalStructs.sol";
-import "forge-std/console.sol";
 
 abstract contract Pyth is
     PythGetters,

--- a/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
@@ -274,7 +274,7 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
             bool valid;
             (valid, endOffset) = MerkleTree.isProofValid(
                 encodedProof,
-                offset, // proofOffset
+                offset,
                 merkleRoot,
                 encodedMessage
             );

--- a/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
@@ -13,8 +13,6 @@ import "./PythInternalStructs.sol";
 
 import "../libraries/MerkleTree.sol";
 
-import "forge-std/console.sol";
-
 abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
     uint32 constant ACCUMULATOR_MAGIC = 0x504e4155; // Stands for PNAU (Pyth Network Accumulator Update)
     uint32 constant ACCUMULATOR_WORMHOLE_MAGIC = 0x41555756; // Stands for AUWV (Accumulator Update Wormhole Verficiation)

--- a/target_chains/ethereum/contracts/forge-test/Pyth.WormholeMerkleAccumulator.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pyth.WormholeMerkleAccumulator.t.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "forge-std/Test.sol";
-import "forge-std/console.sol";
 
 import "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
 import "@pythnetwork/pyth-sdk-solidity/PythErrors.sol";
@@ -90,7 +89,6 @@ contract PythWormholeMerkleAccumulatorTest is
         setRandSeed(seed);
 
         uint numPriceFeeds = (getRandUint() % 10) + 1;
-        console.log("generating price feed messages");
         PriceFeedMessage[]
             memory priceFeedMessages = generateRandomPriceFeedMessage(
                 numPriceFeeds
@@ -99,19 +97,15 @@ contract PythWormholeMerkleAccumulatorTest is
             bytes[] memory updateData,
             uint updateFee
         ) = createWormholeMerkleUpdateData(priceFeedMessages);
-        console.log("generated price feed messages");
-        console.log("updating price feeds");
+
         pyth.updatePriceFeeds{value: updateFee}(updateData);
 
-        console.log("first assert");
         for (uint i = 0; i < numPriceFeeds; i++) {
             assertPriceFeedMessageStored(priceFeedMessages[i]);
         }
 
-        console.log("updating price feeds again");
         // Update the prices again with the same data should work
         pyth.updatePriceFeeds{value: updateFee}(updateData);
-        console.log("finished updatePriceFeeds");
 
         for (uint i = 0; i < numPriceFeeds; i++) {
             assertPriceFeedMessageStored(priceFeedMessages[i]);
@@ -131,11 +125,9 @@ contract PythWormholeMerkleAccumulatorTest is
             priceFeedMessages[i].emaConf = getRandUint64();
         }
 
-        console.log("creating wh merkle update data");
         (updateData, updateFee) = createWormholeMerkleUpdateData(
             priceFeedMessages
         );
-        console.log("created wh merkle update data");
 
         pyth.updatePriceFeeds{value: updateFee}(updateData);
 
@@ -440,7 +432,6 @@ contract PythWormholeMerkleAccumulatorTest is
         setRandSeed(seed);
 
         uint numPriceFeeds = (getRandUint() % 10) + 1;
-        console.log("numPriceFeeds: %d", numPriceFeeds);
         PriceFeedMessage[]
             memory priceFeedMessages = generateRandomPriceFeedMessage(
                 numPriceFeeds
@@ -453,8 +444,6 @@ contract PythWormholeMerkleAccumulatorTest is
         for (uint i = 0; i < numPriceFeeds; i++) {
             priceIds[i] = priceFeedMessages[i].priceId;
         }
-        console.log("generated price feed messages");
-        console.log("parsing  price feeds");
         PythStructs.PriceFeed[] memory priceFeeds = pyth.parsePriceFeedUpdates{
             value: updateFee
         }(updateData, priceIds, 0, MAX_UINT64);
@@ -479,47 +468,6 @@ contract PythWormholeMerkleAccumulatorTest is
                 priceFeedMessages[i].publishTime
             );
         }
-        /*
-        console.log("first assert");
-        for (uint i = 0; i < numPriceFeeds; i++) {
-            assertPriceFeedMessageStored(priceFeedMessages[i]);
-        }
-
-        console.log("updating price feeds again");
-        // Update the prices again with the same data should work
-        pyth.updatePriceFeeds{value: updateFee}(updateData);
-        console.log("finished updatePriceFeeds");
-
-        for (uint i = 0; i < numPriceFeeds; i++) {
-            assertPriceFeedMessageStored(priceFeedMessages[i]);
-        }
-
-        // Update the prices again with updated data should update the prices
-        for (uint i = 0; i < numPriceFeeds; i++) {
-            priceFeedMessages[i].price = getRandInt64();
-            priceFeedMessages[i].conf = getRandUint64();
-            priceFeedMessages[i].expo = getRandInt32();
-
-            // Increase the publish time if it is not causing an overflow
-            if (priceFeedMessages[i].publishTime != type(uint64).max) {
-                priceFeedMessages[i].publishTime += 1;
-            }
-            priceFeedMessages[i].emaPrice = getRandInt64();
-            priceFeedMessages[i].emaConf = getRandUint64();
-        }
-
-        console.log("creating wh merkle update data");
-        (updateData, updateFee) = createWormholeMerkleUpdateData(
-            priceFeedMessages
-        );
-        console.log("created wh merkle update data");
-
-
-        pyth.updatePriceFeeds{value: updateFee}(updateData);
-
-        for (uint i = 0; i < numPriceFeeds; i++) {
-            assertPriceFeedMessageStored(priceFeedMessages[i]);
-        }
-        */
+        // TODO: add more tests
     }
 }

--- a/target_chains/ethereum/contracts/forge-test/Pyth.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pyth.t.sol
@@ -15,7 +15,7 @@ import "./utils/RandTestUtils.t.sol";
 contract PythTest is Test, WormholeTestUtils, PythTestUtils, RandTestUtils {
     IPyth public pyth;
 
-    // -1 is equal to 0x111111 which is the biggest uint if converted back
+    // -1 is equal to 0xffffff which is the biggest uint if converted back
     uint64 constant MAX_UINT64 = uint64(int64(-1));
 
     function setUp() public {


### PR DESCRIPTION
### Summary
Add support accumulator update data in `parsePriceFeeds`

### Changes
- Refactor `PythAccumulator.sol` and Pyth.sol` and add support for purely parsing
- Add test for parsePriceFeedUpdates with Accumulator update data