### PR TITLE
[eth] more update/parsePriceFeed optimizations

### DIFF
--- a/target_chains/ethereum/contracts/contracts/libraries/MerkleTree.sol
+++ b/target_chains/ethereum/contracts/contracts/libraries/MerkleTree.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import "./external/UnsafeBytesLib.sol";
+import "./external/UnsafeCalldataBytesLib.sol";
 
 /**
  * @dev This library provides methods to construct and verify Merkle Tree proofs efficiently.
@@ -36,7 +36,7 @@ library MerkleTree {
         return hash(abi.encodePacked(MERKLE_NODE_PREFIX, childA, childB));
     }
 
-    /// @notice Verify Merkle Tree proof for given leaf data.
+    /// @notice Verify Merkle Tree proof for given leaf data based on data on memory.
     /// @dev To optimize gas usage, this method doesn't take the proof as a bytes array
     /// but rather takes the encoded proof and the offset of the proof in the
     /// encoded proof array possibly containing multiple proofs. Also, the method
@@ -45,20 +45,23 @@ library MerkleTree {
     /// that the `encodedProof` is long enough to contain the proof and the
     /// `proofOffset` is not out of bound.
     function isProofValid(
-        bytes memory encodedProof,
+        bytes calldata encodedProof,
         uint proofOffset,
         bytes20 root,
-        bytes memory leafData
+        bytes calldata leafData
     ) internal pure returns (bool valid, uint endOffset) {
         unchecked {
             bytes20 currentDigest = MerkleTree.leafHash(leafData);
 
-            uint8 proofSize = UnsafeBytesLib.toUint8(encodedProof, proofOffset);
+            uint8 proofSize = UnsafeCalldataBytesLib.toUint8(
+                encodedProof,
+                proofOffset
+            );
             proofOffset += 1;
 
             for (uint i = 0; i < proofSize; i++) {
                 bytes20 siblingDigest = bytes20(
-                    UnsafeBytesLib.toAddress(encodedProof, proofOffset)
+                    UnsafeCalldataBytesLib.toAddress(encodedProof, proofOffset)
                 );
                 proofOffset += 20;
 

--- a/target_chains/ethereum/contracts/contracts/libraries/external/UnsafeCalldataBytesLib.sol
+++ b/target_chains/ethereum/contracts/contracts/libraries/external/UnsafeCalldataBytesLib.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Unlicense
+/*
+ * @title Solidity Bytes Arrays Utils
+ * @author Gonçalo Sá <goncalo.sa@consensys.net>
+ *
+ * @dev Bytes tightly packed arrays utility library for ethereum contracts written in Solidity.
+ *      The library lets you concatenate, slice and type cast bytes arrays both in memory and storage.
+ *
+ * @notice This is the **unsafe** version of BytesLib which removed all the checks (out of bound, ...)
+ * to be more gas efficient.
+ */
+pragma solidity >=0.8.0 <0.9.0;
+
+library UnsafeCalldataBytesLib {
+    function slice(
+        bytes calldata _bytes,
+        uint256 _start,
+        uint256 _length
+    ) internal pure returns (bytes calldata) {
+        return _bytes[_start:_start + _length];
+    }
+
+    function toAddress(
+        bytes calldata _bytes,
+        uint256 _start
+    ) internal pure returns (address) {
+        address tempAddress;
+
+        assembly {
+            tempAddress := shr(96, calldataload(add(_bytes.offset, _start)))
+        }
+
+        return tempAddress;
+    }
+
+    function toUint8(
+        bytes calldata _bytes,
+        uint256 _start
+    ) internal pure returns (uint8) {
+        uint8 tempUint;
+
+        assembly {
+            tempUint := shr(248, calldataload(add(_bytes.offset, _start)))
+        }
+
+        return tempUint;
+    }
+
+    function toUint16(
+        bytes calldata _bytes,
+        uint256 _start
+    ) internal pure returns (uint16) {
+        uint16 tempUint;
+
+        assembly {
+            tempUint := shr(240, calldataload(add(_bytes.offset, _start)))
+        }
+
+        return tempUint;
+    }
+
+    function toUint32(
+        bytes calldata _bytes,
+        uint256 _start
+    ) internal pure returns (uint32) {
+        uint32 tempUint;
+
+        assembly {
+            tempUint := shr(224, calldataload(add(_bytes.offset, _start)))
+        }
+
+        return tempUint;
+    }
+
+    function toUint64(
+        bytes calldata _bytes,
+        uint256 _start
+    ) internal pure returns (uint64) {
+        uint64 tempUint;
+
+        assembly {
+            tempUint := shr(192, calldataload(add(_bytes.offset, _start)))
+        }
+
+        return tempUint;
+    }
+
+    function toUint96(
+        bytes calldata _bytes,
+        uint256 _start
+    ) internal pure returns (uint96) {
+        uint96 tempUint;
+
+        assembly {
+            tempUint := shr(160, calldataload(add(_bytes.offset, _start)))
+        }
+
+        return tempUint;
+    }
+
+    function toUint128(
+        bytes calldata _bytes,
+        uint256 _start
+    ) internal pure returns (uint128) {
+        uint128 tempUint;
+
+        assembly {
+            tempUint := shr(128, calldataload(add(_bytes.offset, _start)))
+        }
+
+        return tempUint;
+    }
+
+    function toUint256(
+        bytes calldata _bytes,
+        uint256 _start
+    ) internal pure returns (uint256) {
+        uint256 tempUint;
+
+        assembly {
+            tempUint := calldataload(add(_bytes.offset, _start))
+        }
+
+        return tempUint;
+    }
+
+    function toBytes32(
+        bytes calldata _bytes,
+        uint256 _start
+    ) internal pure returns (bytes32) {
+        bytes32 tempBytes32;
+
+        assembly {
+            tempBytes32 := calldataload(add(_bytes.offset, _start))
+        }
+
+        return tempBytes32;
+    }
+}

