### PR TITLE
Initial version of parsePriceFeed with uniqueness validation

### DIFF
--- a/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
@@ -727,6 +727,6 @@ abstract contract Pyth is
     }
 
     function version() public pure returns (string memory) {
-        return "1.3.1";
+        return "1.3.2";
     }
 }

--- a/target_chains/ethereum/contracts/contracts/pyth/PythInternalStructs.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythInternalStructs.sol
@@ -9,6 +9,12 @@ import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
 contract PythInternalStructs {
     using BytesLib for bytes;
 
+    struct ParseConfig {
+        uint64 minPublishTime;
+        uint64 maxPublishTime;
+        bool checkUniqueness;
+    }
+
     struct PriceInfo {
         // slot 1
         uint64 publishTime;

--- a/target_chains/ethereum/contracts/forge-test/GasBenchmark.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/GasBenchmark.t.sol
@@ -65,7 +65,7 @@ contract GasBenchmark is Test, WormholeTestUtils, PythTestUtils {
         }
 
         for (uint i = 0; i < NUM_PRICES; ++i) {
-            uint64 publishTime = uint64(getRand() % 10);
+            uint64 publishTime = uint64(getRand() % 10) + 1; // to make sure prevPublishTime is >= 0
 
             cachedPrices.push(
                 PythStructs.Price(
@@ -271,6 +271,37 @@ contract GasBenchmark is Test, WormholeTestUtils, PythTestUtils {
             ids,
             0,
             50
+        );
+    }
+
+    function testBenchmarkParsePriceFeedUpdatesUniqueForWhMerkle() public {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = priceIds[0];
+
+        pyth.parsePriceFeedUpdatesUnique{
+            value: freshPricesWhMerkleUpdateFee[0]
+        }(
+            freshPricesWhMerkleUpdateData[0],
+            ids,
+            uint64(freshPrices[0].publishTime),
+            100
+        );
+    }
+
+    function testBenchmarkParsePriceFeedUpdatesUniqueWhMerkleForOnePriceFeedNotWithinRange()
+        public
+    {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = priceIds[0];
+
+        vm.expectRevert(PythErrors.PriceFeedNotFoundWithinRange.selector);
+        pyth.parsePriceFeedUpdatesUnique{
+            value: freshPricesWhMerkleUpdateFee[0]
+        }(
+            freshPricesWhMerkleUpdateData[0],
+            ids,
+            uint64(freshPrices[0].publishTime) - 1,
+            100
         );
     }
 

--- a/target_chains/ethereum/contracts/forge-test/Pyth.WormholeMerkleAccumulator.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pyth.WormholeMerkleAccumulator.t.sol
@@ -418,7 +418,7 @@ contract PythWormholeMerkleAccumulatorTest is
         assertPriceFeedMessageStored(priceFeedMessages1[0]);
     }
 
-    function testParsePriceFeedUpdatesWithWormholeMerklWorksWithOutOfOrderUpdateMultiCall()
+    function testParsePriceFeedUpdatesWithWormholeMerkleWorksWithOutOfOrderUpdateMultiCall()
         public
     {
         PriceFeedMessage[]

--- a/target_chains/ethereum/contracts/forge-test/Pyth.WormholeMerkleAccumulator.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pyth.WormholeMerkleAccumulator.t.sol
@@ -418,7 +418,7 @@ contract PythWormholeMerkleAccumulatorTest is
         assertPriceFeedMessageStored(priceFeedMessages1[0]);
     }
 
-    function testParsePriceFeedUpdatesWithWormholeMerklWorksWithOurOfOrderUpdateMultiCall()
+    function testParsePriceFeedUpdatesWithWormholeMerklWorksWithOutOfOrderUpdateMultiCall()
         public
     {
         PriceFeedMessage[]
@@ -849,6 +849,53 @@ contract PythWormholeMerkleAccumulatorTest is
                 priceIds[i]
             );
         }
+    }
+
+    function testParsePriceFeedUniqueWithWormholeMerkleWorks(uint seed) public {
+        setRandSeed(seed);
+
+        uint numPriceFeeds = (getRandUint() % 10) + 1;
+        PriceFeedMessage[]
+            memory priceFeedMessages = generateRandomPriceFeedMessage(
+                numPriceFeeds
+            );
+        uint64 publishTime = getRandUint64();
+        bytes32[] memory priceIds = new bytes32[](1);
+        priceIds[0] = priceFeedMessages[0].priceId;
+        for (uint i = 0; i < numPriceFeeds; i++) {
+            priceFeedMessages[i].priceId = priceFeedMessages[0].priceId;
+            priceFeedMessages[i].publishTime = publishTime;
+            priceFeedMessages[i].prevPublishTime = publishTime;
+        }
+        uint firstUpdate = (getRandUint() % numPriceFeeds);
+        priceFeedMessages[firstUpdate].prevPublishTime = publishTime - 1;
+        (
+            bytes[] memory updateData,
+            uint updateFee
+        ) = createWormholeMerkleUpdateData(priceFeedMessages);
+
+        vm.expectRevert(PythErrors.PriceFeedNotFoundWithinRange.selector);
+        PythStructs.PriceFeed[] memory priceFeeds = pyth
+            .parsePriceFeedUpdatesUnique{value: updateFee}(
+            updateData,
+            priceIds,
+            publishTime - 1,
+            MAX_UINT64
+        );
+
+        priceFeeds = pyth.parsePriceFeedUpdatesUnique{value: updateFee}(
+            updateData,
+            priceIds,
+            publishTime,
+            MAX_UINT64
+        );
+        assertEq(priceFeeds.length, 1);
+
+        assertParsedPriceFeedEqualsMessage(
+            priceFeeds[0],
+            priceFeedMessages[firstUpdate],
+            priceIds[0]
+        );
     }
 
     function testParsePriceFeedWithWormholeMerkleWorksRandomDistinctUpdatesInput(

--- a/target_chains/ethereum/contracts/forge-test/utils/PythTestUtils.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/utils/PythTestUtils.t.sol
@@ -354,6 +354,9 @@ abstract contract PythTestUtils is Test, WormholeTestUtils {
             priceFeedMessages[i].conf = prices[i].conf;
             priceFeedMessages[i].expo = prices[i].expo;
             priceFeedMessages[i].publishTime = uint64(prices[i].publishTime);
+            priceFeedMessages[i].prevPublishTime =
+                uint64(prices[i].publishTime) -
+                1;
             priceFeedMessages[i].emaPrice = prices[i].price;
             priceFeedMessages[i].emaConf = prices[i].conf;
         }

--- a/target_chains/ethereum/contracts/package.json
+++ b/target_chains/ethereum/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-evm-contract",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "",
   "private": "true",
   "devDependencies": {
@@ -25,7 +25,7 @@
     "coverage": "./coverage.sh"
   },
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "dependencies": {
     "@certusone/wormhole-sdk": "^0.9.22",
     "@matterlabs/hardhat-zksync-deploy": "^0.6.2",

--- a/target_chains/ethereum/sdk/solidity/AbstractPyth.sol
+++ b/target_chains/ethereum/sdk/solidity/AbstractPyth.sol
@@ -121,4 +121,16 @@ abstract contract AbstractPyth is IPyth {
         virtual
         override
         returns (PythStructs.PriceFeed[] memory priceFeeds);
+
+    function parsePriceFeedUpdatesUnique(
+        bytes[] calldata updateData,
+        bytes32[] calldata priceIds,
+        uint64 minPublishTime,
+        uint64 maxPublishTime
+    )
+        external
+        payable
+        virtual
+        override
+        returns (PythStructs.PriceFeed[] memory priceFeeds);
 }

--- a/target_chains/ethereum/sdk/solidity/IPyth.sol
+++ b/target_chains/ethereum/sdk/solidity/IPyth.sol
@@ -136,4 +136,23 @@ interface IPyth is IPythEvents {
         uint64 minPublishTime,
         uint64 maxPublishTime
     ) external payable returns (PythStructs.PriceFeed[] memory priceFeeds);
+
+    /// @notice Similar to `parsePriceFeedUpdates` but ensures the updates returned are
+    /// the first updates published in minPublishTime. That is, if there are multiple updates for a given timestamp,
+    /// this method will return the first update.
+    ///
+    ///
+    /// @dev Reverts if the transferred fee is not sufficient or the updateData is invalid or there is
+    /// no update for any of the given `priceIds` within the given time range and uniqueness condition.
+    /// @param updateData Array of price update data.
+    /// @param priceIds Array of price ids.
+    /// @param minPublishTime minimum acceptable publishTime for the given `priceIds`.
+    /// @param maxPublishTime maximum acceptable publishTime for the given `priceIds`.
+    /// @return priceFeeds Array of the price feeds corresponding to the given `priceIds` (with the same order).
+    function parsePriceFeedUpdatesUnique(
+        bytes[] calldata updateData,
+        bytes32[] calldata priceIds,
+        uint64 minPublishTime,
+        uint64 maxPublishTime
+    ) external payable returns (PythStructs.PriceFeed[] memory priceFeeds);
 }

--- a/target_chains/ethereum/sdk/solidity/MockPyth.sol
+++ b/target_chains/ethereum/sdk/solidity/MockPyth.sol
@@ -111,6 +111,15 @@ contract MockPyth is AbstractPyth {
         }
     }
 
+    function parsePriceFeedUpdatesUnique(
+        bytes[] calldata updateData,
+        bytes32[] calldata priceIds,
+        uint64 minPublishTime,
+        uint64 maxPublishTime
+    ) external payable override returns (PythStructs.PriceFeed[] memory feeds) {
+        revert PythErrors.InvalidArgument();
+    }
+
     function createPriceFeedUpdateData(
         bytes32 id,
         int64 price,

--- a/target_chains/ethereum/sdk/solidity/abis/AbstractPyth.json
+++ b/target_chains/ethereum/sdk/solidity/abis/AbstractPyth.json
@@ -450,6 +450,101 @@
   {
     "inputs": [
       {
+        "internalType": "bytes[]",
+        "name": "updateData",
+        "type": "bytes[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "priceIds",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint64",
+        "name": "minPublishTime",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "maxPublishTime",
+        "type": "uint64"
+      }
+    ],
+    "name": "parsePriceFeedUpdatesUnique",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "components": [
+              {
+                "internalType": "int64",
+                "name": "price",
+                "type": "int64"
+              },
+              {
+                "internalType": "uint64",
+                "name": "conf",
+                "type": "uint64"
+              },
+              {
+                "internalType": "int32",
+                "name": "expo",
+                "type": "int32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "publishTime",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct PythStructs.Price",
+            "name": "price",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "int64",
+                "name": "price",
+                "type": "int64"
+              },
+              {
+                "internalType": "uint64",
+                "name": "conf",
+                "type": "uint64"
+              },
+              {
+                "internalType": "int32",
+                "name": "expo",
+                "type": "int32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "publishTime",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct PythStructs.Price",
+            "name": "emaPrice",
+            "type": "tuple"
+          }
+        ],
+        "internalType": "struct PythStructs.PriceFeed[]",
+        "name": "priceFeeds",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "id",
         "type": "bytes32"

--- a/target_chains/ethereum/sdk/solidity/abis/IPyth.json
+++ b/target_chains/ethereum/sdk/solidity/abis/IPyth.json
@@ -438,6 +438,101 @@
         "internalType": "bytes[]",
         "name": "updateData",
         "type": "bytes[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "priceIds",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint64",
+        "name": "minPublishTime",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "maxPublishTime",
+        "type": "uint64"
+      }
+    ],
+    "name": "parsePriceFeedUpdatesUnique",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "components": [
+              {
+                "internalType": "int64",
+                "name": "price",
+                "type": "int64"
+              },
+              {
+                "internalType": "uint64",
+                "name": "conf",
+                "type": "uint64"
+              },
+              {
+                "internalType": "int32",
+                "name": "expo",
+                "type": "int32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "publishTime",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct PythStructs.Price",
+            "name": "price",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "int64",
+                "name": "price",
+                "type": "int64"
+              },
+              {
+                "internalType": "uint64",
+                "name": "conf",
+                "type": "uint64"
+              },
+              {
+                "internalType": "int32",
+                "name": "expo",
+                "type": "int32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "publishTime",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct PythStructs.Price",
+            "name": "emaPrice",
+            "type": "tuple"
+          }
+        ],
+        "internalType": "struct PythStructs.PriceFeed[]",
+        "name": "priceFeeds",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "updateData",
+        "type": "bytes[]"
       }
     ],
     "name": "updatePriceFeeds",

