### PR TITLE
[sui 16/x] - update imports

### DIFF
--- a/target_chains/sui/scripts/package.json
+++ b/target_chains/sui/scripts/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "@certusone/wormhole-sdk": "^0.9.12",
     "@mysten/sui.js": "^0.32.2",
-    "@optke3/sui.js": "0.33.0",
     "@pythnetwork/client": "^2.17.0",
     "@pythnetwork/price-service-client": "^1.4.0",
     "@pythnetwork/price-service-sdk": "^1.2.0",

--- a/target_chains/sui/scripts/pyth/create_all_price_feeds.ts
+++ b/target_chains/sui/scripts/pyth/create_all_price_feeds.ts
@@ -10,7 +10,7 @@ import {
   JsonRpcProvider,
   Ed25519Keypair,
   Connection,
-} from "@optke3/sui.js";
+} from "@mysten/sui.js";
 
 dotenv.config({ path: "~/.env" });
 

--- a/target_chains/sui/scripts/pyth/create_price_feed.ts
+++ b/target_chains/sui/scripts/pyth/create_price_feed.ts
@@ -8,7 +8,7 @@ import {
   JsonRpcProvider,
   Ed25519Keypair,
   Connection,
-} from "@optke3/sui.js";
+} from "@mysten/sui.js";
 
 dotenv.config({ path: "~/.env" });
 

--- a/target_chains/sui/scripts/pyth/deploy.ts
+++ b/target_chains/sui/scripts/pyth/deploy.ts
@@ -8,7 +8,7 @@ import {
   JsonRpcProvider,
   Ed25519Keypair,
   Connection,
-} from "@optke3/sui.js";
+} from "@mysten/sui.js";
 import { execSync } from "child_process";
 
 import dotenv from "dotenv";

--- a/target_chains/sui/scripts/pyth/init_state.ts
+++ b/target_chains/sui/scripts/pyth/init_state.ts
@@ -6,7 +6,7 @@ import {
   JsonRpcProvider,
   Ed25519Keypair,
   Connection,
-} from "@optke3/sui.js";
+} from "@mysten/sui.js";
 
 import { REGISTRY, NETWORK, INITIAL_DATA_SOURCES } from "../registry";
 dotenv.config({ path: "~/.env" });

--- a/target_chains/sui/scripts/pyth/pyth_create_all_price_feeds.ts
+++ b/target_chains/sui/scripts/pyth/pyth_create_all_price_feeds.ts
@@ -10,7 +10,7 @@ import {
   JsonRpcProvider,
   Ed25519Keypair,
   Connection,
-} from "@optke3/sui.js";
+} from "@mysten/sui.js";
 
 dotenv.config({ path: "~/.env" });
 

--- a/target_chains/sui/scripts/pyth/pyth_create_price_feed.ts
+++ b/target_chains/sui/scripts/pyth/pyth_create_price_feed.ts
@@ -8,7 +8,7 @@ import {
   JsonRpcProvider,
   Ed25519Keypair,
   Connection,
-} from "@optke3/sui.js";
+} from "@mysten/sui.js";
 
 dotenv.config({ path: "~/.env" });
 

--- a/target_chains/sui/scripts/pyth/pyth_deploy.ts
+++ b/target_chains/sui/scripts/pyth/pyth_deploy.ts
@@ -8,7 +8,7 @@ import {
   JsonRpcProvider,
   Ed25519Keypair,
   Connection,
-} from "@optke3/sui.js";
+} from "@mysten/sui.js";
 import { execSync } from "child_process";
 
 import dotenv from "dotenv";

--- a/target_chains/sui/scripts/pyth/pyth_init_state.ts
+++ b/target_chains/sui/scripts/pyth/pyth_init_state.ts
@@ -6,7 +6,7 @@ import {
   JsonRpcProvider,
   Ed25519Keypair,
   Connection,
-} from "@optke3/sui.js";
+} from "@mysten/sui.js";
 
 import { REGISTRY, NETWORK, INITIAL_DATA_SOURCES } from "../registry";
 dotenv.config({ path: "~/.env" });

--- a/target_chains/sui/scripts/pyth/pyth_update_price_feeds.ts
+++ b/target_chains/sui/scripts/pyth/pyth_update_price_feeds.ts
@@ -13,7 +13,7 @@ import {
   JsonRpcProvider,
   Ed25519Keypair,
   Connection,
-} from "@optke3/sui.js";
+} from "@mysten/sui.js";
 
 dotenv.config({ path: "~/.env" });
 

--- a/target_chains/sui/scripts/pyth/update_price_feeds.ts
+++ b/target_chains/sui/scripts/pyth/update_price_feeds.ts
@@ -10,7 +10,7 @@ import {
   JsonRpcProvider,
   Ed25519Keypair,
   Connection,
-} from "@optke3/sui.js";
+} from "@mysten/sui.js";
 
 dotenv.config({ path: "~/.env" });
 

--- a/target_chains/sui/scripts/utils/transfer_tokens.ts
+++ b/target_chains/sui/scripts/utils/transfer_tokens.ts
@@ -8,7 +8,7 @@ import {
   JsonRpcProvider,
   Ed25519Keypair,
   Connection,
-} from "@optke3/sui.js";
+} from "@mysten/sui.js";
 
 dotenv.config({ path: "~/.env" });
 


### PR DESCRIPTION
## Summary
- use official Mysten [sui.js](https://www.npmjs.com/package/@mysten/sui.js) lib in various Pyth TS scripts, including ones for deployment and contract initialization (previously there was a bug in the official package, so we had to fix it and use our own package)
