### PR TITLE
fix(price-service/client): remove axios version lock

### DIFF
--- a/price_pusher/package.json
+++ b/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "5.6.2",
+  "version": "5.6.3",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/price_service/client/js/package.json
+++ b/price_service/client/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-service-client",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Pyth price service client",
   "author": {
     "name": "Pyth Data Association"
@@ -50,8 +50,8 @@
   "dependencies": {
     "@pythnetwork/price-service-sdk": "*",
     "@types/ws": "^8.5.3",
-    "axios": "=1.1.0",
-    "axios-retry": "~3.3.0",
+    "axios": "^1.5.1",
+    "axios-retry": "^3.8.0",
     "isomorphic-ws": "^4.0.1",
     "ts-log": "^2.2.4",
     "ws": "^8.6.0"

--- a/price_service/sdk/js/package.json
+++ b/price_service/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-service-sdk",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Pyth price service SDK",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",
@@ -38,7 +38,7 @@
     "eslint": "^8.13.0",
     "jest": "^29.4.0",
     "prettier": "^2.6.2",
-    "quicktype": "^15.0.261",
+    "quicktype": "^23.0.76",
     "ts-jest": "^29.0.5",
     "typescript": "^4.6.3"
   }

--- a/price_service/server/package.json
+++ b/price_service/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-service-server",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Webservice for retrieving prices from the Pyth oracle.",
   "private": "true",
   "main": "index.js",

--- a/target_chains/aptos/sdk/js/package.json
+++ b/target_chains/aptos/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-aptos-js",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Pyth Network Aptos Utilities",
   "homepage": "https://pyth.network",
   "author": {

--- a/target_chains/cosmwasm/sdk/js/package.json
+++ b/target_chains/cosmwasm/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-terra-js",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Pyth Network Terra Utils in JS",
   "homepage": "https://pyth.network",
   "author": {

--- a/target_chains/ethereum/sdk/js/package.json
+++ b/target_chains/ethereum/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-evm-js",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "description": "Pyth Network EVM Utils in JS",
   "homepage": "https://pyth.network",
   "author": {

--- a/target_chains/sui/sdk/js/package.json
+++ b/target_chains/sui/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-sui-js",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Pyth Network Sui Utilities",
   "homepage": "https://pyth.network",
   "author": {


### PR DESCRIPTION
Some users have reported that the old version of axios and axios-retry have some problems raising exceptions handling the responses from price service and hermes. This PR removes the version lock of these two (which was introduced to keep these two packages compatible) and updates them to the latest versions.