### PR TITLE
Sui pusher updates

### DIFF
--- a/price_pusher/package.json
+++ b/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "5.3.2",
+  "version": "5.4.0",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/price_pusher/src/sui/command.ts
+++ b/price_pusher/src/sui/command.ts
@@ -58,6 +58,13 @@ export default {
       type: "string",
       required: true,
     } as Options,
+    "max-vaas-per-ptb": {
+      description:
+        "Maximum number of VAAs that can be included in a single PTB.",
+      type: "number",
+      required: true,
+      default: 1,
+    } as Options,
     ...options.priceConfigFile,
     ...options.priceServiceEndpoint,
     ...options.mnemonicFile,
@@ -77,6 +84,7 @@ export default {
       wormholePackageId,
       wormholeStateId,
       priceFeedToPriceInfoObjectTableId,
+      maxVaasPerPtb,
     } = argv;
 
     const priceConfigs = readPriceConfigFile(priceConfigFile);
@@ -90,6 +98,9 @@ export default {
           error: console.error,
           debug: () => undefined,
           trace: () => undefined,
+        },
+        priceFeedRequestConfig: {
+          binary: true,
         },
       }
     );
@@ -116,6 +127,7 @@ export default {
       wormholePackageId,
       wormholeStateId,
       priceFeedToPriceInfoObjectTableId,
+      maxVaasPerPtb,
       endpoint,
       mnemonic
     );

--- a/price_service/client/js/src/PriceServiceConnection.ts
+++ b/price_service/client/js/src/PriceServiceConnection.ts
@@ -111,7 +111,9 @@ export class PriceServiceConnection {
    * @param priceIds Array of hex-encoded price ids.
    * @returns Array of PriceFeeds
    */
-  async getLatestPriceFeeds(priceIds: HexString[]): Promise<PriceFeed[]> {
+  async getLatestPriceFeeds(
+    priceIds: HexString[]
+  ): Promise<PriceFeed[] | undefined> {
     if (priceIds.length === 0) {
       return [];
     }

--- a/price_service/client/js/src/PriceServiceConnection.ts
+++ b/price_service/client/js/src/PriceServiceConnection.ts
@@ -111,9 +111,7 @@ export class PriceServiceConnection {
    * @param priceIds Array of hex-encoded price ids.
    * @returns Array of PriceFeeds
    */
-  async getLatestPriceFeeds(
-    priceIds: HexString[]
-  ): Promise<PriceFeed[] | undefined> {
+  async getLatestPriceFeeds(priceIds: HexString[]): Promise<PriceFeed[]> {
     if (priceIds.length === 0) {
       return [];
     }


### PR DESCRIPTION
Two small updates:
1. Flag to avoid sending duplicate transactions. This is a different approach to avoiding concurrent transactions that's sup-specific, as opposed to the previous `await` PR (which i closed).
2. CLI flag to set the maximum number of VAAs that can be included in a single sui PTB. At the moment, the SUI cost of our PTBs grows superlinearly with the number VAAs, so we want to split price updates into multiple PTBs to keep the costs down.