### PR TITLE
feat(hermes): Check price ids exist before each request

### DIFF
--- a/hermes/Cargo.lock
+++ b/hermes/Cargo.lock
@@ -1858,7 +1858,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermes"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/hermes/Cargo.toml
+++ b/hermes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "hermes"
-version     = "0.1.21"
+version     = "0.1.22"
 description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
 edition     = "2021"
 

--- a/hermes/src/aggregate.rs
+++ b/hermes/src/aggregate.rs
@@ -313,7 +313,7 @@ async fn build_message_states(
 
 async fn get_verified_price_feeds<S>(
     state: &S,
-    price_ids: Vec<PriceIdentifier>,
+    price_ids: &[PriceIdentifier],
     request_time: RequestTime,
 ) -> Result<PriceFeedsWithUpdateData>
 where
@@ -373,14 +373,14 @@ where
 
 pub async fn get_price_feeds_with_update_data<S>(
     state: &S,
-    price_ids: Vec<PriceIdentifier>,
+    price_ids: &[PriceIdentifier],
     request_time: RequestTime,
 ) -> Result<PriceFeedsWithUpdateData>
 where
     S: AggregateCache,
     S: Benchmarks,
 {
-    match get_verified_price_feeds(state, price_ids.clone(), request_time.clone()).await {
+    match get_verified_price_feeds(state, price_ids, request_time.clone()).await {
         Ok(price_feeds_with_update_data) => Ok(price_feeds_with_update_data),
         Err(e) => {
             if let RequestTime::FirstAfter(publish_time) = request_time {
@@ -567,7 +567,7 @@ mod test {
         // price feed with correct update data.
         let price_feeds_with_update_data = get_price_feeds_with_update_data(
             &*state,
-            vec![PriceIdentifier::new([100; 32])],
+            &[PriceIdentifier::new([100; 32])],
             RequestTime::Latest,
         )
         .await
@@ -688,7 +688,7 @@ mod test {
         // Get the price feeds with update data
         let price_feeds_with_update_data = get_price_feeds_with_update_data(
             &*state,
-            vec![PriceIdentifier::new([100; 32])],
+            &[PriceIdentifier::new([100; 32])],
             RequestTime::Latest,
         )
         .await
@@ -753,7 +753,7 @@ mod test {
         for slot in 900..1000 {
             let price_feeds_with_update_data = get_price_feeds_with_update_data(
                 &*state,
-                vec![
+                &[
                     PriceIdentifier::new([100; 32]),
                     PriceIdentifier::new([200; 32]),
                 ],
@@ -770,9 +770,9 @@ mod test {
         for slot in 0..900 {
             assert!(get_price_feeds_with_update_data(
                 &*state,
-                vec![
+                &[
                     PriceIdentifier::new([100; 32]),
-                    PriceIdentifier::new([200; 32]),
+                    PriceIdentifier::new([200; 32])
                 ],
                 RequestTime::FirstAfter(slot as i64),
             )

--- a/hermes/src/state/benchmarks.rs
+++ b/hermes/src/state/benchmarks.rs
@@ -80,7 +80,7 @@ impl TryFrom<BenchmarkUpdates> for PriceFeedsWithUpdateData {
 pub trait Benchmarks {
     async fn get_verified_price_feeds(
         &self,
-        price_ids: Vec<PriceIdentifier>,
+        price_ids: &[PriceIdentifier],
         publish_time: UnixTimestamp,
     ) -> Result<PriceFeedsWithUpdateData>;
 }
@@ -89,7 +89,7 @@ pub trait Benchmarks {
 impl Benchmarks for crate::state::State {
     async fn get_verified_price_feeds(
         &self,
-        price_ids: Vec<PriceIdentifier>,
+        price_ids: &[PriceIdentifier],
         publish_time: UnixTimestamp,
     ) -> Result<PriceFeedsWithUpdateData> {
         let endpoint = self


### PR DESCRIPTION
This check will make rejects faster (and block invalid requests to benchmarks). The other benefit is that we can log the errors from the get_price_feeds_with_update_data since it should not fail anymore.