### PR TITLE
[hermes] Add docs for 1 method

### DIFF
--- a/hermes/README.md
+++ b/hermes/README.md
@@ -43,6 +43,12 @@ To set up and run a Hermes node, follow the steps below:
    Your Hermes node will now start and connect to the specified networks. You
    can interact with the node using the REST and Websocket APIs on port 33999.
 
+For local development, consider running with cargo watch:
+
+```bash
+cargo watch -w src -x "run -- run --pythnet-http-endpoint https://pythnet.rpcpool.com --pythnet-ws-endpoint wss://pythnet.rpcpool.com"
+```
+
 ## Architecture Overview
 
 For users who simply want to run the software, this section can be skipped.

--- a/hermes/README.md
+++ b/hermes/README.md
@@ -35,19 +35,22 @@ To set up and run a Hermes node, follow the steps below:
    ```
    This will create a binary in the target/release directory.
 5. **Run the node**: To run Hermes for Pythnet, use the following command:
+
    ```bash
    ./target/release/hermes run \
      --pythnet-http-endpoint https://pythnet-rpc/ \
      --pythnet-ws-endpoint wss://pythnet-rpc/
    ```
+
    Your Hermes node will now start and connect to the specified networks. You
    can interact with the node using the REST and Websocket APIs on port 33999.
 
-For local development, consider running with cargo watch:
+   For local development, you can also run the node with cargo watch to restart
+   it automatically when the code changes:
 
-```bash
-cargo watch -w src -x "run -- run --pythnet-http-endpoint https://pythnet.rpcpool.com --pythnet-ws-endpoint wss://pythnet.rpcpool.com"
-```
+   ```bash
+   cargo watch -w src -x "run -- run --pythnet-http-endpoint https://pythnet.rpcpool.com --pythnet-ws-endpoint wss://pythnet.rpcpool.com"
+   ```
 
 ## Architecture Overview
 

--- a/hermes/rust-toolchain
+++ b/hermes/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2023-07-23"

--- a/hermes/rust-toolchain
+++ b/hermes/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-07-23"
+channel = "nightly"

--- a/hermes/src/api.rs
+++ b/hermes/src/api.rs
@@ -74,8 +74,11 @@ pub async fn run(store: Arc<Store>, mut update_rx: Receiver<()>, rpc_addr: Strin
         .route("/api/get_vaa_ccip", get(rest::get_vaa_ccip))
         .route("/api/price_feed_ids", get(rest::price_feed_ids))
         .with_state(state.clone())
-        .layer(CorsLayer::permissive()) // Permissive CORS layer to allow all origins
-        .layer(Extension(QsQueryConfig::new(5, false))); // non-strict mode permits escaped [] in URL parameters
+        // Permissive CORS layer to allow all origins
+        .layer(CorsLayer::permissive())
+        // non-strict mode permits escaped [] in URL parameters.
+        // 5 is the allowed depth (also the default value for this parameter).
+        .layer(Extension(QsQueryConfig::new(false)));
 
 
     // Call dispatch updates to websocket every 1 seconds

--- a/hermes/src/api/rest.rs
+++ b/hermes/src/api/rest.rs
@@ -97,26 +97,34 @@ pub async fn latest_vaas(
 }
 
 #[derive(Debug, serde::Deserialize, IntoParams)]
+#[into_params(parameter_in=Query)]
 pub struct LatestPriceFeedsQueryParams {
-    #[param(value_type = String)]
+    /// Get the most recent price update for these price feed ids.
+    /// Provide this parameter multiple times to retrieve multiple price updates,
+    /// ids[]=a12...&ids[]=b4c...
+    #[param(
+        rename = "ids[]",
+        example = "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43"
+    )]
     ids:     Vec<PriceIdInput>,
+    /// If true, include the `metadata` field in the response with additional metadata about
+    /// the price update.
     #[serde(default)]
-    #[param(value_type = Option<bool>, required = false, nullable = true)]
     verbose: bool,
+    /// If true, include the binary price update in the `vaa` field of each returned feed.
+    /// This binary data can be submitted to Pyth contracts to update the on-chain price.
     #[serde(default)]
-    #[param(value_type = Option<bool>, required = false, nullable = true)]
     binary:  bool,
 }
 
-/// Get the latest prices by price feed ids.
+/// Get the latest price updates by price feed id.
 ///
-/// Get the latest price updates for a provided collection of price feed ids.
-///
+/// Given a collection of price feed ids, retrieve the latest Pyth price for each price feed.
 #[utoipa::path(
   get,
   path = "/api/latest_price_feeds",
   responses(
-    (status = 200, description = "Price feeds retrieved successfully", body = [Vec<RpcPriceFeed>])
+    (status = 200, description = "Price updates retrieved successfully", body = [Vec<RpcPriceFeed>])
   ),
   params(
     LatestPriceFeedsQueryParams


### PR DESCRIPTION
This PR adds reasonable docs for the 1 method that is documented. Everything seems to work *except* the schemas for PriceId and Price, which are defined in a different crate so will need some special handling.

This was relatively painful to get working (I had to trial and error a bunch of stuff), but I think it's pretty repeatable at this point. We just have to copy paste the exact same macros over to the remaining API endpoints.