### PR TITLE
[hermes] Fix concurrency issue

### DIFF
--- a/hermes/Cargo.lock
+++ b/hermes/Cargo.lock
@@ -1659,7 +1659,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermes"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1678,6 +1678,7 @@ dependencies = [
  "libc",
  "libp2p",
  "log",
+ "prometheus-client",
  "pyth-sdk",
  "pythnet-sdk",
  "rand 0.8.5",
@@ -3633,6 +3634,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c2f43e8969d51935d2a7284878ae053ba30034cd563f673cde37ba5205685e"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot 0.12.1",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b6a5217beb0ad503ee7fa752d451c905113d70721b937126158f3106a48cc1"
+dependencies = [
+ "proc-macro2 1.0.56",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/hermes/Cargo.toml
+++ b/hermes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name                   = "hermes"
-version                = "0.1.3"
+version                = "0.1.4"
 edition                = "2021"
 
 [dependencies]
@@ -35,6 +35,7 @@ libp2p                 = { version = "0.42.2", features = [
 ]}
 
 log                    = { version = "0.4.17" }
+prometheus-client      = { version = "0.21.1" }
 pyth-sdk               = { version = "0.7.0" }
 
 # Parse Wormhole attester price attestations.

--- a/hermes/src/store.rs
+++ b/hermes/src/store.rs
@@ -19,10 +19,7 @@ use {
             construct_message_states_proofs,
             store_wormhole_merkle_verified_message,
         },
-        storage::{
-            AccumulatorState,
-            CompletedAccumulatorState,
-        },
+        storage::CompletedAccumulatorState,
         types::{
             ProofSet,
             UnixTimestamp,
@@ -150,18 +147,14 @@ impl Store {
             Update::AccumulatorMessages(accumulator_messages) => {
                 let slot = accumulator_messages.slot;
                 log::info!("Storing accumulator messages for slot {:?}.", slot,);
-                let mut accumulator_state = self
-                    .storage
-                    .fetch_accumulator_state(slot)
-                    .await?
-                    .unwrap_or(AccumulatorState {
-                        slot,
-                        accumulator_messages: None,
-                        wormhole_merkle_state: None,
-                    });
-                accumulator_state.accumulator_messages = Some(accumulator_messages);
                 self.storage
-                    .store_accumulator_state(accumulator_state)
+                    .update_accumulator_state(
+                        slot,
+                        Box::new(|mut state| {
+                            state.accumulator_messages = Some(accumulator_messages);
+                            state
+                        }),
+                    )
                     .await?;
                 slot
             }

--- a/hermes/src/store/storage.rs
+++ b/hermes/src/store/storage.rs
@@ -134,8 +134,20 @@ pub trait Storage: Send + Sync {
         filter: MessageStateFilter,
     ) -> Result<Vec<MessageState>>;
 
+    /// Store the accumulator state. Please note that this call will replace the
+    /// existing accumulator state for the given state's slot. If you wish to
+    /// update the accumulator state, use `update_accumulator_state` instead.
     async fn store_accumulator_state(&self, state: AccumulatorState) -> Result<()>;
     async fn fetch_accumulator_state(&self, slot: Slot) -> Result<Option<AccumulatorState>>;
+
+    /// Update the accumulator state inplace using the provided callback. The callback
+    /// takes the current state and returns the new state. If there is no accumulator
+    /// state for the given slot, the callback will be called with an empty accumulator state.
+    async fn update_accumulator_state(
+        &self,
+        slot: Slot,
+        callback: Box<dyn (FnOnce(AccumulatorState) -> AccumulatorState) + Send>,
+    ) -> Result<()>;
 }
 
 pub type StorageInstance = Box<dyn Storage>;


### PR DESCRIPTION
Because of the storage design there was a race condition happening that both wh and pythnet try to store their state in the accumulator state and they ignore the other one because fetch and store are not done together consistently. This PR fixes that by adding `update_accumulator_state` to the Storage interface which takes a callback to apply.