### PR TITLE
[xc-admin] break when key is too long

### DIFF
--- a/governance/xc_admin/packages/xc_admin_frontend/components/common/CopyPubkey.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/common/CopyPubkey.tsx
@@ -6,7 +6,7 @@ const CopyPubkey: React.FC<{
 }> = ({ pubkey }) => {
   return (
     <div
-      className="-ml-1 inline-flex cursor-pointer items-center px-1 hover:bg-dark hover:text-white active:bg-darkGray3"
+      className="-ml-1 inline-flex cursor-pointer items-center px-1 hover:bg-dark hover:text-white active:bg-darkGray3 break-all"
       onClick={() => {
         copy(pubkey)
       }}


### PR DESCRIPTION
before: 
<img width="1322" alt="image" src="https://github.com/pyth-network/pyth-crosschain/assets/26521733/482eee56-87a8-4e92-b0ed-bcef63b8443a">

after:
<img width="1191" alt="image" src="https://github.com/pyth-network/pyth-crosschain/assets/26521733/395e0b84-98e0-4cf7-8d4a-5c4f85b63b12">
