### PR TITLE
[eth] Add setWormholeAddress governance message

### DIFF
--- a/governance/xc_governance_sdk_js/src/index.ts
+++ b/governance/xc_governance_sdk_js/src/index.ts
@@ -2,6 +2,7 @@ export {
   DataSource,
   AptosAuthorizeUpgradeContractInstruction,
   EthereumUpgradeContractInstruction,
+  EthereumSetWormholeAddress,
   HexString20Bytes,
   HexString32Bytes,
   SetDataSourcesInstruction,

--- a/governance/xc_governance_sdk_js/src/instructions.ts
+++ b/governance/xc_governance_sdk_js/src/instructions.ts
@@ -14,6 +14,7 @@ enum TargetAction {
   SetFee,
   SetValidPeriod,
   RequestGovernanceDataSourceTransfer,
+  SetWormholeAddress,
 }
 
 abstract class HexString implements Serializable {
@@ -192,5 +193,15 @@ export class RequestGovernanceDataSourceTransferInstruction extends TargetInstru
     return new BufferBuilder()
       .addUint32(this.governanceDataSourceIndex)
       .build();
+  }
+}
+
+export class EthereumSetWormholeAddress extends TargetInstruction {
+  constructor(targetChainId: ChainId, private address: HexString20Bytes) {
+    super(TargetAction.SetWormholeAddress, targetChainId);
+  }
+
+  protected serializePayload(): Buffer {
+    return this.address.serialize();
   }
 }

--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernance.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernance.sol
@@ -221,23 +221,25 @@ abstract contract PythGovernance is
             revert PythErrors.InvalidGovernanceMessage();
 
         if (vm.sequence != lastExecutedGovernanceSequence())
-            revert PythErrors.InvalidGovernanceMessage();
+            revert PythErrors.InvalidWormholeAddressToSet();
 
         GovernanceInstruction memory gi = parseGovernanceInstruction(
             vm.payload
         );
 
         if (gi.action != GovernanceAction.SetWormholeAddress)
-            revert PythErrors.InvalidGovernanceMessage();
+            revert PythErrors.InvalidWormholeAddressToSet();
 
         // Purposefully, we don't check whether the chainId is the same as the current chainId because
         // we might want to change the chain id of the wormhole contract.
 
+        // The following check is not necessary for security, but is a sanity check that the new wormhole
+        // contract parses the payload correctly.
         SetWormholeAddressPayload
             memory newPayload = parseSetWormholeAddressPayload(gi.payload);
 
         if (newPayload.newWormholeAddress != payload.newWormholeAddress)
-            revert PythErrors.InvalidGovernanceMessage();
+            revert PythErrors.InvalidWormholeAddressToSet();
 
         emit WormholeAddressSet(oldWormholeAddress, address(wormhole()));
     }

--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
@@ -30,7 +30,8 @@ contract PythGovernanceInstructions {
         SetDataSources, // 2
         SetFee, // 3
         SetValidPeriod, // 4
-        RequestGovernanceDataSourceTransfer // 5
+        RequestGovernanceDataSourceTransfer, // 5
+        SetWormholeAddress // 6
     }
 
     struct GovernanceInstruction {
@@ -67,6 +68,10 @@ contract PythGovernanceInstructions {
 
     struct SetValidPeriodPayload {
         uint newValidPeriod;
+    }
+
+    struct SetWormholeAddressPayload {
+        address newWormholeAddress;
     }
 
     /// @dev Parse a GovernanceInstruction
@@ -195,6 +200,19 @@ contract PythGovernanceInstructions {
 
         svp.newValidPeriod = uint256(encodedPayload.toUint64(index));
         index += 8;
+
+        if (encodedPayload.length != index)
+            revert PythErrors.InvalidGovernanceMessage();
+    }
+
+    /// @dev Parse a UpdateWormholeAddressPayload (action 6) with minimal validation
+    function parseSetWormholeAddressPayload(
+        bytes memory encodedPayload
+    ) public pure returns (SetWormholeAddressPayload memory sw) {
+        uint index = 0;
+
+        sw.newWormholeAddress = address(encodedPayload.toAddress(index));
+        index += 20;
 
         if (encodedPayload.length != index)
             revert PythErrors.InvalidGovernanceMessage();

--- a/target_chains/ethereum/contracts/hardhat.config.ts
+++ b/target_chains/ethereum/contracts/hardhat.config.ts
@@ -80,7 +80,7 @@ module.exports = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 5000,
+        runs: 2000,
       },
     },
   },

