### PR TITLE
fix(hermes): fix metrics content-type

### DIFF
--- a/hermes/Cargo.lock
+++ b/hermes/Cargo.lock
@@ -1574,7 +1574,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermes"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/hermes/Cargo.toml
+++ b/hermes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "hermes"
-version     = "0.4.1"
+version     = "0.4.2"
 description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
 edition     = "2021"
 

--- a/hermes/src/metrics_server.rs
+++ b/hermes/src/metrics_server.rs
@@ -10,6 +10,7 @@ use {
     anyhow::Result,
     axum::{
         extract::State,
+        http::header,
         response::IntoResponse,
         routing::get,
         Router,
@@ -55,5 +56,11 @@ pub async fn metrics(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     // to write to the buffer.
     encode(&mut buffer, &registry).unwrap();
 
-    buffer
+    (
+        [(
+            header::CONTENT_TYPE,
+            "application/openmetrics-text; version=1.0.0; charset=utf-8",
+        )],
+        buffer,
+    )
 }


### PR DESCRIPTION
Openmetrics specification expects its own content-type instead of plain text. I didn't set it before as Prometheus still accepts text format but apparently there are some scrapers (like datadog) that decide dynamically what format to use for parsing based on the content type and our format follows Openmetrics specification. Prometheus should be able to parse it but weirdly it didn't work in our situation. An example of inconsistency is how counters are represented. In Openmetrics specification the metric name is appended by `_total` whereas normal prometheus just uses the metric name.

[This](https://github.com/DataDog/integrations-core/issues/14772) is the relevant issue mentioning datadog behaviour on parsing Prometheus and Openmetrics metrics.