### PR TITLE
chore(ethereum): add html coverage bits

### DIFF
--- a/target_chains/ethereum/contracts/.gitignore
+++ b/target_chains/ethereum/contracts/.gitignore
@@ -8,3 +8,5 @@ cache
 cache-zk
 artifacts-zk
 artifacts
+lcov.info
+filtered-lcov.info

--- a/target_chains/ethereum/contracts/.gitignore
+++ b/target_chains/ethereum/contracts/.gitignore
@@ -10,3 +10,4 @@ artifacts-zk
 artifacts
 lcov.info
 filtered-lcov.info
+coverage

--- a/target_chains/ethereum/contracts/README.md
+++ b/target_chains/ethereum/contracts/README.md
@@ -31,7 +31,13 @@ npm run install-forge-deps
 ```
 
 After installing the dependencies. Run `forge build` to build the contracts and `forge test` to
-test the contracts using tests in `forge-test` directory.
+test the contracts using tests in `forge-test` directory. To see line by line test coverage:
+
+```
+npm run coverage
+```
+
+Open `coverage/index.html` in your web browser to see the results.
 
 ### Governance tests
 

--- a/target_chains/ethereum/contracts/coverage.sh
+++ b/target_chains/ethereum/contracts/coverage.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# Generate the lcov.info file
+forge coverage --report lcov
+
+# Filter out unnecessary stuff from the coverage report
+lcov \
+    --rc lcov_branch_coverage=1 \
+    --remove lcov.info \
+    --output-file filtered-lcov.info \
+    "*node_modules*" "*mock*" "contracts/libraries/external/*.sol" "contracts/pyth/mock/*"
+
+# Generate the filtered summary
+lcov \
+    --rc lcov_branch_coverage=1 \
+    --list filtered-lcov.info
+
+# Generate the html coverage file
+genhtml \
+    --rc genhtml_branch_coverage=1 \
+    --output-directory coverage \
+    filtered-lcov.info
+
+echo "Test coverage results successfully generated in the 'coverage' directory"

--- a/target_chains/ethereum/contracts/coverage.sh
+++ b/target_chains/ethereum/contracts/coverage.sh
@@ -6,20 +6,22 @@ forge coverage --report lcov
 
 # Filter out unnecessary stuff from the coverage report
 lcov \
-    --rc lcov_branch_coverage=1 \
+    --rc branch_coverage=1 \
     --remove lcov.info \
     --output-file filtered-lcov.info \
-    "*node_modules*" "*mock*" "contracts/libraries/external/*.sol" "contracts/pyth/mock/*"
+    "*node_modules*" "*mock*" "contracts/libraries/external/*.sol" \
 
 # Generate the filtered summary
 lcov \
-    --rc lcov_branch_coverage=1 \
+    --rc branch_coverage=1 \
     --list filtered-lcov.info
 
 # Generate the html coverage file
 genhtml \
-    --rc genhtml_branch_coverage=1 \
+    --rc branch_coverage=1 \
     --output-directory coverage \
+    --ignore-errors category \
+    --ignore-errors category,category \
     filtered-lcov.info
 
 echo "Test coverage results successfully generated in the 'coverage' directory"

--- a/target_chains/ethereum/contracts/package.json
+++ b/target_chains/ethereum/contracts/package.json
@@ -21,7 +21,8 @@
     "migrate": "truffle migrate",
     "receiver-submit-guardian-sets": "truffle exec scripts/receiverSubmitGuardianSetUpgrades.js",
     "verify": "truffle run verify $npm_config_module@$npm_config_contract_address --network $npm_config_network",
-    "install-forge-deps": "forge install foundry-rs/forge-std@2c7cbfc6fbede6d7c9e6b17afe997e3fdfe22fef --no-git --no-commit"
+    "install-forge-deps": "forge install foundry-rs/forge-std@2c7cbfc6fbede6d7c9e6b17afe997e3fdfe22fef --no-git --no-commit",
+    "coverage": "./coverage.sh"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Add an npm helper to output the html coverage files via:

    npm run coverage

This requires lcov and genhtml to be installed.