### PR TITLE
chore(hermes): bump to version 0.3.0, backwards incompatible CLI features

### DIFF
--- a/hermes/Cargo.lock
+++ b/hermes/Cargo.lock
@@ -1898,7 +1898,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermes"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/hermes/Cargo.toml
+++ b/hermes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "hermes"
-version     = "0.2.1"
+version     = "0.3.0"
 description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
 edition     = "2021"
 


### PR DESCRIPTION
Forgot to bump this in previous PR.