### PR TITLE
Update aptos pusher to support high TPS

### DIFF
--- a/price_pusher/package.json
+++ b/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "5.4.2",
+  "version": "5.4.3",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/price_pusher/src/aptos/command.ts
+++ b/price_pusher/src/aptos/command.ts
@@ -5,7 +5,12 @@ import fs from "fs";
 import { PythPriceListener } from "../pyth-price-listener";
 import { Controller } from "../controller";
 import { Options } from "yargs";
-import { AptosPriceListener, AptosPricePusher } from "./aptos";
+import {
+  AptosPriceListener,
+  AptosPricePusher,
+  APTOS_ACCOUNT_HD_PATH,
+} from "./aptos";
+import { AptosAccount } from "aptos";
 
 export default {
   command: "aptos",
@@ -61,6 +66,11 @@ export default {
       }
     );
     const mnemonic = fs.readFileSync(mnemonicFile, "utf-8").trim();
+    const account = AptosAccount.fromDerivePath(
+      APTOS_ACCOUNT_HD_PATH,
+      mnemonic
+    );
+    console.log(`Pushing from account address: ${account.address()}`);
 
     const priceItems = priceConfigs.map(({ id, alias }) => ({ id, alias }));
 


### PR DESCRIPTION
The aptos pusher can't submit more than 1 transaction per 3 seconds. The problem seems to be that the submitted transactions don't land on chain, so the pusher tries to reuse an old sequence number, or simulation fails.

This change updates the pusher to fix this problem. It does three main things:
1. add local sequence number tracking and send each transaction with an incremented sequence number
2. remove the simulation / transaction replacement logic. The simulation RPC call fails often when you're submitting many transaction sequentially, presumably because the transaction is using the wrong blockchain state.
3. Stop using the update_if_necessary contract method, because we don't have a good way to track the "current" on-chain state as of when the tx is submitted.