### PR TITLE
[pythnet-sdk] Allow as_bytes()/to_bytes() for MerkleRoot/MerklePath

### DIFF
--- a/pythnet/pythnet_sdk/src/accumulators/merkle.rs
+++ b/pythnet/pythnet_sdk/src/accumulators/merkle.rs
@@ -36,11 +36,33 @@ const NODE_PREFIX: &[u8] = &[1];
 const NULL_PREFIX: &[u8] = &[2];
 
 /// A MerklePath contains a list of hashes that form a proof for membership in a tree.
-#[derive(Clone, Default, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Default,
+    Debug,
+    Hash,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
 pub struct MerklePath<H: Hasher>(Vec<H::Hash>);
 
 /// A MerkleRoot contains the root hash of a MerkleTree.
-#[derive(Clone, Default, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Default,
+    Debug,
+    Hash,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
 pub struct MerkleRoot<H: Hasher>(H::Hash);
 
 /// A MerkleTree is a binary tree where each node is the hash of its children.
@@ -48,8 +70,10 @@ pub struct MerkleRoot<H: Hasher>(H::Hash);
     Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize, Default,
 )]
 pub struct MerkleTree<H: Hasher = Keccak256> {
-    pub root:  MerkleRoot<H>,
+    pub root: MerkleRoot<H>,
+
     #[serde(skip)]
+    #[borsh_skip]
     pub nodes: Vec<H::Hash>,
 }
 

--- a/pythnet/pythnet_sdk/src/accumulators/merkle.rs
+++ b/pythnet/pythnet_sdk/src/accumulators/merkle.rs
@@ -68,6 +68,10 @@ impl<H: Hasher> MerkleRoot<H> {
         }
         current == self.0
     }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_ref()
+    }
 }
 
 /// Implements functionality for working with MerklePath (proofs).
@@ -75,6 +79,13 @@ impl<H: Hasher> MerklePath<H> {
     /// Given a Vector of hashes representing a merkle proof, construct a MerklePath.
     pub fn new(path: Vec<H::Hash>) -> Self {
         Self(path)
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0
+            .iter()
+            .flat_map(|hash| hash.as_ref().to_vec())
+            .collect()
     }
 }
 

--- a/pythnet/pythnet_sdk/src/hashers.rs
+++ b/pythnet/pythnet_sdk/src/hashers.rs
@@ -1,4 +1,8 @@
 use {
+    borsh::{
+        BorshDeserialize,
+        BorshSerialize,
+    },
     serde::{
         Deserialize,
         Serialize,
@@ -21,17 +25,18 @@ where
     Self: Clone,
     Self: Debug,
     Self: Default,
-    Self: Serialize,
 {
     type Hash: Copy
         + AsRef<[u8]>
+        + BorshSerialize
+        + BorshDeserialize
         + Debug
         + Default
         + Eq
         + std::hash::Hash
         + PartialOrd
         + PartialEq
-        + serde::Serialize
+        + Serialize
         + for<'a> Deserialize<'a>;
 
     fn hashv(data: &[impl AsRef<[u8]>]) -> Self::Hash;


### PR DESCRIPTION
This allows getting the byte representation of a MerkleRoot/MerklePath. The MerkleRoot is a transparent as_bytes(), for MerklePath we don't have a byte slice representation so we provide to_bytes() - note that this implies a serialization format but It's a reasonable one, where it simply returns `Component_1 || Component_2 || ... || Component_n`. A `Serialize` trait exists on the type for other serialization choices, the byte methods are merely meant to be the easiest reasonable compact representations for the merkle components. Additionally, this applies BorshSerialize/Deserialize to the remaining types for full coverage for Anchor usage.