### PR TITLE
Allow changing the symbol

### DIFF
--- a/governance/xc_admin/packages/xc_admin_frontend/components/tabs/General.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/tabs/General.tsx
@@ -442,7 +442,7 @@ const General = ({ proposerServerUrl }: { proposerServerUrl: string }) => {
             // create update product account instruction
             instructions.push(
               await pythProgramClient.methods
-                .updProduct({symbol, ...newChanges.metadata}) // If there's a symbol in newChanges.metadata, it will overwrite the current symbol
+                .updProduct({ symbol, ...newChanges.metadata }) // If there's a symbol in newChanges.metadata, it will overwrite the current symbol
                 .accounts({
                   fundingAccount,
                   productAccount: new PublicKey(prev.address),

--- a/governance/xc_admin/packages/xc_admin_frontend/components/tabs/General.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/tabs/General.tsx
@@ -442,7 +442,7 @@ const General = ({ proposerServerUrl }: { proposerServerUrl: string }) => {
             // create update product account instruction
             instructions.push(
               await pythProgramClient.methods
-                .updProduct({ ...newChanges.metadata, symbol: symbol })
+                .updProduct({symbol, ...newChanges.metadata}) // If there's a symbol in newChanges.metadata, it will overwrite the current symbol
                 .accounts({
                   fundingAccount,
                   productAccount: new PublicKey(prev.address),
@@ -547,7 +547,6 @@ const General = ({ proposerServerUrl }: { proposerServerUrl: string }) => {
 
   const MetadataChangesRows = ({ changes }: { changes: any }) => {
     const addPriceFeed = changes.prev === undefined && changes.new !== undefined
-
     return (
       <>
         {Object.keys(changes.new).map(


### PR DESCRIPTION
Users can now add a "symbol" field in the metadata in the JSON. This will change the symbol of the price feed. 