### PR TITLE
chore: update spy guardian version

### DIFF
--- a/price_pusher/docker-compose.mainnet.sample.yaml
+++ b/price_pusher/docker-compose.mainnet.sample.yaml
@@ -1,7 +1,7 @@
 services:
   spy:
     # Find latest Guardian images in https://github.com/wormhole-foundation/wormhole/pkgs/container/guardiand
-    image: ghcr.io/wormhole-foundation/guardiand:v2.19.0
+    image: ghcr.io/wormhole-foundation/guardiand:v2.23.14
     command:
       - "spy"
       - "--nodeKey"

--- a/price_pusher/docker-compose.testnet.sample.yaml
+++ b/price_pusher/docker-compose.testnet.sample.yaml
@@ -1,7 +1,7 @@
 services:
   spy:
     # Find latest Guardian images in https://github.com/wormhole-foundation/wormhole/pkgs/container/guardiand
-    image: ghcr.io/wormhole-foundation/guardiand:v2.19.0
+    image: ghcr.io/wormhole-foundation/guardiand:v2.23.14
     command:
       - "spy"
       - "--nodeKey"

--- a/price_service/server/docker-compose.mainnet.yaml
+++ b/price_service/server/docker-compose.mainnet.yaml
@@ -1,7 +1,7 @@
 services:
   spy:
     # Find latest Guardian images in https://github.com/wormhole-foundation/wormhole/pkgs/container/guardiand
-    image: ghcr.io/wormhole-foundation/guardiand:v2.19.0
+    image: ghcr.io/wormhole-foundation/guardiand:v2.23.14
     restart: on-failure
     command:
       - "spy"

--- a/price_service/server/docker-compose.testnet.yaml
+++ b/price_service/server/docker-compose.testnet.yaml
@@ -1,7 +1,7 @@
 services:
   spy:
     # Find latest Guardian images in https://github.com/wormhole-foundation/wormhole/pkgs/container/guardiand
-    image: ghcr.io/wormhole-foundation/guardiand:v2.19.0
+    image: ghcr.io/wormhole-foundation/guardiand:v2.23.14
     restart: on-failure
     command:
       - "spy"


### PR DESCRIPTION
The old version of spy doesn't work any more on testnet. This PR updates the version to make sure spy can work on testnet.