### PR TITLE
[audit] Only eth changes

### DIFF
--- a/target_chains/ethereum/contracts/contracts/libraries/MerkleTree.sol
+++ b/target_chains/ethereum/contracts/contracts/libraries/MerkleTree.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "./external/UnsafeCalldataBytesLib.sol";
+
+/**
+ * @dev This library provides methods to construct and verify Merkle Tree proofs efficiently.
+ *
+ */
+
+library MerkleTree {
+    uint8 constant MERKLE_LEAF_PREFIX = 0;
+    uint8 constant MERKLE_NODE_PREFIX = 1;
+    uint8 constant MERKLE_EMPTY_LEAF_PREFIX = 2;
+
+    function hash(bytes memory input) internal pure returns (bytes20) {
+        return bytes20(keccak256(input));
+    }
+
+    function emptyLeafHash() internal pure returns (bytes20) {
+        return hash(abi.encodePacked(MERKLE_EMPTY_LEAF_PREFIX));
+    }
+
+    function leafHash(bytes memory data) internal pure returns (bytes20) {
+        return hash(abi.encodePacked(MERKLE_LEAF_PREFIX, data));
+    }
+
+    function nodeHash(
+        bytes20 childA,
+        bytes20 childB
+    ) internal pure returns (bytes20) {
+        if (childA > childB) {
+            (childA, childB) = (childB, childA);
+        }
+        return hash(abi.encodePacked(MERKLE_NODE_PREFIX, childA, childB));
+    }
+
+    /// @notice Verify Merkle Tree proof for given leaf data based on data on memory.
+    /// @dev To optimize gas usage, this method doesn't take the proof as a bytes array
+    /// but rather takes the encoded proof and the offset of the proof in the
+    /// encoded proof array possibly containing multiple proofs. Also, the method
+    /// does not perform any check on the boundry of the `encodedProof` and  the
+    /// `proofOffset` parameters. It is the caller's responsibility to ensure
+    /// that the `encodedProof` is long enough to contain the proof and the
+    /// `proofOffset` is not out of bound.
+    function isProofValid(
+        bytes calldata encodedProof,
+        uint proofOffset,
+        bytes20 root,
+        bytes calldata leafData
+    ) internal pure returns (bool valid, uint endOffset) {
+        unchecked {
+            bytes20 currentDigest = MerkleTree.leafHash(leafData);
+
+            uint8 proofSize = UnsafeCalldataBytesLib.toUint8(
+                encodedProof,
+                proofOffset
+            );
+            proofOffset += 1;
+
+            for (uint i = 0; i < proofSize; i++) {
+                bytes20 siblingDigest = bytes20(
+                    UnsafeCalldataBytesLib.toAddress(encodedProof, proofOffset)
+                );
+                proofOffset += 20;
+
+                currentDigest = MerkleTree.nodeHash(
+                    currentDigest,
+                    siblingDigest
+                );
+            }
+
+            valid = currentDigest == root;
+            endOffset = proofOffset;
+        }
+    }
+
+    /// @notice Construct Merkle Tree proofs for given list of messages.
+    /// @dev This function is only used for testing purposes and is not efficient
+    /// for production use-cases.
+    ///
+    /// This method creates a merkle tree with leaf size of (2^depth) with the
+    /// messages as leafs (in the same given order) and returns the root digest
+    /// and the proofs for each message. If the number of messages is not a power
+    /// of 2, the tree is padded with empty messages.
+    function constructProofs(
+        bytes[] memory messages,
+        uint8 depth
+    ) internal pure returns (bytes20 root, bytes[] memory proofs) {
+        require((1 << depth) >= messages.length, "depth too small");
+
+        bytes20[] memory tree = new bytes20[]((1 << (depth + 1)));
+
+        // The tree is structured as follows:
+        // 1
+        // 2 3
+        // 4 5 6 7
+        // ...
+        // In this structure the parent of node x is x//2 and the children
+        // of node x are x*2 and x*2 + 1. Also, the sibling of the node x
+        // is x^1. The root is at index 1 and index 0 is not used.
+
+        // Filling the leaf hashes
+        bytes20 cachedEmptyLeafHash = emptyLeafHash();
+
+        for (uint i = 0; i < (1 << depth); i++) {
+            if (i < messages.length) {
+                tree[(1 << depth) + i] = leafHash(messages[i]);
+            } else {
+                tree[(1 << depth) + i] = cachedEmptyLeafHash;
+            }
+        }
+
+        // Filling the node hashes from bottom to top
+        for (uint k = depth; k > 0; k--) {
+            uint level = k - 1;
+            uint levelNumNodes = (1 << level);
+            for (uint i = 0; i < levelNumNodes; i++) {
+                uint id = (1 << level) + i;
+                tree[id] = nodeHash(tree[id * 2], tree[id * 2 + 1]);
+            }
+        }
+
+        root = tree[1];
+
+        proofs = new bytes[](messages.length);
+
+        for (uint i = 0; i < messages.length; i++) {
+            // depth is the number of sibling nodes in the path from the leaf to the root
+            proofs[i] = abi.encodePacked(depth);
+
+            uint idx = (1 << depth) + i;
+
+            // This loop iterates through the leaf and its parents
+            // and keeps adding the sibling of the current node to the proof.
+            while (idx > 1) {
+                proofs[i] = abi.encodePacked(
+                    proofs[i],
+                    tree[idx ^ 1] // Sibling of this node
+                );
+
+                // Jump to parent
+                idx /= 2;
+            }
+        }
+    }
+}

--- a/target_chains/ethereum/contracts/contracts/libraries/external/UnsafeCalldataBytesLib.sol
+++ b/target_chains/ethereum/contracts/contracts/libraries/external/UnsafeCalldataBytesLib.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Unlicense
+/*
+ * @title Solidity Bytes Arrays Utils
+ * @author Gonçalo Sá <goncalo.sa@consensys.net>
+ *
+ * @dev Bytes tightly packed arrays utility library for ethereum contracts written in Solidity.
+ *      The library lets you concatenate, slice and type cast bytes arrays both in memory and storage.
+ *
+ * @notice This is the **unsafe** version of BytesLib which removed all the checks (out of bound, ...)
+ * to be more gas efficient.
+ */
+pragma solidity >=0.8.0 <0.9.0;
+
+library UnsafeCalldataBytesLib {
+    function slice(
+        bytes calldata _bytes,
+        uint256 _start,
+        uint256 _length
+    ) internal pure returns (bytes calldata) {
+        return _bytes[_start:_start + _length];
+    }
+
+    function sliceFrom(
+        bytes calldata _bytes,
+        uint256 _start
+    ) internal pure returns (bytes calldata) {
+        return _bytes[_start:_bytes.length];
+    }
+
+    function toAddress(
+        bytes calldata _bytes,
+        uint256 _start
+    ) internal pure returns (address) {
+        address tempAddress;
+
+        assembly {
+            tempAddress := shr(96, calldataload(add(_bytes.offset, _start)))
+        }
+
+        return tempAddress;
+    }
+
+    function toUint8(
+        bytes calldata _bytes,
+        uint256 _start
+    ) internal pure returns (uint8) {
+        uint8 tempUint;
+
+        assembly {
+            tempUint := shr(248, calldataload(add(_bytes.offset, _start)))
+        }
+
+        return tempUint;
+    }
+
+    function toUint16(
+        bytes calldata _bytes,
+        uint256 _start
+    ) internal pure returns (uint16) {
+        uint16 tempUint;
+
+        assembly {
+            tempUint := shr(240, calldataload(add(_bytes.offset, _start)))
+        }
+
+        return tempUint;
+    }
+
+    function toUint32(
+        bytes calldata _bytes,
+        uint256 _start
+    ) internal pure returns (uint32) {
+        uint32 tempUint;
+
+        assembly {
+            tempUint := shr(224, calldataload(add(_bytes.offset, _start)))
+        }
+
+        return tempUint;
+    }
+
+    function toUint64(
+        bytes calldata _bytes,
+        uint256 _start
+    ) internal pure returns (uint64) {
+        uint64 tempUint;
+
+        assembly {
+            tempUint := shr(192, calldataload(add(_bytes.offset, _start)))
+        }
+
+        return tempUint;
+    }
+
+    function toUint96(
+        bytes calldata _bytes,
+        uint256 _start
+    ) internal pure returns (uint96) {
+        uint96 tempUint;
+
+        assembly {
+            tempUint := shr(160, calldataload(add(_bytes.offset, _start)))
+        }
+
+        return tempUint;
+    }
+
+    function toUint128(
+        bytes calldata _bytes,
+        uint256 _start
+    ) internal pure returns (uint128) {
+        uint128 tempUint;
+
+        assembly {
+            tempUint := shr(128, calldataload(add(_bytes.offset, _start)))
+        }
+
+        return tempUint;
+    }
+
+    function toUint256(
+        bytes calldata _bytes,
+        uint256 _start
+    ) internal pure returns (uint256) {
+        uint256 tempUint;
+
+        assembly {
+            tempUint := calldataload(add(_bytes.offset, _start))
+        }
+
+        return tempUint;
+    }
+
+    function toBytes32(
+        bytes calldata _bytes,
+        uint256 _start
+    ) internal pure returns (bytes32) {
+        bytes32 tempBytes32;
+
+        assembly {
+            tempBytes32 := calldataload(add(_bytes.offset, _start))
+        }
+
+        return tempBytes32;
+    }
+}

