### PR TITLE
Cosmwasm refactor and preparation for parse price feeds

### DIFF
--- a/target_chains/cosmwasm/README.md
+++ b/target_chains/cosmwasm/README.md
@@ -22,8 +22,8 @@ First, build the contracts within [the current directory](./). You must have Doc
 cd ./tools
 npm ci
 
-# if you want to build specifically for injective
-npm run build-contract -- --injective
+# if you want to build specifically for one chain
+npm run build-contract -- --[injective|osmosis]
 
 # else a generic cosmwasm contract can be build using
 npm run build-contract -- --cosmwasm

--- a/target_chains/cosmwasm/contracts/pyth/src/contract.rs
+++ b/target_chains/cosmwasm/contracts/pyth/src/contract.rs
@@ -174,20 +174,6 @@ pub fn execute(
         ExecuteMsg::ExecuteGovernanceInstruction { data } => {
             execute_governance_instruction(deps, env, info, &data)
         }
-        ExecuteMsg::ParsePriceFeedUpdates {
-            updates,
-            price_feeds,
-            min_publish_time,
-            max_publish_time,
-        } => parse_price_feed_updates(
-            deps,
-            env,
-            info,
-            &updates,
-            price_feeds,
-            min_publish_time,
-            max_publish_time,
-        ),
     }
 }
 
@@ -682,6 +668,10 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     }
 }
 
+
+/// This function is not used in the contract yet but mimicks the behavior implemented
+/// in the EVM contract. We are yet to finalize how the parsed prices should be consumed
+/// in injective as well as other chains.
 pub fn parse_price_feed_updates(
     deps: DepsMut,
     env: Env,
@@ -727,20 +717,7 @@ pub fn parse_price_feed_updates(
         .map(|(_, feed)| feed.unwrap())
         .collect::<Vec<PriceFeed>>();
     let response = Response::new();
-    #[cfg(feature = "injective")]
-    {
-        let inj_message = create_relay_pyth_prices_msg(env.contract.address, total_new_feeds);
-        Ok(response
-            .add_message(inj_message)
-            .add_attribute("action", "update_price_feeds")
-            .add_attribute("num_attestations", format!("{num_total_attestations}"))
-            .add_attribute("num_updated", format!("{num_total_new_attestations}")))
-    }
-
-    #[cfg(not(feature = "injective"))]
-    {
-        Ok(response.add_attribute("action", "update_price_feeds"))
-    }
+    Ok(response.add_attribute("action", "parse_price_feeds"))
 }
 
 /// Get the most recent value of the price feed indicated by `feed_id`.

--- a/target_chains/cosmwasm/contracts/pyth/src/contract.rs
+++ b/target_chains/cosmwasm/contracts/pyth/src/contract.rs
@@ -1307,6 +1307,13 @@ mod test {
             false,
         );
         assert_eq!(get_update_fee_amount(&deps.as_ref(), &[msg]).unwrap(), 500);
+
+        let batch_msg = create_price_update_msg(default_emitter_addr().as_slice(), EMITTER_CHAIN);
+        let msg = create_accumulator_message(&[feed1, feed2, feed3], &[feed1, feed2, feed3], false);
+        assert_eq!(
+            get_update_fee_amount(&deps.as_ref(), &[msg, batch_msg]).unwrap(),
+            400
+        );
     }
 
 

--- a/target_chains/cosmwasm/sdk/rust/src/lib.rs
+++ b/target_chains/cosmwasm/sdk/rust/src/lib.rs
@@ -28,8 +28,18 @@ use {
 #[derive(Eq)]
 #[cw_serde]
 pub enum ExecuteMsg {
-    UpdatePriceFeeds { data: Vec<Binary> },
-    ExecuteGovernanceInstruction { data: Binary },
+    UpdatePriceFeeds {
+        data: Vec<Binary>,
+    },
+    ExecuteGovernanceInstruction {
+        data: Binary,
+    },
+    ParsePriceFeedUpdates {
+        updates:          Vec<Binary>,
+        price_feeds:      Vec<PriceIdentifier>,
+        min_publish_time: UnixTimestamp,
+        max_publish_time: UnixTimestamp,
+    },
 }
 
 #[cw_serde]

--- a/target_chains/cosmwasm/sdk/rust/src/lib.rs
+++ b/target_chains/cosmwasm/sdk/rust/src/lib.rs
@@ -28,18 +28,8 @@ use {
 #[derive(Eq)]
 #[cw_serde]
 pub enum ExecuteMsg {
-    UpdatePriceFeeds {
-        data: Vec<Binary>,
-    },
-    ExecuteGovernanceInstruction {
-        data: Binary,
-    },
-    ParsePriceFeedUpdates {
-        updates:          Vec<Binary>,
-        price_feeds:      Vec<PriceIdentifier>,
-        min_publish_time: UnixTimestamp,
-        max_publish_time: UnixTimestamp,
-    },
+    UpdatePriceFeeds { data: Vec<Binary> },
+    ExecuteGovernanceInstruction { data: Binary },
 }
 
 #[cw_serde]

--- a/target_chains/cosmwasm/tools/src/build-contract.ts
+++ b/target_chains/cosmwasm/tools/src/build-contract.ts
@@ -80,6 +80,7 @@ function build() {
 
   const buildCommand = `
           docker run --rm -v "$(cd ..; pwd)":/code \
+          -v "$(cd ../../../pythnet; pwd)":/pythnet \
           -v "$(cd ../../../wormhole_attester; pwd)":/wormhole_attester \
           --mount type=volume,source="$(basename "$(cd ..; pwd)")_cache",target=/code/target \
           --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \


### PR DESCRIPTION
This PR separates the parsing logic for applying updates logic so that the former can be used independently for parse_price_feed messages.
Parsing functions do not need `DepsMut` and they have been changed to use a `Deps` dependency instead. 