### PR TITLE
[price-service] Add minSymbols check to liveness

### DIFF
--- a/price_service/server/package.json
+++ b/price_service/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-service-server",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Webservice for retrieving prices from the Pyth oracle.",
   "private": "true",
   "main": "index.js",

--- a/price_service/server/src/rest.ts
+++ b/price_service/server/src/rest.ts
@@ -525,6 +525,7 @@ export class RestAPI {
     app.get("/live", (_, res: Response) => {
       const threshold = 60;
       const stalePriceTreshold = 10;
+      const minimumNumPrices = 100;
 
       const currentTime: TimestampInSec = Math.floor(Date.now() / 1000);
 
@@ -540,7 +541,10 @@ export class RestAPI {
         }
       }
 
-      if (stalePriceCnt > stalePriceTreshold) {
+      if (
+        priceIds.length < minimumNumPrices ||
+        stalePriceCnt > stalePriceTreshold
+      ) {
         res.sendStatus(StatusCodes.SERVICE_UNAVAILABLE);
       } else {
         res.sendStatus(StatusCodes.OK);


### PR DESCRIPTION
Although we have added the staleness check, there is a case that spy never connects to price service and it causes the liveness to return OK whereas it has no price feeds. This PR adds a check for a min price feed number in the liveness. 

This is not ideal that we are adding constants in the liveness and ideally they should be configurable, but as this service is going to sunset in favor of hermes it's fine. We should have a better liveness and readiness metric on hermes. 