### PR TITLE
[eth] Finalize accumulator contract

### DIFF
--- a/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
@@ -679,6 +679,6 @@ abstract contract Pyth is
     }
 
     function version() public pure returns (string memory) {
-        return "1.3.0-alpha";
+        return "1.3.0";
     }
 }

--- a/target_chains/ethereum/contracts/contracts/wormhole-receiver/ReceiverMessages.sol
+++ b/target_chains/ethereum/contracts/contracts/wormhole-receiver/ReceiverMessages.sol
@@ -74,7 +74,7 @@ contract ReceiverMessages is ReceiverGetters {
                 // 66 is the length of each signature
                 // 1 (guardianIndex) + 32 (r) + 32 (s) + 1 (v)
                 uint hashIndex = index + (signersLen * 66);
-                if (hashIndex > encodedVM.length) {
+                if (hashIndex >= encodedVM.length) {
                     return (vm, false, "invalid signature length");
                 }
                 // Hash the body

--- a/target_chains/ethereum/contracts/package.json
+++ b/target_chains/ethereum/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-evm-contract",
-  "version": "1.3.0-alpha",
+  "version": "1.3.0",
   "description": "",
   "private": "true",
   "devDependencies": {


### PR DESCRIPTION
This PR changes the contract version from `1.3.0-alpha` to `1.3.0` as the audits came out positive. There is a one liner change in Wormhole Receiver `parseAndVerifyVM` method to catch an error earlier that is suggested by the auditors.