### PR TITLE
[hermes] Fix memory leak

### DIFF
--- a/hermes/Cargo.lock
+++ b/hermes/Cargo.lock
@@ -1926,7 +1926,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermes"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/hermes/Cargo.toml
+++ b/hermes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name                           = "hermes"
-version                        = "0.1.0"
+version                        = "0.1.1"
 edition                        = "2021"
 
 [dependencies]

--- a/hermes/src/network/p2p.go
+++ b/hermes/src/network/p2p.go
@@ -203,11 +203,11 @@ func RegisterObservationCallback(f C.callback_t, network_id, bootstrap_addrs, li
 					case *GossipMessage_SignedVaaWithQuorum:
 						vaaBytes := msg.GetSignedVaaWithQuorum().GetVaa()
 						cBytes := C.CBytes(vaaBytes)
-						defer C.free(cBytes)
 						C.invoke(f, C.observation_t{
 							vaa:     (*C.char)(cBytes),
 							vaa_len: C.size_t(len(vaaBytes)),
 						})
+						C.free(cBytes)
 					}
 				}
 			}

--- a/hermes/src/network/p2p.rs
+++ b/hermes/src/network/p2p.rs
@@ -81,6 +81,8 @@ extern "C" fn proxy(o: ObservationC) {
     {
         log::error!("Failed to send observation: {}", e);
     }
+
+    unsafe { libc::free(o.vaa as *mut std::ffi::c_void) };
 }
 
 /// This function handles bootstrapping libp2p (in Go) and listening for Wormhole Observations.

--- a/hermes/src/network/p2p.rs
+++ b/hermes/src/network/p2p.rs
@@ -81,8 +81,6 @@ extern "C" fn proxy(o: ObservationC) {
     {
         log::error!("Failed to send observation: {}", e);
     }
-
-    unsafe { libc::free(o.vaa as *mut std::ffi::c_void) };
 }
 
 /// This function handles bootstrapping libp2p (in Go) and listening for Wormhole Observations.


### PR DESCRIPTION
@thmzlt identified a memory leak in our edge deployment. @Reisen and I worked on investigating it. We had an initial suspicion about libp2p because price service also apparently has a memory leak. Because of that in #876 we added go profiler to hermes. However, after more investigations, we realized that in price-service the node part has a leak and then  it is probably not the libp2p and it's our code.

@Reisen suggested using [heaptrack](https://github.com/KDE/heaptrack) to profile the heap and I created a separate image with heaptrack and deployed it in the cluster. Using `heaptrack_print` (the cli tool) we can get the peak memory usages and after analyzing the logs over time I realized that the memory usages of this part of the code is increasing:

```
PEAK MEMORY CONSUMERS
86.58MB peak memory consumed over 111920 calls from                                                                                                                               
_cgo_7dd252f4a8ad_Cfunc__Cmalloc                                                                                                                                                  
  at /tmp/go-build/_cgo_export.c:53                                                                                                                                               
  in /usr/local/bin/hermes                                                                                                                                                        
86.58MB consumed over 111920 calls from:                                                                                                                                          
    runtime.asmcgocall                                                                                                                                                            
      at /usr/local/go/src/runtime/asm_amd64.s:848                                                                                                                                
      in /usr/local/bin/hermes
```

And then we checked our proxy method for communicating with go and found the issue. The issue was that apparently the go caller of our proxy method doesn't free the input that it passes to the method because the defer in a loop runs after the loop is over. I ran the fix for a couple of hours and the heap grow from this call stopped. 