### PR TITLE
[hermes] Use raw_message for future-compatibility

### DIFF
--- a/hermes/src/store/storage.rs
+++ b/hermes/src/store/storage.rs
@@ -4,6 +4,7 @@ use {
         types::{
             AccumulatorMessages,
             ProofSet,
+            RawMessage,
             RequestTime,
             Slot,
             UnixTimestamp,
@@ -71,6 +72,7 @@ pub struct MessageStateTime {
 pub struct MessageState {
     pub slot:        Slot,
     pub message:     Message,
+    pub raw_message: RawMessage,
     pub proof_set:   ProofSet,
     pub received_at: UnixTimestamp,
 }
@@ -92,6 +94,7 @@ impl MessageState {
 
     pub fn new(
         message: Message,
+        raw_message: RawMessage,
         proof_set: ProofSet,
         slot: Slot,
         received_at: UnixTimestamp,
@@ -99,6 +102,7 @@ impl MessageState {
         Self {
             slot,
             message,
+            raw_message,
             proof_set,
             received_at,
         }
@@ -151,20 +155,20 @@ mod test {
             wormhole_merkle_state: None,
         };
 
-        assert!(CompletedAccumulatorState::try_from(accumulator_state.clone()).is_err());
+        assert!(CompletedAccumulatorState::try_from(accumulator_state).is_err());
 
         let accumulator_state = AccumulatorState {
             slot:                  1,
             accumulator_messages:  Some(AccumulatorMessages {
-                slot:      1,
-                magic:     [0; 4],
-                ring_size: 10,
-                messages:  vec![],
+                slot:         1,
+                magic:        [0; 4],
+                ring_size:    10,
+                raw_messages: vec![],
             }),
             wormhole_merkle_state: None,
         };
 
-        assert!(CompletedAccumulatorState::try_from(accumulator_state.clone()).is_err());
+        assert!(CompletedAccumulatorState::try_from(accumulator_state).is_err());
 
         let accumulator_state = AccumulatorState {
             slot:                  1,
@@ -179,15 +183,15 @@ mod test {
             }),
         };
 
-        assert!(CompletedAccumulatorState::try_from(accumulator_state.clone()).is_err());
+        assert!(CompletedAccumulatorState::try_from(accumulator_state).is_err());
 
         let accumulator_state = AccumulatorState {
             slot:                  1,
             accumulator_messages:  Some(AccumulatorMessages {
-                slot:      1,
-                magic:     [0; 4],
-                ring_size: 10,
-                messages:  vec![],
+                slot:         1,
+                magic:        [0; 4],
+                ring_size:    10,
+                raw_messages: vec![],
             }),
             wormhole_merkle_state: Some(WormholeMerkleState {
                 vaa:  vec![],
@@ -200,14 +204,14 @@ mod test {
         };
 
         assert_eq!(
-            CompletedAccumulatorState::try_from(accumulator_state.clone()).unwrap(),
+            CompletedAccumulatorState::try_from(accumulator_state).unwrap(),
             CompletedAccumulatorState {
                 slot:                  1,
                 accumulator_messages:  AccumulatorMessages {
-                    slot:      1,
-                    magic:     [0; 4],
-                    ring_size: 10,
-                    messages:  vec![],
+                    slot:         1,
+                    magic:        [0; 4],
+                    ring_size:    10,
+                    raw_messages: vec![],
                 },
                 wormhole_merkle_state: WormholeMerkleState {
                     vaa:  vec![],

--- a/hermes/src/store/storage/local_storage.rs
+++ b/hermes/src/store/storage/local_storage.rs
@@ -211,6 +211,7 @@ mod test {
     ) -> MessageState {
         MessageState {
             slot,
+            raw_message: vec![],
             message: Message::PriceFeedMessage(PriceFeedMessage {
                 feed_id,
                 publish_time,
@@ -574,10 +575,10 @@ mod test {
         // Change the state to have accumulator messages
         // We mutate the existing state because the normal flow is like this.
         accumulator_state.accumulator_messages = Some(AccumulatorMessages {
-            magic:     [0; 4],
-            slot:      10,
-            ring_size: 3,
-            messages:  vec![],
+            magic:        [0; 4],
+            slot:         10,
+            ring_size:    3,
+            raw_messages: vec![],
         });
 
         // Store the accumulator state again.

--- a/hermes/src/store/types.rs
+++ b/hermes/src/store/types.rs
@@ -1,9 +1,7 @@
 use {
     super::proof::wormhole_merkle::WormholeMerkleMessageProof,
-    pythnet_sdk::messages::{
-        Message,
-        PriceFeedMessage,
-    },
+    borsh::BorshDeserialize,
+    pythnet_sdk::messages::PriceFeedMessage,
 };
 
 #[derive(Clone, PartialEq, Debug)]
@@ -20,12 +18,20 @@ pub enum RequestTime {
     FirstAfter(UnixTimestamp),
 }
 
-#[derive(Clone, PartialEq, Debug)]
+pub type RawMessage = Vec<u8>;
+
+/// Accumulator messages coming from Pythnet validators.
+///
+/// The validators writes the accumulator messages using Borsh with
+/// the following struct. We cannot directly have messages as Vec<Messages>
+/// because they are serialized using big-endian byte order and Borsh
+/// uses little-endian byte order.
+#[derive(Clone, PartialEq, Debug, BorshDeserialize)]
 pub struct AccumulatorMessages {
-    pub magic:     [u8; 4],
-    pub slot:      Slot,
-    pub ring_size: u32,
-    pub messages:  Vec<Message>,
+    pub magic:        [u8; 4],
+    pub slot:         u64,
+    pub ring_size:    u32,
+    pub raw_messages: Vec<RawMessage>,
 }
 
 impl AccumulatorMessages {


### PR DESCRIPTION
In hermes we used to deserialize raw_messages and store only the messages. In the old approach we serialized the messages again once we wanted to construct the proofs and that was not future compatible. This PR changes the codebase to store raw_messages instead of messages (and in some places it stores both).