### PR TITLE
fix(eth): update legacy updateFee method pricing

### DIFF
--- a/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
@@ -98,7 +98,10 @@ abstract contract Pyth is
     function getUpdateFee(
         uint updateDataSize
     ) public view returns (uint feeAmount) {
-        return singleUpdateFeeInWei() * updateDataSize;
+        // In the accumulator update data a single update can contain
+        // up to 255 messages and we charge a singleUpdateFee per each
+        // message
+        return 255 * singleUpdateFeeInWei() * updateDataSize;
     }
 
     function getUpdateFee(
@@ -679,6 +682,6 @@ abstract contract Pyth is
     }
 
     function version() public pure returns (string memory) {
-        return "1.3.0";
+        return "1.3.1";
     }
 }

--- a/target_chains/ethereum/contracts/package.json
+++ b/target_chains/ethereum/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-evm-contract",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "private": "true",
   "devDependencies": {


### PR DESCRIPTION
We have a deprecated `getUpdateFee` method that takes the size of updateData as argument and returns the price. We needed to keep it to keep backward compatibility. However, to keep it fully backward compatible we need to update its logic to always remain a over estimate of the actual cost.