### PR TITLE
[price_pusher] Create gas pool for Sui

### DIFF
--- a/price_pusher/README.md
+++ b/price_pusher/README.md
@@ -91,18 +91,19 @@ npm run start -- aptos --endpoint https://fullnode.testnet.aptoslabs.com/v1 \
     [--polling-frequency 5] \
 
 # For Sui
-npm run start -- sui
-  --endpoint https://sui-testnet-rpc.allthatnode.com,
-  --pyth-package-id 0x975e063f398f720af4f33ec06a927f14ea76ca24f7f8dd544aa62ab9d5d15f44,
-  --pyth-state-id 0xd8afde3a48b4ff7212bd6829a150f43f59043221200d63504d981f62bff2e27a,
-  --wormhole-package-id 0xcc029e2810f17f9f43f52262f40026a71fbdca40ed3803ad2884994361910b7e,
-  --wormhole-state-id 0xebba4cc4d614f7a7cdbe883acc76d1cc767922bc96778e7b68be0d15fce27c02,
-  --price-feed-to-price-info-object-table-id 0xf8929174008c662266a1adde78e1e8e33016eb7ad37d379481e860b911e40ed5,
-  --price-service-endpoint https://xc-testnet.pyth.network,
-  --mnemonic-file ./mnemonic,
-  --price-config-file ./price-config.testnet.sample.yaml
+npm run start -- sui \
+  --endpoint https://sui-testnet-rpc.allthatnode.com \
+  --pyth-package-id 0x975e063f398f720af4f33ec06a927f14ea76ca24f7f8dd544aa62ab9d5d15f44 \
+  --pyth-state-id 0xd8afde3a48b4ff7212bd6829a150f43f59043221200d63504d981f62bff2e27a \
+  --wormhole-package-id 0xcc029e2810f17f9f43f52262f40026a71fbdca40ed3803ad2884994361910b7e \
+  --wormhole-state-id 0xebba4cc4d614f7a7cdbe883acc76d1cc767922bc96778e7b68be0d15fce27c02 \
+  --price-feed-to-price-info-object-table-id 0xf8929174008c662266a1adde78e1e8e33016eb7ad37d379481e860b911e40ed5 \
+  --price-service-endpoint https://xc-testnet.pyth.network \
+  --mnemonic-file ./mnemonic \
+  --price-config-file ./price-config.testnet.sample.yaml \
   [--pushing-frequency 10] \
   [--polling-frequency 5] \
+  [--num-gas-objects 30]
 
 
 # Or, run the price pusher docker image instead of building from the source

--- a/price_pusher/package.json
+++ b/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/price_pusher/src/sui/command.ts
+++ b/price_pusher/src/sui/command.ts
@@ -66,6 +66,12 @@ export default {
       required: true,
       default: 1,
     } as Options,
+    "num-gas-objects": {
+      description: "Number of gas objects in the pool.",
+      type: "number",
+      required: true,
+      default: 30,
+    } as Options,
     ...options.priceConfigFile,
     ...options.priceServiceEndpoint,
     ...options.mnemonicFile,
@@ -86,6 +92,7 @@ export default {
       wormholeStateId,
       priceFeedToPriceInfoObjectTableId,
       maxVaasPerPtb,
+      numGasObjects,
     } = argv;
 
     const priceConfigs = readPriceConfigFile(priceConfigFile);
