### PR TITLE
Add slot variable in constructing fake wormhole payloads

### DIFF
--- a/target_chains/ethereum/contracts/forge-test/Pyth.WormholeMerkleAccumulator.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pyth.WormholeMerkleAccumulator.t.sol
@@ -522,6 +522,7 @@ contract PythWormholeMerkleAccumulatorTest is
                 isNotMatch(forgeItem, "whUpdateType")
                     ? uint8(PythAccumulator.UpdateType.WormholeMerkle)
                     : uint8(PythAccumulator.UpdateType.WormholeMerkle) + 1,
+                uint64(0), // Slot, not used in target networks
                 uint32(0), // Storage index, not used in target networks
                 isNotMatch(forgeItem, "rootDigest")
                     ? rootDigest
@@ -595,6 +596,18 @@ contract PythWormholeMerkleAccumulatorTest is
             0,
             MAX_UINT64
         );
+    }
+
+    function testUpdatePriceFeedWithWormholeMerkleWorksWithoutForging() public {
+        // In this test we make sure the structure returned by createAndForgeWormholeMerkleUpdateData
+        // is valid if no particular forge flag is set
+        (
+            bytes[] memory updateData,
+            uint updateFee,
+            bytes32[] memory priceIds
+        ) = createAndForgeWormholeMerkleUpdateData("");
+
+        pyth.updatePriceFeeds{value: updateFee}(updateData);
     }
 
     function testUpdatePriceFeedWithWormholeMerkleRevertsOnWrongVAAPayloadUpdateType()


### PR DESCRIPTION
The structure of the fake payload was not as expected. Some tests were failing for the wrong reason but with the right error code.