### PR TITLE
feat(hermes): use ip from request headers for ratelimiting

### DIFF
--- a/hermes/Cargo.lock
+++ b/hermes/Cargo.lock
@@ -481,7 +481,7 @@ dependencies = [
  "async-trait",
  "axum-core",
  "axum-macros",
- "base64 0.21.2",
+ "base64 0.21.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -566,9 +566,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "base64ct"
@@ -1898,13 +1898,13 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermes"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",
  "axum",
  "axum-macros",
- "base64 0.21.2",
+ "base64 0.21.4",
  "borsh 0.10.3",
  "byteorder",
  "chrono",
@@ -4503,7 +4503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
  "async-compression",
- "base64 0.21.2",
+ "base64 0.21.4",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4744,7 +4744,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.4",
 ]
 
 [[package]]
@@ -6277,7 +6277,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.2",
+ "base64 0.21.4",
  "bytes",
  "h2",
  "http",

--- a/hermes/Cargo.toml
+++ b/hermes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "hermes"
-version     = "0.3.2"
+version     = "0.3.3"
 description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
 edition     = "2021"
 

--- a/hermes/src/config/rpc.rs
+++ b/hermes/src/config/rpc.rs
@@ -5,6 +5,7 @@ use {
 };
 
 const DEFAULT_RPC_ADDR: &str = "127.0.0.1:33999";
+const DEFAULT_RPC_REQUESTER_IP_HEADER_NAME: &str = "X-Forwarded-For";
 
 #[derive(Args, Clone, Debug)]
 #[command(next_help_heading = "RPC Options")]
@@ -21,4 +22,10 @@ pub struct Options {
     #[arg(value_delimiter = ',')]
     #[arg(env = "RPC_WS_WHITELIST")]
     pub ws_whitelist: Vec<IpNet>,
+
+    /// Header name (case insensitive) to fetch requester IP from.
+    #[arg(long = "rpc-requester-ip-header-name")]
+    #[arg(default_value = DEFAULT_RPC_REQUESTER_IP_HEADER_NAME)]
+    #[arg(env = "RPC_REQUESTER_IP_HEADER_NAME")]
+    pub requester_ip_header_name: String,
 }


### PR DESCRIPTION
Previously we were using ip address from connecting socket for rate limiting but it is often an internal IP in production environments (as the service is behind a load balancer or proxy). This PR uses ip inside headers (by default `X-Forwarded-For`) instead to make sure we get the actual requester ip.