### PR TITLE
refactor(hermes): refactor configuration

### DIFF
--- a/hermes/Cargo.lock
+++ b/hermes/Cargo.lock
@@ -137,6 +137,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,11 +925,57 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags 1.3.2",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
 ]
+
+[[package]]
+name = "clap"
+version = "4.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d7b8d5ec32af0fadc644bf1fd509a688c2103b185644bb1e29d164e0703136"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5179bb514e4d7c2051749d8fcefa2ed6d06a9f4e6d69faf3805f5d80b8cf8d56"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.10.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2 1.0.66",
+ "quote 1.0.31",
+ "syn 2.0.26",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concurrent-queue"
@@ -1764,7 +1858,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermes"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1774,6 +1868,7 @@ dependencies = [
  "borsh 0.10.3",
  "byteorder",
  "chrono",
+ "clap 4.4.4",
  "dashmap",
  "derive_more",
  "env_logger 0.10.0",
@@ -1799,7 +1894,6 @@ dependencies = [
  "solana-account-decoder",
  "solana-client",
  "solana-sdk",
- "structopt",
  "strum",
  "tokio",
  "tower-http",
@@ -5001,7 +5095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76b0c923e89c64ed398964ec2a3ddecacb5a712664d19812ebbf65eefd599145"
 dependencies = [
  "chrono",
- "clap",
+ "clap 2.34.0",
  "rpassword",
  "solana-perf",
  "solana-remote-wallet",
@@ -5040,7 +5134,7 @@ dependencies = [
  "bincode",
  "bs58",
  "bytes",
- "clap",
+ "clap 2.34.0",
  "crossbeam-channel",
  "enum_dispatch",
  "futures",
@@ -5105,7 +5199,7 @@ checksum = "c9aae7a9b16c3e81b6532c3a5d886c58ee0cb518ee6b417f28ea0cfee972ac60"
 dependencies = [
  "bincode",
  "byteorder",
- "clap",
+ "clap 2.34.0",
  "crossbeam-channel",
  "log",
  "serde",
@@ -5197,7 +5291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3093c7701cc7d3603a32aec204e5a2e4935f71b37eabd7302d5b67bdb4ea0a02"
 dependencies = [
  "bincode",
- "clap",
+ "clap 2.34.0",
  "crossbeam-channel",
  "log",
  "nix 0.23.2",
@@ -5615,28 +5709,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
-name = "structopt"
-version = "0.3.26"
+name = "strsim"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
- "syn 1.0.109",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
@@ -6344,6 +6420,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utoipa"

--- a/hermes/Cargo.toml
+++ b/hermes/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-name    = "hermes"
-version = "0.1.20"
-edition = "2021"
+name        = "hermes"
+version     = "0.1.21"
+description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
+edition     = "2021"
 
 [dependencies]
 async-trait        = { version = "0.1.73" }
@@ -33,7 +34,7 @@ serde_json         = { version = "1.0.93" }
 serde_qs           = { version = "0.12.0", features = ["axum"] }
 serde_wormhole     = { git     = "https://github.com/wormhole-foundation/wormhole", tag = "v2.17.1" }
 sha3               = { version = "0.10.4" }
-structopt          = { version = "0.3.26" }
+clap               = { version = "4.4.4", features = ["derive", "env", "cargo"] }
 strum              = { version = "0.24.1", features = ["derive"] }
 tokio              = { version = "1.26.0", features = ["full"] }
 tower-http         = { version = "0.4.0", features = ["cors"] }

--- a/hermes/src/api.rs
+++ b/hermes/src/api.rs
@@ -54,7 +54,7 @@ pub async fn run(
     state: Arc<State>,
     mut update_rx: Receiver<AggregationEvent>,
 ) -> Result<()> {
-    tracing::info!(endpoint = %opts.api_addr, "Starting RPC Server.");
+    tracing::info!(endpoint = %opts.rpc.addr, "Starting RPC Server.");
 
     #[derive(OpenApi)]
     #[openapi(
@@ -130,7 +130,7 @@ pub async fn run(
 
     // Binds the axum's server to the configured address and port. This is a blocking call and will
     // not return until the server is shutdown.
-    axum::Server::try_bind(&opts.api_addr)?
+    axum::Server::try_bind(&opts.rpc.addr)?
         .serve(app.into_make_service())
         .with_graceful_shutdown(async {
             // Ignore Ctrl+C errors, either way we need to shut down. The main Ctrl+C handler

--- a/hermes/src/config.rs
+++ b/hermes/src/config.rs
@@ -1,98 +1,58 @@
-use {
-    libp2p::Multiaddr,
-    reqwest::Url,
-    solana_sdk::pubkey::Pubkey,
-    std::net::SocketAddr,
-    structopt::StructOpt,
+use clap::{
+    crate_authors,
+    crate_description,
+    crate_name,
+    crate_version,
+    Args,
+    Parser,
 };
 
-const DEFAULT_NETWORK_ID: &str = "/wormhole/mainnet/2";
-const DEFAULT_WORMHOLE_BOOTSTRAP_ADDRS: &str = "/dns4/wormhole-mainnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWQp644DK27fd3d4Km3jr7gHiuJJ5ZGmy8hH4py7fP4FP7,/dns4/wormhole-v2-mainnet-bootstrap.xlabs.xyz/udp/8999/quic/p2p/12D3KooWNQ9tVrcb64tw6bNs2CaNrUGPM7yRrKvBBheQ5yCyPHKC";
-const DEFAULT_WORMHOLE_LISTEN_ADDRS: &str = "/ip4/0.0.0.0/udp/30910/quic,/ip6/::/udp/30910/quic";
-const DEFAULT_API_ADDR: &str = "127.0.0.1:33999";
+mod benchmarks;
+mod pythnet;
+mod rpc;
+mod wormhole;
 
-/// `Options` is a structup definition to provide clean command-line args for Hermes.
-#[derive(StructOpt, Debug)]
-#[structopt(name = "hermes", about = "Hermes")]
+// `Options` is a structup definition to provide clean command-line args for Hermes.
+#[derive(Parser, Debug)]
+#[command(name = crate_name!())]
+#[command(author = crate_authors!())]
+#[command(about = crate_description!())]
+#[command(version = crate_version!())]
+#[allow(clippy::large_enum_variant)]
 pub enum Options {
-    /// Run the hermes service.
+    /// Run the Hermes Price Service.
     Run(RunOptions),
+
+    /// Show Overridden Environment Variables.
+    ShowEnv(ShowEnvOptions),
 }
 
-#[derive(Clone, Debug, StructOpt)]
+#[derive(Args, Clone, Debug)]
 pub struct RunOptions {
     /// Wormhole Options.
-    #[structopt(flatten)]
-    pub wormhole: WormholeOptions,
+    #[command(flatten)]
+    pub wormhole: wormhole::Options,
 
     /// PythNet Options
-    #[structopt(flatten)]
-    pub pythnet: PythNetOptions,
+    #[command(flatten)]
+    pub pythnet: pythnet::Options,
 
     /// RPC Options
-    #[structopt(flatten)]
-    pub rpc: RpcOptions,
+    #[command(flatten)]
+    pub rpc: rpc::Options,
 
     /// Benchmarks Options
-    #[structopt(flatten)]
-    pub benchmarks: BenchmarksOptions,
+    #[command(flatten)]
+    pub benchmarks: benchmarks::Options,
 }
 
-#[derive(Clone, Debug, StructOpt)]
-pub struct WormholeOptions {
-    /// Multiaddresses for Wormhole bootstrap peers (separated by comma).
-    #[structopt(long)]
-    #[structopt(use_delimiter = true)]
-    #[structopt(default_value = DEFAULT_WORMHOLE_BOOTSTRAP_ADDRS)]
-    #[structopt(env = "WORMHOLE_BOOTSTRAP_ADDRS")]
-    pub bootstrap_addrs: Vec<Multiaddr>,
-
-    /// Address of the Wormhole contract on the target PythNet cluster.
-    #[structopt(long)]
-    #[structopt(default_value = "H3fxXJ86ADW2PNuDDmZJg6mzTtPxkYCpNuQUTgmJ7AjU")]
-    #[structopt(env = "WORMHOLE_CONTRACT_ADDR")]
-    pub contract_addr: Pubkey,
-
-    /// Multiaddresses to bind Wormhole P2P to (separated by comma)
-    #[structopt(long)]
-    #[structopt(use_delimiter = true)]
-    #[structopt(default_value = DEFAULT_WORMHOLE_LISTEN_ADDRS)]
-    #[structopt(env = "WORMHOLE_LISTEN_ADDRS")]
-    pub listen_addrs: Vec<Multiaddr>,
-
-    /// Network ID for Wormhole
-    #[structopt(long)]
-    #[structopt(default_value = DEFAULT_NETWORK_ID)]
-    #[structopt(env = "WORMHOLE_NETWORK_ID")]
-    pub network_id: String,
-}
-
-#[derive(Clone, Debug, StructOpt)]
-pub struct PythNetOptions {
-    /// Address of a PythNet compatible websocket RPC endpoint.
-    #[structopt(long)]
-    #[structopt(env = "PYTHNET_WS_ENDPOINT")]
-    pub ws_endpoint: String,
-
-    /// Addres of a PythNet compatible HTP RPC endpoint.
-    #[structopt(long)]
-    #[structopt(env = "PYTHNET_HTTP_ENDPOINT")]
-    pub http_endpoint: String,
-}
-
-#[derive(Clone, Debug, StructOpt)]
-pub struct RpcOptions {
-    /// Address to bind the API server to.
-    #[structopt(long)]
-    #[structopt(default_value = DEFAULT_API_ADDR)]
-    #[structopt(env = "API_ADDR")]
-    pub addr: SocketAddr,
-}
-
-#[derive(Clone, Debug, StructOpt)]
-pub struct BenchmarksOptions {
-    /// Benchmarks endpoint to retrieve historical update data from.
-    #[structopt(long)]
-    #[structopt(env = "BENCHMARKS_ENDPOINT")]
-    pub endpoint: Option<Url>,
+#[derive(Args, Clone, Debug)]
+pub struct ShowEnvOptions {
+    /// Show Hermes environment variables.
+    ///
+    /// By default this command will attempt to read the variable from the environment and fall
+    /// back to the argument default if not present. Set this flag if you want only the defaults
+    /// and to ignore the current environment.
+    #[arg(long = "defaults")]
+    pub defaults: bool,
 }

--- a/hermes/src/config.rs
+++ b/hermes/src/config.rs
@@ -21,50 +21,78 @@ pub enum Options {
 
 #[derive(Clone, Debug, StructOpt)]
 pub struct RunOptions {
-    /// The address to bind the API server to.
-    #[structopt(long)]
-    #[structopt(default_value = DEFAULT_API_ADDR)]
-    #[structopt(env = "API_ADDR")]
-    pub api_addr: SocketAddr,
+    /// Wormhole Options.
+    #[structopt(flatten)]
+    pub wormhole: WormholeOptions,
 
-    /// Address of a PythNet compatible websocket RPC endpoint.
-    #[structopt(long)]
-    #[structopt(env = "PYTHNET_WS_ENDPOINT")]
-    pub pythnet_ws_endpoint: String,
+    /// PythNet Options
+    #[structopt(flatten)]
+    pub pythnet: PythNetOptions,
 
-    /// Addres of a PythNet compatible HTP RPC endpoint.
-    #[structopt(long)]
-    #[structopt(env = "PYTHNET_HTTP_ENDPOINT")]
-    pub pythnet_http_endpoint: String,
+    /// RPC Options
+    #[structopt(flatten)]
+    pub rpc: RpcOptions,
 
+    /// Benchmarks Options
+    #[structopt(flatten)]
+    pub benchmarks: BenchmarksOptions,
+}
+
+#[derive(Clone, Debug, StructOpt)]
+pub struct WormholeOptions {
     /// Multiaddresses for Wormhole bootstrap peers (separated by comma).
     #[structopt(long)]
     #[structopt(use_delimiter = true)]
     #[structopt(default_value = DEFAULT_WORMHOLE_BOOTSTRAP_ADDRS)]
     #[structopt(env = "WORMHOLE_BOOTSTRAP_ADDRS")]
-    pub wh_bootstrap_addrs: Vec<Multiaddr>,
+    pub bootstrap_addrs: Vec<Multiaddr>,
 
     /// Address of the Wormhole contract on the target PythNet cluster.
     #[structopt(long)]
     #[structopt(default_value = "H3fxXJ86ADW2PNuDDmZJg6mzTtPxkYCpNuQUTgmJ7AjU")]
     #[structopt(env = "WORMHOLE_CONTRACT_ADDR")]
-    pub wh_contract_addr: Pubkey,
+    pub contract_addr: Pubkey,
 
     /// Multiaddresses to bind Wormhole P2P to (separated by comma)
     #[structopt(long)]
     #[structopt(use_delimiter = true)]
     #[structopt(default_value = DEFAULT_WORMHOLE_LISTEN_ADDRS)]
     #[structopt(env = "WORMHOLE_LISTEN_ADDRS")]
-    pub wh_listen_addrs: Vec<Multiaddr>,
+    pub listen_addrs: Vec<Multiaddr>,
 
     /// Network ID for Wormhole
     #[structopt(long)]
     #[structopt(default_value = DEFAULT_NETWORK_ID)]
     #[structopt(env = "WORMHOLE_NETWORK_ID")]
-    pub wh_network_id: String,
+    pub network_id: String,
+}
 
+#[derive(Clone, Debug, StructOpt)]
+pub struct PythNetOptions {
+    /// Address of a PythNet compatible websocket RPC endpoint.
+    #[structopt(long)]
+    #[structopt(env = "PYTHNET_WS_ENDPOINT")]
+    pub ws_endpoint: String,
+
+    /// Addres of a PythNet compatible HTP RPC endpoint.
+    #[structopt(long)]
+    #[structopt(env = "PYTHNET_HTTP_ENDPOINT")]
+    pub http_endpoint: String,
+}
+
+#[derive(Clone, Debug, StructOpt)]
+pub struct RpcOptions {
+    /// Address to bind the API server to.
+    #[structopt(long)]
+    #[structopt(default_value = DEFAULT_API_ADDR)]
+    #[structopt(env = "API_ADDR")]
+    pub addr: SocketAddr,
+}
+
+#[derive(Clone, Debug, StructOpt)]
+pub struct BenchmarksOptions {
     /// Benchmarks endpoint to retrieve historical update data from.
     #[structopt(long)]
     #[structopt(env = "BENCHMARKS_ENDPOINT")]
-    pub benchmarks_endpoint: Option<Url>,
+    pub endpoint: Option<Url>,
 }

--- a/hermes/src/config/benchmarks.rs
+++ b/hermes/src/config/benchmarks.rs
@@ -1,0 +1,14 @@
+use {
+    clap::Args,
+    reqwest::Url,
+};
+
+#[derive(Args, Clone, Debug)]
+#[command(next_help_heading = "Benchmark Options")]
+#[group(id = "Benchmarks")]
+pub struct Options {
+    /// Benchmarks endpoint to retrieve historical update data from.
+    #[arg(long = "benchmarks-endpoint")]
+    #[arg(env = "BENCHMARKS_ENDPOINT")]
+    pub endpoint: Option<Url>,
+}

--- a/hermes/src/config/pythnet.rs
+++ b/hermes/src/config/pythnet.rs
@@ -1,0 +1,16 @@
+use clap::Args;
+
+#[derive(Args, Clone, Debug)]
+#[command(next_help_heading = "Pythnet Options")]
+#[group(id = "Pythnet")]
+pub struct Options {
+    /// Address of a PythNet compatible websocket RPC endpoint.
+    #[arg(long = "pythnet-ws-addr")]
+    #[arg(env = "PYTHNET_WS_ENDPOINT")]
+    pub ws_endpoint: String,
+
+    /// Addres of a PythNet compatible HTP RPC endpoint.
+    #[arg(long = "pythnet-http-addr")]
+    #[arg(env = "PYTHNET_HTTP_ENDPOINT")]
+    pub http_endpoint: String,
+}

--- a/hermes/src/config/rpc.rs
+++ b/hermes/src/config/rpc.rs
@@ -1,0 +1,17 @@
+use {
+    clap::Args,
+    std::net::SocketAddr,
+};
+
+const DEFAULT_RPC_ADDR: &str = "127.0.0.1:33999";
+
+#[derive(Args, Clone, Debug)]
+#[command(next_help_heading = "RPC Options")]
+#[group(id = "RPC")]
+pub struct Options {
+    /// Address and port the RPC server will bind to.
+    #[arg(long = "rpc-listen-addr")]
+    #[arg(default_value = DEFAULT_RPC_ADDR)]
+    #[arg(env = "RPC_ADDR")]
+    pub addr: SocketAddr,
+}

--- a/hermes/src/config/wormhole.rs
+++ b/hermes/src/config/wormhole.rs
@@ -1,0 +1,48 @@
+use {
+    clap::Args,
+    libp2p::Multiaddr,
+    solana_sdk::pubkey::Pubkey,
+};
+
+const DEFAULT_LISTEN_ADDRS: &str = "/ip4/0.0.0.0/udp/30910/quic,/ip6/::/udp/30910/quic";
+const DEFAULT_CONTRACT_ADDR: &str = "H3fxXJ86ADW2PNuDDmZJg6mzTtPxkYCpNuQUTgmJ7AjU";
+const DEFAULT_NETWORK_ID: &str = "/wormhole/mainnet/2";
+const DEFAULT_BOOTSTRAP_ADDRS: &str = concat![
+    "/dns4/wormhole-mainnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWQp644DK27fd3d4Km3jr7gHiuJJ5ZGmy8hH4py7fP4FP7,",
+    "/dns4/wormhole-v2-mainnet-bootstrap.xlabs.xyz/udp/8999/quic/p2p/12D3KooWNQ9tVrcb64tw6bNs2CaNrUGPM7yRrKvBBheQ5yCyPHKC",
+];
+
+#[derive(Args, Clone, Debug)]
+#[command(next_help_heading = "Wormhole Options")]
+#[group(id = "Wormhole")]
+pub struct Options {
+    /// Multiaddresses for Wormhole bootstrap peers (separated by comma).
+    ///
+    /// Bootstraps can be found from the official Wormhole repository, note that these addresses
+    /// are only used to bootstrap peer discovery and are not necessarily used for data transfer.
+    /// Adding more peers will speed up P2P peer discovery.
+    #[arg(long = "wormhole-bootstrap-addrs")]
+    #[arg(value_delimiter = ',')]
+    #[arg(default_value = DEFAULT_BOOTSTRAP_ADDRS)]
+    #[arg(env = "WORMHOLE_BOOTSTRAP_ADDRS")]
+    pub bootstrap_addrs: Vec<Multiaddr>,
+
+    /// Address of the Wormhole contract on the target PythNet cluster.
+    #[arg(long = "wormhole-contract-addr")]
+    #[arg(default_value = DEFAULT_CONTRACT_ADDR)]
+    #[arg(env = "WORMHOLE_CONTRACT_ADDR")]
+    pub contract_addr: Pubkey,
+
+    /// Multiaddresses to bind for Wormhole P2P (separated by comma)
+    #[arg(long = "wormhole-listen-addrs")]
+    #[arg(value_delimiter = ',')]
+    #[arg(default_value = DEFAULT_LISTEN_ADDRS)]
+    #[arg(env = "WORMHOLE_LISTEN_ADDRS")]
+    pub listen_addrs: Vec<Multiaddr>,
+
+    /// Network ID for Wormhole
+    #[arg(long = "wormhole-network-id")]
+    #[arg(default_value = DEFAULT_NETWORK_ID)]
+    #[arg(env = "WORMHOLE_NETWORK_ID")]
+    pub network_id: String,
+}

--- a/hermes/src/main.rs
+++ b/hermes/src/main.rs
@@ -45,7 +45,7 @@ async fn init() -> Result<()> {
             let (update_tx, update_rx) = tokio::sync::mpsc::channel(1000);
 
             // Initialize a cache store with a 1000 element circular buffer.
-            let store = State::new(update_tx.clone(), 1000, opts.benchmarks_endpoint.clone());
+            let store = State::new(update_tx.clone(), 1000, opts.benchmarks.endpoint.clone());
 
             // Listen for Ctrl+C so we can set the exit flag and wait for a graceful shutdown.
             spawn(async move {

--- a/hermes/src/network/p2p.rs
+++ b/hermes/src/network/p2p.rs
@@ -138,13 +138,13 @@ pub fn bootstrap(
 // Spawn's the P2P layer as a separate thread via Go.
 #[tracing::instrument(skip(opts, state))]
 pub async fn spawn(opts: RunOptions, state: Arc<State>) -> Result<()> {
-    tracing::info!(listeners = ?opts.wh_listen_addrs, "Starting P2P Server");
+    tracing::info!(listeners = ?opts.wormhole.listen_addrs, "Starting P2P Server");
 
     std::thread::spawn(|| {
         if bootstrap(
-            opts.wh_network_id,
-            opts.wh_bootstrap_addrs,
-            opts.wh_listen_addrs,
+            opts.wormhole.network_id,
+            opts.wormhole.bootstrap_addrs,
+            opts.wormhole.listen_addrs,
         )
         .is_err()
         {

--- a/hermes/src/network/pythnet.rs
+++ b/hermes/src/network/pythnet.rs
@@ -256,20 +256,20 @@ async fn fetch_existing_guardian_sets(
 #[tracing::instrument(skip(opts, state))]
 pub async fn spawn(opts: RunOptions, state: Arc<State>) -> Result<()> {
     tracing::info!(
-        endpoint = opts.pythnet_ws_endpoint,
+        endpoint = opts.pythnet.ws_endpoint,
         "Started Pythnet Listener."
     );
 
     fetch_existing_guardian_sets(
         state.clone(),
-        opts.pythnet_http_endpoint.clone(),
-        opts.wh_contract_addr,
+        opts.pythnet.http_endpoint.clone(),
+        opts.wormhole.contract_addr,
     )
     .await?;
 
     let task_listener = {
         let store = state.clone();
-        let pythnet_ws_endpoint = opts.pythnet_ws_endpoint.clone();
+        let pythnet_ws_endpoint = opts.pythnet.ws_endpoint.clone();
         tokio::spawn(async move {
             while !crate::SHOULD_EXIT.load(Ordering::Acquire) {
                 let current_time = Instant::now();
@@ -289,7 +289,7 @@ pub async fn spawn(opts: RunOptions, state: Arc<State>) -> Result<()> {
 
     let task_guadian_watcher = {
         let store = state.clone();
-        let pythnet_http_endpoint = opts.pythnet_http_endpoint.clone();
+        let pythnet_http_endpoint = opts.pythnet.http_endpoint.clone();
         tokio::spawn(async move {
             while !crate::SHOULD_EXIT.load(Ordering::Acquire) {
                 // Poll for new guardian sets every 60 seconds. We use a short wait time so we can
@@ -305,7 +305,7 @@ pub async fn spawn(opts: RunOptions, state: Arc<State>) -> Result<()> {
                 match fetch_existing_guardian_sets(
                     store.clone(),
                     pythnet_http_endpoint.clone(),
-                    opts.wh_contract_addr,
+                    opts.wormhole.contract_addr,
                 )
                 .await
                 {


### PR DESCRIPTION
Since clap v3, structopt has been in maintenance mode. Structopt functionality was merged directly into clap, this PR moves us to clap v4,and refactors the current hermes configuration code while doing so, in particular:

- Breaks the configuration object into multiple modules.
- Cleans up argument defaults.
- Cleans up the command and argument documentation strings.
- Fixes the output to be over more lines for clarity (when `--help` not `-h`)
- Adds a new subcommand `show-env` that prints all configuration environment variables.

This renames some of the commands so this does break the current argument scheme. The changes in particular are just to make the commands a little more verbose/clear/consistent:

- `--pythnet-ws-endpoint` -> `--pythnet-ws-addr`
- `--pythnet-http-endpoint` -> `--pythnet-http-addr`
- `--api-addr` -> `--rpc-listen-addr`
- `--wh-contract-addr` -> `--wormhole-contract-addr`

An example of the `show-env` command, useful for creating `.env` files:

```sh
$ API_ADDR=192.168.1.1:8080 cargo run -- show-env
API_ADDR=192.168.1.1:8080
BENCHMARKS_ENDPOINT=
PYTHNET_WS_ENDPOINT=
PYTHNET_HTTP_ENDPOINT=
WORMHOLE_BOOTSTRAP_ADDRS=/dns4/wormhole-mainnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWQp644DK27fd3d4Km3jr7gHiuJJ5ZGmy8hH4py7fP4FP7
WORMHOLE_CONTRACT_ADDR=H3fxXJ86ADW2PNuDDmZJg6mzTtPxkYCpNuQUTgmJ7AjU
WORMHOLE_LISTEN_ADDRS=/ip4/0.0.0.0/udp/30910/quic,/ip6/::/udp/30910/quic
WORMHOLE_NETWORK_ID=/wormhole/mainnet/2
```

It's also possible to print out only the default values and not inherit from the environment:

```sh
$ API_ADDR=192.168.1.1:8080 cargo run -- show-env --defaults
API_ADDR=127.0.0.1:33999
BENCHMARKS_ENDPOINT=
PYTHNET_WS_ENDPOINT=
PYTHNET_HTTP_ENDPOINT=
WORMHOLE_BOOTSTRAP_ADDRS=/dns4/wormhole-mainnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWQp644DK27fd3d4Km3jr7gHiuJJ5ZGmy8hH4py7fP4FP7
WORMHOLE_CONTRACT_ADDR=H3fxXJ86ADW2PNuDDmZJg6mzTtPxkYCpNuQUTgmJ7AjU
WORMHOLE_LISTEN_ADDRS=/ip4/0.0.0.0/udp/30910/quic,/ip6/::/udp/30910/quic
WORMHOLE_NETWORK_ID=/wormhole/mainnet/2
```

And the new `run --help` output:

```
Run the Hermes Price Service

Usage: hermes run [OPTIONS] --pythnet-ws-addr <WS_ENDPOINT> --pythnet-http-addr <HTTP_ENDPOINT>

Options:
  -h, --help
          Print help (see a summary with '-h')

Wormhole Options:
      --wormhole-bootstrap-addrs <BOOTSTRAP_ADDRS>
          Multiaddresses for Wormhole bootstrap peers (separated by comma).
          
          Bootstraps can be found from the official Wormhole repository, note that these
          addresses are only used to bootstrap peer discovery and are not necessarily used
          for data transfer. Adding more peers will speed up P2P peer discovery.
          
          [env: WORMHOLE_BOOTSTRAP_ADDRS=]
          [default: /dns4/wormhole-mainnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWQp644DK27fd3d4Km3jr7gHiuJJ5ZGmy8hH4py7fP4FP7,/dns4/wormhole-v2-mainnet-bootstrap.xlabs.xyz/udp/8999/quic/p2p/12D3KooWNQ9tVrcb64tw6bNs2CaNrUGPM7yRrKvBBheQ5yCyPHKC]

      --wormhole-contract-addr <CONTRACT_ADDR>
          Address of the Wormhole contract on the target PythNet cluster
          
          [env: WORMHOLE_CONTRACT_ADDR=]
          [default: H3fxXJ86ADW2PNuDDmZJg6mzTtPxkYCpNuQUTgmJ7AjU]

      --wormhole-listen-addrs <LISTEN_ADDRS>
          Multiaddresses to bind for Wormhole P2P (separated by comma)
          
          [env: WORMHOLE_LISTEN_ADDRS=]
          [default: /ip4/0.0.0.0/udp/30910/quic,/ip6/::/udp/30910/quic]

      --wormhole-network-id <NETWORK_ID>
          Network ID for Wormhole
          
          [env: WORMHOLE_NETWORK_ID=]
          [default: /wormhole/mainnet/2]

Pythnet Options:
      --pythnet-ws-addr <WS_ENDPOINT>
          Address of a PythNet compatible websocket RPC endpoint
          
          [env: PYTHNET_WS_ENDPOINT=]

      --pythnet-http-addr <HTTP_ENDPOINT>
          Addres of a PythNet compatible HTP RPC endpoint
          
          [env: PYTHNET_HTTP_ENDPOINT=]

RPC Options:
      --rpc-listen-addr <ADDR>
          Address and port the RPC server will bind to
          
          [env: RPC_ADDR=]
          [default: 127.0.0.1:33999]

Benchmark Options:
      --benchmarks-endpoint <ENDPOINT>
          Benchmarks endpoint to retrieve historical update data from
          
          [env: BENCHMARKS_ENDPOINT=]
```