### PR TITLE
[price_pusher] Refresh sui object versions

### DIFF
--- a/price_pusher/package.json
+++ b/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "5.4.5",
+  "version": "5.4.6",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",


### PR DESCRIPTION
It seems like sui pusher's reliability problem is caused by the object versions of the gas coins in this code getting mismatched with the ones on-chain. This PR refreshes the version of the gas objects every time a transaction fails, which hopefully will fix the issue.

It's not easy to test this since it takes a long time to hit the error in the first place, but it should be safe to deploy this and see what happens. It's definitely not going to make things worse.