@@ -137,7 +144,8 @@ export default {
       priceFeedToPriceInfoObjectTableId,
       maxVaasPerPtb,
       endpoint,
-      mnemonic
+      mnemonic,
+      numGasObjects
     );
 
     const controller = new Controller(

--- a/price_pusher/src/sui/command.ts
+++ b/price_pusher/src/sui/command.ts
@@ -72,6 +72,12 @@ export default {
       required: true,
       default: 30,
     } as Options,
+    "gas-budget": {
+      description: "Gas budget for each price update",
+      type: "number",
+      required: true,
+      default: 500_000_000,
+    } as Options,
     ...options.priceConfigFile,
     ...options.priceServiceEndpoint,
     ...options.mnemonicFile,
@@ -93,6 +99,7 @@ export default {
       priceFeedToPriceInfoObjectTableId,
       maxVaasPerPtb,
       numGasObjects,
+      gasBudget,
     } = argv;
 
     const priceConfigs = readPriceConfigFile(priceConfigFile);
@@ -145,7 +152,8 @@ export default {
       maxVaasPerPtb,
       endpoint,
       mnemonic,
-      numGasObjects
+      numGasObjects,
+      gasBudget
     );
 
     const controller = new Controller(

--- a/price_pusher/src/sui/command.ts
+++ b/price_pusher/src/sui/command.ts
@@ -153,7 +153,7 @@ export default {
       endpoint,
       mnemonic,
       gasBudget,
-      numGasObjects,
+      numGasObjects
     );
 
     const controller = new Controller(

--- a/price_pusher/src/sui/command.ts
+++ b/price_pusher/src/sui/command.ts
@@ -84,7 +84,7 @@ export default {
     ...options.pollingFrequency,
     ...options.pushingFrequency,
   },
-  handler: function (argv: any) {
+  handler: async function (argv: any) {
     const {
       endpoint,
       priceConfigFile,
@@ -142,7 +142,7 @@ export default {
       priceItems,
       { pollingFrequency }
     );
-    const suiPusher = new SuiPricePusher(
+    const suiPusher = await SuiPricePusher.createWithAutomaticGasPool(
       priceServiceConnection,
       pythPackageId,
       pythStateId,
@@ -152,8 +152,8 @@ export default {
       maxVaasPerPtb,
       endpoint,
       mnemonic,
+      gasBudget,
       numGasObjects,
-      gasBudget
     );
 
     const controller = new Controller(

--- a/price_pusher/src/sui/sui.ts
+++ b/price_pusher/src/sui/sui.ts
@@ -315,8 +315,8 @@ export class SuiPricePusher implements IPricePusher {
       });
 
       nextGasObject = getTransactionEffects(result)
-        ?.mutated!.map((obj) => obj.reference)
-        .find((ref) => ref.objectId === gasObject.objectId)!;
+        ?.mutated?.map((obj) => obj.reference)
+        .find((ref) => ref.objectId === gasObject.objectId);
 
       console.log(
         "Successfully updated price with transaction digest ",

--- a/price_pusher/src/sui/sui.ts
+++ b/price_pusher/src/sui/sui.ts
@@ -130,11 +130,14 @@ export class SuiPricePusher implements IPricePusher {
       );
     }
 
-    // TODO: we should not need this for loop
-    for (let i = 0; i < this.numGasObjects; i++) {
-      const coin = tx.splitCoins(tx.gas, [tx.pure(split_amount)]);
-      tx.transferObjects([coin], tx.pure(signerAddress));
-    }
+    const coins = tx.splitCoins(
+      tx.gas,
+      Array.from({ length: this.numGasObjects }, () => tx.pure(split_amount))
+    );
+    tx.transferObjects(
+      Array.from({ length: this.numGasObjects }, (_, i) => coins[i]),
+      tx.pure(signerAddress)
+    );
 
     const result = await this.signer.signAndExecuteTransactionBlock({
       transactionBlock: tx,

--- a/price_pusher/src/sui/sui.ts
+++ b/price_pusher/src/sui/sui.ts
@@ -101,7 +101,8 @@ export class SuiPricePusher implements IPricePusher {
     private maxVaasPerPtb: number,
     endpoint: string,
     mnemonic: string,
-    private numGasObjects: number
+    private numGasObjects: number,
+    private gasBudget: number
   ) {
     this.signer = new RawSigner(
       Ed25519Keypair.deriveKeypair(mnemonic),
@@ -298,6 +299,7 @@ export class SuiPricePusher implements IPricePusher {
           return;
         }
         tx.setGasPayment([gasObject]);
+        tx.setGasBudget(this.gasBudget);
         const result = await this.signer.signAndExecuteTransactionBlock({
           transactionBlock: tx,
           options: {


### PR DESCRIPTION
This PR is a version of https://github.com/pyth-network/pyth-crosschain/pull/918 that fixes a couple minor issues and CI. The  jist of the change is to split the SUI coins owned by the wallet into multiple roughly-equal-size coins, then maintain a queue of those coins in the pusher. Each transaction uses the gas coin from the head of the queue, returning it once the tx is done. This approach allows the blockchain to properly parallelize the execution of multiple concurrent transactions.