--- a/target_chains/ethereum/contracts/truffle-config.js
+++ b/target_chains/ethereum/contracts/truffle-config.js
@@ -288,7 +288,7 @@ module.exports = {
       settings: {
         optimizer: {
           enabled: true,
-          runs: 5000,
+          runs: 2000,
         },
       },
     },

--- a/target_chains/ethereum/sdk/solidity/PythErrors.sol
+++ b/target_chains/ethereum/sdk/solidity/PythErrors.sol
@@ -4,31 +4,45 @@ pragma solidity ^0.8.0;
 
 library PythErrors {
     // Function arguments are invalid (e.g., the arguments lengths mismatch)
+    // Signature: 0xa9cb9e0d
     error InvalidArgument();
     // Update data is coming from an invalid data source.
+    // Signature: 0xe60dce71
     error InvalidUpdateDataSource();
     // Update data is invalid (e.g., deserialization error)
+    // Signature: 0xe69ffece
     error InvalidUpdateData();
     // Insufficient fee is paid to the method.
+    // Signature: 0x025dbdd4
     error InsufficientFee();
     // There is no fresh update, whereas expected fresh updates.
+    // Signature: 0xde2c57fa
     error NoFreshUpdate();
     // There is no price feed found within the given range or it does not exists.
+    // Signature: 0x45805f5d
     error PriceFeedNotFoundWithinRange();
     // Price feed not found or it is not pushed on-chain yet.
+    // Signature: 0x14aebe68
     error PriceFeedNotFound();
     // Requested price is stale.
+    // Signature: 0x19abf40e
     error StalePrice();
     // Given message is not a valid Wormhole VAA.
+    // Signature: 0x2acbe915
     error InvalidWormholeVaa();
     // Governance message is invalid (e.g., deserialization error).
+    // Signature: 0x97363b35
     error InvalidGovernanceMessage();
     // Governance message is not for this contract.
+    // Signature: 0x63daeb77
     error InvalidGovernanceTarget();
     // Governance message is coming from an invalid data source.
+    // Signature: 0x360f2d87
     error InvalidGovernanceDataSource();
     // Governance message is old.
+    // Signature: 0x88d1b847
     error OldGovernanceMessage();
     // The wormhole address to set in SetWormholeAddress governance is invalid.
+    // Signature: 0x13d3ed82
     error InvalidWormholeAddressToSet();
 }

--- a/target_chains/ethereum/sdk/solidity/PythErrors.sol
+++ b/target_chains/ethereum/sdk/solidity/PythErrors.sol
@@ -29,4 +29,6 @@ library PythErrors {
     error InvalidGovernanceDataSource();
     // Governance message is old.
     error OldGovernanceMessage();
+    // The wormhole address to set in SetWormholeAddress governance is invalid.
+    error InvalidWormholeAddressToSet();
 }

--- a/target_chains/ethereum/sdk/solidity/abis/PythErrors.json
+++ b/target_chains/ethereum/sdk/solidity/abis/PythErrors.json
@@ -36,6 +36,11 @@
   },
   {
     "inputs": [],
+    "name": "InvalidWormholeAddressToSet",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "InvalidWormholeVaa",
     "type": "error"
   },


### PR DESCRIPTION
This PR adds a new governance message to update wormhole address that is used in Pyth. This will allow us to change the Wormhole that Pyth uses to a gas optimized version of it developed in the PR #901. Per @jayantk suggestion, I added some sanity checks to make sure that the new Wormhole contract works properly and reject otherwise.  

## How to test
I added the tests to the js test suite because the rest of governance messages are tested there. To test you can either use tilt to do that automatically or manually run ganache-cli as a blockchain instance and test it. To do the latter, do the following:
1. Run `npx ganache-cli -e 10000 --deterministic --time="1970-01-02T00:00:00+00:00" --host=0.0.0.0` on a separate terminal to spawn a new network.
2. Run `cp .env.test .env && npx truffle compile --all && npx truffle migrate` to deploy the contracts
3. Run `npm run test-contract` to test the contract.

## Gas difference
The optimizer runs has not changed and hence no gas difference in benchmark tests. I updated truffle and hardhat to correspond with foundry that is used is gas benchmark.