### PR TITLE
fix: Use generic_err constructor instead of literal

### DIFF
--- a/target_chains/cosmwasm/Cargo.lock
+++ b/target_chains/cosmwasm/Cargo.lock
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-sdk-cw"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/target_chains/cosmwasm/sdk/rust/Cargo.toml
+++ b/target_chains/cosmwasm/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-sdk-cw"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Pyth Data Foundation"]
 edition = "2018"
 license = "Apache-2.0"

--- a/target_chains/cosmwasm/sdk/rust/src/error.rs
+++ b/target_chains/cosmwasm/sdk/rust/src/error.rs
@@ -76,8 +76,6 @@ pub enum PythContractError {
 
 impl From<PythContractError> for StdError {
     fn from(other: PythContractError) -> StdError {
-        StdError::GenericErr {
-            msg: format!("{other}"),
-        }
+        StdError::generic_err(format!("{other}"))
     }
 }


### PR DESCRIPTION
The cosmwasm-std `StdError` struct has a feature-gated field `backtraces` that you forgot to fill. This breaks compilation for anyone who depends on the Pyth SDK and tries to enable the backtraces feature. This PR simply uses the `StdError::generic_err` instead of creating the struct literal so that you don't have create the backtrace yourself.

See this issue for more info: https://github.com/CosmWasm/cosmwasm/issues/1760