--- a/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "../libraries/external/UnsafeBytesLib.sol";
+import "../libraries/external/UnsafeCalldataBytesLib.sol";
+import "@pythnetwork/pyth-sdk-solidity/AbstractPyth.sol";
+import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
+
+import "@pythnetwork/pyth-sdk-solidity/PythErrors.sol";
+import "./PythGetters.sol";
+import "./PythSetters.sol";
+import "./PythInternalStructs.sol";
+
+import "../libraries/MerkleTree.sol";
+
+abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
+    uint32 constant ACCUMULATOR_MAGIC = 0x504e4155; // Stands for PNAU (Pyth Network Accumulator Update)
+    uint32 constant ACCUMULATOR_WORMHOLE_MAGIC = 0x41555756; // Stands for AUWV (Accumulator Update Wormhole Verficiation)
+    uint8 constant MINIMUM_ALLOWED_MINOR_VERSION = 0;
+    uint8 constant MAJOR_VERSION = 1;
+
+    enum UpdateType {
+        WormholeMerkle
+    }
+
+    enum MessageType {
+        PriceFeed
+    }
+
+    // This method is also used by batch attestation but moved here
+    // as the batch attestation will deprecate soon.
+    function parseAndVerifyPythVM(
+        bytes calldata encodedVm
+    ) internal view returns (IWormhole.VM memory vm) {
+        {
+            bool valid;
+            (vm, valid, ) = wormhole().parseAndVerifyVM(encodedVm);
+            if (!valid) revert PythErrors.InvalidWormholeVaa();
+        }
+
+        if (!isValidDataSource(vm.emitterChainId, vm.emitterAddress))
+            revert PythErrors.InvalidUpdateDataSource();
+    }
+
+    function extractUpdateTypeFromAccumulatorHeader(
+        bytes calldata accumulatorUpdate
+    ) internal pure returns (uint offset, UpdateType updateType) {
+        unchecked {
+            offset = 0;
+
+            {
+                uint32 magic = UnsafeCalldataBytesLib.toUint32(
+                    accumulatorUpdate,
+                    offset
+                );
+                offset += 4;
+
+                if (magic != ACCUMULATOR_MAGIC)
+                    revert PythErrors.InvalidUpdateData();
+
+                uint8 majorVersion = UnsafeCalldataBytesLib.toUint8(
+                    accumulatorUpdate,
+                    offset
+                );
+
+                offset += 1;
+
+                if (majorVersion != MAJOR_VERSION)
+                    revert PythErrors.InvalidUpdateData();
+
+                uint8 minorVersion = UnsafeCalldataBytesLib.toUint8(
+                    accumulatorUpdate,
+                    offset
+                );
+
+                offset += 1;
+
+                // Minor versions are forward compatible, so we only check
+                // that the minor version is not less than the minimum allowed
+                if (minorVersion < MINIMUM_ALLOWED_MINOR_VERSION)
+                    revert PythErrors.InvalidUpdateData();
+
+                // This field ensure that we can add headers in the future
+                // without breaking the contract (future compatibility)
+                uint8 trailingHeaderSize = UnsafeCalldataBytesLib.toUint8(
+                    accumulatorUpdate,
+                    offset
+                );
+                offset += 1;
+
+                // We use another offset for the trailing header and in the end add the
+                // offset by trailingHeaderSize to skip the future headers.
+                //
+                // An example would be like this:
+                // uint trailingHeaderOffset = offset
+                // uint x = UnsafeBytesLib.ToUint8(accumulatorUpdate, trailingHeaderOffset)
+                // trailingHeaderOffset += 1
+
+                offset += trailingHeaderSize;
+            }
+
+            updateType = UpdateType(
+                UnsafeCalldataBytesLib.toUint8(accumulatorUpdate, offset)
+            );
+
+            offset += 1;
+
+            if (accumulatorUpdate.length < offset)
+                revert PythErrors.InvalidUpdateData();
+        }
+    }
+
+    function extractWormholeMerkleHeaderDigestAndNumUpdatesAndEncodedFromAccumulatorUpdate(
+        bytes calldata accumulatorUpdate,
+        uint encodedOffset
+    )
+        internal
+        view
+        returns (
+            uint offset,
+            bytes20 digest,
+            uint8 numUpdates,
+            bytes calldata encoded
+        )
+    {
+        unchecked {
+            encoded = UnsafeCalldataBytesLib.slice(
+                accumulatorUpdate,
+                encodedOffset,
+                accumulatorUpdate.length - encodedOffset
+            );
+            offset = 0;
+
+            uint16 whProofSize = UnsafeCalldataBytesLib.toUint16(
+                encoded,
+                offset
+            );
+            offset += 2;
+
+            {
+                bytes memory encodedPayload;
+                {
+                    IWormhole.VM memory vm = parseAndVerifyPythVM(
+                        UnsafeCalldataBytesLib.slice(
+                            encoded,
+                            offset,
+                            whProofSize
+                        )
+                    );
+                    offset += whProofSize;
+
+                    // TODO: Do we need to emit an update for accumulator update? If so what should we emit?
+                    // emit AccumulatorUpdate(vm.chainId, vm.sequence);
+                    encodedPayload = vm.payload;
+                }
+
+                uint payloadOffset = 0;
+                {
+                    uint32 magic = UnsafeBytesLib.toUint32(
+                        encodedPayload,
+                        payloadOffset
+                    );
+                    payloadOffset += 4;
+
+                    if (magic != ACCUMULATOR_WORMHOLE_MAGIC)
+                        revert PythErrors.InvalidUpdateData();
+
+                    UpdateType updateType = UpdateType(
+                        UnsafeBytesLib.toUint8(encodedPayload, payloadOffset)
+                    );
+                    ++payloadOffset;
+
+                    if (updateType != UpdateType.WormholeMerkle)
+                        revert PythErrors.InvalidUpdateData();
+
+                    // This field is not used
+                    // uint64 slot = UnsafeBytesLib.toUint64(encodedPayload, payloadoffset);
+                    payloadOffset += 8;
+
+                    // This field is not used
+                    // uint32 ringSize = UnsafeBytesLib.toUint32(encodedPayload, payloadoffset);
+                    payloadOffset += 4;
+
+                    digest = bytes20(
+                        UnsafeBytesLib.toAddress(encodedPayload, payloadOffset)
+                    );
+                    payloadOffset += 20;
+
+                    // We don't check equality to enable future compatibility.
+                    if (payloadOffset > encodedPayload.length)
+                        revert PythErrors.InvalidUpdateData();
+                }
+            }
+
+            numUpdates = UnsafeCalldataBytesLib.toUint8(encoded, offset);
+            offset += 1;
+        }
+    }
+
+    function parseWormholeMerkleHeaderNumUpdates(
+        bytes calldata wormholeMerkleUpdate,
+        uint offset
+    ) internal pure returns (uint8 numUpdates) {
+        uint16 whProofSize = UnsafeCalldataBytesLib.toUint16(
+            wormholeMerkleUpdate,
+            offset
+        );
+        offset += 2;
+        offset += whProofSize;
+        numUpdates = UnsafeCalldataBytesLib.toUint8(
+            wormholeMerkleUpdate,
+            offset
+        );
+    }
+
+    function extractPriceInfoFromMerkleProof(
+        bytes20 digest,
+        bytes calldata encoded,
+        uint offset
+    )
+        internal
+        pure
+        returns (
+            uint endOffset,
+            PythInternalStructs.PriceInfo memory priceInfo,
+            bytes32 priceId
+        )
+    {
+        unchecked {
+            bytes calldata encodedMessage;
+            uint16 messageSize = UnsafeCalldataBytesLib.toUint16(
+                encoded,
+                offset
+            );
+            offset += 2;
+
+            encodedMessage = UnsafeCalldataBytesLib.slice(
+                encoded,
+                offset,
+                messageSize
+            );
+            offset += messageSize;
+
+            bool valid;
+            (valid, endOffset) = MerkleTree.isProofValid(
+                encoded,
+                offset,
+                digest,
+                encodedMessage
+            );
+            if (!valid) {
+                revert PythErrors.InvalidUpdateData();
+            }
+
+            MessageType messageType = MessageType(
+                UnsafeCalldataBytesLib.toUint8(encodedMessage, 0)
+            );
+            if (messageType == MessageType.PriceFeed) {
+                (priceInfo, priceId) = parsePriceFeedMessage(encodedMessage, 1);
+            } else {
+                revert PythErrors.InvalidUpdateData();
+            }
+
+            return (endOffset, priceInfo, priceId);
+        }
+    }
+
+    function parsePriceFeedMessage(
+        bytes calldata encodedPriceFeed,
+        uint offset
+    )
+        private
+        pure
+        returns (
+            PythInternalStructs.PriceInfo memory priceInfo,
+            bytes32 priceId
+        )
+    {
+        unchecked {
+            priceId = UnsafeCalldataBytesLib.toBytes32(
+                encodedPriceFeed,
+                offset
+            );
+            offset += 32;
+
+            priceInfo.price = int64(
+                UnsafeCalldataBytesLib.toUint64(encodedPriceFeed, offset)
+            );
+            offset += 8;
+
+            priceInfo.conf = UnsafeCalldataBytesLib.toUint64(
+                encodedPriceFeed,
+                offset
+            );
+            offset += 8;
+
+            priceInfo.expo = int32(
+                UnsafeCalldataBytesLib.toUint32(encodedPriceFeed, offset)
+            );
+            offset += 4;
+
+            // Publish time is i64 in some environments due to the standard in that
+            // environment. This would not cause any problem because since the signed
+            // integer is represented in two's complement, the value would be the same
+            // in both cases (for a million year at least)
+            priceInfo.publishTime = UnsafeCalldataBytesLib.toUint64(
+                encodedPriceFeed,
+                offset
+            );
+            offset += 8;
+
+            // We do not store this field because it is not used on the latest feed queries.
+            // uint64 prevPublishTime = UnsafeBytesLib.toUint64(encodedPriceFeed, offset);
+            offset += 8;
+
+            priceInfo.emaPrice = int64(
+                UnsafeCalldataBytesLib.toUint64(encodedPriceFeed, offset)
+            );
+            offset += 8;
+
+            priceInfo.emaConf = UnsafeCalldataBytesLib.toUint64(
+                encodedPriceFeed,
+                offset
+            );
+            offset += 8;
+
+            if (offset > encodedPriceFeed.length)
+                revert PythErrors.InvalidUpdateData();
+        }
+    }
+
+    function updatePriceInfosFromAccumulatorUpdate(
+        bytes calldata accumulatorUpdate
+    ) internal returns (uint8 numUpdates) {
+        (
+            uint encodedOffset,
+            UpdateType updateType
+        ) = extractUpdateTypeFromAccumulatorHeader(accumulatorUpdate);
+
+        if (updateType != UpdateType.WormholeMerkle) {
+            revert PythErrors.InvalidUpdateData();
+        }
+
+        uint offset;
+        bytes20 digest;
+        bytes calldata encoded;
+        (
+            offset,
+            digest,
+            numUpdates,
+            encoded
+        ) = extractWormholeMerkleHeaderDigestAndNumUpdatesAndEncodedFromAccumulatorUpdate(
+            accumulatorUpdate,
+            encodedOffset
+        );
+
+        unchecked {
+            for (uint i = 0; i < numUpdates; i++) {
+                PythInternalStructs.PriceInfo memory priceInfo;
+                bytes32 priceId;
+                (offset, priceInfo, priceId) = extractPriceInfoFromMerkleProof(
+                    digest,
+                    encoded,
+                    offset
+                );
+                uint64 latestPublishTime = latestPriceInfoPublishTime(priceId);
+                if (priceInfo.publishTime > latestPublishTime) {
+                    setLatestPriceInfo(priceId, priceInfo);
+                    emit PriceFeedUpdate(
+                        priceId,
+                        priceInfo.publishTime,
+                        priceInfo.price,
+                        priceInfo.conf
+                    );
+                }
+            }
+        }
+        if (offset != encoded.length) revert PythErrors.InvalidUpdateData();
+    }
+}

--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernance.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernance.sol
@@ -34,6 +34,10 @@ abstract contract PythGovernance is
     );
     event FeeSet(uint oldFee, uint newFee);
     event ValidPeriodSet(uint oldValidPeriod, uint newValidPeriod);
+    event WormholeAddressSet(
+        address oldWormholeAddress,
+        address newWormholeAddress
+    );
 
     function verifyGovernanceVM(
         bytes memory encodedVM
@@ -86,6 +90,13 @@ abstract contract PythGovernance is
         ) {
             // RequestGovernanceDataSourceTransfer can be only part of AuthorizeGovernanceDataSourceTransfer message
             revert PythErrors.InvalidGovernanceMessage();
+        } else if (gi.action == GovernanceAction.SetWormholeAddress) {
+            if (gi.targetChainId == 0)
+                revert PythErrors.InvalidGovernanceTarget();
+            setWormholeAddress(
+                parseSetWormholeAddressPayload(gi.payload),
+                encodedVM
+            );
         } else {
             revert PythErrors.InvalidGovernanceMessage();
         }
@@ -189,5 +200,47 @@ abstract contract PythGovernance is
         setValidTimePeriodSeconds(payload.newValidPeriod);
 
         emit ValidPeriodSet(oldValidPeriod, validTimePeriodSeconds());
+    }
+
+    function setWormholeAddress(
+        SetWormholeAddressPayload memory payload,
+        bytes memory encodedVM
+    ) internal {
+        address oldWormholeAddress = address(wormhole());
+        setWormhole(payload.newWormholeAddress);
+
+        // We want to verify that the new wormhole address is valid, so we make sure that it can
+        // parse and verify the same governance VAA that is used to set it.
+        (IWormhole.VM memory vm, bool valid, ) = wormhole().parseAndVerifyVM(
+            encodedVM
+        );
+
+        if (!valid) revert PythErrors.InvalidGovernanceMessage();
+
+        if (!isValidGovernanceDataSource(vm.emitterChainId, vm.emitterAddress))
+            revert PythErrors.InvalidGovernanceMessage();
+
+        if (vm.sequence != lastExecutedGovernanceSequence())
+            revert PythErrors.InvalidWormholeAddressToSet();
+
+        GovernanceInstruction memory gi = parseGovernanceInstruction(
+            vm.payload
+        );
+
+        if (gi.action != GovernanceAction.SetWormholeAddress)
+            revert PythErrors.InvalidWormholeAddressToSet();
+
+        // Purposefully, we don't check whether the chainId is the same as the current chainId because
+        // we might want to change the chain id of the wormhole contract.
+
+        // The following check is not necessary for security, but is a sanity check that the new wormhole
+        // contract parses the payload correctly.
+        SetWormholeAddressPayload
+            memory newPayload = parseSetWormholeAddressPayload(gi.payload);
+
+        if (newPayload.newWormholeAddress != payload.newWormholeAddress)
+            revert PythErrors.InvalidWormholeAddressToSet();
+
+        emit WormholeAddressSet(oldWormholeAddress, address(wormhole()));
     }
 }

