### PR TITLE
[ethereum] - charge updateFee per number of updates

### DIFF
--- a/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
@@ -624,12 +624,6 @@ abstract contract Pyth is
         return totalNumUpdates * singleUpdateFeeInWei();
     }
 
-    function getFeeBatch(
-        uint updateDataLength
-    ) private view returns (uint requiredFee) {
-        return updateDataLength * singleUpdateFeeInWei();
-    }
-
     function findIndexOfPriceId(
         bytes32[] calldata priceIds,
         bytes32 targetPriceId

--- a/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
@@ -118,16 +118,10 @@ abstract contract Pyth is
                 if (updateType != UpdateType.WormholeMerkle) {
                     revert PythErrors.InvalidUpdateData();
                 }
-                (
-                    ,
-                    ,
-                    uint8 numUpdates,
-
-                ) = extractWormholeMerkleHeaderDigestAndNumUpdatesAndEncodedFromAccumulatorUpdate(
-                        updateData[i],
-                        offset
-                    );
-                totalNumUpdates += numUpdates;
+                totalNumUpdates += parseWormholeMerkleHeaderNumUpdates(
+                    updateData[i],
+                    offset
+                );
             }
         }
 

--- a/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
@@ -82,14 +82,12 @@ abstract contract Pyth is
                 );
             } else {
                 updatePriceBatchFromVm(updateData[i]);
+                totalNumUpdates += 1;
             }
 
             unchecked {
                 i++;
             }
-        }
-        if (totalNumUpdates == 0) {
-            totalNumUpdates = updateData.length;
         }
         uint requiredFee = getTotalFee(totalNumUpdates);
         if (msg.value < requiredFee) revert PythErrors.InsufficientFee();
@@ -122,11 +120,9 @@ abstract contract Pyth is
                     updateData[i],
                     offset
                 );
+            } else {
+                totalNumUpdates += 1;
             }
-        }
-
-        if (totalNumUpdates == 0) {
-            totalNumUpdates = updateData.length;
         }
         return getTotalFee(totalNumUpdates);
     }
@@ -604,6 +600,7 @@ abstract contract Pyth is
 
                         index += attestationSize;
                     }
+                    totalNumUpdates += 1;
                 }
             }
 
@@ -614,9 +611,6 @@ abstract contract Pyth is
             }
 
             {
-                if (totalNumUpdates == 0) {
-                    totalNumUpdates = updateData.length;
-                }
                 uint requiredFee = getTotalFee(totalNumUpdates);
                 if (msg.value < requiredFee)
                     revert PythErrors.InsufficientFee();

--- a/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
@@ -185,6 +185,19 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
         }
     }
 
+    function parseWormholeMerkleHeaderNumUpdates(
+        bytes calldata wormholeMerkleUpdate,
+        uint offset
+    ) internal view returns (uint8 numUpdates) {
+        uint16 whProofSize = UnsafeBytesLib.toUint16(
+            wormholeMerkleUpdate,
+            offset
+        );
+        offset += 2;
+        offset += whProofSize;
+        numUpdates = UnsafeBytesLib.toUint8(wormholeMerkleUpdate, offset);
+    }
+
     function extractPriceInfoFromMerkleProof(
         bytes20 digest,
         bytes memory encoded,

--- a/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
@@ -185,19 +185,6 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
         }
     }
 
