### PR TITLE
[price-pusher] Bugfix in handling account sequence mismatch in injective

### DIFF
--- a/price_pusher/package.json
+++ b/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "5.4.8",
+  "version": "5.4.9",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/price_pusher/src/injective/injective.ts
+++ b/price_pusher/src/injective/injective.ts
@@ -133,37 +133,37 @@ export class InjectivePricePusher implements IPricePusher {
 
     const txService = new TxGrpcClient(this.grpcEndpoint);
     // simulation
-    const {
-      gasInfo: { gasUsed },
-    } = await txService.simulate(simulateTxRaw);
-
-    // simulation returns us the approximate gas used
-    // gas passed with the transaction should be more than that
-    // in order for it to be successfully executed
-    // this multiplier takes care of that
-    const gas = (gasUsed * this.chainConfig.gasMultiplier).toFixed();
-    const fee = {
-      amount: [
-        {
-          denom: "inj",
-          amount: (Number(gas) * this.chainConfig.gasPrice).toFixed(),
-        },
-      ],
-      gas,
-    };
-
-    const { signBytes, txRaw } = createTransactionFromMsg({
-      sequence: this.account.baseAccount.sequence,
-      accountNumber: this.account.baseAccount.accountNumber,
-      message: msg,
-      chainId: this.chainConfig.chainId,
-      fee,
-      pubKey: this.wallet.toPublicKey().toBase64(),
-    });
-
-    const sig = await this.wallet.sign(Buffer.from(signBytes));
-
     try {
+      const {
+        gasInfo: { gasUsed },
+      } = await txService.simulate(simulateTxRaw);
+
+      // simulation returns us the approximate gas used
+      // gas passed with the transaction should be more than that
+      // in order for it to be successfully executed
+      // this multiplier takes care of that
+      const gas = (gasUsed * this.chainConfig.gasMultiplier).toFixed();
+      const fee = {
+        amount: [
+          {
+            denom: "inj",
+            amount: (Number(gas) * this.chainConfig.gasPrice).toFixed(),
+          },
+        ],
+        gas,
+      };
+
+      const { signBytes, txRaw } = createTransactionFromMsg({
+        sequence: this.account.baseAccount.sequence,
+        accountNumber: this.account.baseAccount.accountNumber,
+        message: msg,
+        chainId: this.chainConfig.chainId,
+        fee,
+        pubKey: this.wallet.toPublicKey().toBase64(),
+      });
+
+      const sig = await this.wallet.sign(Buffer.from(signBytes));
+
       this.account.baseAccount.sequence++;
 
       /** Append Signatures */


### PR DESCRIPTION
account sequence mismatch error could happen in the simulation but the try catch did not cover that part
Verified the fix by manually incrementing the sequence number twice after each transaction so a refetch was necessary