### PR TITLE
fix(hermes): send close message on WS closure

### DIFF
--- a/hermes/Cargo.lock
+++ b/hermes/Cargo.lock
@@ -404,9 +404,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a1de45611fdb535bfde7b7de4fd54f4fd2b17b1737c0a59b69bf9b92074b8c"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -432,7 +432,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.19.0",
+ "tokio-tungstenite 0.20.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1764,7 +1764,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermes"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -5900,14 +5900,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec509ac96e9a0c43427c74f003127d953a265737636129424288d27cb5c4b12c"
+checksum = "2b2dbec703c26b00d74844519606ef15d09a7d6857860f84ad223dec002ddea2"
 dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.19.0",
+ "tungstenite 0.20.0",
 ]
 
 [[package]]
@@ -6102,9 +6102,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
+checksum = "e862a1c4128df0112ab625f55cd5c934bcb4312ba80b39ae4b4835a3fd58e649"
 dependencies = [
  "byteorder",
  "bytes",

--- a/hermes/Cargo.toml
+++ b/hermes/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name                   = "hermes"
-version                = "0.1.7"
+version                = "0.1.8"
 edition                = "2021"
 
 [dependencies]
 anyhow                 = { version = "1.0.69" }
-axum                   = { version = "0.6.9", features = ["json", "ws", "macros"] }
-axum-macros            = { version = "0.3.4" }
+axum                   = { version = "0.6.20", features = ["json", "ws", "macros"] }
+axum-macros            = { version = "0.3.8" }
 base64                 = { version = "0.21.0" }
 borsh                  = { version = "0.10.3" }
 byteorder              = { version = "1.4.3" }


### PR DESCRIPTION
Some WS clients were receiving "Abnormal Connection Closure" errors. Usually clients handle this without any problem but not all of them. This PR fixes the issue by sending specific close message upon receiving close message from client. I tested it using Postman (to produce the error and check the fix).

This PR also refactors the ws.rs code by making it simpler and using tokio::time::Interval instead of a manually implemented interval. Lastly, it updates the axum package to include newer patches.