### PR TITLE
fix(price-service/server): add max payload size

### DIFF
--- a/price_service/server/package.json
+++ b/price_service/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-service-server",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Webservice for retrieving prices from the Pyth oracle.",
   "private": "true",
   "main": "index.js",

--- a/price_service/server/src/ws.ts
+++ b/price_service/server/src/ws.ts
@@ -215,7 +215,11 @@ export class WebSocketAPI {
   }
 
   run(server: http.Server): WebSocketServer {
-    const wss = new WebSocketServer({ server, path: "/ws" });
+    const wss = new WebSocketServer({
+      server,
+      path: "/ws",
+      maxPayload: 100 * 1024, // 100 KiB
+    });
 
     wss.on("connection", (ws: WebSocket, request: http.IncomingMessage) => {
       logger.info(


### PR DESCRIPTION
By default ws library has max payload size of 100 MiB but actually the biggest valid call is 20 KiB. This change sets the limit to 100 KiB to add more resilliency on the web socket. The biggest call size can increase when there are new symbols but this service is not going to live seeing the 5x current price feeds!