--- a/target_chains/ethereum/sdk/solidity/abis/MockPyth.json
+++ b/target_chains/ethereum/sdk/solidity/abis/MockPyth.json
@@ -131,6 +131,11 @@
         "internalType": "uint64",
         "name": "publishTime",
         "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "prevPublishTime",
+        "type": "uint64"
       }
     ],
     "name": "createPriceFeedUpdateData",

--- a/target_chains/ethereum/sdk/solidity/abis/MockPyth.json
+++ b/target_chains/ethereum/sdk/solidity/abis/MockPyth.json
@@ -530,6 +530,101 @@
   {
     "inputs": [
       {
+        "internalType": "bytes[]",
+        "name": "updateData",
+        "type": "bytes[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "priceIds",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint64",
+        "name": "minPublishTime",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "maxPublishTime",
+        "type": "uint64"
+      }
+    ],
+    "name": "parsePriceFeedUpdatesUnique",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "components": [
+              {
+                "internalType": "int64",
+                "name": "price",
+                "type": "int64"
+              },
+              {
+                "internalType": "uint64",
+                "name": "conf",
+                "type": "uint64"
+              },
+              {
+                "internalType": "int32",
+                "name": "expo",
+                "type": "int32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "publishTime",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct PythStructs.Price",
+            "name": "price",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "int64",
+                "name": "price",
+                "type": "int64"
+              },
+              {
+                "internalType": "uint64",
+                "name": "conf",
+                "type": "uint64"
+              },
+              {
+                "internalType": "int32",
+                "name": "expo",
+                "type": "int32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "publishTime",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct PythStructs.Price",
+            "name": "emaPrice",
+            "type": "tuple"
+          }
+        ],
+        "internalType": "struct PythStructs.PriceFeed[]",
+        "name": "feeds",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "id",
         "type": "bytes32"

--- a/target_chains/ethereum/sdk/solidity/package.json
+++ b/target_chains/ethereum/sdk/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Read prices from the Pyth oracle",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Tried to reuse the logic as much as possible to limit additional bytecode.
After the changes the PythUpgradable bytecode is 24.22 KiB.