--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
@@ -30,7 +30,8 @@ contract PythGovernanceInstructions {
         SetDataSources, // 2
         SetFee, // 3
         SetValidPeriod, // 4
-        RequestGovernanceDataSourceTransfer // 5
+        RequestGovernanceDataSourceTransfer, // 5
+        SetWormholeAddress // 6
     }
 
     struct GovernanceInstruction {
@@ -67,6 +68,10 @@ contract PythGovernanceInstructions {
 
     struct SetValidPeriodPayload {
         uint newValidPeriod;
+    }
+
+    struct SetWormholeAddressPayload {
+        address newWormholeAddress;
     }
 
     /// @dev Parse a GovernanceInstruction
@@ -195,6 +200,19 @@ contract PythGovernanceInstructions {
 
         svp.newValidPeriod = uint256(encodedPayload.toUint64(index));
         index += 8;
+
+        if (encodedPayload.length != index)
+            revert PythErrors.InvalidGovernanceMessage();
+    }
+
+    /// @dev Parse a UpdateWormholeAddressPayload (action 6) with minimal validation
+    function parseSetWormholeAddressPayload(
+        bytes memory encodedPayload
+    ) public pure returns (SetWormholeAddressPayload memory sw) {
+        uint index = 0;
+
+        sw.newWormholeAddress = address(encodedPayload.toAddress(index));
+        index += 20;
 
         if (encodedPayload.length != index)
             revert PythErrors.InvalidGovernanceMessage();

--- a/target_chains/ethereum/contracts/forge-test/Pyth.WormholeMerkleAccumulator.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pyth.WormholeMerkleAccumulator.t.sol
@@ -1,0 +1,1077 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "forge-std/Test.sol";
+
+import "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
+import "@pythnetwork/pyth-sdk-solidity/PythErrors.sol";
+import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
+import "./utils/WormholeTestUtils.t.sol";
+import "./utils/PythTestUtils.t.sol";
+import "./utils/RandTestUtils.t.sol";
+
+import "../contracts/libraries/MerkleTree.sol";
+
+contract PythWormholeMerkleAccumulatorTest is
+    Test,
+    WormholeTestUtils,
+    PythTestUtils,
+    RandTestUtils
+{
+    IPyth public pyth;
+
+    // -1 is equal to 0xffffff which is the biggest uint if converted back
+    uint64 constant MAX_UINT64 = uint64(int64(-1));
+
+    function setUp() public {
+        pyth = IPyth(setUpPyth(setUpWormholeReceiver(1)));
+    }
+
+    function assertPriceFeedMessageStored(
+        PriceFeedMessage memory priceFeedMessage
+    ) internal {
+        PythStructs.Price memory aggregatePrice = pyth.getPriceUnsafe(
+            priceFeedMessage.priceId
+        );
+        assertEq(aggregatePrice.price, priceFeedMessage.price);
+        assertEq(aggregatePrice.conf, priceFeedMessage.conf);
+        assertEq(aggregatePrice.expo, priceFeedMessage.expo);
+        assertEq(aggregatePrice.publishTime, priceFeedMessage.publishTime);
+
+        PythStructs.Price memory emaPrice = pyth.getEmaPriceUnsafe(
+            priceFeedMessage.priceId
+        );
+        assertEq(emaPrice.price, priceFeedMessage.emaPrice);
+        assertEq(emaPrice.conf, priceFeedMessage.emaConf);
+        assertEq(emaPrice.expo, priceFeedMessage.expo);
+        assertEq(emaPrice.publishTime, priceFeedMessage.publishTime);
+    }
+
+    function assertParsedPriceFeedEqualsMessage(
+        PythStructs.PriceFeed memory priceFeed,
+        PriceFeedMessage memory priceFeedMessage,
+        bytes32 priceId
+    ) internal {
+        assertEq(priceFeed.id, priceId);
+        assertEq(priceFeed.price.price, priceFeedMessage.price);
+        assertEq(priceFeed.price.conf, priceFeedMessage.conf);
+        assertEq(priceFeed.price.expo, priceFeedMessage.expo);
+        assertEq(priceFeed.price.publishTime, priceFeedMessage.publishTime);
+        assertEq(priceFeed.emaPrice.price, priceFeedMessage.emaPrice);
+        assertEq(priceFeed.emaPrice.conf, priceFeedMessage.emaConf);
+        assertEq(priceFeed.emaPrice.expo, priceFeedMessage.expo);
+        assertEq(priceFeed.emaPrice.publishTime, priceFeedMessage.publishTime);
+    }
+
+    function assertParsedPriceFeedStored(
+        PythStructs.PriceFeed memory priceFeed
+    ) internal {
+        PythStructs.Price memory aggregatePrice = pyth.getPriceUnsafe(
+            priceFeed.id
+        );
+        assertEq(aggregatePrice.price, priceFeed.price.price);
+        assertEq(aggregatePrice.conf, priceFeed.price.conf);
+        assertEq(aggregatePrice.expo, priceFeed.price.expo);
+        assertEq(aggregatePrice.publishTime, priceFeed.price.publishTime);
+
+        PythStructs.Price memory emaPrice = pyth.getEmaPriceUnsafe(
+            priceFeed.id
+        );
+        assertEq(emaPrice.price, priceFeed.emaPrice.price);
+        assertEq(emaPrice.conf, priceFeed.emaPrice.conf);
+        assertEq(emaPrice.expo, priceFeed.emaPrice.expo);
+        assertEq(emaPrice.publishTime, priceFeed.emaPrice.publishTime);
+    }
+
+    function assertPriceFeedEqual(
+        PythStructs.PriceFeed memory priceFeed1,
+        PythStructs.PriceFeed memory priceFeed2
+    ) internal {
+        assertEq(priceFeed1.id, priceFeed2.id);
+        assertEq(priceFeed1.price.price, priceFeed2.price.price);
+        assertEq(priceFeed1.price.conf, priceFeed2.price.conf);
+        assertEq(priceFeed1.price.expo, priceFeed2.price.expo);
+        assertEq(priceFeed1.price.publishTime, priceFeed2.price.publishTime);
+        assertEq(priceFeed1.emaPrice.price, priceFeed2.emaPrice.price);
+        assertEq(priceFeed1.emaPrice.conf, priceFeed2.emaPrice.conf);
+        assertEq(priceFeed1.emaPrice.expo, priceFeed2.emaPrice.expo);
+        assertEq(
+            priceFeed1.emaPrice.publishTime,
+            priceFeed2.emaPrice.publishTime
+        );
+    }
+
+    function generateRandomPriceFeedMessage(
+        uint numPriceFeeds
+    ) internal returns (PriceFeedMessage[] memory priceFeedMessages) {
+        priceFeedMessages = new PriceFeedMessage[](numPriceFeeds);
+        for (uint i = 0; i < numPriceFeeds; i++) {
+            priceFeedMessages[i] = PriceFeedMessage({
+                priceId: getRandBytes32(),
+                price: getRandInt64(),
+                conf: getRandUint64(),
+                expo: getRandInt32(),
+                publishTime: getRandUint64(),
+                prevPublishTime: getRandUint64(),
+                emaPrice: getRandInt64(),
+                emaConf: getRandUint64()
+            });
+        }
+    }
+
+    function createWormholeMerkleUpdateData(
+        PriceFeedMessage[] memory priceFeedMessages
+    ) internal returns (bytes[] memory updateData, uint updateFee) {
+        updateData = new bytes[](1);
+
+        uint8 depth = 0;
+        while ((1 << depth) < priceFeedMessages.length) {
+            depth++;
+        }
+
+        depth += getRandUint8() % 3;
+
+        updateData[0] = generateWhMerkleUpdate(priceFeedMessages, depth, 1);
+
+        updateFee = pyth.getUpdateFee(updateData);
+    }
+
+    /// @notice This method creates a forward compatible wormhole update data by using a newer minor version,
+    /// setting a trailing header size and generating additional trailing header data of size `trailingHeaderSize`
+    function createFowardCompatibleWormholeMerkleUpdateData(
+        PriceFeedMessage[] memory priceFeedMessages,
+        uint8 minorVersion,
+        uint8 trailingHeaderSize
+    ) internal returns (bytes[] memory updateData, uint updateFee) {
+        updateData = new bytes[](1);
+
+        uint8 depth = 0;
+        while ((1 << depth) < priceFeedMessages.length) {
+            depth++;
+        }
+
+        depth += getRandUint8() % 3;
+        bytes memory trailingHeaderData = new bytes(uint8(0));
+        for (uint i = 0; i < trailingHeaderSize; i++) {
+            trailingHeaderData = abi.encodePacked(trailingHeaderData, uint8(i));
+        }
+        updateData[0] = generateForwardCompatibleWhMerkleUpdate(
+            priceFeedMessages,
+            depth,
+            1,
+            minorVersion,
+            trailingHeaderData
+        );
+
+        updateFee = pyth.getUpdateFee(updateData);
+    }
+
+    /// Testing update price feeds method using wormhole merkle update type.
+    function testUpdatePriceFeedWithWormholeMerkleWorks(uint seed) public {
+        setRandSeed(seed);
+
+        uint numPriceFeeds = (getRandUint() % 10) + 1;
+        PriceFeedMessage[]
+            memory priceFeedMessages = generateRandomPriceFeedMessage(
+                numPriceFeeds
+            );
+        (
+            bytes[] memory updateData,
+            uint updateFee
+        ) = createWormholeMerkleUpdateData(priceFeedMessages);
+
+        pyth.updatePriceFeeds{value: updateFee}(updateData);
+
+        for (uint i = 0; i < numPriceFeeds; i++) {
+            assertPriceFeedMessageStored(priceFeedMessages[i]);
+        }
+
+        // Update the prices again with the same data should work
+        pyth.updatePriceFeeds{value: updateFee}(updateData);
+
+        for (uint i = 0; i < numPriceFeeds; i++) {
+            assertPriceFeedMessageStored(priceFeedMessages[i]);
+        }
+
+        // Update the prices again with updated data should update the prices
+        for (uint i = 0; i < numPriceFeeds; i++) {
+            priceFeedMessages[i].price = getRandInt64();
+            priceFeedMessages[i].conf = getRandUint64();
+            priceFeedMessages[i].expo = getRandInt32();
+
+            // Increase the publish time if it is not causing an overflow
+            if (priceFeedMessages[i].publishTime != type(uint64).max) {
+                priceFeedMessages[i].publishTime += 1;
+            }
+            priceFeedMessages[i].emaPrice = getRandInt64();
+            priceFeedMessages[i].emaConf = getRandUint64();
+        }
+
+        (updateData, updateFee) = createWormholeMerkleUpdateData(
+            priceFeedMessages
+        );
+
+        pyth.updatePriceFeeds{value: updateFee}(updateData);
+
+        for (uint i = 0; i < numPriceFeeds; i++) {
+            assertPriceFeedMessageStored(priceFeedMessages[i]);
+        }
+    }
+
+    function testUpdatePriceFeedWithWormholeMerkleWorksOnMultiUpdate() public {
+        PriceFeedMessage[]
+            memory priceFeedMessages1 = generateRandomPriceFeedMessage(2);
+        PriceFeedMessage[]
+            memory priceFeedMessages2 = generateRandomPriceFeedMessage(2);
+
+        // Make the 2nd message of the second update the same as the 1st message of the first update
+        priceFeedMessages2[1].priceId = priceFeedMessages1[0].priceId;
+        // Adjust the timestamps so the second timestamp is greater than the first
+        priceFeedMessages1[0].publishTime = 5;
+        priceFeedMessages2[1].publishTime = 10;
+
+        bytes[] memory updateData = new bytes[](2);
+
+        uint8 depth = 1; // 2 messages
+        uint8 numSigners = 1;
+        updateData[0] = generateWhMerkleUpdate(
+            priceFeedMessages1,
+            depth,
+            numSigners
+        );
+        updateData[1] = generateWhMerkleUpdate(
+            priceFeedMessages2,
+            depth,
+            numSigners
+        );
+
+        uint updateFee = pyth.getUpdateFee(updateData);
+
+        bytes32[] memory priceIds = new bytes32[](3);
+        priceIds[0] = priceFeedMessages1[0].priceId;
+        priceIds[1] = priceFeedMessages1[1].priceId;
+        priceIds[2] = priceFeedMessages2[0].priceId;
+        // parse price feeds before updating since parsing price feeds should be independent
+        // of whatever is currently stored in the contract.
+        PythStructs.PriceFeed[] memory priceFeeds = pyth.parsePriceFeedUpdates{
+            value: updateFee
+        }(updateData, priceIds, 0, MAX_UINT64);
+
+        PriceFeedMessage[]
+            memory expectedPriceFeedMessages = new PriceFeedMessage[](3);
+        // Only the first occurrence of a valid priceFeedMessage for a paritcular priceFeed.id
+        // within an updateData will be parsed which is why we exclude priceFeedMessages2[1]
+        // since it has the same priceFeed.id as priceFeedMessages1[0] even though it has a later publishTime.
+        // This is different than how updatePriceFeed behaves which will always update using the data
+        // of the priceFeedMessage with the latest publishTime for a particular priceFeed.id
+        expectedPriceFeedMessages[0] = priceFeedMessages1[0];
+        expectedPriceFeedMessages[1] = priceFeedMessages1[1];
+        expectedPriceFeedMessages[2] = priceFeedMessages2[0];
+        for (uint i = 0; i < expectedPriceFeedMessages.length; i++) {
+            assertParsedPriceFeedEqualsMessage(
+                priceFeeds[i],
+                expectedPriceFeedMessages[i],
+                priceIds[i]
+            );
+        }
+
+        // parse updateData[1] for priceFeedMessages1[0].priceId since this has the latest publishTime
+        // for that priceId and should be the one that is stored.
+        bytes32[] memory priceIds1 = new bytes32[](1);
+        priceIds1[0] = priceFeedMessages1[0].priceId;
+        bytes[] memory parseUpdateDataInput1 = new bytes[](1);
+        parseUpdateDataInput1[0] = updateData[1];
+
+        PythStructs.PriceFeed[] memory priceFeeds1 = pyth.parsePriceFeedUpdates{
+            value: updateFee
+        }(parseUpdateDataInput1, priceIds1, 0, MAX_UINT64);
+
+        pyth.updatePriceFeeds{value: updateFee}(updateData);
+
+        // check stored price feed information matches updateData
+        assertPriceFeedMessageStored(priceFeedMessages1[1]);
+        assertPriceFeedMessageStored(priceFeedMessages2[0]);
+        assertPriceFeedMessageStored(priceFeedMessages2[1]);
+
+        PythStructs.PriceFeed[]
+            memory expectedPriceFeeds = new PythStructs.PriceFeed[](3);
+        expectedPriceFeeds[0] = priceFeeds1[0];
+        expectedPriceFeeds[1] = priceFeeds[1];
+        expectedPriceFeeds[2] = priceFeeds[2];
+
+        // check stored price feed information matches parsed price feeds
+        for (uint i = 0; i < expectedPriceFeeds.length; i++) {
+            assertParsedPriceFeedStored(expectedPriceFeeds[i]);
+        }
+    }
+
+    function testUpdatePriceFeedWithWormholeMerkleIgnoresOutOfOrderUpdateSingleCall()
+        public
+    {
+        PriceFeedMessage[]
+            memory priceFeedMessages1 = generateRandomPriceFeedMessage(1);
+        PriceFeedMessage[]
+            memory priceFeedMessages2 = generateRandomPriceFeedMessage(1);
+
+        // Make the price ids the same
+        priceFeedMessages2[0].priceId = priceFeedMessages1[0].priceId;
+        // Adjust the timestamps so the second timestamp is smaller than the first
+        // so it doesn't get stored.
+        priceFeedMessages1[0].publishTime = 10;
+        priceFeedMessages2[0].publishTime = 5;
+
+        bytes[] memory updateData = new bytes[](2);
+
+        uint8 depth = 0; // 1 messages
+        uint8 numSigners = 1;
+
+        updateData[0] = generateWhMerkleUpdate(
+            priceFeedMessages1,
+            depth,
+            numSigners
+        );
+        updateData[1] = generateWhMerkleUpdate(
+            priceFeedMessages2,
+            depth,
+            numSigners
+        );
+
+        uint updateFee = pyth.getUpdateFee(updateData);
+
+        pyth.updatePriceFeeds{value: updateFee}(updateData);
+
+        assertPriceFeedMessageStored(priceFeedMessages1[0]);
+
+        bytes32[] memory priceIds = new bytes32[](1);
+        priceIds[0] = priceFeedMessages1[0].priceId;
+
+        PythStructs.PriceFeed[] memory priceFeeds = pyth.parsePriceFeedUpdates{
+            value: updateFee
+        }(updateData, priceIds, 0, MAX_UINT64);
+        assertEq(priceFeeds.length, 1);
+        assertParsedPriceFeedStored(priceFeeds[0]);
+
+        // parsePriceFeedUpdates should return the first priceFeed in the case
+        // that the updateData contains multiple feeds with the same id.
+        // Swap the order of updates in updateData to verify that the other priceFeed is returned
+        bytes[] memory updateData1 = new bytes[](2);
+        updateData1[0] = updateData[1];
+        updateData1[1] = updateData[0];
+
+        PythStructs.PriceFeed[] memory priceFeeds1 = pyth.parsePriceFeedUpdates{
+            value: updateFee
+        }(updateData1, priceIds, 0, MAX_UINT64);
+        assertEq(priceFeeds1.length, 1);
+        assertEq(priceFeeds1[0].price.publishTime, 5);
+    }
+
+    function testUpdatePriceFeedWithWormholeMerkleIgnoresOutOfOrderUpdateMultiCall()
+        public
+    {
+        PriceFeedMessage[]
+            memory priceFeedMessages1 = generateRandomPriceFeedMessage(1);
+        PriceFeedMessage[]
+            memory priceFeedMessages2 = generateRandomPriceFeedMessage(1);
+
+        // Make the price ids the same
+        priceFeedMessages2[0].priceId = priceFeedMessages1[0].priceId;
+        // Adjust the timestamps so the second timestamp is smaller than the first
+        // so it doesn't get stored.
+        priceFeedMessages1[0].publishTime = 10;
+        priceFeedMessages2[0].publishTime = 5;
+
+        (
+            bytes[] memory updateData,
+            uint updateFee
+        ) = createWormholeMerkleUpdateData(priceFeedMessages1);
+        pyth.updatePriceFeeds{value: updateFee}(updateData);
+
+        (updateData, updateFee) = createWormholeMerkleUpdateData(
+            priceFeedMessages2
+        );
+        pyth.updatePriceFeeds{value: updateFee}(updateData);
+        // Make sure that the old value is still stored
+        assertPriceFeedMessageStored(priceFeedMessages1[0]);
+    }
+
+    function testParsePriceFeedUpdatesWithWormholeMerklWorksWithOurOfOrderUpdateMultiCall()
+        public
+    {
+        PriceFeedMessage[]
+            memory priceFeedMessages1 = generateRandomPriceFeedMessage(1);
+        PriceFeedMessage[]
+            memory priceFeedMessages2 = generateRandomPriceFeedMessage(1);
+
+        // Make the price ids the same
+        priceFeedMessages2[0].priceId = priceFeedMessages1[0].priceId;
+        // Adjust the timestamps so the second timestamp is smaller than the first
+        // Parse should work regardless of what's stored on chain.
+        priceFeedMessages1[0].publishTime = 10;
+        priceFeedMessages2[0].publishTime = 5;
+
+        (
+            bytes[] memory updateData,
+            uint updateFee
+        ) = createWormholeMerkleUpdateData(priceFeedMessages1);
+        bytes32[] memory priceIds = new bytes32[](1);
+        priceIds[0] = priceFeedMessages1[0].priceId;
+        PythStructs.PriceFeed[] memory priceFeeds = pyth.parsePriceFeedUpdates{
+            value: updateFee
+        }(updateData, priceIds, 0, MAX_UINT64);
+
+        // Parse should always return the same value regardless of what's stored on chain.
+        assertEq(priceFeeds.length, 1);
+        assertParsedPriceFeedEqualsMessage(
+            priceFeeds[0],
+            priceFeedMessages1[0],
+            priceIds[0]
+        );
+        pyth.updatePriceFeeds{value: updateFee}(updateData);
+        priceFeeds = pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+        assertEq(priceFeeds.length, 1);
+        assertParsedPriceFeedEqualsMessage(
+            priceFeeds[0],
+            priceFeedMessages1[0],
+            priceIds[0]
+        );
+
+        (
+            bytes[] memory updateData1,
+            uint updateFee1
+        ) = createWormholeMerkleUpdateData(priceFeedMessages2);
+        pyth.updatePriceFeeds{value: updateFee1}(updateData1);
+        // reparse the original updateData should still return the same thing
+        priceFeeds = pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+        assertEq(priceFeeds.length, 1);
+        assertParsedPriceFeedEqualsMessage(
+            priceFeeds[0],
+            priceFeedMessages1[0],
+            priceIds[0]
+        );
+
+        // parsing the second message should return the data based on the second messagef
+        priceFeeds = pyth.parsePriceFeedUpdates{value: updateFee1}(
+            updateData1,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+        assertEq(priceFeeds.length, 1);
+        assertParsedPriceFeedEqualsMessage(
+            priceFeeds[0],
+            priceFeedMessages2[0],
+            priceIds[0]
+        );
+    }
+
+    /// @notice This method creates a forged invalid wormhole update data.
+    /// The caller should pass the forgeItem as string and if it matches the
+    /// expected value, that item will be forged to be invalid.
+    function createAndForgeWormholeMerkleUpdateData(
+        bytes memory forgeItem
+    )
+        public
+        returns (
+            bytes[] memory updateData,
+            uint updateFee,
+            bytes32[] memory priceIds
+        )
+    {
+        uint numPriceFeeds = 10;
+        PriceFeedMessage[]
+            memory priceFeedMessages = generateRandomPriceFeedMessage(
+                numPriceFeeds
+            );
+        priceIds = new bytes32[](numPriceFeeds);
+        for (uint i = 0; i < numPriceFeeds; i++) {
+            priceIds[i] = priceFeedMessages[i].priceId;
+        }
+
+        bytes[] memory encodedPriceFeedMessages = encodePriceFeedMessages(
+            priceFeedMessages
+        );
+
+        (bytes20 rootDigest, bytes[] memory proofs) = MerkleTree
+            .constructProofs(encodedPriceFeedMessages, 4); // 4 is the depth of the tree (enough for 16 messages)
+
+        bytes memory wormholePayload;
+        unchecked {
+            wormholePayload = abi.encodePacked(
+                isNotMatch(forgeItem, "whMagic")
+                    ? uint32(0x41555756)
+                    : uint32(0x41555750),
+                isNotMatch(forgeItem, "whUpdateType")
+                    ? uint8(PythAccumulator.UpdateType.WormholeMerkle)
+                    : uint8(PythAccumulator.UpdateType.WormholeMerkle) + 1,
+                uint64(0), // Slot, not used in target networks
+                uint32(0), // Storage index, not used in target networks
+                isNotMatch(forgeItem, "rootDigest")
+                    ? rootDigest
+                    : bytes20(uint160(rootDigest) + 1)
+            );
+        }
+
+        bytes memory wormholeMerkleVaa = generateVaa(
+            0,
+            isNotMatch(forgeItem, "whSourceChain")
+                ? SOURCE_EMITTER_CHAIN_ID
+                : SOURCE_EMITTER_CHAIN_ID + 1,
+            isNotMatch(forgeItem, "whSourceAddress")
+                ? SOURCE_EMITTER_ADDRESS
+                : bytes32(
+                    0x71f8dcb863d176e2c420ad6610cf687359612b6fb392e0642b0ca6b1f186aa00
+                ),
+            0,
+            wormholePayload,
+            1 // num signers
+        );
+
+        updateData = new bytes[](1);
+
+        updateData[0] = abi.encodePacked(
+            isNotMatch(forgeItem, "headerMagic")
+                ? uint32(0x504e4155)
+                : uint32(0x504e4150), // PythAccumulator.ACCUMULATOR_MAGIC
+            isNotMatch(forgeItem, "headerMajorVersion") ? uint8(1) : uint8(2), // major version
+            uint8(0), // minor version
+            uint8(0), // trailing header size
+            uint8(PythAccumulator.UpdateType.WormholeMerkle),
+            uint16(wormholeMerkleVaa.length),
+            wormholeMerkleVaa,
+            uint8(priceFeedMessages.length)
+        );
+
+        for (uint i = 0; i < priceFeedMessages.length; i++) {
+            updateData[0] = abi.encodePacked(
+                updateData[0],
+                uint16(encodedPriceFeedMessages[i].length),
+                encodedPriceFeedMessages[i],
+                isNotMatch(forgeItem, "proofItem") ? proofs[i] : proofs[0]
+            );
+        }
+
+        // manually calculate the fee
+        // so this helper method doesn't trigger the error.
+        // updateFee = pyth.getUpdateFee(numPriceFeeds);
+        updateFee = singleUpdateFeeInWei() * numPriceFeeds;
+    }
+
+    function testUpdatePriceFeedWithWormholeMerkleRevertsOnWrongVAAPayloadMagic()
+        public
+    {
+        // In this test the Wormhole accumulator magic is wrong and the update gets reverted.
+        (
+            bytes[] memory updateData,
+            uint updateFee,
+            bytes32[] memory priceIds
+        ) = createAndForgeWormholeMerkleUpdateData("whMagic");
+
+        vm.expectRevert(PythErrors.InvalidUpdateData.selector);
+        pyth.updatePriceFeeds{value: updateFee}(updateData);
+
+        vm.expectRevert(PythErrors.InvalidUpdateData.selector);
+
+        pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+    }
+
+    function testUpdatePriceFeedWithWormholeMerkleWorksWithoutForging() public {
+        // In this test we make sure the structure returned by createAndForgeWormholeMerkleUpdateData
+        // is valid if no particular forge flag is set
+        (
+            bytes[] memory updateData,
+            uint updateFee,
+            bytes32[] memory priceIds
+        ) = createAndForgeWormholeMerkleUpdateData("");
+
+        pyth.updatePriceFeeds{value: updateFee}(updateData);
+    }
+
+    function testUpdatePriceFeedWithWormholeMerkleRevertsOnWrongVAAPayloadUpdateType()
+        public
+    {
+        // In this test the Wormhole accumulator magic is wrong and the update gets
+        // reverted.
+
+        (
+            bytes[] memory updateData,
+            uint updateFee,
+            bytes32[] memory priceIds
+        ) = createAndForgeWormholeMerkleUpdateData("whUpdateType");
+        vm.expectRevert(); // Reason: Conversion into non-existent enum type. However it
+        // was not possible to check the revert reason in the test.
+        pyth.updatePriceFeeds{value: updateFee}(updateData);
+
+        vm.expectRevert();
+        pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+    }
+
+    function testUpdatePriceFeedWithWormholeMerkleRevertsOnWrongVAASource()
+        public
+    {
+        // In this test the Wormhole message source is wrong.
+        (
+            bytes[] memory updateData,
+            uint updateFee,
+            bytes32[] memory priceIds
+        ) = createAndForgeWormholeMerkleUpdateData("whSourceAddress");
+        vm.expectRevert(PythErrors.InvalidUpdateDataSource.selector);
+        pyth.updatePriceFeeds{value: updateFee}(updateData);
+        vm.expectRevert(PythErrors.InvalidUpdateDataSource.selector);
+        pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+
+        (
+            updateData,
+            updateFee,
+            priceIds
+        ) = createAndForgeWormholeMerkleUpdateData("whSourceChain");
+        vm.expectRevert(PythErrors.InvalidUpdateDataSource.selector);
+        pyth.updatePriceFeeds{value: updateFee}(updateData);
+
+        vm.expectRevert(PythErrors.InvalidUpdateDataSource.selector);
+        pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+    }
+
+    function testUpdatePriceFeedWithWormholeMerkleRevertsOnWrongRootDigest()
+        public
+    {
+        // In this test the Wormhole merkle proof digest is wrong
+        (
+            bytes[] memory updateData,
+            uint updateFee,
+            bytes32[] memory priceIds
+        ) = createAndForgeWormholeMerkleUpdateData("rootDigest");
+        vm.expectRevert(PythErrors.InvalidUpdateData.selector);
+        pyth.updatePriceFeeds{value: updateFee}(updateData);
+
+        vm.expectRevert(PythErrors.InvalidUpdateData.selector);
+        pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+    }
+
+    function testUpdatePriceFeedWithWormholeMerkleRevertsOnWrongProofItem()
+        public
+    {
+        // In this test all Wormhole merkle proof items are the first item proof
+        (
+            bytes[] memory updateData,
+            uint updateFee,
+            bytes32[] memory priceIds
+        ) = createAndForgeWormholeMerkleUpdateData("proofItem");
+        vm.expectRevert(PythErrors.InvalidUpdateData.selector);
+        pyth.updatePriceFeeds{value: updateFee}(updateData);
+
+        vm.expectRevert(PythErrors.InvalidUpdateData.selector);
+        pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+    }
+
+    function testUpdatePriceFeedWithWormholeMerkleRevertsOnWrongHeader()
+        public
+    {
+        // In this test the message headers are wrong
+        (
+            bytes[] memory updateData,
+            uint updateFee,
+            bytes32[] memory priceIds
+        ) = createAndForgeWormholeMerkleUpdateData("headerMagic");
+        vm.expectRevert(); // The revert reason is not deterministic because when it doesn't match it goes through
+        // the old approach.
+        pyth.updatePriceFeeds{value: updateFee}(updateData);
+        vm.expectRevert();
+        pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+
+        (
+            updateData,
+            updateFee,
+            priceIds
+        ) = createAndForgeWormholeMerkleUpdateData("headerMajorVersion");
+        vm.expectRevert(PythErrors.InvalidUpdateData.selector);
+        pyth.updatePriceFeeds{value: updateFee}(updateData);
+
+        vm.expectRevert(PythErrors.InvalidUpdateData.selector);
+        pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+    }
+
+    function testUpdatePriceFeedWithWormholeMerkleRevertsIfUpdateFeeIsNotPaid()
+        public
+    {
+        uint numPriceFeeds = (getRandUint() % 10) + 1;
+        PriceFeedMessage[]
+            memory priceFeedMessages = generateRandomPriceFeedMessage(
+                numPriceFeeds
+            );
+        (bytes[] memory updateData, ) = createWormholeMerkleUpdateData(
+            priceFeedMessages
+        );
+
+        bytes32[] memory priceIds = new bytes32[](numPriceFeeds);
+        for (uint i = 0; i < numPriceFeeds; i++) {
+            priceIds[i] = priceFeedMessages[i].priceId;
+        }
+        vm.expectRevert(PythErrors.InsufficientFee.selector);
+        pyth.updatePriceFeeds{value: 0}(updateData);
+
+        vm.expectRevert(PythErrors.InsufficientFee.selector);
+        pyth.parsePriceFeedUpdates{value: 0}(
+            updateData,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+    }
+
+    function testParsePriceFeedWithWormholeMerkleWorks(uint seed) public {
+        setRandSeed(seed);
+
+        uint numPriceFeeds = (getRandUint() % 10) + 1;
+        PriceFeedMessage[]
+            memory priceFeedMessages = generateRandomPriceFeedMessage(
+                numPriceFeeds
+            );
+        (
+            bytes[] memory updateData,
+            uint updateFee
+        ) = createWormholeMerkleUpdateData(priceFeedMessages);
+        bytes32[] memory priceIds = new bytes32[](numPriceFeeds);
+        for (uint i = 0; i < numPriceFeeds; i++) {
+            priceIds[i] = priceFeedMessages[i].priceId;
+        }
+        PythStructs.PriceFeed[] memory priceFeeds = pyth.parsePriceFeedUpdates{
+            value: updateFee
+        }(updateData, priceIds, 0, MAX_UINT64);
+
+        for (uint i = 0; i < priceFeeds.length; i++) {
+            assertParsedPriceFeedEqualsMessage(
+                priceFeeds[i],
+                priceFeedMessages[i],
+                priceIds[i]
+            );
+        }
+
+        // update priceFeedMessages
+        for (uint i = 0; i < numPriceFeeds; i++) {
+            priceFeedMessages[i].price = getRandInt64();
+            priceFeedMessages[i].conf = getRandUint64();
+            priceFeedMessages[i].expo = getRandInt32();
+            priceFeedMessages[i].publishTime = getRandUint64();
+            priceFeedMessages[i].emaPrice = getRandInt64();
+            priceFeedMessages[i].emaConf = getRandUint64();
+        }
+
+        (updateData, updateFee) = createWormholeMerkleUpdateData(
+            priceFeedMessages
+        );
+
+        // reparse
+        priceFeeds = pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+
+        for (uint i = 0; i < priceFeeds.length; i++) {
+            assertParsedPriceFeedEqualsMessage(
+                priceFeeds[i],
+                priceFeedMessages[i],
+                priceIds[i]
+            );
+        }
+    }
+
+    function testParsePriceFeedWithWormholeMerkleWorksRandomDistinctUpdatesInput(
+        uint seed
+    ) public {
+        setRandSeed(seed);
+
+        uint numPriceFeeds = (getRandUint() % 10) + 1;
+        PriceFeedMessage[]
+            memory priceFeedMessages = generateRandomPriceFeedMessage(
+                numPriceFeeds
+            );
+
+        (
+            bytes[] memory updateData,
+            uint updateFee
+        ) = createWormholeMerkleUpdateData(priceFeedMessages);
+        bytes32[] memory priceIds = new bytes32[](numPriceFeeds);
+        for (uint i = 0; i < numPriceFeeds; i++) {
+            priceIds[i] = priceFeedMessages[i].priceId;
+        }
+
+        // Shuffle the priceFeedMessages
+        for (uint i = 1; i < numPriceFeeds; i++) {
+            uint swapWith = getRandUint() % (i + 1);
+            (priceFeedMessages[i], priceFeedMessages[swapWith]) = (
+                priceFeedMessages[swapWith],
+                priceFeedMessages[i]
+            );
+            (priceIds[i], priceIds[swapWith]) = (
+                priceIds[swapWith],
+                priceIds[i]
+            );
+        }
+
+        // Select only first numSelectedPriceFeeds. numSelectedPriceFeeds will be in [0, numPriceFeeds]
+        uint numSelectedPriceFeeds = getRandUint() % (numPriceFeeds + 1);
+
+        PriceFeedMessage[]
+            memory selectedPriceFeedsMessages = new PriceFeedMessage[](
+                numSelectedPriceFeeds
+            );
+        bytes32[] memory selectedPriceIds = new bytes32[](
+            numSelectedPriceFeeds
+        );
+
+        for (uint i = 0; i < numSelectedPriceFeeds; i++) {
+            selectedPriceFeedsMessages[i] = priceFeedMessages[i];
+            selectedPriceIds[i] = priceIds[i];
+        }
+
+        PythStructs.PriceFeed[] memory priceFeeds = pyth.parsePriceFeedUpdates{
+            value: updateFee
+        }(updateData, selectedPriceIds, 0, MAX_UINT64);
+        for (uint i = 0; i < numSelectedPriceFeeds; i++) {
+            assertParsedPriceFeedEqualsMessage(
+                priceFeeds[i],
+                selectedPriceFeedsMessages[i],
+                selectedPriceIds[i]
+            );
+        }
+    }
+
+    function testParsePriceFeedWithWormholeMerkleRevertsIfPriceIdNotIncluded()
+        public
+    {
+        PriceFeedMessage[] memory priceFeedMessages = new PriceFeedMessage[](1);
+        priceFeedMessages[0] = PriceFeedMessage({
+            priceId: bytes32(uint(1)),
+            price: getRandInt64(),
+            conf: getRandUint64(),
+            expo: getRandInt32(),
+            publishTime: getRandUint64(),
+            prevPublishTime: getRandUint64(),
+            emaPrice: getRandInt64(),
+            emaConf: getRandUint64()
+        });
+
+        (
+            bytes[] memory updateData,
+            uint updateFee
+        ) = createWormholeMerkleUpdateData(priceFeedMessages);
+        bytes32[] memory priceIds = new bytes32[](1);
+        priceIds[0] = bytes32(uint(2));
+
+        vm.expectRevert(PythErrors.PriceFeedNotFoundWithinRange.selector);
+        pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+    }
+
+    function testParsePriceFeedUpdateRevertsIfPricesOutOfTimeRange() public {
+        uint numPriceFeeds = (getRandUint() % 10) + 1;
+        PriceFeedMessage[]
+            memory priceFeedMessages = generateRandomPriceFeedMessage(
+                numPriceFeeds
+            );
+        for (uint i = 0; i < numPriceFeeds; i++) {
+            priceFeedMessages[i].publishTime = uint64(
+                100 + (getRandUint() % 101)
+            ); // All between [100, 200]
+        }
+
+        (
+            bytes[] memory updateData,
+            uint updateFee
+        ) = createWormholeMerkleUpdateData(priceFeedMessages);
+
+        bytes32[] memory priceIds = new bytes32[](numPriceFeeds);
+        for (uint i = 0; i < numPriceFeeds; i++) {
+            priceIds[i] = priceFeedMessages[i].priceId;
+        }
+
+        // Request for parse within the given time range should work
+        pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            100,
+            200
+        );
+
+        // Request for parse after the time range should revert.
+        vm.expectRevert(PythErrors.PriceFeedNotFoundWithinRange.selector);
+        pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            300,
+            MAX_UINT64
+        );
+
+        // Request for parse before the time range should revert.
+        vm.expectRevert(PythErrors.PriceFeedNotFoundWithinRange.selector);
+        pyth.parsePriceFeedUpdates{value: updateFee}(
+            updateData,
+            priceIds,
+            0,
+            99
+        );
+    }
+
+    function testGetUpdateFeeWorksForWhMerkle() public {
+        uint numPriceFeeds = (getRandUint() % 10) + 1;
+        PriceFeedMessage[]
+            memory priceFeedMessages = generateRandomPriceFeedMessage(
+                numPriceFeeds
+            );
+        (bytes[] memory updateData, ) = createWormholeMerkleUpdateData(
+            priceFeedMessages
+        );
+
+        uint updateFee = pyth.getUpdateFee(updateData);
+        assertEq(updateFee, SINGLE_UPDATE_FEE_IN_WEI * numPriceFeeds);
+    }
+
+    function testGetUpdateFeeWorksForWhMerkleBasedOnNumUpdates() public {
+        uint numPriceFeeds = (getRandUint() % 10) + 1;
+        PriceFeedMessage[]
+            memory priceFeedMessages = generateRandomPriceFeedMessage(
+                numPriceFeeds
+            );
+        // Set the priceId of the second message to be the same as the first.
+        priceFeedMessages[1].priceId = priceFeedMessages[0].priceId;
+        (bytes[] memory updateData, ) = createWormholeMerkleUpdateData(
+            priceFeedMessages
+        );
+
+        uint updateFee = pyth.getUpdateFee(updateData);
+        // updateFee should still be based on numUpdates not distinct number of priceIds
+        assertEq(updateFee, SINGLE_UPDATE_FEE_IN_WEI * numPriceFeeds);
+    }
+
+    function testParsePriceFeedUpdatesWithWhMerkleUpdateWorksForForwardCompatibility()
+        public
+    {
+        uint numPriceFeeds = (getRandUint() % 10) + 1;
+        PriceFeedMessage[]
+            memory priceFeedMessages = generateRandomPriceFeedMessage(
+                numPriceFeeds
+            );
+        (
+            bytes[] memory updateData,
+            uint updateFee
+        ) = createWormholeMerkleUpdateData(priceFeedMessages);
+
+        bytes32[] memory priceIds = new bytes32[](numPriceFeeds);
+        for (uint i = 0; i < numPriceFeeds; i++) {
+            priceIds[i] = priceFeedMessages[i].priceId;
+        }
+        PythStructs.PriceFeed[] memory priceFeeds = pyth.parsePriceFeedUpdates{
+            value: updateFee
+        }(updateData, priceIds, 0, MAX_UINT64);
+        uint8 futureMinorVersion = uint8(2);
+        uint8 futureTrailingHeaderSize = uint8(20);
+        (
+            bytes[] memory updateDataFromFuture,
+            uint updateFeeFromFuture
+        ) = createFowardCompatibleWormholeMerkleUpdateData(
+                priceFeedMessages,
+                futureMinorVersion,
+                futureTrailingHeaderSize
+            );
+
+        PythStructs.PriceFeed[] memory priceFeedsFromFutureUpdateData = pyth
+            .parsePriceFeedUpdates{value: updateFeeFromFuture}(
+            updateDataFromFuture,
+            priceIds,
+            0,
+            MAX_UINT64
+        );
+        assertEq(updateFee, updateFeeFromFuture);
+
+        for (uint i = 0; i < priceFeeds.length; i++) {
+            assertPriceFeedEqual(
+                priceFeeds[i],
+                priceFeedsFromFutureUpdateData[i]
+            );
+        }
+    }
+
+    function testUpdatePriceFeedUpdatesWithWhMerkleUpdateWorksForForwardCompatibility()
+        public
+    {
+        uint numPriceFeeds = (getRandUint() % 10) + 1;
+        PriceFeedMessage[]
+            memory priceFeedMessages = generateRandomPriceFeedMessage(
+                numPriceFeeds
+            );
+        uint8 futureMinorVersion = uint8(2);
+        uint8 futureTrailingHeaderSize = uint8(20);
+        (
+            bytes[] memory forwardCompatibleUpdateData,
+            uint updateFee
+        ) = createFowardCompatibleWormholeMerkleUpdateData(
+                priceFeedMessages,
+                futureMinorVersion,
+                futureTrailingHeaderSize
+            );
+
+        pyth.updatePriceFeeds{value: updateFee}(forwardCompatibleUpdateData);
+
+        for (uint i = 0; i < priceFeedMessages.length; i++) {
+            assertPriceFeedMessageStored(priceFeedMessages[i]);
+        }
+    }
+}

--- a/target_chains/ethereum/contracts/forge-test/Pyth.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pyth.t.sol
@@ -15,11 +15,11 @@ import "./utils/RandTestUtils.t.sol";
 contract PythTest is Test, WormholeTestUtils, PythTestUtils, RandTestUtils {
     IPyth public pyth;
 
-    // -1 is equal to 0x111111 which is the biggest uint if converted back
+    // -1 is equal to 0xffffff which is the biggest uint if converted back
     uint64 constant MAX_UINT64 = uint64(int64(-1));
 
     function setUp() public {
-        pyth = IPyth(setUpPyth(setUpWormhole(1)));
+        pyth = IPyth(setUpPyth(setUpWormholeReceiver(1)));
     }
 
     function generateRandomPriceAttestations(
@@ -77,7 +77,7 @@ contract PythTest is Test, WormholeTestUtils, PythTestUtils, RandTestUtils {
                 batchAttestations[j - i] = attestations[j];
             }
 
-            updateData[i / batchSize] = generatePriceFeedUpdateVAA(
+            updateData[i / batchSize] = generateWhBatchUpdate(
                 batchAttestations,
                 0,
                 1

--- a/target_chains/ethereum/contracts/forge-test/VerificationExperiments.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/VerificationExperiments.t.sol
@@ -67,7 +67,9 @@ contract VerificationExperiments is
     uint64 sequence;
 
     function setUp() public {
-        address payable wormhole = payable(setUpWormhole(NUM_GUARDIANS));
+        address payable wormhole = payable(
+            setUpWormholeReceiver(NUM_GUARDIANS)
+        );
 
         // Deploy experimental contract
         PythExperimental implementation = new PythExperimental();
@@ -82,7 +84,6 @@ contract VerificationExperiments is
 
         bytes32[] memory emitterAddresses = new bytes32[](1);
         emitterAddresses[0] = PythTestUtils.SOURCE_EMITTER_ADDRESS;
-
         pyth.initialize(
             wormhole,
             vm.addr(THRESHOLD_KEY),
@@ -134,6 +135,7 @@ contract VerificationExperiments is
             cachedPricesUpdateData,
             cachedPricesUpdateFee
         ) = generateWormholeUpdateDataAndFee(cachedPrices);
+
         pyth.updatePriceFeeds{value: cachedPricesUpdateFee}(
             cachedPricesUpdateData
         );
@@ -186,7 +188,7 @@ contract VerificationExperiments is
     function generateWormholeUpdateDataAndFee(
         PythStructs.Price[] memory prices
     ) internal returns (bytes[] memory updateData, uint updateFee) {
-        bytes memory vaa = generatePriceFeedUpdateVAA(
+        bytes memory vaa = generateWhBatchUpdate(
             pricesToPriceAttestations(priceIds, prices),
             sequence,
             NUM_GUARDIAN_SIGNERS
@@ -310,7 +312,7 @@ contract VerificationExperiments is
         return ThresholdUpdate(signature, data);
     }
 
-    function testWormholeBatchUpdate() public {
+    function testWhBatchUpdate() public {
         pyth.updatePriceFeeds{value: freshPricesUpdateFee}(
             freshPricesUpdateData
         );

--- a/target_chains/ethereum/contracts/forge-test/utils/PythTestUtils.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/utils/PythTestUtils.t.sol
@@ -4,6 +4,10 @@ pragma solidity ^0.8.0;
 
 import "../../contracts/pyth/PythUpgradable.sol";
 import "../../contracts/pyth/PythInternalStructs.sol";
+import "../../contracts/pyth/PythAccumulator.sol";
+
+import "../../contracts/libraries/MerkleTree.sol";
+
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
 import "@pythnetwork/pyth-sdk-solidity/IPythEvents.sol";
@@ -20,6 +24,7 @@ abstract contract PythTestUtils is Test, WormholeTestUtils {
     uint16 constant GOVERNANCE_EMITTER_CHAIN_ID = 0x1;
     bytes32 constant GOVERNANCE_EMITTER_ADDRESS =
         0x0000000000000000000000000000000000000000000000000000000000000011;
+    uint constant SINGLE_UPDATE_FEE_IN_WEI = 1;
 
     function setUpPyth(address wormhole) public returns (address) {
         PythUpgradable implementation = new PythUpgradable();
@@ -43,10 +48,14 @@ abstract contract PythTestUtils is Test, WormholeTestUtils {
             GOVERNANCE_EMITTER_ADDRESS,
             0, // Initial governance sequence
             60, // Valid time period in seconds
-            1 // single update fee in wei
+            SINGLE_UPDATE_FEE_IN_WEI // single update fee in wei
         );
 
         return address(pyth);
+    }
+
+    function singleUpdateFeeInWei() public view returns (uint) {
+        return SINGLE_UPDATE_FEE_IN_WEI;
     }
 
     /// Utilities to help generating price attestations and VAAs for them
@@ -74,9 +83,169 @@ abstract contract PythTestUtils is Test, WormholeTestUtils {
         uint64 prevConf;
     }
 
+    struct PriceFeedMessage {
+        bytes32 priceId;
+        int64 price;
+        uint64 conf;
+        int32 expo;
+        uint64 publishTime;
+        uint64 prevPublishTime;
+        int64 emaPrice;
+        uint64 emaConf;
+    }
+
+    function encodePriceFeedMessages(
+        PriceFeedMessage[] memory priceFeedMessages
+    ) internal pure returns (bytes[] memory encodedPriceFeedMessages) {
+        encodedPriceFeedMessages = new bytes[](priceFeedMessages.length);
+
+        for (uint i = 0; i < priceFeedMessages.length; i++) {
+            encodedPriceFeedMessages[i] = abi.encodePacked(
+                uint8(PythAccumulator.MessageType.PriceFeed),
+                priceFeedMessages[i].priceId,
+                priceFeedMessages[i].price,
+                priceFeedMessages[i].conf,
+                priceFeedMessages[i].expo,
+                priceFeedMessages[i].publishTime,
+                priceFeedMessages[i].prevPublishTime,
+                priceFeedMessages[i].emaPrice,
+                priceFeedMessages[i].emaConf
+            );
+        }
+    }
+
+    function generateWhMerkleUpdate(
+        PriceFeedMessage[] memory priceFeedMessages,
+        uint8 depth,
+        uint8 numSigners
+    ) internal returns (bytes memory whMerkleUpdateData) {
+        bytes[] memory encodedPriceFeedMessages = encodePriceFeedMessages(
+            priceFeedMessages
+        );
+
+        (bytes20 rootDigest, bytes[] memory proofs) = MerkleTree
+            .constructProofs(encodedPriceFeedMessages, depth);
+
+        bytes memory wormholePayload = abi.encodePacked(
+            uint32(0x41555756), // PythAccumulator.ACCUMULATOR_WORMHOLE_MAGIC
+            uint8(PythAccumulator.UpdateType.WormholeMerkle),
+            uint64(0), // Slot, not used in target networks
+            uint32(0), // Ring size, not used in target networks
+            rootDigest
+        );
+
+        bytes memory wormholeMerkleVaa = generateVaa(
+            0,
+            SOURCE_EMITTER_CHAIN_ID,
+            SOURCE_EMITTER_ADDRESS,
+            0,
+            wormholePayload,
+            numSigners
+        );
+
+        whMerkleUpdateData = abi.encodePacked(
+            uint32(0x504e4155), // PythAccumulator.ACCUMULATOR_MAGIC
+            uint8(1), // major version
+            uint8(0), // minor version
+            uint8(0), // trailing header size
+            uint8(PythAccumulator.UpdateType.WormholeMerkle),
+            uint16(wormholeMerkleVaa.length),
+            wormholeMerkleVaa,
+            uint8(priceFeedMessages.length)
+        );
+
+        for (uint i = 0; i < priceFeedMessages.length; i++) {
+            whMerkleUpdateData = abi.encodePacked(
+                whMerkleUpdateData,
+                uint16(encodedPriceFeedMessages[i].length),
+                encodedPriceFeedMessages[i],
+                proofs[i]
+            );
+        }
+    }
+
+    function generateForwardCompatibleWhMerkleUpdate(
+        PriceFeedMessage[] memory priceFeedMessages,
+        uint8 depth,
+        uint8 numSigners,
+        uint8 minorVersion,
+        bytes memory trailingHeaderData
+    ) internal returns (bytes memory whMerkleUpdateData) {
+        bytes[] memory encodedPriceFeedMessages = encodePriceFeedMessages(
+            priceFeedMessages
+        );
+
+        (bytes20 rootDigest, bytes[] memory proofs) = MerkleTree
+            .constructProofs(encodedPriceFeedMessages, depth);
+        // refactoring some of these generateWormhole functions was necessary
+        // to workaround the stack too deep limit.
+        bytes
+            memory wormholeMerkleVaa = generateForwardCompatibleWormholeMerkleVaa(
+                rootDigest,
+                trailingHeaderData,
+                numSigners
+            );
+        {
+            whMerkleUpdateData = abi.encodePacked(
+                generateForwardCompatibleWormholeMerkleUpdateHeader(
+                    minorVersion,
+                    trailingHeaderData
+                ),
+                uint16(wormholeMerkleVaa.length),
+                wormholeMerkleVaa,
+                uint8(priceFeedMessages.length)
+            );
+        }
+
+        for (uint i = 0; i < priceFeedMessages.length; i++) {
+            whMerkleUpdateData = abi.encodePacked(
+                whMerkleUpdateData,
+                uint16(encodedPriceFeedMessages[i].length),
+                encodedPriceFeedMessages[i],
+                proofs[i]
+            );
+        }
+    }
+
+    function generateForwardCompatibleWormholeMerkleUpdateHeader(
+        uint8 minorVersion,
+        bytes memory trailingHeaderData
+    ) private returns (bytes memory whMerkleUpdateHeader) {
+        whMerkleUpdateHeader = abi.encodePacked(
+            uint32(0x504e4155), // PythAccumulator.ACCUMULATOR_MAGIC
+            uint8(1), // major version
+            minorVersion,
+            uint8(trailingHeaderData.length), // trailing header size
+            trailingHeaderData,
+            uint8(PythAccumulator.UpdateType.WormholeMerkle)
+        );
+    }
+
+    function generateForwardCompatibleWormholeMerkleVaa(
+        bytes20 rootDigest,
+        bytes memory futureData,
+        uint8 numSigners
+    ) internal returns (bytes memory wormholeMerkleVaa) {
+        wormholeMerkleVaa = generateVaa(
+            0,
+            SOURCE_EMITTER_CHAIN_ID,
+            SOURCE_EMITTER_ADDRESS,
+            0,
+            abi.encodePacked(
+                uint32(0x41555756), // PythAccumulator.ACCUMULATOR_WORMHOLE_MAGIC
+                uint8(PythAccumulator.UpdateType.WormholeMerkle),
+                uint64(0), // Slot, not used in target networks
+                uint32(0), // Ring size, not used in target networks
+                rootDigest, // this can have bytes past this for future versions
+                futureData
+            ),
+            numSigners
+        );
+    }
+
     // Generates byte-encoded payload for the given price attestations. You can use this to mock wormhole
     // call using `vm.mockCall` and return a VM struct with this payload.
-    // You can use generatePriceFeedUpdateVAA to generate a VAA for a price update.
+    // You can use generatePriceFeedUpdate to generate a VAA for a price update.
     function generatePriceFeedUpdatePayload(
         PriceAttestation[] memory attestations
     ) public pure returns (bytes memory payload) {
@@ -124,7 +293,7 @@ abstract contract PythTestUtils is Test, WormholeTestUtils {
     // Generates a VAA for the given attestations.
     // This method calls generatePriceFeedUpdatePayload and then creates a VAA with it.
     // The VAAs generated from this method use block timestamp as their timestamp.
-    function generatePriceFeedUpdateVAA(
+    function generateWhBatchUpdate(
         PriceAttestation[] memory attestations,
         uint64 sequence,
         uint8 numSigners
@@ -170,6 +339,24 @@ abstract contract PythTestUtils is Test, WormholeTestUtils {
             attestations[i].prevConf = prices[i].conf;
         }
     }
+
+    function pricesToPriceFeedMessages(
+        bytes32[] memory priceIds,
+        PythStructs.Price[] memory prices
+    ) public returns (PriceFeedMessage[] memory priceFeedMessages) {
+        assertGe(priceIds.length, prices.length);
+        priceFeedMessages = new PriceFeedMessage[](prices.length);
+
+        for (uint i = 0; i < prices.length; ++i) {
+            priceFeedMessages[i].priceId = priceIds[i];
+            priceFeedMessages[i].price = prices[i].price;
+            priceFeedMessages[i].conf = prices[i].conf;
+            priceFeedMessages[i].expo = prices[i].expo;
+            priceFeedMessages[i].publishTime = uint64(prices[i].publishTime);
+            priceFeedMessages[i].emaPrice = prices[i].price;
+            priceFeedMessages[i].emaConf = prices[i].conf;
+        }
+    }
 }
 
 contract PythTestUtilsTest is
@@ -178,10 +365,10 @@ contract PythTestUtilsTest is
     PythTestUtils,
     IPythEvents
 {
-    function testGeneratePriceFeedUpdateVAAWorks() public {
+    function testGenerateWhBatchUpdateWorks() public {
         IPyth pyth = IPyth(
             setUpPyth(
-                setUpWormhole(
+                setUpWormholeReceiver(
                     1 // Number of guardians
                 )
             )
@@ -200,7 +387,7 @@ contract PythTestUtilsTest is
             1 // Publish time
         );
 
-        bytes memory vaa = generatePriceFeedUpdateVAA(
+        bytes memory vaa = generateWhBatchUpdate(
             pricesToPriceAttestations(priceIds, prices),
             1, // Sequence
             1 // No. Signers
@@ -211,7 +398,7 @@ contract PythTestUtilsTest is
 
         uint updateFee = pyth.getUpdateFee(updateData);
 
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, false, false, true);
         emit PriceFeedUpdate(priceIds[0], 1, 100, 10);
 
         pyth.updatePriceFeeds{value: updateFee}(updateData);

--- a/target_chains/ethereum/contracts/forge-test/utils/RandTestUtils.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/utils/RandTestUtils.t.sol
@@ -38,4 +38,8 @@ contract RandTestUtils is Test {
     function getRandInt32() internal returns (int32) {
         return int32(getRandUint32());
     }
+
+    function getRandUint8() internal returns (uint8) {
+        return uint8(getRandUint());
+    }
 }

--- a/target_chains/ethereum/contracts/forge-test/utils/WormholeTestUtils.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/utils/WormholeTestUtils.t.sol
@@ -7,9 +7,21 @@ import "../../contracts/wormhole/Setup.sol";
 import "../../contracts/wormhole/Wormhole.sol";
 import "../../contracts/wormhole/interfaces/IWormhole.sol";
 
+import "../../contracts/wormhole-receiver/ReceiverImplementation.sol";
+import "../../contracts/wormhole-receiver/ReceiverSetup.sol";
+import "../../contracts/wormhole-receiver/WormholeReceiver.sol";
+import "../../contracts/wormhole-receiver/ReceiverGovernanceStructs.sol";
+
 import "forge-std/Test.sol";
 
 abstract contract WormholeTestUtils is Test {
+    uint256[] currentSigners;
+    address wormholeReceiverAddr;
+    uint16 constant CHAIN_ID = 2; // Ethereum
+    uint16 constant GOVERNANCE_CHAIN_ID = 1; // solana
+    bytes32 constant GOVERNANCE_CONTRACT =
+        0x0000000000000000000000000000000000000000000000000000000000000004;
+
     function setUpWormhole(uint8 numGuardians) public returns (address) {
         Implementation wormholeImpl = new Implementation();
         Setup wormholeSetup = new Setup();
@@ -17,9 +29,11 @@ abstract contract WormholeTestUtils is Test {
         Wormhole wormhole = new Wormhole(address(wormholeSetup), new bytes(0));
 
         address[] memory initSigners = new address[](numGuardians);
+        currentSigners = new uint256[](numGuardians);
 
         for (uint256 i = 0; i < numGuardians; ++i) {
-            initSigners[i] = vm.addr(i + 1); // i+1 is the private key for the i-th signer.
+            currentSigners[i] = i + 1;
+            initSigners[i] = vm.addr(currentSigners[i]); // i+1 is the private key for the i-th signer.
         }
 
         // These values are the default values used in our tilt test environment
@@ -27,12 +41,52 @@ abstract contract WormholeTestUtils is Test {
         Setup(address(wormhole)).setup(
             address(wormholeImpl),
             initSigners,
-            2, // Ethereum chain ID
-            1, // Governance source chain ID (1 = solana)
-            0x0000000000000000000000000000000000000000000000000000000000000004 // Governance source address
+            CHAIN_ID, // Ethereum chain ID
+            GOVERNANCE_CHAIN_ID, // Governance source chain ID (1 = solana)
+            GOVERNANCE_CONTRACT // Governance source address
         );
 
         return address(wormhole);
+    }
+
+    function setUpWormholeReceiver(
+        uint8 numGuardians
+    ) public returns (address) {
+        ReceiverImplementation wormholeReceiverImpl = new ReceiverImplementation();
+        ReceiverSetup wormholeReceiverSetup = new ReceiverSetup();
+
+        WormholeReceiver wormholeReceiver = new WormholeReceiver(
+            address(wormholeReceiverSetup),
+            new bytes(0)
+        );
+
+        address[] memory initSigners = new address[](numGuardians);
+        currentSigners = new uint256[](numGuardians);
+
+        for (uint256 i = 0; i < numGuardians; ++i) {
+            currentSigners[i] = i + 1;
+            initSigners[i] = vm.addr(currentSigners[i]); // i+1 is the private key for the i-th signer.
+        }
+
+        // These values are the default values used in our tilt test environment
+        // and are not important.
+        ReceiverSetup(address(wormholeReceiver)).setup(
+            address(wormholeReceiverImpl),
+            initSigners,
+            CHAIN_ID, // Ethereum chain ID
+            GOVERNANCE_CHAIN_ID, // Governance source chain ID (1 = solana)
+            GOVERNANCE_CONTRACT // Governance source address
+        );
+        wormholeReceiverAddr = address(wormholeReceiver);
+
+        return wormholeReceiverAddr;
+    }
+
+    function isNotMatch(
+        bytes memory a,
+        bytes memory b
+    ) public pure returns (bool) {
+        return keccak256(a) != keccak256(b);
     }
 
     function generateVaa(
@@ -58,7 +112,8 @@ abstract contract WormholeTestUtils is Test {
         bytes memory signatures = new bytes(0);
 
         for (uint256 i = 0; i < numSigners; ++i) {
-            (uint8 v, bytes32 r, bytes32 s) = vm.sign(i + 1, hash);
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(currentSigners[i], hash);
+
             // encodePacked uses padding for arrays and we don't want it, so we manually concat them.
             signatures = abi.encodePacked(
                 signatures,
@@ -71,37 +126,389 @@ abstract contract WormholeTestUtils is Test {
 
         vaa = abi.encodePacked(
             uint8(1), // Version
-            uint32(0), // Guardian set index. it is initialized by 0
+            IWormhole(wormholeReceiverAddr).getCurrentGuardianSetIndex(), // Guardian set index. it is initialized by 0
             numSigners,
             signatures,
             body
         );
     }
+
+    function forgeVaa(
+        uint32 timestamp,
+        uint16 emitterChainId,
+        bytes32 emitterAddress,
+        uint64 sequence,
+        bytes memory payload,
+        uint8 numSigners,
+        bytes memory forgeItem
+    ) public returns (bytes memory vaa) {
+        bytes memory body = abi.encodePacked(
+            timestamp,
+            uint32(0), // Nonce. It is zero for single VAAs.
+            emitterChainId,
+            emitterAddress,
+            sequence,
+            uint8(0), // Consistency level (sometimes no. confirmation block). Not important here.
+            payload
+        );
+
+        bytes32 hash = keccak256(abi.encodePacked(keccak256(body)));
+
+        bytes memory signatures = new bytes(0);
+
+        for (uint256 i = 0; i < numSigners; ++i) {
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(
+                isNotMatch(forgeItem, "vaaSignature")
+                    ? currentSigners[i]
+                    : currentSigners[i] + 1000,
+                hash
+            );
+            // encodePacked uses padding for arrays and we don't want it, so we manually concat them.
+            signatures = abi.encodePacked(
+                signatures,
+                isNotMatch(forgeItem, "vaaSignatureIndex")
+                    ? uint8(i)
+                    : uint8(0), // Guardian index of the signature
+                r,
+                s,
+                v - 27 // v is either 27 or 28. 27 is added to v in Eth (following BTC) but Wormhole doesn't use it.
+            );
+        }
+
+        vaa = abi.encodePacked(
+            isNotMatch(forgeItem, "vaaVersion") ? uint8(1) : uint8(2), // Version
+            isNotMatch(forgeItem, "vaaGuardianSetIndex")
+                ? uint32(0)
+                : uint32(1), // Guardian set index. it is initialized by 0
+            isNotMatch(forgeItem, "vaaNumSigners+")
+                ? isNotMatch(forgeItem, "vaaNumSigners-")
+                    ? numSigners
+                    : numSigners - 1
+                : numSigners + 1,
+            signatures,
+            body
+        );
+    }
+
+    function upgradeGuardianSet(uint256 numGuardians) public {
+        IWormhole wormhole = IWormhole(wormholeReceiverAddr);
+        ReceiverImplementation whReceiverImpl = ReceiverImplementation(
+            payable(wormholeReceiverAddr)
+        );
+        bytes memory newGuardians = new bytes(0);
+
+        for (uint256 i = 0; i < numGuardians; ++i) {
+            // encodePacked uses padding for arrays and we don't want it, so we manually concat them.
+            newGuardians = abi.encodePacked(newGuardians, vm.addr(i + 1 + 10));
+        }
+        uint32 newGuardianSetIndex = uint32(1);
+        bytes memory upgradeGuardianSetPayload = abi.encodePacked(
+            bytes32(
+                0x00000000000000000000000000000000000000000000000000000000436f7265
+            ), // "Core" ReceiverGovernance module
+            uint8(2), // action
+            uint16(0), // chain (unused)
+            wormhole.getCurrentGuardianSetIndex() + 1, // uint32 newGuardianSetIndex;
+            uint8(numGuardians), // uint8 numGuardians;
+            newGuardians // ReceiverStructs.GuardianSet newGuardianSet;
+        );
+        bytes memory setGuardianSetVaa = generateVaa(
+            112,
+            GOVERNANCE_CHAIN_ID, // emitter chainID (solana)
+            GOVERNANCE_CONTRACT, // gov emitter addr
+            10,
+            upgradeGuardianSetPayload,
+            4
+        );
+        whReceiverImpl.submitNewGuardianSet(setGuardianSetVaa);
+
+        currentSigners = new uint256[](numGuardians);
+        for (uint256 i = 0; i < numGuardians; ++i) {
+            currentSigners[i] = i + 1 + 10;
+        }
+    }
 }
 
 contract WormholeTestUtilsTest is Test, WormholeTestUtils {
+    uint32 constant TEST_VAA_TIMESTAMP = 112;
+    uint16 constant TEST_EMITTER_CHAIN_ID = 7;
+    bytes32 constant TEST_EMITTER_ADDR =
+        0x0000000000000000000000000000000000000000000000000000000000000bad;
+    uint64 constant TEST_SEQUENCE = 10;
+    bytes constant TEST_PAYLOAD = hex"deadbeaf";
+    uint8 constant TEST_NUM_SIGNERS = 4;
+
+    function assertVmMatchesTestValues(
+        Structs.VM memory vm,
+        bool valid,
+        string memory reason,
+        bytes memory vaa
+    ) private {
+        assertTrue(valid);
+        assertEq(reason, "");
+        assertEq(vm.timestamp, TEST_VAA_TIMESTAMP);
+        assertEq(vm.emitterChainId, TEST_EMITTER_CHAIN_ID);
+        assertEq(vm.emitterAddress, TEST_EMITTER_ADDR);
+        assertEq(vm.sequence, TEST_SEQUENCE);
+        assertEq(vm.payload, TEST_PAYLOAD);
+        // parseAndVerifyVM() returns an empty signatures array for gas savings since it's not used
+        // after its been verified. parseVM() returns the full signatures array.
+        vm = IWormhole(wormholeReceiverAddr).parseVM(vaa);
+        assertEq(vm.signatures.length, TEST_NUM_SIGNERS);
+    }
+
     function testGenerateVaaWorks() public {
-        IWormhole wormhole = IWormhole(setUpWormhole(5));
+        IWormhole wormhole = IWormhole(setUpWormholeReceiver(5));
 
         bytes memory vaa = generateVaa(
-            112,
-            7,
-            0x0000000000000000000000000000000000000000000000000000000000000bad,
-            10,
-            hex"deadbeaf",
-            4
+            TEST_VAA_TIMESTAMP,
+            TEST_EMITTER_CHAIN_ID,
+            TEST_EMITTER_ADDR,
+            TEST_SEQUENCE,
+            TEST_PAYLOAD,
+            TEST_NUM_SIGNERS
         );
 
-        (Structs.VM memory vm, bool valid, ) = wormhole.parseAndVerifyVM(vaa);
-        assertTrue(valid);
+        (Structs.VM memory vm, bool valid, string memory reason) = wormhole
+            .parseAndVerifyVM(vaa);
+        assertVmMatchesTestValues(vm, valid, reason, vaa);
+    }
 
-        assertEq(vm.timestamp, 112);
-        assertEq(vm.emitterChainId, 7);
-        assertEq(
-            vm.emitterAddress,
-            0x0000000000000000000000000000000000000000000000000000000000000bad
+    function testParseAndVerifyWorksWithoutForging() public {
+        uint8 numGuardians = 5;
+        IWormhole wormhole = IWormhole(setUpWormholeReceiver(numGuardians));
+        bytes memory vaa = forgeVaa(
+            TEST_VAA_TIMESTAMP,
+            TEST_EMITTER_CHAIN_ID,
+            TEST_EMITTER_ADDR,
+            TEST_SEQUENCE,
+            TEST_PAYLOAD,
+            TEST_NUM_SIGNERS,
+            ""
         );
-        assertEq(vm.payload, hex"deadbeaf");
-        assertEq(vm.signatures.length, 4);
+        (Structs.VM memory vm, bool valid, string memory reason) = wormhole
+            .parseAndVerifyVM(vaa);
+        assertVmMatchesTestValues(vm, valid, reason, vaa);
+    }
+
+    function testParseAndVerifyFailsIfVaaIsNotSignedByEnoughGuardians() public {
+        IWormhole wormhole = IWormhole(setUpWormholeReceiver(5));
+        bytes memory vaa = generateVaa(
+            TEST_VAA_TIMESTAMP,
+            TEST_EMITTER_CHAIN_ID,
+            TEST_EMITTER_ADDR,
+            TEST_SEQUENCE,
+            TEST_PAYLOAD,
+            1 //numSigners
+        );
+        (, bool valid, string memory reason) = wormhole.parseAndVerifyVM(vaa);
+        assertEq(valid, false);
+        assertEq(reason, "no quorum");
+    }
+
+    function testParseAndVerifyFailsIfVaaHasInvalidGuardianSetIndex() public {
+        uint8 numGuardians = 5;
+        IWormhole wormhole = IWormhole(setUpWormholeReceiver(numGuardians));
+        bytes memory vaa = forgeVaa(
+            TEST_VAA_TIMESTAMP,
+            TEST_EMITTER_CHAIN_ID,
+            TEST_EMITTER_ADDR,
+            TEST_SEQUENCE,
+            TEST_PAYLOAD,
+            TEST_NUM_SIGNERS,
+            "vaaGuardianSetIndex"
+        );
+        (, bool valid, string memory reason) = wormhole.parseAndVerifyVM(vaa);
+        assertEq(valid, false);
+        assertEq(reason, "invalid guardian set");
+    }
+
+    function testParseAndVerifyFailsIfInvalidGuardianSignatureIndex() public {
+        uint8 numGuardians = 5;
+        address whAddr = setUpWormholeReceiver(numGuardians);
+        IWormhole wormhole = IWormhole(whAddr);
+        ReceiverImplementation whReceiverImpl = ReceiverImplementation(
+            payable(whAddr)
+        );
+        // generate the vaa and sign with the initial wormhole guardian set
+        bytes memory vaa = forgeVaa(
+            TEST_VAA_TIMESTAMP,
+            TEST_EMITTER_CHAIN_ID,
+            TEST_EMITTER_ADDR,
+            TEST_SEQUENCE,
+            TEST_PAYLOAD,
+            TEST_NUM_SIGNERS,
+            "vaaSignatureIndex"
+        );
+        vm.expectRevert(
+            // workaround for this error not being in an external library
+            abi.encodeWithSignature("SignatureIndexesNotAscending()")
+        );
+        wormhole.parseAndVerifyVM(vaa);
+    }
+
+    function testParseAndVerifyFailsIfIncorrectVersion() public {
+        uint8 numGuardians = 5;
+        address whAddr = setUpWormholeReceiver(numGuardians);
+        IWormhole wormhole = IWormhole(whAddr);
+        ReceiverImplementation whReceiverImpl = ReceiverImplementation(
+            payable(whAddr)
+        );
+        // generate the vaa and sign with the initial wormhole guardian set
+        bytes memory vaa = forgeVaa(
+            TEST_VAA_TIMESTAMP,
+            TEST_EMITTER_CHAIN_ID,
+            TEST_EMITTER_ADDR,
+            TEST_SEQUENCE,
+            TEST_PAYLOAD,
+            TEST_NUM_SIGNERS,
+            "vaaVersion"
+        );
+        vm.expectRevert(
+            // workaround for this error not being in an external library
+            abi.encodeWithSignature("VmVersionIncompatible()")
+        );
+        wormhole.parseAndVerifyVM(vaa);
+    }
+
+    function testUpgradeGuardianSetWorks() public {
+        uint8 numGuardians = 5;
+        address whAddr = setUpWormholeReceiver(numGuardians);
+        IWormhole wormhole = IWormhole(whAddr);
+        ReceiverImplementation whReceiverImpl = ReceiverImplementation(
+            payable(whAddr)
+        );
+        upgradeGuardianSet(5);
+        // generate the vaa and sign with the new wormhole guardian set
+        bytes memory vaa = generateVaa(
+            TEST_VAA_TIMESTAMP,
+            TEST_EMITTER_CHAIN_ID,
+            TEST_EMITTER_ADDR,
+            TEST_SEQUENCE,
+            TEST_PAYLOAD,
+            TEST_NUM_SIGNERS
+        );
+        uint32 guardianSetIdx = wormhole.getCurrentGuardianSetIndex();
+        vm.warp(block.timestamp + 5 days);
+
+        (Structs.VM memory vm, bool valid, string memory reason) = wormhole
+            .parseAndVerifyVM(vaa);
+        assertVmMatchesTestValues(vm, valid, reason, vaa);
+    }
+
+    function testParseAndVerifyWorksIfUsingPreviousVaaGuardianSetBeforeItExpires()
+        public
+    {
+        uint8 numGuardians = 5;
+        address whAddr = setUpWormholeReceiver(numGuardians);
+        IWormhole wormhole = IWormhole(whAddr);
+        ReceiverImplementation whReceiverImpl = ReceiverImplementation(
+            payable(whAddr)
+        );
+        // generate the vaa and sign with the initial wormhole guardian set
+        bytes memory vaa = generateVaa(
+            TEST_VAA_TIMESTAMP,
+            TEST_EMITTER_CHAIN_ID,
+            TEST_EMITTER_ADDR,
+            TEST_SEQUENCE,
+            TEST_PAYLOAD,
+            TEST_NUM_SIGNERS
+        );
+
+        upgradeGuardianSet(numGuardians);
+        uint32 guardianSetIdx = wormhole.getCurrentGuardianSetIndex();
+        uint previousGuardianSetExpiration = wormhole
+            .getGuardianSet(0)
+            .expirationTime;
+        // warp to 5 seconds before the previous guardian set expires
+        vm.warp(previousGuardianSetExpiration - 5);
+        (Structs.VM memory vm, bool valid, string memory reason) = wormhole
+            .parseAndVerifyVM(vaa);
+        assertVmMatchesTestValues(vm, valid, reason, vaa);
+    }
+
+    function testParseAndVerifyFailsIfVaaGuardianSetHasExpired() public {
+        uint8 numGuardians = 5;
+        address whAddr = setUpWormholeReceiver(numGuardians);
+        IWormhole wormhole = IWormhole(whAddr);
+        ReceiverImplementation whReceiverImpl = ReceiverImplementation(
+            payable(whAddr)
+        );
+        // generate the vaa and sign with the current wormhole guardian set
+        bytes memory vaa = generateVaa(
+            TEST_VAA_TIMESTAMP,
+            TEST_EMITTER_CHAIN_ID,
+            TEST_EMITTER_ADDR,
+            TEST_SEQUENCE,
+            TEST_PAYLOAD,
+            TEST_NUM_SIGNERS
+        );
+
+        upgradeGuardianSet(numGuardians);
+        uint32 guardianSetIdx = wormhole.getCurrentGuardianSetIndex();
+        vm.warp(block.timestamp + 5 days);
+        (, bool valid, string memory reason) = wormhole.parseAndVerifyVM(vaa);
+        assertEq(valid, false);
+        assertEq(reason, "guardian set has expired");
+    }
+
+    function testParseAndVerifyFailsIfInvalidGuardianSignature() public {
+        uint8 numGuardians = 5;
+        address whAddr = setUpWormholeReceiver(numGuardians);
+        IWormhole wormhole = IWormhole(whAddr);
+        ReceiverImplementation whReceiverImpl = ReceiverImplementation(
+            payable(whAddr)
+        );
+        // generate the vaa and sign with the current wormhole guardian set
+        bytes memory vaa = forgeVaa(
+            TEST_VAA_TIMESTAMP,
+            TEST_EMITTER_CHAIN_ID,
+            TEST_EMITTER_ADDR,
+            TEST_SEQUENCE,
+            TEST_PAYLOAD,
+            TEST_NUM_SIGNERS,
+            "vaaSignature"
+        );
+
+        (, bool valid, string memory reason) = wormhole.parseAndVerifyVM(vaa);
+        assertEq(valid, false);
+        assertEq(reason, "VM signature invalid");
+    }
+
+    function testParseAndVerifyFailsIfInvalidNumSignatures() public {
+        uint8 numGuardians = 5;
+        address whAddr = setUpWormholeReceiver(numGuardians);
+        IWormhole wormhole = IWormhole(whAddr);
+        ReceiverImplementation whReceiverImpl = ReceiverImplementation(
+            payable(whAddr)
+        );
+        // generate the vaa and sign with the current wormhole guardian set
+        bytes memory vaa = forgeVaa(
+            TEST_VAA_TIMESTAMP,
+            TEST_EMITTER_CHAIN_ID,
+            TEST_EMITTER_ADDR,
+            TEST_SEQUENCE,
+            TEST_PAYLOAD,
+            TEST_NUM_SIGNERS,
+            "vaaNumSigners+"
+        );
+
+        (, bool valid, string memory reason) = wormhole.parseAndVerifyVM(vaa);
+        assertEq(valid, false);
+        assertEq(reason, "invalid signature length");
+
+        vaa = forgeVaa(
+            TEST_VAA_TIMESTAMP,
+            TEST_EMITTER_CHAIN_ID,
+            TEST_EMITTER_ADDR,
+            TEST_SEQUENCE,
+            TEST_PAYLOAD,
+            TEST_NUM_SIGNERS,
+            "vaaNumSigners-"
+        );
+
+        (, valid, reason) = wormhole.parseAndVerifyVM(vaa);
+        assertEq(valid, false);
+        assertEq(reason, "VM signature invalid");
     }
 }

--- a/target_chains/ethereum/contracts/foundry.toml
+++ b/target_chains/ethereum/contracts/foundry.toml
@@ -1,7 +1,7 @@
 [profile.default]
 solc_version = '0.8.4'
 optimizer = true
-optimizer_runs = 10000
+optimizer_runs = 2000
 src = 'contracts'
 # We put the tests into the forge-test directory (instead of test) so that
 # truffle doesn't try to build them

--- a/target_chains/ethereum/contracts/hardhat.config.ts
+++ b/target_chains/ethereum/contracts/hardhat.config.ts
@@ -80,7 +80,7 @@ module.exports = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 10000,
+        runs: 2000,
       },
     },
   },

--- a/target_chains/ethereum/contracts/package.json
+++ b/target_chains/ethereum/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-evm-contract",
-  "version": "1.2.0",
+  "version": "1.3.0-alpha",
   "description": "",
   "private": "true",
   "devDependencies": {

--- a/target_chains/ethereum/contracts/test/pyth.js
+++ b/target_chains/ethereum/contracts/test/pyth.js
@@ -10,7 +10,17 @@ const {
 const { assert, expect } = require("chai");
 
 // Use "WormholeReceiver" if you are testing with Wormhole Receiver
+const Setup = artifacts.require("Setup");
+const Implementation = artifacts.require("Implementation");
 const Wormhole = artifacts.require("Wormhole");
+
+const ReceiverSetup = artifacts.require("ReceiverSetup");
+const ReceiverImplementation = artifacts.require("ReceiverImplementation");
+const WormholeReceiver = artifacts.require("WormholeReceiver");
+
+const wormholeGovernanceChainId = governance.CHAINS.solana;
+const wormholeGovernanceContract =
+  "0x0000000000000000000000000000000000000000000000000000000000000004";
 
 const PythUpgradable = artifacts.require("PythUpgradable");
 const MockPythUpgrade = artifacts.require("MockPythUpgrade");
@@ -1067,6 +1077,136 @@ contract("Pyth", function () {
 
     // The behaviour of valid time period is extensively tested before,
     // and adding it here will cause more complexity (and is not so short).
+  });
+
+  it("Setting wormhole address should work", async function () {
+    // Deploy a new wormhole contract
+    const newSetup = await Setup.new();
+    const newImpl = await Implementation.new();
+
+    // encode initialisation data
+    const initData = newSetup.contract.methods
+      .setup(
+        newImpl.address,
+        [testSigner1.address],
+        governance.CHAINS.polygon, // changing the chain id to polygon
+        wormholeGovernanceChainId,
+        wormholeGovernanceContract
+      )
+      .encodeABI();
+
+    const newWormhole = await Wormhole.new(newSetup.address, initData);
+
+    // Creating the vaa to set the new wormhole address
+    const data = new governance.EthereumSetWormholeAddress(
+      governance.CHAINS.ethereum,
+      new governance.HexString20Bytes(newWormhole.address)
+    ).serialize();
+
+    const vaa = await createVAAFromUint8Array(
+      data,
+      testGovernanceChainId,
+      testGovernanceEmitter,
+      1
+    );
+
+    assert.equal(await this.pythProxy.chainId(), governance.CHAINS.ethereum);
+
+    const oldWormholeAddress = await this.pythProxy.wormhole();
+
+    const receipt = await this.pythProxy.executeGovernanceInstruction(vaa);
+    expectEvent(receipt, "WormholeAddressSet", {
+      oldWormholeAddress: oldWormholeAddress,
+      newWormholeAddress: newWormhole.address,
+    });
+
+    assert.equal(await this.pythProxy.wormhole(), newWormhole.address);
+    assert.equal(await this.pythProxy.chainId(), governance.CHAINS.polygon);
+  });
+
+  it("Setting wormhole address to WormholeReceiver should work", async function () {
+    // Deploy a new wormhole receiver contract
+    const newReceiverSetup = await ReceiverSetup.new();
+    const newReceiverImpl = await ReceiverImplementation.new();
+
+    // encode initialisation data
+    const initData = newReceiverSetup.contract.methods
+      .setup(
+        newReceiverImpl.address,
+        [testSigner1.address],
+        governance.CHAINS.polygon, // changing the chain id to polygon
+        wormholeGovernanceChainId,
+        wormholeGovernanceContract
+      )
+      .encodeABI();
+
+    const newWormholeReceiver = await WormholeReceiver.new(
+      newReceiverSetup.address,
+      initData
+    );
+
+    // Creating the vaa to set the new wormhole address
+    const data = new governance.EthereumSetWormholeAddress(
+      governance.CHAINS.ethereum,
+      new governance.HexString20Bytes(newWormholeReceiver.address)
+    ).serialize();
+
+    const vaa = await createVAAFromUint8Array(
+      data,
+      testGovernanceChainId,
+      testGovernanceEmitter,
+      1
+    );
+
+    assert.equal(await this.pythProxy.chainId(), governance.CHAINS.ethereum);
+
+    const oldWormholeAddress = await this.pythProxy.wormhole();
+
+    const receipt = await this.pythProxy.executeGovernanceInstruction(vaa);
+    expectEvent(receipt, "WormholeAddressSet", {
+      oldWormholeAddress: oldWormholeAddress,
+      newWormholeAddress: newWormholeReceiver.address,
+    });
+
+    assert.equal(await this.pythProxy.wormhole(), newWormholeReceiver.address);
+    assert.equal(await this.pythProxy.chainId(), governance.CHAINS.polygon);
+  });
+
+  it("Setting wormhole address to a wrong contract should reject", async function () {
+    // Deploy a new wormhole contract
+    const newSetup = await Setup.new();
+    const newImpl = await Implementation.new();
+
+    // encode initialisation data
+    const initData = newSetup.contract.methods
+      .setup(
+        newImpl.address,
+        [testSigner2.address], // A wrong signer
+        governance.CHAINS.ethereum,
+        wormholeGovernanceChainId,
+        wormholeGovernanceContract
+      )
+      .encodeABI();
+
+    const newWormhole = await Wormhole.new(newSetup.address, initData);
+
+    // Creating the vaa to set the new wormhole address
+    const data = new governance.EthereumSetWormholeAddress(
+      governance.CHAINS.ethereum,
+      new governance.HexString20Bytes(newWormhole.address)
+    ).serialize();
+
+    const wrongVaa = await createVAAFromUint8Array(
+      data,
+      testGovernanceChainId,
+      testGovernanceEmitter,
+      1
+    );
+
+    await expectRevertCustomError(
+      this.pythProxy.executeGovernanceInstruction(wrongVaa),
+      "InvalidGovernanceMessage"
+    );
   });
 
   // Version

--- a/target_chains/ethereum/contracts/truffle-config.js
+++ b/target_chains/ethereum/contracts/truffle-config.js
@@ -228,7 +228,7 @@ module.exports = {
       verify: {
         apiUrl: "https://api-goerli.basescan.org/api",
         explorerUrl: "https://goerli.basescan.org/",
-        apiKey: "",
+        apiKey: "there_should_be_a_dummy_value_here_to_avoid_error",
       },
     },
     evmos: {
@@ -263,6 +263,23 @@ module.exports = {
       provider: payerProvider("https://evmtestnet.confluxrpc.com"),
       network_id: 71,
     },
+    neon: {
+      provider: payerProvider("NEON_RPC_PLACEHOLDER"), // Replace this by the neon RPC node endpoint
+      network_id: 245022934,
+    },
+    kava: {
+      provider: payerProvider("https://evm.kava.io"),
+      network_id: 2222,
+      verify: {
+        apiUrl: "https://explorer.kava.io/api",
+        explorerUrl: "https://explorer.kava.io/",
+        apiKey: "there_should_be_a_dummy_value_here_to_avoid_error",
+      },
+    },
+    kava_testnet: {
+      provider: payerProvider("https://evm.testnet.kava.io"),
+      network_id: 2221,
+    },
   },
 
   compilers: {
@@ -271,7 +288,7 @@ module.exports = {
       settings: {
         optimizer: {
           enabled: true,
-          runs: 10000,
+          runs: 2000,
         },
       },
     },
@@ -288,5 +305,6 @@ module.exports = {
     optimistic_etherscan: process.env.OPTIMISTIC_ETHERSCAN_KEY,
     aurorascan: process.env.AURORASCAN_KEY,
     arbiscan: process.env.ARBISCAN_KEY,
+    gnosisscan: process.env.GNOSISSCAN_KEY,
   },
 };

--- a/target_chains/ethereum/sdk/solidity/MockPyth.sol
+++ b/target_chains/ethereum/sdk/solidity/MockPyth.sol
@@ -33,7 +33,7 @@ contract MockPyth is AbstractPyth {
     }
 
     // Takes an array of encoded price feeds and stores them.
-    // You can create this data either by calling createPriceFeedData or
+    // You can create this data either by calling createPriceFeedUpdateData or
     // by using web3.js or ethers abi utilities.
     function updatePriceFeeds(
         bytes[] calldata updateData

--- a/target_chains/ethereum/sdk/solidity/PythErrors.sol
+++ b/target_chains/ethereum/sdk/solidity/PythErrors.sol
@@ -4,29 +4,45 @@ pragma solidity ^0.8.0;
 
 library PythErrors {
     // Function arguments are invalid (e.g., the arguments lengths mismatch)
+    // Signature: 0xa9cb9e0d
     error InvalidArgument();
     // Update data is coming from an invalid data source.
+    // Signature: 0xe60dce71
     error InvalidUpdateDataSource();
     // Update data is invalid (e.g., deserialization error)
+    // Signature: 0xe69ffece
     error InvalidUpdateData();
     // Insufficient fee is paid to the method.
+    // Signature: 0x025dbdd4
     error InsufficientFee();
     // There is no fresh update, whereas expected fresh updates.
+    // Signature: 0xde2c57fa
     error NoFreshUpdate();
     // There is no price feed found within the given range or it does not exists.
+    // Signature: 0x45805f5d
     error PriceFeedNotFoundWithinRange();
     // Price feed not found or it is not pushed on-chain yet.
+    // Signature: 0x14aebe68
     error PriceFeedNotFound();
     // Requested price is stale.
+    // Signature: 0x19abf40e
     error StalePrice();
     // Given message is not a valid Wormhole VAA.
+    // Signature: 0x2acbe915
     error InvalidWormholeVaa();
     // Governance message is invalid (e.g., deserialization error).
+    // Signature: 0x97363b35
     error InvalidGovernanceMessage();
     // Governance message is not for this contract.
+    // Signature: 0x63daeb77
     error InvalidGovernanceTarget();
     // Governance message is coming from an invalid data source.
+    // Signature: 0x360f2d87
     error InvalidGovernanceDataSource();
     // Governance message is old.
+    // Signature: 0x88d1b847
     error OldGovernanceMessage();
+    // The wormhole address to set in SetWormholeAddress governance is invalid.
+    // Signature: 0x13d3ed82
+    error InvalidWormholeAddressToSet();
 }

--- a/target_chains/ethereum/sdk/solidity/scripts/generateAbi.js
+++ b/target_chains/ethereum/sdk/solidity/scripts/generateAbi.js
@@ -2,7 +2,13 @@ const fs = require("fs");
 const solc = require("solc");
 
 // Assuming each contract is in the file with the same name.
-var contracts = ["IPyth", "IPythEvents", "AbstractPyth", "MockPyth"];
+var contracts = [
+  "IPyth",
+  "IPythEvents",
+  "AbstractPyth",
+  "MockPyth",
+  "PythErrors",
+];
 
 var sources = {};
 var outputSelection = {};


### PR DESCRIPTION
Important files to look at:
- `target_chains/ethereum/contracts/contracts/libraries/MerkleTree.sol`
- `target_chains/ethereum/contracts/contracts/libraries/external/UnsafeCalldataBytesLib.sol`
- `target_chains/ethereum/contracts/contracts/pyth/Pyth.sol`
- `target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol`
- `target_chains/ethereum/contracts/contracts/wormhole-receiver/ReceiverMessages.sol`

Steps that produced this diff:

```
git checkout 5e44fa4c95ae7120ee8a05f145b27470d2c48e7b
git checkout -b audit-accumulator/start-eth

# Get all changes since start-diff (when accumulator changes started)
# and store everything except eth changes in start-eth branch
git reset --soft audit-accumulator/start-diff
git restore --staged target_chains/ethereum
git add ... # add irrelevant files
git commit -m "Changes without eth since diff"

# Store the unstaged eth changes in end-eth branch
git checkout -b audit-accumulator/end-eth
git add target_chains/ethereum/
git commit -m "Only eth changes"
```