-    function parseWormholeMerkleHeaderNumUpdates(
-        bytes calldata wormholeMerkleUpdate,
-        uint offset
-    ) internal view returns (uint8 numUpdates) {
-        uint16 whProofSize = UnsafeBytesLib.toUint16(
-            wormholeMerkleUpdate,
-            offset
-        );
-        offset += 2;
-        offset += whProofSize;
-        numUpdates = UnsafeBytesLib.toUint8(wormholeMerkleUpdate, offset);
-    }
-
     function extractPriceInfoFromMerkleProof(
         bytes20 digest,
         bytes memory encoded,

--- a/target_chains/ethereum/contracts/forge-test/GasBenchmark.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/GasBenchmark.t.sol
@@ -340,9 +340,12 @@ contract GasBenchmark is Test, WormholeTestUtils, PythTestUtils {
         ids[0] = priceIds[4];
         ids[1] = priceIds[2];
         ids[2] = priceIds[0];
-        pyth.parsePriceFeedUpdates{
-            value: freshPricesWhMerkleUpdateFee[numIds - 1]
-        }(freshPricesWhMerkleUpdateData[4], ids, 0, 50);
+        pyth.parsePriceFeedUpdates{value: freshPricesWhMerkleUpdateFee[4]}( // updateFee based on number of priceFeeds in updateData
+            freshPricesWhMerkleUpdateData[4],
+            ids,
+            0,
+            50
+        );
     }
 
     function testBenchmarkParsePriceFeedUpdatesWhMerkleForOnePriceFeedNotWithinRange()

--- a/target_chains/ethereum/contracts/forge-test/GasBenchmark.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/GasBenchmark.t.sol
@@ -398,23 +398,23 @@ contract GasBenchmark is Test, WormholeTestUtils, PythTestUtils {
         pyth.getUpdateFee(freshPricesWhBatchUpdateData);
     }
 
-    function testBenchrmarkGetUpdateFeeWhMerkle1() public view {
+    function testBenchmarkGetUpdateFeeWhMerkle1() public view {
         pyth.getUpdateFee(freshPricesWhMerkleUpdateData[0]);
     }
 
-    function testBenchrmarkGetUpdateFeeWhMerkle2() public view {
+    function testBenchmarkGetUpdateFeeWhMerkle2() public view {
         pyth.getUpdateFee(freshPricesWhMerkleUpdateData[1]);
     }
 
-    function testBenchrmarkGetUpdateFeeWhMerkle3() public view {
+    function testBenchmarkGetUpdateFeeWhMerkle3() public view {
         pyth.getUpdateFee(freshPricesWhMerkleUpdateData[2]);
     }
 
-    function testBenchrmarkGetUpdateFeeWhMerkle4() public view {
+    function testBenchmarkGetUpdateFeeWhMerkle4() public view {
         pyth.getUpdateFee(freshPricesWhMerkleUpdateData[3]);
     }
 
-    function testBenchrmarkGetUpdateFeeWhMerkle5() public view {
+    function testBenchmarkGetUpdateFeeWhMerkle5() public view {
         pyth.getUpdateFee(freshPricesWhMerkleUpdateData[4]);
     }
 }

--- a/target_chains/ethereum/contracts/forge-test/GasBenchmark.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/GasBenchmark.t.sol
@@ -394,7 +394,27 @@ contract GasBenchmark is Test, WormholeTestUtils, PythTestUtils {
         pyth.getEmaPrice(priceIds[0]);
     }
 
-    function testBenchmarkGetUpdateFee() public view {
+    function testBenchmarkGetUpdateFeeWhBatch() public view {
         pyth.getUpdateFee(freshPricesWhBatchUpdateData);
+    }
+
+    function testBenchrmarkGetUpdateFeeWhMerkle1() public view {
+        pyth.getUpdateFee(freshPricesWhMerkleUpdateData[0]);
+    }
+
+    function testBenchrmarkGetUpdateFeeWhMerkle2() public view {
+        pyth.getUpdateFee(freshPricesWhMerkleUpdateData[1]);
+    }
+
+    function testBenchrmarkGetUpdateFeeWhMerkle3() public view {
+        pyth.getUpdateFee(freshPricesWhMerkleUpdateData[2]);
+    }
+
+    function testBenchrmarkGetUpdateFeeWhMerkle4() public view {
+        pyth.getUpdateFee(freshPricesWhMerkleUpdateData[3]);
+    }
+
+    function testBenchrmarkGetUpdateFeeWhMerkle5() public view {
+        pyth.getUpdateFee(freshPricesWhMerkleUpdateData[4]);
     }
 }

--- a/target_chains/ethereum/contracts/forge-test/Pyth.WormholeMerkleAccumulator.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pyth.WormholeMerkleAccumulator.t.sol
@@ -520,7 +520,10 @@ contract PythWormholeMerkleAccumulatorTest is
             );
         }
 
-        updateFee = pyth.getUpdateFee(updateData);
+        // manually calculate the fee
+        // so this helper method doesn't trigger the error.
+        // updateFee = pyth.getUpdateFee(numPriceFeeds);
+        updateFee = singleUpdateFeeInWei() * numPriceFeeds;
     }
 
     function testUpdatePriceFeedWithWormholeMerkleRevertsOnWrongVAAPayloadMagic()

--- a/target_chains/ethereum/contracts/forge-test/Pyth.WormholeMerkleAccumulator.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pyth.WormholeMerkleAccumulator.t.sol
@@ -916,6 +916,37 @@ contract PythWormholeMerkleAccumulatorTest is
         );
     }
 
