### PR TITLE
[entropy] make the SDK public

### DIFF
--- a/target_chains/ethereum/entropy_sdk/solidity/package.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/pyth-network/pyth-crosschain",
     "directory": "target_chains/ethereum/entropy_sdk/solidity"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "format": "npx prettier --write ."
   },


### PR DESCRIPTION
I think I need this field to get NPM to publish this new package.