### PR TITLE
[sui-pusher] Add option to choose a different account derived from the same mnemonic

### DIFF
--- a/price_pusher/package.json
+++ b/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "5.6.3",
+  "version": "5.7.0",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/price_pusher/src/sui/command.ts
+++ b/price_pusher/src/sui/command.ts
@@ -50,6 +50,12 @@ export default {
       required: true,
       default: 500_000_000,
     } as Options,
+    "account-index": {
+      description: "Index of the account to use derived by the mnemonic",
+      type: "number",
+      required: true,
+      default: 0,
+    } as Options,
     ...options.priceConfigFile,
     ...options.priceServiceEndpoint,
     ...options.mnemonicFile,
@@ -68,6 +74,7 @@ export default {
       wormholeStateId,
       numGasObjects,
       gasBudget,
+      accountIndex,
     } = argv;
 
     const priceConfigs = readPriceConfigFile(priceConfigFile);
@@ -88,10 +95,12 @@ export default {
       }
     );
     const mnemonic = fs.readFileSync(mnemonicFile, "utf-8").trim();
+    const keypair = Ed25519Keypair.deriveKeypair(
+      mnemonic,
+      `m/44'/784'/${accountIndex}'/0'/0'`
+    );
     console.log(
-      `Pushing updates from wallet address: ${Ed25519Keypair.deriveKeypair(
-        mnemonic
-      )
+      `Pushing updates from wallet address: ${keypair
         .getPublicKey()
         .toSuiAddress()}`
     );
@@ -115,7 +124,7 @@ export default {
       pythStateId,
       wormholeStateId,
       endpoint,
-      mnemonic,
+      keypair,
       gasBudget,
       numGasObjects
     );

--- a/price_pusher/src/sui/sui.ts
+++ b/price_pusher/src/sui/sui.ts
@@ -121,7 +121,7 @@ export class SuiPricePusher implements IPricePusher {
     private wormholePackageId: string,
     private wormholeStateId: string,
     endpoint: string,
-    mnemonic: string,
+    keypair: Ed25519Keypair,
     private gasBudget: number,
     private gasPool: SuiObjectRef[],
     private pythClient: SuiPythClient
@@ -162,14 +162,14 @@ export class SuiPricePusher implements IPricePusher {
 
   /**
    * Create a price pusher with a pool of `numGasObjects` gas coins that will be used to send transactions.
-   * The gas coins of the wallet for the provided mnemonic will be merged and then evenly split into `numGasObjects`.
+   * The gas coins of the wallet for the provided keypair will be merged and then evenly split into `numGasObjects`.
    */
   static async createWithAutomaticGasPool(
     priceServiceConnection: PriceServiceConnection,
     pythStateId: string,
     wormholeStateId: string,
     endpoint: string,
-    mnemonic: string,
+    keypair: Ed25519Keypair,
     gasBudget: number,
     numGasObjects: number
   ): Promise<SuiPricePusher> {
@@ -182,10 +182,7 @@ export class SuiPricePusher implements IPricePusher {
     const provider = new JsonRpcProvider(
       new Connection({ fullnode: endpoint })
     );
-    const signer = new RawSigner(
-      Ed25519Keypair.deriveKeypair(mnemonic),
-      provider
-    );
+    const signer = new RawSigner(keypair, provider);
     const pythPackageId = await SuiPricePusher.getPackageId(
       provider,
       pythStateId
@@ -214,7 +211,7 @@ export class SuiPricePusher implements IPricePusher {
       wormholePackageId,
       wormholeStateId,
       endpoint,
-      mnemonic,
+      keypair,
       gasBudget,
       gasPool,
       pythClient


### PR DESCRIPTION
This is useful for running 2 pushers in parallel