### PR TITLE
Fix test by increasing major version instead of minor version

### DIFF
--- a/target_chains/cosmwasm/contracts/pyth/src/contract.rs
+++ b/target_chains/cosmwasm/contracts/pyth/src/contract.rs
@@ -1480,7 +1480,7 @@ mod test {
 
         let feed1 = create_dummy_price_feed_message(100);
         let mut msg = create_accumulator_message(&[feed1], &[feed1], false);
-        msg.0[5] = 3;
+        msg.0[4] = 3; // major version
         let info = mock_info("123", &[]);
         let result = update_price_feeds(deps.as_mut(), env, info, &[msg]);
         assert!(result.is_err());


### PR DESCRIPTION
SDK now allows minor version updates, so the test was not failing anymore as expected