### PR TITLE
[pythnet-sdk] Add merkleRoot

### DIFF
--- a/governance/xc_admin/packages/xc_admin_cli/src/index.ts
+++ b/governance/xc_admin/packages/xc_admin_cli/src/index.ts
@@ -29,6 +29,7 @@ import {
   proposeArbitraryPayload,
   proposeInstructions,
   WORMHOLE_ADDRESS,
+  WormholeMultisigInstruction,
 } from "xc_admin_common";
 import { pythOracleProgram } from "@pythnetwork/client";
 import { Wallet } from "@coral-xyz/anchor/dist/cjs/provider";
@@ -297,6 +298,10 @@ program
         2
       )
     );
+
+    if (parsed[0] instanceof WormholeMultisigInstruction) {
+      console.log(parsed[0].args.payload.toString("hex"));
+    }
   });
 
 multisigCommand("approve", "Approve a transaction sitting in the multisig")

--- a/governance/xc_admin/packages/xc_admin_cli/src/index.ts
+++ b/governance/xc_admin/packages/xc_admin_cli/src/index.ts
@@ -29,7 +29,6 @@ import {
   proposeArbitraryPayload,
   proposeInstructions,
   WORMHOLE_ADDRESS,
-  WormholeMultisigInstruction,
 } from "xc_admin_common";
 import { pythOracleProgram } from "@pythnetwork/client";
 import { Wallet } from "@coral-xyz/anchor/dist/cjs/provider";
@@ -298,10 +297,6 @@ program
         2
       )
     );
-
-    if (parsed[0] instanceof WormholeMultisigInstruction) {
-      console.log(parsed[0].args.payload.toString("hex"));
-    }
   });
 
 multisigCommand("approve", "Approve a transaction sitting in the multisig")


### PR DESCRIPTION
Adds an extra struct MerkleRoot that is just a tuple struct that wraps the actual root as a hash.
This struct is exported and is useful to check proofs when you don't have access to the element set of the tree.