### PR TITLE
refactor(hermes): pass run args as struct, add docstrings

### DIFF
--- a/hermes/src/config.rs
+++ b/hermes/src/config.rs
@@ -5,52 +5,60 @@ use {
     structopt::StructOpt,
 };
 
-/// StructOpt definitions that provides the following arguments and commands:
-///
-/// Some of these arguments are not currently used, but are included for future use to guide the
-/// structure of the application.
+const DEFAULT_NETWORK_ID: &str = "/wormhole/mainnet/2";
+const DEFAULT_WORMHOLE_BOOTSTRAP_ADDRS: &str = "/dns4/wormhole-mainnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWQp644DK27fd3d4Km3jr7gHiuJJ5ZGmy8hH4py7fP4FP7";
+const DEFAULT_WORMHOLE_LISTEN_ADDRS: &str = "/ip4/0.0.0.0/udp/30910/quic,/ip6/::/udp/30910/quic";
+const DEFAULT_API_ADDR: &str = "127.0.0.1:33999";
+
+/// `Options` is a structup definition to provide clean command-line args for Hermes.
 #[derive(StructOpt, Debug)]
 #[structopt(name = "hermes", about = "Hermes")]
 pub enum Options {
-    Run {
-        #[structopt(long, env = "PYTHNET_WS_ENDPOINT")]
-        pythnet_ws_endpoint: String,
+    /// Run the hermes service.
+    Run(RunOptions),
+}
 
-        #[structopt(long, env = "PYTHNET_HTTP_ENDPOINT")]
-        pythnet_http_endpoint: String,
+#[derive(Clone, Debug, StructOpt)]
+pub struct RunOptions {
+    /// The address to bind the API server to.
+    #[structopt(long)]
+    #[structopt(default_value = DEFAULT_API_ADDR)]
+    #[structopt(env = "API_ADDR")]
+    pub api_addr: SocketAddr,
 
-        /// Network ID for Wormhole
-        #[structopt(
-            long,
-            default_value = "/wormhole/mainnet/2",
-            env = "WORMHOLE_NETWORK_ID"
-        )]
-        wh_network_id: String,
+    /// Address of a PythNet compatible websocket RPC endpoint.
+    #[structopt(long)]
+    #[structopt(env = "PYTHNET_WS_ENDPOINT")]
+    pub pythnet_ws_endpoint: String,
 
-        /// Multiaddresses for Wormhole bootstrap peers (separated by comma).
-        #[structopt(
-            long,
-            use_delimiter = true,
-            default_value = "/dns4/wormhole-mainnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWQp644DK27fd3d4Km3jr7gHiuJJ5ZGmy8hH4py7fP4FP7",
-            env = "WORMHOLE_BOOTSTRAP_ADDRS"
-        )]
-        wh_bootstrap_addrs: Vec<Multiaddr>,
+    /// Addres of a PythNet compatible HTP RPC endpoint.
+    #[structopt(long)]
+    #[structopt(env = "PYTHNET_HTTP_ENDPOINT")]
+    pub pythnet_http_endpoint: String,
 
-        /// Multiaddresses to bind Wormhole P2P to (separated by comma)
-        #[structopt(
-            long,
-            use_delimiter = true,
-            default_value = "/ip4/0.0.0.0/udp/30910/quic,/ip6/::/udp/30910/quic",
-            env = "WORMHOLE_LISTEN_ADDRS"
-        )]
-        wh_listen_addrs: Vec<Multiaddr>,
+    /// Multiaddresses for Wormhole bootstrap peers (separated by comma).
+    #[structopt(long)]
+    #[structopt(use_delimiter = true)]
+    #[structopt(default_value = DEFAULT_WORMHOLE_BOOTSTRAP_ADDRS)]
+    #[structopt(env = "WORMHOLE_BOOTSTRAP_ADDRS")]
+    pub wh_bootstrap_addrs: Vec<Multiaddr>,
 
-        /// The address to bind the API server to.
-        #[structopt(long, default_value = "127.0.0.1:33999")]
-        api_addr: SocketAddr,
+    /// Address of the Wormhole contract on the target PythNet cluster.
+    #[structopt(long)]
+    #[structopt(default_value = "H3fxXJ86ADW2PNuDDmZJg6mzTtPxkYCpNuQUTgmJ7AjU")]
+    #[structopt(env = "WORMHOLE_CONTRACT_ADDR")]
+    pub wh_contract_addr: Pubkey,
 
-        /// Address of the Wormhole contract on the target PythNet cluster.
-        #[structopt(long, default_value = "H3fxXJ86ADW2PNuDDmZJg6mzTtPxkYCpNuQUTgmJ7AjU")]
-        wh_contract_addr: Pubkey,
-    },
+    /// Multiaddresses to bind Wormhole P2P to (separated by comma)
+    #[structopt(long)]
+    #[structopt(use_delimiter = true)]
+    #[structopt(default_value = DEFAULT_WORMHOLE_LISTEN_ADDRS)]
+    #[structopt(env = "WORMHOLE_LISTEN_ADDRS")]
+    pub wh_listen_addrs: Vec<Multiaddr>,
+
+    /// Network ID for Wormhole
+    #[structopt(long)]
+    #[structopt(default_value = DEFAULT_NETWORK_ID)]
+    #[structopt(env = "WORMHOLE_NETWORK_ID")]
+    pub wh_network_id: String,
 }

--- a/hermes/src/network/p2p.rs
+++ b/hermes/src/network/p2p.rs
@@ -10,9 +10,12 @@
 //! their infrastructure.
 
 use {
-    crate::store::{
-        types::Update,
-        Store,
+    crate::{
+        config::RunOptions,
+        store::{
+            types::Update,
+            Store,
+        },
     },
     anyhow::Result,
     libp2p::Multiaddr,
@@ -122,13 +125,17 @@ pub fn bootstrap(
 }
 
 // Spawn's the P2P layer as a separate thread via Go.
-pub async fn spawn(
-    store: Arc<Store>,
-    network_id: String,
-    wh_bootstrap_addrs: Vec<Multiaddr>,
-    wh_listen_addrs: Vec<Multiaddr>,
-) -> Result<()> {
-    std::thread::spawn(|| bootstrap(network_id, wh_bootstrap_addrs, wh_listen_addrs).unwrap());
+pub async fn spawn(opts: RunOptions, store: Arc<Store>) -> Result<()> {
+    log::info!("Starting P2P server on {:?}", opts.wh_listen_addrs);
+
+    std::thread::spawn(|| {
+        bootstrap(
+            opts.wh_network_id,
+            opts.wh_bootstrap_addrs,
+            opts.wh_listen_addrs,
+        )
+        .unwrap()
+    });
 
     tokio::spawn(async move {
         // Listen in the background for new VAA's from the p2p layer


### PR DESCRIPTION
In some cases arguments are passed and accidentally renamed (like `api_addr -> rpc_addr`) or are unnecesarily converted (see `api_addr.to_string()` which is then parsed again with `api_addr.parse()`. In the future, we are likely to add many more arguments to Hermes as well, so this commit moves them into a separate struct which is then forwarded throughout the application instead which has the side effect of clearing some of these inconsistencies up as well.

The struct by default is cloned, but this only happens during launch of a hermes service components and can be passed by ref everywhere else so the cost doesn't matter.

As a drive by this makes an opinionated reformatting of attributes to reduce indentation (or increase it) for clarity. And moves logging to the sites they are most related to.