### PR TITLE
Update price feeds early if part of a batch

### DIFF
--- a/price_pusher/README.md
+++ b/price_pusher/README.md
@@ -37,8 +37,19 @@ The parameters above are configured per price feed in a price configuration YAML
   time_difference: 60 # Time difference threshold (in seconds) to push a newer price feed.
   price_deviation: 0.5 # The price deviation (%) threshold to push a newer price feed.
   confidence_ratio: 1 # The confidence/price (%) threshold to push a newer price feed.
+  # Optional block to configure whether this feed can be early updated. If at least one feed meets the
+  # triggering conditions above, all other feeds who meet the early update conditions will be included in
+  # the submitted batch of prices. This logic takes advantage of the fact that adding a feed to a larger
+  # batch of updates incurs a minimal gas cost. All fields below are optional (and interpreted as infinity if omitted)
+  # and have the same semantics as the corresponding fields above.
+  early_update:
+    time_difference: 30
+    price_deviation: 0.1
+    confidence_ratio: 0.5
 - ...
 ```
+
+Two sample YAML configuration files are available in the root of this repo.
 
 You can get the list of available price feeds from
 [here](https://pyth.network/developers/price-feed-ids/).
@@ -57,7 +68,7 @@ cd price_pusher
 npm run start -- evm --endpoint wss://example-rpc.com \
     --pyth-contract-address 0xff1a0f4744e8582DF...... \
     --price-service-endpoint https://example-pyth-price.com \
-    --price-config-file "path/to/price-config-file.yaml.testnet.sample.yaml" \
+    --price-config-file "path/to/price-config.testnet.sample.yaml" \
     --mnemonic-file "path/to/mnemonic.txt" \
     [--pushing-frequency 10] \
     [--polling-frequency 5] \
@@ -66,7 +77,7 @@ npm run start -- evm --endpoint wss://example-rpc.com \
 # For Injective
 npm run start -- injective --grpc-endpoint https://grpc-endpoint.com \
     --pyth-contract-address inj1z60tg0... --price-service-endpoint "https://example-pyth-price.com" \
-    --price-config-file "path/to/price-config-file.yaml.testnet.sample.yaml" \
+    --price-config-file "path/to/price-config.testnet.sample.yaml" \
     --mnemonic-file "path/to/mnemonic.txt" \
     [--pushing-frequency 10] \
     [--polling-frequency 5] \
@@ -92,15 +103,6 @@ npm run start -- sui
   --price-config-file ./price-config.testnet.sample.yaml
   [--pushing-frequency 10] \
   [--polling-frequency 5] \
-
-
-
---endpoint https://fullnode.testnet.aptoslabs.com/v1 \
-    --pyth-contract-address 0x7e783b349d3e89cf5931af376ebeadbfab855b3fa239b7ada8f5a92fbea6b387 --price-service-endpoint "https://xc-testnet.pyth.network" \
-    --price-config-file "./price-config.testnet.sample.yaml" \
-    --mnemonic-file "path/to/mnemonic.txt" \
-    [--pushing-frequency 10] \
-    [--polling-frequency 5] \
 
 
 # Or, run the price pusher docker image instead of building from the source

--- a/price_pusher/price-config.mainnet.sample.yaml
+++ b/price_pusher/price-config.mainnet.sample.yaml
@@ -8,3 +8,7 @@
   time_difference: 60
   price_deviation: 1
   confidence_ratio: 1
+  early_update:
+    time_difference: 30
+    price_deviation: 0.5
+    confidence_ratio: 0.1

--- a/price_pusher/price-config.testnet.sample.yaml
+++ b/price_pusher/price-config.testnet.sample.yaml
@@ -8,3 +8,7 @@
   time_difference: 60
   price_deviation: 1
   confidence_ratio: 1
+  early_update:
+    time_difference: 30
+    price_deviation: 0.5
+    confidence_ratio: 0.1

--- a/price_pusher/src/evm/command.ts
+++ b/price_pusher/src/evm/command.ts
@@ -91,6 +91,11 @@ export default {
       mnemonic,
       pythContractAddress
     );
+    console.log(
+      `Pushing updates from wallet address: ${pythContractFactory
+        .createWeb3PayerProvider()
+        .getAddress()}`
+    );
 
     const evmListener = new EvmPriceListener(pythContractFactory, priceItems, {
       pollingFrequency,

--- a/price_pusher/src/evm/evm.ts
+++ b/price_pusher/src/evm/evm.ts
@@ -224,7 +224,7 @@ export class EvmPricePusher implements IPricePusher {
           // the update data is valid there is no possible rejection cause other than
           // the target chain price being already updated.
           console.log(
-            "Execution reverted. With high probablity, the target chain price " +
+            "Execution reverted. With high probability, the target chain price " +
               "has already updated, Skipping this push."
           );
           return;


### PR DESCRIPTION
I was looking at the sui pusher's txs and I noticed that it currently only updates a subset of the price feeds in the pushed VAA. This behavior is an interaction between the structure of the sui contract (with the hot potato etc) and the price pusher.

I'm fixing this problem by adding a feature we'll want anyway, which is to piggyback additional price updates on to a push. With accumulators, it's very cheap to add an additional update to an existing price push, so we'll want to take advantage of this by pushing more feeds than just the ones that met the triggering conditions.

This PR adds an extra set of triggering conditions for an early update. If at least one feed meets the normal triggering conditions, we'll push a batch of updates that includes the original update + all feeds meeting the early update conditions. Using this, we can also set early_update.time_difference = 0 in the sui config to solve the specific problem as well.

I haven't been able to run this since testnet is down, but i will make sure it works before merging.