### PR TITLE
update Aptos examples Pyth dependency subdir

### DIFF
--- a/target_chains/aptos/examples/fetch_btc_price/Move.toml
+++ b/target_chains/aptos/examples/fetch_btc_price/Move.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 upgrade_policy = "compatible"
 
 [dependencies]
-Pyth = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "aptos/contracts", rev = "main" }
+Pyth = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/aptos/contracts", rev = "main" }
 
 [addresses]
 example = "0xac74082dfffb80824955aaefb2b0a98634b1368e37f42cbff14564ea430b97dc"

--- a/target_chains/aptos/examples/mint_nft/Move.toml
+++ b/target_chains/aptos/examples/mint_nft/Move.toml
@@ -6,7 +6,7 @@ upgrade_policy = "compatible"
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "main" }
 AptosToken = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-token/", rev = "main" }
-Pyth = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "aptos/contracts", rev = "main" }
+Pyth = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/aptos/contracts", rev = "main" }
 
 [addresses]
 # These are testnet addresses https://docs.pyth.network/documentation/pythnet-price-feeds/aptos#addresses


### PR DESCRIPTION
After moving contracts to "target_chains" directory code for Aptos examples were not updated.

This PR updates Pyth dependency subdirs in these two examples.