### PR TITLE
fix(hermes): use compatible ws format as xc-server

### DIFF
--- a/hermes/Cargo.lock
+++ b/hermes/Cargo.lock
@@ -1764,7 +1764,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermes"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "axum",

--- a/hermes/Cargo.toml
+++ b/hermes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name                   = "hermes"
-version                = "0.1.8"
+version                = "0.1.9"
 edition                = "2021"
 
 [dependencies]

--- a/hermes/src/api/ws.rs
+++ b/hermes/src/api/ws.rs
@@ -243,7 +243,8 @@ impl Subscriber {
 
         self.sender
             .send(
-                serde_json::to_string(&ServerMessage::Response(ServerResponseMessage::Ok))?.into(),
+                serde_json::to_string(&ServerMessage::Response(ServerResponseMessage::Success))?
+                    .into(),
             )
             .await?;
 
@@ -328,8 +329,8 @@ enum ServerMessage {
 #[derive(Serialize, Debug, Clone)]
 #[serde(tag = "status")]
 enum ServerResponseMessage {
-    #[serde(rename = "ok")]
-    Ok,
+    #[serde(rename = "success")]
+    Success,
     #[serde(rename = "error")]
     Err { error: String },
 }


### PR DESCRIPTION
The server response on hermes was "ok" instead of "success" on a correct request from client. We didn't catch it earlier because the client code only relied on whether it's error or not.