### PR TITLE
[xc-admin] Contract management tool

### DIFF
--- a/governance/xc_admin/packages/xc_admin_cli/package.json
+++ b/governance/xc_admin/packages/xc_admin_cli/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsc",
     "format": "prettier --write \"src/**/*.ts\"",
-    "cli": "npm run build && node lib/contracts/cli.js"
+    "cli": "npm run build && node lib/cli.js"
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.26.0",

--- a/governance/xc_admin/packages/xc_admin_cli/package.json
+++ b/governance/xc_admin/packages/xc_admin_cli/package.json
@@ -16,7 +16,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "format": "prettier --write \"src/**/*.ts\""
+    "format": "prettier --write \"src/**/*.ts\"",
+    "cli": "npm run build && node lib/contracts/cli.js"
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.26.0",

--- a/governance/xc_admin/packages/xc_admin_cli/src/cli.ts
+++ b/governance/xc_admin/packages/xc_admin_cli/src/cli.ts
@@ -1,7 +1,5 @@
-import { ContractType } from "xc_admin_common/lib/contracts/Contract";
-import { loadContractConfig } from "xc_admin_common/lib/contracts/config";
+import { loadContractConfig, ContractType } from "xc_admin_common";
 
-// TODO: load these from files
 const contractsConfig = [
   {
     type: ContractType.EvmPythUpgradable,

--- a/governance/xc_admin/packages/xc_admin_cli/src/cli.ts
+++ b/governance/xc_admin/packages/xc_admin_cli/src/cli.ts
@@ -1,5 +1,7 @@
-import { ContractType, EvmPythUpgradable, loadFromConfig } from "./Contract";
+import { ContractType } from "xc_admin_common/lib/contracts/Contract";
+import { loadContractConfig } from "xc_admin_common/lib/contracts/config";
 
+// TODO: load these from files
 const contractsConfig = [
   {
     type: ContractType.EvmPythUpgradable,
@@ -40,16 +42,15 @@ const networksConfig = {
   },
 };
 
-async function checkEvmPythUpgradableState(
-  contract: EvmPythUpgradable,
-  state: EvmPythUpgradableState
-) {
-  if ((await contract.wormholeAddress()) !== state.wormholeAddress) {
-  }
-}
+const multisigs = [
+  {
+    name: "",
+    wormholeNetwork: "mainnet",
+  },
+];
 
 async function main() {
-  const contracts = loadFromConfig(contractsConfig, networksConfig);
+  const contracts = loadContractConfig(contractsConfig, networksConfig);
 
   for (const contract of contracts) {
     const state = await contract.getState();
@@ -59,6 +60,14 @@ async function main() {
       type: contract.type,
       state: state,
     });
+  }
+
+  const state = await contracts[0].getState();
+  state["validTimePeriod"] = 30;
+
+  const ops = await contracts[0].sync(state);
+  for (const op of ops) {
+    console.log(op);
   }
 }
 

--- a/governance/xc_admin/packages/xc_admin_cli/src/cli.ts
+++ b/governance/xc_admin/packages/xc_admin_cli/src/cli.ts
@@ -2,6 +2,7 @@ import { program } from "commander";
 import { loadContractConfig, ContractType, SyncOp } from "xc_admin_common";
 import * as fs from "fs";
 
+// TODO: extract this configuration to a file
 const contractsConfig = [
   {
     type: ContractType.EvmPythUpgradable,
@@ -56,7 +57,7 @@ program
   .version("0.1.0");
 
 program
-  .command("search")
+  .command("get")
   .description("Find Pyth contracts matching the given search criteria")
   .option("-n, --network <network-id>", "Find contracts on the given network")
   .option("-a, --address <address>", "Find contracts with the given address")

--- a/governance/xc_admin/packages/xc_admin_common/package.json
+++ b/governance/xc_admin/packages/xc_admin_common/package.json
@@ -17,14 +17,17 @@
   "scripts": {
     "build": "tsc",
     "format": "prettier --write \"src/**/*.ts\"",
-    "test": "jest"
+    "test": "jest",
+    "cli": "npm run build && node lib/contracts/cli.js"
   },
   "dependencies": {
     "@certusone/wormhole-sdk": "^0.9.8",
     "@pythnetwork/client": "^2.17.0",
+    "@pythnetwork/pyth-sdk-solidity": "*",
     "@solana/buffer-layout": "^4.0.1",
     "@solana/web3.js": "^1.73.0",
     "@sqds/mesh": "^1.0.6",
+    "ethers": "^6.5.1",
     "lodash": "^4.17.21",
     "typescript": "^4.9.4"
   },

--- a/governance/xc_admin/packages/xc_admin_common/package.json
+++ b/governance/xc_admin/packages/xc_admin_common/package.json
@@ -27,7 +27,7 @@
     "@solana/buffer-layout": "^4.0.1",
     "@solana/web3.js": "^1.73.0",
     "@sqds/mesh": "^1.0.6",
-    "ethers": "^6.5.1",
+    "ethers": "^5.7.2",
     "lodash": "^4.17.21",
     "typescript": "^4.9.4"
   },

--- a/governance/xc_admin/packages/xc_admin_common/package.json
+++ b/governance/xc_admin/packages/xc_admin_common/package.json
@@ -24,6 +24,7 @@
     "@coral-xyz/anchor": "^0.26.0",
     "@pythnetwork/client": "^2.17.0",
     "@pythnetwork/pyth-sdk-solidity": "*",
+    "@pythnetwork/xc-governance-sdk": "*",
     "@solana/buffer-layout": "^4.0.1",
     "@solana/web3.js": "^1.73.0",
     "@sqds/mesh": "^1.0.6",

--- a/governance/xc_admin/packages/xc_admin_common/package.json
+++ b/governance/xc_admin/packages/xc_admin_common/package.json
@@ -17,8 +17,7 @@
   "scripts": {
     "build": "tsc",
     "format": "prettier --write \"src/**/*.ts\"",
-    "test": "jest",
-    "cli": "npm run build && node lib/contracts/cli.js"
+    "test": "jest"
   },
   "dependencies": {
     "@certusone/wormhole-sdk": "^0.9.8",

--- a/governance/xc_admin/packages/xc_admin_common/src/contracts/Contract.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/contracts/Contract.ts
@@ -1,4 +1,5 @@
 import { ChainId, Instruction } from "@pythnetwork/xc-governance-sdk";
+import { ethers } from "ethers";
 
 export enum ContractType {
   Oracle,
@@ -45,7 +46,10 @@ export interface Contract<State> {
   sync(target: State): Promise<SyncOp[]>;
 }
 
-export interface SyncOp {}
+export interface SyncOp {
+  id(): string;
+  run(cache: Record<string, any>): Promise<boolean>;
+}
 
 export class SendGovernanceInstruction implements SyncOp {
   private instruction: Instruction;
@@ -60,6 +64,11 @@ export class SendGovernanceInstruction implements SyncOp {
     this.instruction = instruction;
     this.sender = from;
     this.submitVaa = submitVaa;
+  }
+
+  public id(): string {
+    // TODO: use a more understandable identifier (also this may not be unique)
+    return ethers.utils.sha256(this.instruction.serialize());
   }
 
   public async run(cache: Record<string, any>): Promise<boolean> {

--- a/governance/xc_admin/packages/xc_admin_common/src/contracts/Contract.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/contracts/Contract.ts
@@ -46,7 +46,11 @@ export interface Contract<State> {
   sync(target: State): Promise<SyncOp[]>;
 }
 
-/** A stateful synchronization operation. This operation can be run */
+/**
+ * An idempotent synchronization operation to update on-chain state. The operation may depend on
+ * external approvals or actions to complete, in which case the operation will pause and need to
+ * be resumed later.
+ */
 export interface SyncOp {
   /**
    * A unique identifier for this operation. The id represents the content of the operation (e.g., "sets the X
@@ -68,6 +72,7 @@ export interface SyncOp {
 export class SendGovernanceInstruction implements SyncOp {
   private instruction: Instruction;
   private sender: WormholeAddress;
+  // function to submit the signed VAA to the target chain contract
   private submitVaa: (vaa: string) => Promise<boolean>;
 
   constructor(
@@ -86,6 +91,7 @@ export class SendGovernanceInstruction implements SyncOp {
   }
 
   public async run(cache: Record<string, any>): Promise<boolean> {
+    // FIXME: this implementation is temporary. replace with something like the commented out code below.
     if (cache["multisigTx"] === undefined) {
       cache["multisigTx"] = "fooooo";
       return false;

--- a/governance/xc_admin/packages/xc_admin_common/src/contracts/Contract.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/contracts/Contract.ts
@@ -1,0 +1,124 @@
+/** A contract is the basic unit that is managed by xc_admin. */
+import {ChainId, RECEIVER_CHAINS} from "@pythnetwork/xc-governance-sdk";
+import { ethers } from "ethers";
+import PythAbi from "@pythnetwork/pyth-sdk-solidity/abis/IPyth.json";
+
+export enum ContractType {
+  Oracle,
+  EvmPythUpgradable,
+  EvmWormholeReceiver,
+}
+
+// A unique identifier for a blockchain. Note that this does not exactly line up to ChainId, which currently reuses
+// some ids across mainnet / testnet chains (e.g., ethereum goerli has the same id as ethereum mainnet).
+export type NetworkId = string;
+
+export interface Contract {
+  type: ContractType,
+  networkId: NetworkId,
+  // note: not a unified format across chains
+  getAddress(): string,
+  // Must return an object that can be rendered as JSON
+  getState(): Promise<any>,
+}
+
+export class EvmTargetChainContract implements Contract {
+  public type = ContractType.EvmPythUpgradable;
+  public networkId;
+  private address;
+
+  private contract: ethers.Contract;
+
+  constructor(networkId: NetworkId, address: string, contract: ethers.Contract) {
+    this.networkId = networkId;
+    this.address = address;
+    this.contract = contract;
+  }
+
+  public getAddress() {
+    return this.address;
+  }
+
+  public async getState(): Promise<any> {
+    const bytecodeSha = ethers.sha256(await this.contract.getDeployedCode() as string);
+    const validTimePeriod = (await this.contract['getValidTimePeriod'].staticCallResult())[0];
+    // TODO: add more state info here -- this will need the full PythUpgradable ABI
+    return {
+      bytecodeSha,
+      validTimePeriod,
+    };
+  }
+}
+
+export class EvmWormholeReceiver implements Contract {
+  public type = ContractType.EvmWormholeReceiver;
+  public networkId;
+  private address;
+
+  private contract: ethers.Contract;
+
+  constructor(networkId: NetworkId, address: string, contract: ethers.Contract) {
+    this.networkId = networkId;
+    this.address = address;
+    this.contract = contract;
+  }
+
+  public getAddress() {
+    return this.address;
+  }
+
+  public async getState(): Promise<any> {
+    const bytecodeSha = ethers.sha256(await this.contract.getDeployedCode() as string);
+
+    return {
+      bytecodeSha
+    }
+  }
+}
+
+export function loadFromConfig(contractsConfig: any, networksConfig: any): Contract[] {
+  const contracts = []
+  for (const contractConfig of contractsConfig) {
+    contracts.push(fromConfig(contractConfig, networksConfig));
+  }
+  return contracts;
+}
+
+export function fromConfig(contractConfig: any, networksConfig: any): Contract {
+  switch (contractConfig.type) {
+    case ContractType.EvmPythUpgradable: {
+      const ethersContract = new ethers.Contract(
+        contractConfig.address,
+        PythAbi,
+        getEvmProvider(contractConfig.networkId, networksConfig)
+      );
+
+      return new EvmTargetChainContract(
+        contractConfig.networkId,
+        contractConfig.address,
+        ethersContract,
+      );
+    }
+    case ContractType.EvmWormholeReceiver: {
+      const ethersContract = new ethers.Contract(
+        contractConfig.address,
+        // TODO: pass in an appropriate ABI here
+        [],
+        getEvmProvider(contractConfig.networkId, networksConfig)
+      );
+
+      return new EvmWormholeReceiver(
+        contractConfig.networkId,
+        contractConfig.address,
+        ethersContract,
+      );
+    }
+    default:
+      throw new Error(`unknown contract type: ${contractConfig.type}`);
+  }
+}
+
+export function getEvmProvider(networkId: NetworkId, networksConfig: any): ethers.Provider {
+  const networkConfig = networksConfig["evm"][networkId]!
+  return ethers.getDefaultProvider(networkConfig.url);
+}

--- a/governance/xc_admin/packages/xc_admin_common/src/contracts/Contract.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/contracts/Contract.ts
@@ -46,8 +46,22 @@ export interface Contract<State> {
   sync(target: State): Promise<SyncOp[]>;
 }
 
+/** A stateful synchronization operation. This operation can be run */
 export interface SyncOp {
+  /**
+   * A unique identifier for this operation. The id represents the content of the operation (e.g., "sets the X
+   * field to Y on contract Z"), so can be used to identify the "same" operation across multiple runs of this program.
+   */
   id(): string;
+  /**
+   * Run this operation from a previous state (recorded in cache). The operation can modify cache
+   * to record progress, then returns true if the operation has completed. If this function returns false,
+   * it is waiting on an external operation to complete (e.g., a multisig transaction to be approved).
+   * Re-run this function again once that operation is completed to continue making progress.
+   *
+   * The caller of this function is responsible for preserving the contents of `cache` between calls to
+   * this function.
+   */
   run(cache: Record<string, any>): Promise<boolean>;
 }
 

--- a/governance/xc_admin/packages/xc_admin_common/src/contracts/EvmPythUpgradable.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/contracts/EvmPythUpgradable.ts
@@ -1,0 +1,102 @@
+import {
+  Contract,
+  ContractType,
+  NetworkId,
+  SendGovernanceInstruction,
+  SyncOp,
+  WormholeAddress,
+  WormholeNetwork,
+} from "./Contract";
+import {
+  ChainId,
+  SetValidPeriodInstruction,
+} from "@pythnetwork/xc-governance-sdk";
+import { ethers } from "ethers";
+
+export class EvmPythUpgradable implements Contract<EvmPythUpgradableState> {
+  public type = ContractType.EvmPythUpgradable;
+  public networkId;
+  private address;
+
+  private contract: ethers.Contract;
+
+  constructor(
+    networkId: NetworkId,
+    address: string,
+    contract: ethers.Contract
+  ) {
+    this.networkId = networkId;
+    this.address = address;
+    this.contract = contract;
+  }
+
+  public getAddress() {
+    return this.address;
+  }
+
+  // ??? do we want this?
+  public async getValidTimePeriod(): Promise<bigint> {
+    return (await this.contract["getValidTimePeriod"].staticCallResult())[0];
+  }
+
+  public async getAuthority(): Promise<WormholeAddress> {
+    // FIXME: read from data sources
+    return {
+      emitter: "123454",
+      chainId: 1,
+      network: "mainnet",
+    };
+  }
+
+  // get the chainId that identifies this contract
+  public async getChainId(): Promise<ChainId> {
+    // FIXME: read from data sources
+    return 23;
+  }
+
+  public async getState(): Promise<EvmPythUpgradableState> {
+    const bytecodeSha = ethers.sha256(
+      (await this.contract.getDeployedCode()) as string
+    );
+    const validTimePeriod = (await this.getValidTimePeriod()) as bigint;
+    // TODO: add more state info here -- this will need the full PythUpgradable ABI
+    return {
+      bytecodeSha,
+      validTimePeriod: validTimePeriod.toString(10),
+    };
+  }
+
+  public async sync(target: EvmPythUpgradableState): Promise<SyncOp[]> {
+    const myState = await this.getState();
+    const authority = await this.getAuthority();
+    const myChainId = await this.getChainId();
+    const whInstructions = [];
+
+    if (myState.validTimePeriod !== target.validTimePeriod) {
+      whInstructions.push(
+        new SetValidPeriodInstruction(myChainId, BigInt(target.validTimePeriod))
+      );
+    }
+
+    return whInstructions.map(
+      (value) =>
+        new SendGovernanceInstruction(
+          value,
+          authority,
+          this.submitGovernanceVaa
+        )
+    );
+  }
+
+  public async submitGovernanceVaa(vaa: string): Promise<boolean> {
+    // FIXME
+    // await this.contract.executeGovernanceInstruction("0x" + vaa)
+    return true;
+  }
+}
+
+export interface EvmPythUpgradableState {
+  bytecodeSha: string;
+  // bigint serialized as a string
+  validTimePeriod: string;
+}

--- a/governance/xc_admin/packages/xc_admin_common/src/contracts/EvmPythUpgradable.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/contracts/EvmPythUpgradable.ts
@@ -34,11 +34,7 @@ export class EvmPythUpgradable implements Contract<EvmPythUpgradableState> {
     return this.address;
   }
 
-  // ??? do we want this?
-  public async getValidTimePeriod(): Promise<bigint> {
-    return await this.contract.getValidTimePeriod();
-  }
-
+  // TODO: these getters will need the full PythUpgradable ABI
   public async getAuthority(): Promise<WormholeAddress> {
     // FIXME: read from data sources
     return {
@@ -58,8 +54,8 @@ export class EvmPythUpgradable implements Contract<EvmPythUpgradableState> {
     const bytecodeSha = ethers.utils.sha256(
       (await this.contract.provider.getCode(this.contract.address)) as string
     );
-    const validTimePeriod = (await this.getValidTimePeriod()) as bigint;
-    // TODO: add more state info here -- this will need the full PythUpgradable ABI
+    const validTimePeriod =
+      (await this.contract.getValidTimePeriod()) as bigint;
     return {
       bytecodeSha,
       validTimePeriod: validTimePeriod.toString(),
@@ -89,7 +85,7 @@ export class EvmPythUpgradable implements Contract<EvmPythUpgradableState> {
   }
 
   public async submitGovernanceVaa(vaa: string): Promise<boolean> {
-    // FIXME
+    // FIXME: also needs the full PythUpgradable ABI
     // await this.contract.executeGovernanceInstruction("0x" + vaa)
     return true;
   }

--- a/governance/xc_admin/packages/xc_admin_common/src/contracts/EvmPythUpgradable.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/contracts/EvmPythUpgradable.ts
@@ -36,7 +36,7 @@ export class EvmPythUpgradable implements Contract<EvmPythUpgradableState> {
 
   // ??? do we want this?
   public async getValidTimePeriod(): Promise<bigint> {
-    return (await this.contract["getValidTimePeriod"].staticCallResult())[0];
+    return await this.contract.getValidTimePeriod();
   }
 
   public async getAuthority(): Promise<WormholeAddress> {
@@ -56,7 +56,7 @@ export class EvmPythUpgradable implements Contract<EvmPythUpgradableState> {
 
   public async getState(): Promise<EvmPythUpgradableState> {
     const bytecodeSha = ethers.utils.sha256(
-      (await this.contract.getDeployedCode()) as string
+      (await this.contract.provider.getCode(this.contract.address)) as string
     );
     const validTimePeriod = (await this.getValidTimePeriod()) as bigint;
     // TODO: add more state info here -- this will need the full PythUpgradable ABI

--- a/governance/xc_admin/packages/xc_admin_common/src/contracts/EvmPythUpgradable.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/contracts/EvmPythUpgradable.ts
@@ -55,7 +55,7 @@ export class EvmPythUpgradable implements Contract<EvmPythUpgradableState> {
   }
 
   public async getState(): Promise<EvmPythUpgradableState> {
-    const bytecodeSha = ethers.sha256(
+    const bytecodeSha = ethers.utils.sha256(
       (await this.contract.getDeployedCode()) as string
     );
     const validTimePeriod = (await this.getValidTimePeriod()) as bigint;

--- a/governance/xc_admin/packages/xc_admin_common/src/contracts/EvmPythUpgradable.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/contracts/EvmPythUpgradable.ts
@@ -62,7 +62,7 @@ export class EvmPythUpgradable implements Contract<EvmPythUpgradableState> {
     // TODO: add more state info here -- this will need the full PythUpgradable ABI
     return {
       bytecodeSha,
-      validTimePeriod: validTimePeriod.toString(10),
+      validTimePeriod: validTimePeriod.toString(),
     };
   }
 

--- a/governance/xc_admin/packages/xc_admin_common/src/contracts/EvmWormholeReceiver.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/contracts/EvmWormholeReceiver.ts
@@ -24,7 +24,7 @@ export class EvmWormholeReceiver implements Contract<EvmWormholeReceiverState> {
 
   public async getState(): Promise<EvmWormholeReceiverState> {
     const bytecodeSha = ethers.utils.sha256(
-      (await this.contract.getDeployedCode()) as string
+      (await this.contract.provider.getCode(this.contract.address)) as string
     );
 
     return {

--- a/governance/xc_admin/packages/xc_admin_common/src/contracts/EvmWormholeReceiver.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/contracts/EvmWormholeReceiver.ts
@@ -23,7 +23,7 @@ export class EvmWormholeReceiver implements Contract<EvmWormholeReceiverState> {
   }
 
   public async getState(): Promise<EvmWormholeReceiverState> {
-    const bytecodeSha = ethers.sha256(
+    const bytecodeSha = ethers.utils.sha256(
       (await this.contract.getDeployedCode()) as string
     );
 

--- a/governance/xc_admin/packages/xc_admin_common/src/contracts/EvmWormholeReceiver.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/contracts/EvmWormholeReceiver.ts
@@ -1,0 +1,43 @@
+import { ethers } from "ethers";
+import { Contract, ContractType, NetworkId, SyncOp } from "./Contract";
+
+export class EvmWormholeReceiver implements Contract<EvmWormholeReceiverState> {
+  public type = ContractType.EvmWormholeReceiver;
+  public networkId;
+  private address;
+
+  private contract: ethers.Contract;
+
+  constructor(
+    networkId: NetworkId,
+    address: string,
+    contract: ethers.Contract
+  ) {
+    this.networkId = networkId;
+    this.address = address;
+    this.contract = contract;
+  }
+
+  public getAddress() {
+    return this.address;
+  }
+
+  public async getState(): Promise<EvmWormholeReceiverState> {
+    const bytecodeSha = ethers.sha256(
+      (await this.contract.getDeployedCode()) as string
+    );
+
+    return {
+      bytecodeSha,
+    };
+  }
+
+  public async sync(target: EvmWormholeReceiverState): Promise<SyncOp[]> {
+    // TODO
+    return [];
+  }
+}
+
+export interface EvmWormholeReceiverState {
+  bytecodeSha: string;
+}

--- a/governance/xc_admin/packages/xc_admin_common/src/contracts/cli.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/contracts/cli.ts
@@ -1,4 +1,4 @@
-import {ContractType, loadFromConfig} from "./Contract";
+import { ContractType, EvmPythUpgradable, loadFromConfig } from "./Contract";
 
 const contractsConfig = [
   {
@@ -20,8 +20,8 @@ const contractsConfig = [
     type: ContractType.EvmPythUpgradable,
     networkId: "avalanche",
     address: "0x4305FB66699C3B2702D4d05CF36551390A4c69C6",
-  }
-]
+  },
+];
 
 const networksConfig = {
   evm: {
@@ -31,17 +31,25 @@ const networksConfig = {
       network_id: 420,
     },
     arbitrum: {
-      url: 'https://arb1.arbitrum.io/rpc',
+      url: "https://arb1.arbitrum.io/rpc",
       network_id: "0xa4b1",
     },
     avalanche: {
-      url: 'https://api.avax.network/ext/bc/C/rpc',
+      url: "https://api.avax.network/ext/bc/C/rpc",
       network_id: "0xa86a",
     },
     canto: {
-      url: 'https://canto.gravitychain.io',
-      network_id: 7700
-    }
+      url: "https://canto.gravitychain.io",
+      network_id: 7700,
+    },
+  },
+};
+
+async function checkEvmPythUpgradableState(
+  contract: EvmPythUpgradable,
+  state: EvmPythUpgradableState
+) {
+  if ((await contract.wormholeAddress()) !== state.wormholeAddress) {
   }
 }
 

--- a/governance/xc_admin/packages/xc_admin_common/src/contracts/cli.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/contracts/cli.ts
@@ -27,20 +27,15 @@ const networksConfig = {
   evm: {
     optimism_goerli: {
       url: `https://rpc.ankr.com/optimism_testnet`,
-      // TODO:
-      network_id: 420,
     },
     arbitrum: {
       url: "https://arb1.arbitrum.io/rpc",
-      network_id: "0xa4b1",
     },
     avalanche: {
       url: "https://api.avax.network/ext/bc/C/rpc",
-      network_id: "0xa86a",
     },
     canto: {
       url: "https://canto.gravitychain.io",
-      network_id: 7700,
     },
   },
 };

--- a/governance/xc_admin/packages/xc_admin_common/src/contracts/cli.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/contracts/cli.ts
@@ -1,0 +1,62 @@
+import {ContractType, loadFromConfig} from "./Contract";
+
+const contractsConfig = [
+  {
+    type: ContractType.EvmPythUpgradable,
+    networkId: "arbitrum",
+    address: "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C",
+  },
+  {
+    type: ContractType.EvmWormholeReceiver,
+    networkId: "canto",
+    address: "0x87047526937246727E4869C5f76A347160e08672",
+  },
+  {
+    type: ContractType.EvmPythUpgradable,
+    networkId: "canto",
+    address: "0x98046Bd286715D3B0BC227Dd7a956b83D8978603",
+  },
+  {
+    type: ContractType.EvmPythUpgradable,
+    networkId: "avalanche",
+    address: "0x4305FB66699C3B2702D4d05CF36551390A4c69C6",
+  }
+]
+
+const networksConfig = {
+  evm: {
+    optimism_goerli: {
+      url: `https://rpc.ankr.com/optimism_testnet`,
+      // TODO:
+      network_id: 420,
+    },
+    arbitrum: {
+      url: 'https://arb1.arbitrum.io/rpc',
+      network_id: "0xa4b1",
+    },
+    avalanche: {
+      url: 'https://api.avax.network/ext/bc/C/rpc',
+      network_id: "0xa86a",
+    },
+    canto: {
+      url: 'https://canto.gravitychain.io',
+      network_id: 7700
+    }
+  }
+}
+
+async function main() {
+  const contracts = loadFromConfig(contractsConfig, networksConfig);
+
+  for (const contract of contracts) {
+    const state = await contract.getState();
+    console.log({
+      networkId: contract.networkId,
+      address: contract.getAddress(),
+      type: contract.type,
+      state: state,
+    });
+  }
+}
+
+main();

--- a/governance/xc_admin/packages/xc_admin_common/src/contracts/config.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/contracts/config.ts
@@ -1,0 +1,58 @@
+import { ethers } from "ethers";
+import PythAbi from "@pythnetwork/pyth-sdk-solidity/abis/IPyth.json";
+import { Contract, ContractType, NetworkId } from "./Contract";
+import { EvmPythUpgradable } from "./EvmPythUpgradable";
+import { EvmWormholeReceiver } from "./EvmWormholeReceiver";
+
+export function getEvmProvider(
+  networkId: NetworkId,
+  networksConfig: any
+): ethers.Provider {
+  const networkConfig = networksConfig["evm"][networkId]!;
+  return ethers.getDefaultProvider(networkConfig.url);
+}
+
+export function loadContractConfig(
+  contractsConfig: any,
+  networksConfig: any
+): Contract<any>[] {
+  const contracts = [];
+  for (const contractConfig of contractsConfig) {
+    contracts.push(fromConfig(contractConfig, networksConfig));
+  }
+  return contracts;
+}
+
+function fromConfig(contractConfig: any, networksConfig: any): Contract<any> {
+  switch (contractConfig.type) {
+    case ContractType.EvmPythUpgradable: {
+      const ethersContract = new ethers.Contract(
+        contractConfig.address,
+        PythAbi,
+        getEvmProvider(contractConfig.networkId, networksConfig)
+      );
+
+      return new EvmPythUpgradable(
+        contractConfig.networkId,
+        contractConfig.address,
+        ethersContract
+      );
+    }
+    case ContractType.EvmWormholeReceiver: {
+      const ethersContract = new ethers.Contract(
+        contractConfig.address,
+        // TODO: pass in an appropriate ABI here
+        [],
+        getEvmProvider(contractConfig.networkId, networksConfig)
+      );
+
+      return new EvmWormholeReceiver(
+        contractConfig.networkId,
+        contractConfig.address,
+        ethersContract
+      );
+    }
+    default:
+      throw new Error(`unknown contract type: ${contractConfig.type}`);
+  }
+}

--- a/governance/xc_admin/packages/xc_admin_common/src/contracts/config.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/contracts/config.ts
@@ -7,7 +7,7 @@ import { EvmWormholeReceiver } from "./EvmWormholeReceiver";
 export function getEvmProvider(
   networkId: NetworkId,
   networksConfig: any
-): ethers.Provider {
+): ethers.providers.Provider {
   const networkConfig = networksConfig["evm"][networkId]!;
   return ethers.getDefaultProvider(networkConfig.url);
 }

--- a/governance/xc_admin/packages/xc_admin_common/src/contracts/index.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/contracts/index.ts
@@ -1,0 +1,4 @@
+export * from "./config";
+export * from "./Contract";
+export * from "./EvmPythUpgradable";
+export * from "./EvmWormholeReceiver";

--- a/governance/xc_admin/packages/xc_admin_common/src/index.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/index.ts
@@ -9,3 +9,4 @@ export * from "./bpf_upgradable_loader";
 export * from "./deterministic_oracle_accounts";
 export * from "./cranks";
 export * from "./message_buffer";
+export * from "./contracts";

--- a/governance/xc_admin/packages/xc_admin_frontend/next.config.js
+++ b/governance/xc_admin/packages/xc_admin_frontend/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
     externalDir: true,
   },
   webpack(config) {
+    config.experiments = { asyncWebAssembly: true }
     config.resolve.fallback = { fs: false }
     const fileLoaderRule = config.module.rules.find(
       (rule) => rule.test && rule.test.test('.svg')

--- a/target_chains/cosmwasm/tools/src/deployer/injective.ts
+++ b/target_chains/cosmwasm/tools/src/deployer/injective.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "fs";
 import { Bech32, toHex } from "@cosmjs/encoding";
-import { zeroPad } from "ethers/lib/utils.js";
+import { ethers } from "ethers";
 import assert from "assert";
 import { getNetworkInfo, Network } from "@injectivelabs/networks";
 import {
@@ -210,7 +210,7 @@ export class InjectiveDeployer implements Deployer {
 // Injective addresses are "human-readable", but for cross-chain registrations, we
 // want the "canonical" version
 function convert_injective_address_to_hex(human_addr: string) {
-  return "0x" + toHex(zeroPad(Bech32.decode(human_addr).data, 32));
+  return "0x" + toHex(ethers.utils.zeroPad(Bech32.decode(human_addr).data, 32));
 }
 
 // enter key of what to extract

--- a/target_chains/cosmwasm/tools/src/deployer/terra.ts
+++ b/target_chains/cosmwasm/tools/src/deployer/terra.ts
@@ -12,7 +12,7 @@ import {
 } from "@terra-money/terra.js";
 import { readFileSync } from "fs";
 import { Bech32, toHex } from "@cosmjs/encoding";
-import { zeroPad } from "ethers/lib/utils.js";
+import { ethers } from "ethers";
 import assert from "assert";
 import { ContractInfo, Deployer } from ".";
 
@@ -179,7 +179,7 @@ export class TerraDeployer implements Deployer {
 // Terra addresses are "human-readable", but for cross-chain registrations, we
 // want the "canonical" version
 export function convert_terra_address_to_hex(human_addr: string) {
-  return "0x" + toHex(zeroPad(Bech32.decode(human_addr).data, 32));
+  return "0x" + toHex(ethers.utils.zeroPad(Bech32.decode(human_addr).data, 32));
 }
 
 // enter key of what to extract


### PR DESCRIPTION
I've been experimenting with different ways to read / write the state of contracts, and I have an approach that seems reasonable. The idea is to make a collection of Contract objects, each of which represents a single deployed on-chain contract. There can be separate types of Contracts to represent different types of programs (target chain vs. oracle program vs. ...). Each contract exposes its state as a json object which can be both read & written. You can then update contract state by manipulating the JSON object and calling the write method. The JSON interface makes this approach very flexible, as we can change its schema to fit whatever kind of contract we have.

Writing the state back to the chain is a little complicated because we need to run operations that pause and wait for external input (e.g., multisig approvals). I've implemented this using a filesystem dependency, which is not perfect, but is how we've solved this problem in all of our previous implementations. I think we can circle back and fix that dependency later by exposing sufficient APIs on all of our various components to let this code directly query the real world state.

There's also a CLI that lets you query and update the state. The upshot of all of this is that you'll be able to make a change to a set of contracts by running a command like:

`npm run cli -- set --network avalanche --type evmTargetChain validTimePeriod=30` 

then approving the multisig tx and rerunning the above command from the same computer. You can rerun the command whenever and it'll do something sane (e.g., if you approve some proposals but not others, it'll submit the approved changes and wait for the remaining pending changes).

There's still a lot of work to do to finish this up, but I wanted to share to get feedback on the general idea. I'll fix things up in smaller changes as we go.