### PR TITLE
[pythnet-sdk] Expose MerkleTree

### DIFF
--- a/pythnet/pythnet_sdk/src/wire.rs
+++ b/pythnet/pythnet_sdk/src/wire.rs
@@ -127,11 +127,13 @@ pub mod v1 {
 mod tests {
     use crate::wire::{
         array,
+        v1::{
+            AccumulatorUpdateData,
+            Proof,
+        },
         Deserializer,
         PrefixedVec,
         Serializer,
-        v1::AccumulatorUpdateData,
-        v1::Proof,
     };
 
     // Test the arbitrary fixed sized array serialization implementation.
@@ -351,7 +353,7 @@ mod tests {
         use serde::Serialize;
         // Serialize an empty update into a buffer.
         let empty_update = AccumulatorUpdateData::new(Proof::WormholeMerkle {
-            vaa: PrefixedVec::from(vec![]),
+            vaa:     PrefixedVec::from(vec![]),
             updates: vec![],
         });
         let mut buffer = Vec::new();


### PR DESCRIPTION
The Merkle implementation in PythNet SDK has been tied heavily to the Accumulator interface, this generalizes the interface out a bit into all the functionality required to work with just a MerkleTree (which happens to implement the Accumulator interface) in such a way it can be used for other PythNet tasks.