### PR TITLE
Price pusher: fix PTB bug

### DIFF
--- a/price_pusher/package.json
+++ b/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "5.3.2",
+  "version": "5.4.0",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/price_pusher/src/controller.ts
+++ b/price_pusher/src/controller.ts
@@ -66,7 +66,10 @@ export class Controller {
 
         // note that the priceIds are without leading "0x"
         const priceIds = pricesToPush.map((priceConfig) => priceConfig.id);
-        this.targetChainPricePusher.updatePriceFeed(priceIds, pubTimesToPush);
+        await this.targetChainPricePusher.updatePriceFeed(
+          priceIds,
+          pubTimesToPush
+        );
       } else {
         console.log(
           "None of the above values passed the threshold. No push needed."


### PR DESCRIPTION
we forgot an await, and it seems like we're sending multiple concurrent transactions because of that.

I think this await does potentially mess up the loop timing because it stacks with the sleep below, but let's see if this fixes the error and we can adjust the timing logic after.