### PR TITLE
fix(hermes): add lock for the entire message state

### DIFF
--- a/hermes/Cargo.lock
+++ b/hermes/Cargo.lock
@@ -1898,7 +1898,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermes"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/hermes/Cargo.toml
+++ b/hermes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "hermes"
-version     = "0.3.1"
+version     = "0.3.2"
 description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
 edition     = "2021"
 


### PR DESCRIPTION
Before this change, there was a lock for each message and it could cause the updateData for multiple ids have 2 updates (because of the race with the thread updating the states). This change adds a RwLock which makes sure that when the entire message state is updating, no one can read from it while allowing concurrent reads in other occasions.