--- a/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
@@ -186,9 +186,9 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
     }
 
     function parseWormholeMerkleHeaderNumUpdates(
-        bytes calldata wormholeMerkleUpdate,
+        bytes memory wormholeMerkleUpdate,
         uint offset
-    ) internal view returns (uint8 numUpdates) {
+    ) internal pure returns (uint8 numUpdates) {
         uint16 whProofSize = UnsafeBytesLib.toUint16(
             wormholeMerkleUpdate,
             offset
@@ -240,6 +240,9 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
                         1,
                         encodedMessage.length - 1
                     )
+                    // encodedMessage,
+                    // 1
+                    // encodedMessage.length
                 );
             } else {
                 revert PythErrors.InvalidUpdateData();
@@ -308,6 +311,70 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
                 revert PythErrors.InvalidUpdateData();
         }
     }
+
+    // function parsePriceFeedMessage(
+    //     bytes memory encodedPriceFeed,
+    //     uint startOffset
+    //     // uint length
+    // )
+    //     private
+    //     pure
+    //     returns (
+    //         PythInternalStructs.PriceInfo memory priceInfo,
+    //         bytes32 priceId
+    //     )
+    // {
+    //     unchecked {
+    //         uint offset = startOffset;
+
+    //         priceId = UnsafeBytesLib.toBytes32(encodedPriceFeed, offset);
+    //         offset += 32;
+
+    //         priceInfo.price = int64(
+    //             UnsafeBytesLib.toUint64(encodedPriceFeed, offset)
+    //         );
+    //         offset += 8;
+
+    //         priceInfo.conf = UnsafeBytesLib.toUint64(encodedPriceFeed, offset);
+    //         offset += 8;
+
+    //         priceInfo.expo = int32(
+    //             UnsafeBytesLib.toUint32(encodedPriceFeed, offset)
+    //         );
+    //         offset += 4;
+
+    //         // Publish time is i64 in some environments due to the standard in that
+    //         // environment. This would not cause any problem because since the signed
+    //         // integer is represented in two's complement, the value would be the same
+    //         // in both cases (for a million year at least)
+    //         priceInfo.publishTime = UnsafeBytesLib.toUint64(
+    //             encodedPriceFeed,
+    //             offset
+    //         );
+    //         offset += 8;
+
+    //         // We do not store this field because it is not used on the latest feed queries.
+    //         // uint64 prevPublishTime = UnsafeBytesLib.toUint64(encodedPriceFeed, offset);
+    //         offset += 8;
+
+    //         priceInfo.emaPrice = int64(
+    //             UnsafeBytesLib.toUint64(encodedPriceFeed, offset)
+    //         );
+    //         offset += 8;
+
+    //         priceInfo.emaConf = UnsafeBytesLib.toUint64(
+    //             encodedPriceFeed,
+    //             offset
+    //         );
+    //         offset += 8;
+
+    //         // // We don't check equality to enable future compatibility.
+    //         // if (offset > length)
+    //         //     revert PythErrors.InvalidUpdateData();
+    //         if (offset > encodedPriceFeed.length)
+    //             revert PythErrors.InvalidUpdateData();
+    //     }
+    // }
 
     function updatePriceInfosFromAccumulatorUpdate(
         bytes calldata accumulatorUpdate

--- a/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.0;
 
 import "../libraries/external/UnsafeBytesLib.sol";
+import "../libraries/external/UnsafeCalldataBytesLib.sol";
 import "@pythnetwork/pyth-sdk-solidity/AbstractPyth.sol";
 import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
 
@@ -43,13 +44,13 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
     }
 
     function extractUpdateTypeFromAccumulatorHeader(
-        bytes memory accumulatorUpdate
+        bytes calldata accumulatorUpdate
     ) internal pure returns (uint offset, UpdateType updateType) {
         unchecked {
             offset = 0;
 
             {
-                uint32 magic = UnsafeBytesLib.toUint32(
+                uint32 magic = UnsafeCalldataBytesLib.toUint32(
                     accumulatorUpdate,
                     offset
                 );
@@ -58,7 +59,7 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
                 if (magic != ACCUMULATOR_MAGIC)
                     revert PythErrors.InvalidUpdateData();
 
-                uint8 majorVersion = UnsafeBytesLib.toUint8(
+                uint8 majorVersion = UnsafeCalldataBytesLib.toUint8(
                     accumulatorUpdate,
                     offset
                 );
@@ -68,7 +69,7 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
                 if (majorVersion != MAJOR_VERSION)
                     revert PythErrors.InvalidUpdateData();
 
-                uint8 minorVersion = UnsafeBytesLib.toUint8(
+                uint8 minorVersion = UnsafeCalldataBytesLib.toUint8(
                     accumulatorUpdate,
                     offset
                 );
@@ -82,7 +83,7 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
 
                 // This field ensure that we can add headers in the future
                 // without breaking the contract (future compatibility)
-                uint8 trailingHeaderSize = UnsafeBytesLib.toUint8(
+                uint8 trailingHeaderSize = UnsafeCalldataBytesLib.toUint8(
                     accumulatorUpdate,
                     offset
                 );
@@ -100,7 +101,7 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
             }
 
             updateType = UpdateType(
-                UnsafeBytesLib.toUint8(accumulatorUpdate, offset)
+                UnsafeCalldataBytesLib.toUint8(accumulatorUpdate, offset)
             );
 
             offset += 1;
@@ -111,7 +112,7 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
     }
 
     function extractWormholeMerkleHeaderDigestAndNumUpdatesAndEncodedFromAccumulatorUpdate(
-        bytes memory accumulatorUpdate,
+        bytes calldata accumulatorUpdate,
         uint encodedOffset
     )
         internal
@@ -120,25 +121,32 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
             uint offset,
             bytes20 digest,
             uint8 numUpdates,
-            bytes memory encoded
+            bytes calldata encoded
         )
     {
-        encoded = UnsafeBytesLib.slice(
-            accumulatorUpdate,
-            encodedOffset,
-            accumulatorUpdate.length - encodedOffset
-        );
         unchecked {
+            encoded = UnsafeCalldataBytesLib.slice(
+                accumulatorUpdate,
+                encodedOffset,
+                accumulatorUpdate.length - encodedOffset
+            );
             offset = 0;
 
-            uint16 whProofSize = UnsafeBytesLib.toUint16(encoded, offset);
+            uint16 whProofSize = UnsafeCalldataBytesLib.toUint16(
+                encoded,
+                offset
+            );
             offset += 2;
 
             {
                 bytes memory encodedPayload;
                 {
                     IWormhole.VM memory vm = parseAndVerifyPythVM(
-                        UnsafeBytesLib.slice(encoded, offset, whProofSize)
+                        UnsafeCalldataBytesLib.slice(
+                            encoded,
+                            offset,
+                            whProofSize
+                        )
                     );
                     offset += whProofSize;
 
@@ -186,7 +194,7 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
                 }
             }
 
-            numUpdates = UnsafeBytesLib.toUint8(encoded, offset);
+            numUpdates = UnsafeCalldataBytesLib.toUint8(encoded, offset);
             offset += 1;
         }
     }
@@ -206,7 +214,7 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
 
     function extractPriceInfoFromMerkleProof(
         bytes20 digest,
-        bytes memory encoded,
+        bytes calldata encoded,
         uint offset
     )
         internal
@@ -218,11 +226,18 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
         )
     {
         unchecked {
-            bytes memory encodedMessage;
-            uint16 messageSize = UnsafeBytesLib.toUint16(encoded, offset);
+            bytes calldata encodedMessage;
+            uint16 messageSize = UnsafeCalldataBytesLib.toUint16(
+                encoded,
+                offset
+            );
             offset += 2;
 
-            encodedMessage = UnsafeBytesLib.slice(encoded, offset, messageSize);
+            encodedMessage = UnsafeCalldataBytesLib.slice(
+                encoded,
+                offset,
+                messageSize
+            );
             offset += messageSize;
 
             bool valid;
@@ -237,7 +252,7 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
             }
 
             MessageType messageType = MessageType(
-                UnsafeBytesLib.toUint8(encodedMessage, 0)
+                UnsafeCalldataBytesLib.toUint8(encodedMessage, 0)
             );
             if (messageType == MessageType.PriceFeed) {
                 (priceInfo, priceId) = parsePriceFeedMessage(encodedMessage, 1);
@@ -250,7 +265,7 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
     }
 
     function parsePriceFeedMessage(
-        bytes memory encodedPriceFeed,
+        bytes calldata encodedPriceFeed,
         uint offset
     )
         private
@@ -261,19 +276,25 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
         )
     {
         unchecked {
-            priceId = UnsafeBytesLib.toBytes32(encodedPriceFeed, offset);
+            priceId = UnsafeCalldataBytesLib.toBytes32(
+                encodedPriceFeed,
+                offset
+            );
             offset += 32;
 
             priceInfo.price = int64(
-                UnsafeBytesLib.toUint64(encodedPriceFeed, offset)
+                UnsafeCalldataBytesLib.toUint64(encodedPriceFeed, offset)
             );
             offset += 8;
 
-            priceInfo.conf = UnsafeBytesLib.toUint64(encodedPriceFeed, offset);
+            priceInfo.conf = UnsafeCalldataBytesLib.toUint64(
+                encodedPriceFeed,
+                offset
+            );
             offset += 8;
 
             priceInfo.expo = int32(
-                UnsafeBytesLib.toUint32(encodedPriceFeed, offset)
+                UnsafeCalldataBytesLib.toUint32(encodedPriceFeed, offset)
             );
             offset += 4;
 
@@ -281,7 +302,7 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
             // environment. This would not cause any problem because since the signed
             // integer is represented in two's complement, the value would be the same
             // in both cases (for a million year at least)
-            priceInfo.publishTime = UnsafeBytesLib.toUint64(
+            priceInfo.publishTime = UnsafeCalldataBytesLib.toUint64(
                 encodedPriceFeed,
                 offset
             );
@@ -292,11 +313,11 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
             offset += 8;
 
             priceInfo.emaPrice = int64(
-                UnsafeBytesLib.toUint64(encodedPriceFeed, offset)
+                UnsafeCalldataBytesLib.toUint64(encodedPriceFeed, offset)
             );
             offset += 8;
 
-            priceInfo.emaConf = UnsafeBytesLib.toUint64(
+            priceInfo.emaConf = UnsafeCalldataBytesLib.toUint64(
                 encodedPriceFeed,
                 offset
             );
@@ -308,7 +329,7 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
     }
 
     function updatePriceInfosFromAccumulatorUpdate(
-        bytes memory accumulatorUpdate
+        bytes calldata accumulatorUpdate
     ) internal returns (uint8 numUpdates) {
         (
             uint encodedOffset,
@@ -321,7 +342,7 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
 
         uint offset;
         bytes20 digest;
-        bytes memory encoded;
+        bytes calldata encoded;
         (
             offset,
             digest,


### PR DESCRIPTION
### Summary
- changed parameter type from `bytes calldata` to `bytes memory` for some functions
- changed `parsePriceFeedMessage` to use offset instead of making a slice/copy

### Diff
Before
![image](https://github.com/pyth-network/pyth-crosschain/assets/86628128/738b3f81-0fd1-4785-8d0e-65ac786a155a)
After
![image](https://github.com/pyth-network/pyth-crosschain/assets/86628128/7c3d7471-bd89-485d-874f-af506a63c9ff)

After @ali-bahjati change in #888 
![image](https://github.com/pyth-network/pyth-crosschain/assets/86628128/df6287d7-947f-4bec-aa7a-774475c68128)

