### PR TITLE
[xc-admin-frontend] XC admin frontend fix part2

### DIFF
--- a/governance/xc_admin/packages/xc_admin_frontend/components/InstructionViews/WormholeInstructionView.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/InstructionViews/WormholeInstructionView.tsx
@@ -24,6 +24,7 @@ import { ParsedAccountPubkeyRow, SignerTag, WritableTag } from './AccountUtils'
 import { usePythContext } from '../../contexts/PythContext'
 
 import { getMappingCluster, isPubkey } from './utils'
+import { PythCluster } from '@pythnetwork/client'
 
 const GovernanceInstructionView = ({
   instruction,
@@ -48,10 +49,11 @@ const GovernanceInstructionView = ({
 }
 export const WormholeInstructionView = ({
   instruction,
+  cluster,
 }: {
   instruction: WormholeMultisigInstruction
+  cluster: PythCluster
 }) => {
-  const { cluster } = useContext(ClusterContext)
   const {
     priceAccountKeyToSymbolMapping,
     productAccountKeyToSymbolMapping,

--- a/governance/xc_admin/packages/xc_admin_frontend/components/tabs/Proposals.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/tabs/Proposals.tsx
@@ -95,15 +95,39 @@ const ProposalRow = ({
               proposal.publicKey.toBase58().slice(-6)}
           </span>{' '}
         </div>
-        <div>
-          <StatusTag proposalStatus={status} />
+        <div className="flex space-x-2">
+          {proposal.approved.length > 0 && status === 'active' && (
+            <div>
+              <StatusTag
+                proposalStatus="executed"
+                text={`Approved: ${proposal.approved.length}`}
+              />
+            </div>
+          )}
+          {proposal.rejected.length > 0 && status === 'active' && (
+            <div>
+              <StatusTag
+                proposalStatus="rejected"
+                text={`Rejected: ${proposal.rejected.length}`}
+              />
+            </div>
+          )}
+          <div>
+            <StatusTag proposalStatus={status} />
+          </div>
         </div>
       </div>
     </div>
   )
 }
 
-const StatusTag = ({ proposalStatus }: { proposalStatus: string }) => {
+const StatusTag = ({
+  proposalStatus,
+  text,
+}: {
+  proposalStatus: string
+  text?: string
+}) => {
   return (
     <div
       className={`flex items-center justify-center rounded-full ${
@@ -120,7 +144,7 @@ const StatusTag = ({ proposalStatus }: { proposalStatus: string }) => {
           : 'bg-pythPurple'
       } py-1 px-2 text-xs`}
     >
-      {proposalStatus}
+      {text || proposalStatus}
     </div>
   )
 }

--- a/governance/xc_admin/packages/xc_admin_frontend/contexts/PythContext.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/contexts/PythContext.tsx
@@ -86,6 +86,8 @@ export const PythContextProvider: React.FC<PythContextProviderProps> = ({
       connection,
       publisherKeyToNameMapping,
       multisigSignerKeyToNameMapping,
+      priceAccountKeyToSymbolMapping,
+      productAccountKeyToSymbolMapping,
     ]
   )
 


### PR DESCRIPTION
Bugfix on hook dependencies

Show target pyth program if available and unique and use that cluster to calculate product/account mappings:
<img width="1193" alt="image" src="https://github.com/pyth-network/pyth-crosschain/assets/6235952/0da7d768-3311-42c5-b48b-d6a6e4180bd9">


Show approved/rejected count:
<img width="1359" alt="image" src="https://github.com/pyth-network/pyth-crosschain/assets/6235952/19331e0c-597d-429f-afdd-516a9622a8e1">