+    function testGetUpdateFeeWorksForWhMerkle() public {
+        uint numPriceFeeds = (getRandUint() % 10) + 1;
+        PriceFeedMessage[]
+            memory priceFeedMessages = generateRandomPriceFeedMessage(
+                numPriceFeeds
+            );
+        (bytes[] memory updateData, ) = createWormholeMerkleUpdateData(
+            priceFeedMessages
+        );
+
+        uint updateFee = pyth.getUpdateFee(updateData);
+        assertEq(updateFee, SINGLE_UPDATE_FEE_IN_WEI * numPriceFeeds);
+    }
+
+    function testGetUpdateFeeWorksForWhMerkleBasedOnNumUpdates() public {
+        uint numPriceFeeds = (getRandUint() % 10) + 1;
+        PriceFeedMessage[]
+            memory priceFeedMessages = generateRandomPriceFeedMessage(
+                numPriceFeeds
+            );
+        // Set the priceId of the second message to be the same as the first.
+        priceFeedMessages[1].priceId = priceFeedMessages[0].priceId;
+        (bytes[] memory updateData, ) = createWormholeMerkleUpdateData(
+            priceFeedMessages
+        );
+
+        uint updateFee = pyth.getUpdateFee(updateData);
+        // updateFee should still be based on numUpdates not distinct number of priceIds
+        assertEq(updateFee, SINGLE_UPDATE_FEE_IN_WEI * numPriceFeeds);
+    }
+
     //TODO: add some tests of forward compatibility.
     // I.e., create a message where each part that can be expanded in size is expanded and make sure that parsing still works
 }

--- a/target_chains/ethereum/contracts/forge-test/utils/PythTestUtils.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/utils/PythTestUtils.t.sol
@@ -24,6 +24,7 @@ abstract contract PythTestUtils is Test, WormholeTestUtils {
     uint16 constant GOVERNANCE_EMITTER_CHAIN_ID = 0x1;
     bytes32 constant GOVERNANCE_EMITTER_ADDRESS =
         0x0000000000000000000000000000000000000000000000000000000000000011;
+    uint constant SINGLE_UPDATE_FEE_IN_WEI = 1;
 
     function setUpPyth(address wormhole) public returns (address) {
         PythUpgradable implementation = new PythUpgradable();
@@ -47,10 +48,14 @@ abstract contract PythTestUtils is Test, WormholeTestUtils {
             GOVERNANCE_EMITTER_ADDRESS,
             0, // Initial governance sequence
             60, // Valid time period in seconds
-            1 // single update fee in wei
+            SINGLE_UPDATE_FEE_IN_WEI // single update fee in wei
         );
 
         return address(pyth);
+    }
+
+    function singleUpdateFeeInWei() public view returns (uint) {
+        return SINGLE_UPDATE_FEE_IN_WEI;
     }
 
     /// Utilities to help generating price attestations and VAAs for them

--- a/target_chains/ethereum/contracts/foundry.toml
+++ b/target_chains/ethereum/contracts/foundry.toml
@@ -1,7 +1,7 @@
 [profile.default]
 solc_version = '0.8.4'
 optimizer = true
-optimizer_runs = 2500
+optimizer_runs = 2000
 src = 'contracts'
 # We put the tests into the forge-test directory (instead of test) so that
 # truffle doesn't try to build them

--- a/target_chains/ethereum/contracts/foundry.toml
+++ b/target_chains/ethereum/contracts/foundry.toml
@@ -1,7 +1,7 @@
 [profile.default]
 solc_version = '0.8.4'
 optimizer = true
-optimizer_runs = 5000
+optimizer_runs = 2000
 src = 'contracts'
 # We put the tests into the forge-test directory (instead of test) so that
 # truffle doesn't try to build them

--- a/target_chains/ethereum/contracts/foundry.toml
+++ b/target_chains/ethereum/contracts/foundry.toml
@@ -1,7 +1,7 @@
 [profile.default]
 solc_version = '0.8.4'
 optimizer = true
-optimizer_runs = 2000
+optimizer_runs = 2500
 src = 'contracts'
 # We put the tests into the forge-test directory (instead of test) so that
 # truffle doesn't try to build them


### PR DESCRIPTION
### Summary
- change `getUpdateFee` to calculate the total fee based on the numUpdates for accumulator updates. Still uses same logic for batch price
- lowers optimizer_runs to 2000 in order to get the bytesize down
    - optimizer_runs = 5000 had deployment size of 25046
    ![image](https://github.com/pyth-network/pyth-crosschain/assets/86628128/5cba7210-861e-479a-b5b6-7036365e854c)
diff between optimizer_runs = 2000 + this branch and main
![image](https://github.com/pyth-network/pyth-crosschain/assets/86628128/9016b84b-e945-443b-a5dc-25eb74f89ed4)
- `getUpdateFeeWhMerkleX` is high b/c the original implementation returned singleUpdateFee * updateData.length
### Note
- Will make separate PR for optimizing bytesize further and increasing optimizer_runs to get as close to original 5000 runs
