### PR TITLE
[entropy] Entropy gas benchmarks and optimizations

### DIFF
--- a/target_chains/ethereum/contracts/README.md
+++ b/target_chains/ethereum/contracts/README.md
@@ -89,7 +89,7 @@ A gas report should have a couple of tables like this:
 
 For most of the methods, the minimum gas usage is an indication of our desired gas usage. Because the calls that store something in the storage
 for the first time in `setUp` use significantly more gas. For example, in the above table, there are two calls to `updatePriceFeeds`. The first
-call has happend in the `setUp` method and costed over a million gas and is not intended for our Benchmark. So our desired value is the
+call has happened in the `setUp` method and costed over a million gas and is not intended for our Benchmark. So our desired value is the
 minimum value which is around 380k gas.
 
 If you like to optimize the contract and measure the gas optimization you can get gas snapshots using `forge snapshot` and evaluate your

--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -6,6 +6,7 @@ import "@pythnetwork/entropy-sdk-solidity/EntropyStructs.sol";
 import "@pythnetwork/entropy-sdk-solidity/EntropyErrors.sol";
 import "@pythnetwork/entropy-sdk-solidity/EntropyEvents.sol";
 import "@pythnetwork/entropy-sdk-solidity/IEntropy.sol";
+import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "./EntropyState.sol";
 
 // Entropy implements a secure 2-party random number generation procedure. The protocol
@@ -186,7 +187,7 @@ contract Entropy is IEntropy, EntropyState {
         uint128 requiredFee = getFee(provider);
         if (msg.value < requiredFee) revert EntropyErrors.InsufficientFee();
         providerInfo.accruedFeesInWei += providerInfo.feeInWei;
-        _state.accruedPythFeesInWei += (uint128(msg.value) -
+        _state.accruedPythFeesInWei += (SafeCast.toUint128(msg.value) -
             providerInfo.feeInWei);
 
         // Store the user's commitment so that we can fulfill the request later.
@@ -198,7 +199,7 @@ contract Entropy is IEntropy, EntropyState {
         );
         req.provider = provider;
         req.sequenceNumber = assignedSequenceNumber;
-        req.numHashes = uint32(
+        req.numHashes = SafeCast.toUint32(
             assignedSequenceNumber -
                 providerInfo.currentCommitmentSequenceNumber
         );
@@ -207,7 +208,7 @@ contract Entropy is IEntropy, EntropyState {
         );
 
         if (useBlockHash) {
-            req.blockNumber = uint96(block.number);
+            req.blockNumber = SafeCast.toUint96(block.number);
         } else {
             req.blockNumber = 0;
         }

--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -171,10 +171,11 @@ contract Entropy is IEntropy, EntropyState {
         providerInfo.sequenceNumber += 1;
 
         // Check that fees were paid and increment the pyth / provider balances.
-        uint requiredFee = getFee(provider);
+        uint128 requiredFee = getFee(provider);
         if (msg.value < requiredFee) revert EntropyErrors.InsufficientFee();
         providerInfo.accruedFeesInWei += providerInfo.feeInWei;
-        _state.accruedPythFeesInWei += (msg.value - providerInfo.feeInWei);
+        _state.accruedPythFeesInWei += (uint128(msg.value) -
+            providerInfo.feeInWei);
 
         // Store the user's commitment so that we can fulfill the request later.
         EntropyStructs.Request storage req = _state.requests[
@@ -270,7 +271,7 @@ contract Entropy is IEntropy, EntropyState {
 
     function getFee(
         address provider
-    ) public view override returns (uint feeAmount) {
+    ) public view override returns (uint128 feeAmount) {
         return _state.providers[provider].feeInWei + _state.pythFeeInWei;
     }
 

--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -180,7 +180,6 @@ contract Entropy is IEntropy, EntropyState {
         EntropyStructs.Request storage req = _state.requests[
             requestKey(provider, assignedSequenceNumber)
         ];
-        req.provider = provider;
         req.sequenceNumber = assignedSequenceNumber;
         req.userCommitment = userCommitment;
         req.providerCommitment = providerInfo.currentCommitment;
@@ -191,7 +190,7 @@ contract Entropy is IEntropy, EntropyState {
             req.blockNumber = block.number;
         }
 
-        emit Requested(req);
+        emit Requested(provider, req);
     }
 
     // Fulfill a request for a random number. This method validates the provided userRandomness and provider's proof

--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -206,7 +206,6 @@ contract Entropy is IEntropy, EntropyState {
         bytes32 userRandomness,
         bytes32 providerRevelation
     ) public override returns (bytes32 randomNumber) {
-        // TODO: do we need to check that this request exists?
         // TODO: this method may need to be authenticated to prevent griefing
         bytes32 key = requestKey(provider, sequenceNumber);
         EntropyStructs.Request storage req = _state.requests[key];

--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -206,7 +206,7 @@ contract Entropy is IEntropy, EntropyState {
         );
 
         if (useBlockHash) {
-            req.blockNumber = uint128(block.number);
+            req.blockNumber = uint96(block.number);
         } else {
             req.blockNumber = 0;
         }

--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -396,6 +396,11 @@ contract Entropy is IEntropy, EntropyState {
         if (isActive(req)) {
             // There's already a prior active request in the storage slot we want to use.
             // Overflow the prior request to the requestsOverflow mapping.
+            // It is important that this code overflows the *prior* request to the mapping, and not the new request.
+            // There is a chance that some requests never get revealed and remain active forever. We do not want such
+            // requests to fill up all of the space in the array and cause all new requests to incur the higher gas cost
+            // of the mapping.
+            //
             // This operation is expensive, but should be rare. If overflow happens frequently, increase
             // the size of the requests array to support more concurrent active requests.
             (bytes32 reqKey, ) = requestKey(req.provider, req.sequenceNumber);

--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -82,7 +82,7 @@ import "./EntropyState.sol";
 // - off-chain data ERC support?
 contract Entropy is IEntropy, EntropyState {
     // TODO: Use an upgradeable proxy
-    constructor(uint pythFeeInWei) {
+    constructor(uint128 pythFeeInWei) {
         _state.accruedPythFeesInWei = 0;
         _state.pythFeeInWei = pythFeeInWei;
     }
@@ -93,7 +93,7 @@ contract Entropy is IEntropy, EntropyState {
     //
     // chainLength is the number of values in the hash chain *including* the commitment, that is, chainLength >= 1.
     function register(
-        uint feeInWei,
+        uint128 feeInWei,
         bytes32 commitment,
         bytes calldata commitmentMetadata,
         uint64 chainLength
@@ -126,7 +126,7 @@ contract Entropy is IEntropy, EntropyState {
     // Withdraw a portion of the accumulated fees for the provider msg.sender.
     // Calling this function will transfer `amount` wei to the caller (provided that they have accrued a sufficient
     // balance of fees in the contract).
-    function withdraw(uint256 amount) public override {
+    function withdraw(uint128 amount) public override {
         EntropyStructs.ProviderInfo storage providerInfo = _state.providers[
             msg.sender
         ];

--- a/target_chains/ethereum/contracts/contracts/entropy/EntropyState.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/EntropyState.sol
@@ -5,11 +5,15 @@ pragma solidity ^0.8.0;
 import "@pythnetwork/entropy-sdk-solidity/EntropyStructs.sol";
 
 contract EntropyInternalStructs {
+    uint8 public constant NUM_REQUESTS = 8;
+
     struct State {
         uint128 pythFeeInWei;
         uint128 accruedPythFeesInWei;
+        // TODO: must be kept in sync with above
+        EntropyStructs.Request[8] requests;
+        mapping(bytes32 => EntropyStructs.Request) requestsOverflow;
         mapping(address => EntropyStructs.ProviderInfo) providers;
-        mapping(bytes32 => EntropyStructs.Request) requests;
     }
 }
 

--- a/target_chains/ethereum/contracts/contracts/entropy/EntropyState.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/EntropyState.sol
@@ -5,18 +5,38 @@ pragma solidity ^0.8.0;
 import "@pythnetwork/entropy-sdk-solidity/EntropyStructs.sol";
 
 contract EntropyInternalStructs {
-    uint8 public constant NUM_REQUESTS = 8;
-
     struct State {
+        // Fee charged by the pyth protocol in wei.
         uint128 pythFeeInWei;
+        // Total quantity of fees (in wei) earned by the pyth protocol that are currently stored in the contract.
+        // This quantity is incremented when fees are paid and decremented when fees are withdrawn.
+        // Note that u128 can store up to ~10^36 wei, which is ~10^18 in native base tokens, which should be plenty.
         uint128 accruedPythFeesInWei;
-        // TODO: must be kept in sync with above
-        EntropyStructs.Request[8] requests;
+        // Hash table for storing in-flight requests. Table keys are hash(provider, sequenceNumber), and the value is
+        // the current request (if one is currently in-flight).
+        //
+        // Due to the vagaries of EVM opcode costs, it is inefficient to simply use a mapping here. Overwriting zero-valued
+        // storage slots with non-zero values is expensive in EVM (21k gas). Using a mapping, each new request starts
+        // from all-zero values, and thus incurs a substantial write cost. Deleting non-zero values does refund gas, but
+        // unfortunately the refund is not substantial enough to matter.
+        //
+        // This data structure is a two-level hash table. It first tries to store new requests in the requests array at
+        // an index determined by a few bits of the request's key. If that slot in the array is already occupied by a
+        // prior request, the prior request is evicted into the requestsOverflow mapping. Requests in the array are
+        // considered active if their sequenceNumber is > 0.
+        //
+        // WARNING: the number of requests must be kept in sync with the constants below
+        EntropyStructs.Request[32] requests;
         mapping(bytes32 => EntropyStructs.Request) requestsOverflow;
+        // Mapping from randomness providers to information about each them.
         mapping(address => EntropyStructs.ProviderInfo) providers;
     }
 }
 
 contract EntropyState {
+    // The size of the requests hash table. Must be a power of 2.
+    uint8 public constant NUM_REQUESTS = 32;
+    bytes1 public constant NUM_REQUESTS_MASK = 0x1f;
+
     EntropyInternalStructs.State _state;
 }

--- a/target_chains/ethereum/contracts/contracts/entropy/EntropyState.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/EntropyState.sol
@@ -6,8 +6,8 @@ import "@pythnetwork/entropy-sdk-solidity/EntropyStructs.sol";
 
 contract EntropyInternalStructs {
     struct State {
-        uint pythFeeInWei;
-        uint accruedPythFeesInWei;
+        uint128 pythFeeInWei;
+        uint128 accruedPythFeesInWei;
         mapping(address => EntropyStructs.ProviderInfo) providers;
         mapping(bytes32 => EntropyStructs.Request) requests;
     }

--- a/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
@@ -376,8 +376,20 @@ contract EntropyTest is Test, EntropyTestUtils {
         random.register(MAX_UINT128, provider1Proofs[0], hex"0100", 100);
         vm.expectRevert();
         random.getFee(provider1);
+    }
 
-        // TODO: does casting in solidity fail if the value is too large?
+    function testOverflow() public {
+        // msg.value overflows the uint128 fee variable
+        assertRequestReverts(2 ** 128, provider1, 42, false);
+
+        // block number is too large
+        vm.roll(2 ** 96);
+        assertRequestReverts(
+            pythFeeInWei + provider1FeeInWei,
+            provider1,
+            42,
+            true
+        );
     }
 
     function testFees() public {

--- a/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
@@ -5,12 +5,13 @@ pragma solidity ^0.8.0;
 import "forge-std/Test.sol";
 import "@pythnetwork/entropy-sdk-solidity/EntropyStructs.sol";
 import "../contracts/entropy/Entropy.sol";
+import "./utils/EntropyTestUtils.t.sol";
 
 // TODO
 // - what's the impact of # of in-flight requests on gas usage? More requests => more hashes to
 //   verify the provider's value.
 // - fuzz test?
-contract EntropyTest is Test {
+contract EntropyTest is Test, EntropyTestUtils {
     Entropy public random;
 
     uint pythFeeInWei = 7;
@@ -52,19 +53,6 @@ contract EntropyTest is Test {
         provider2Proofs = hashChain2;
         vm.prank(provider2);
         random.register(provider2FeeInWei, provider2Proofs[0], hex"0200", 100);
-    }
-
-    function generateHashChain(
-        address provider,
-        uint64 startSequenceNumber,
-        uint64 size
-    ) public pure returns (bytes32[] memory hashChain) {
-        bytes32 initialValue = keccak256(abi.encodePacked(startSequenceNumber));
-        hashChain = new bytes32[](size);
-        for (uint64 i = 0; i < size; i++) {
-            hashChain[size - (i + 1)] = initialValue;
-            initialValue = keccak256(bytes.concat(initialValue));
-        }
     }
 
     // Test helper method for requesting a random value as user from provider.

--- a/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
@@ -378,6 +378,8 @@ contract EntropyTest is Test, EntropyTestUtils {
         random.register(MAX_UINT128, provider1Proofs[0], hex"0100", 100);
         vm.expectRevert();
         random.getFee(provider1);
+
+        // TODO: does casting in solidity fail if the value is too large?
     }
 
     function testFees() public {

--- a/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
@@ -8,8 +8,6 @@ import "../contracts/entropy/Entropy.sol";
 import "./utils/EntropyTestUtils.t.sol";
 
 // TODO
-// - what's the impact of # of in-flight requests on gas usage? More requests => more hashes to
-//   verify the provider's value.
 // - fuzz test?
 contract EntropyTest is Test, EntropyTestUtils {
     Entropy public random;
@@ -33,7 +31,7 @@ contract EntropyTest is Test, EntropyTestUtils {
     bytes32 ALL_ZEROS = bytes32(uint256(0));
 
     function setUp() public {
-        random = new Entropy(pythFeeInWei);
+        random = new Entropy(pythFeeInWei, false);
 
         bytes32[] memory hashChain1 = generateHashChain(
             provider1,

--- a/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
@@ -14,22 +14,22 @@ import "./utils/EntropyTestUtils.t.sol";
 contract EntropyTest is Test, EntropyTestUtils {
     Entropy public random;
 
-    uint pythFeeInWei = 7;
+    uint128 pythFeeInWei = 7;
 
     address public provider1 = address(1);
     bytes32[] provider1Proofs;
-    uint provider1FeeInWei = 8;
+    uint128 provider1FeeInWei = 8;
     uint64 provider1ChainLength = 100;
 
     address public provider2 = address(2);
     bytes32[] provider2Proofs;
-    uint provider2FeeInWei = 20;
+    uint128 provider2FeeInWei = 20;
 
     address public user1 = address(3);
     address public user2 = address(4);
 
     address public unregisteredProvider = address(7);
-    uint256 MAX_UINT256 = 2 ** 256 - 1;
+    uint128 MAX_UINT128 = 2 ** 128 - 1;
     bytes32 ALL_ZEROS = bytes32(uint256(0));
 
     function setUp() public {
@@ -375,7 +375,7 @@ contract EntropyTest is Test, EntropyTestUtils {
 
         // Check that overflowing the fee arithmetic causes the transaction to revert.
         vm.prank(provider1);
-        random.register(MAX_UINT256, provider1Proofs[0], hex"0100", 100);
+        random.register(MAX_UINT128, provider1Proofs[0], hex"0100", 100);
         vm.expectRevert();
         random.getFee(provider1);
     }
@@ -430,7 +430,7 @@ contract EntropyTest is Test, EntropyTestUtils {
         assertRequestReverts(pythFeeInWei + 12345 - 1, provider1, 42, false);
         requestWithFee(user2, pythFeeInWei + 12345, provider1, 42, false);
 
-        uint providerOneBalance = provider1FeeInWei * 3 + 12345;
+        uint128 providerOneBalance = provider1FeeInWei * 3 + 12345;
         assertEq(
             random.getProviderInfo(provider1).accruedFeesInWei,
             providerOneBalance

--- a/target_chains/ethereum/contracts/forge-test/EntropyGasBenchmark.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/EntropyGasBenchmark.t.sol
@@ -50,8 +50,13 @@ contract EntropyGasBenchmark is Test, EntropyTestUtils {
             provider1ChainLength
         );
 
+        vm.roll(2);
+        // uint64 sequenceNumber = requestHelper(user1, 1000, true);
         // Make a request as well to increment the various counters
-        requestHelper(user1, provider1, 100, true);
+        // for (uint8 i = 0; i < 10; i++) {
+        // uint64 sequenceNumber = requestHelper(user1, 100, true);
+        // revealHelper(sequenceNumber, 100);
+        // }
 
         assert(
             random.getProviderInfo(provider1).currentCommitmentSequenceNumber !=
@@ -62,30 +67,24 @@ contract EntropyGasBenchmark is Test, EntropyTestUtils {
     // Test helper method for requesting a random value as user from provider.
     function requestHelper(
         address user,
-        address provider,
         uint randomNumber,
         bool useBlockhash
     ) public returns (uint64 sequenceNumber) {
-        uint fee = random.getFee(provider);
+        uint fee = random.getFee(provider1);
         vm.deal(user, fee);
         vm.prank(user);
         sequenceNumber = random.request{value: fee}(
-            provider,
+            provider1,
             random.constructUserCommitment(bytes32(randomNumber)),
             useBlockhash
         );
     }
 
-    function testBenchmarkBasicFlow() public {
-        uint userRandom = 42;
-        uint64 sequenceNumber = requestHelper(
-            user1,
-            provider1,
-            userRandom,
-            true
-        );
-
-        random.reveal(
+    function revealHelper(
+        uint64 sequenceNumber,
+        uint userRandom
+    ) public returns (bytes32 randomNumber) {
+        randomNumber = random.reveal(
             provider1,
             sequenceNumber,
             bytes32(userRandom),
@@ -96,5 +95,13 @@ contract EntropyGasBenchmark is Test, EntropyTestUtils {
                         .originalCommitmentSequenceNumber
             ]
         );
+    }
+
+    function testBenchmarkBasicFlow() public {
+        vm.roll(3);
+        uint userRandom = 42;
+        uint64 sequenceNumber = requestHelper(user1, userRandom, true);
+
+        revealHelper(sequenceNumber, userRandom);
     }
 }

--- a/target_chains/ethereum/contracts/forge-test/EntropyGasBenchmark.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/EntropyGasBenchmark.t.sol
@@ -50,7 +50,10 @@ contract EntropyGasBenchmark is Test, EntropyTestUtils {
             provider1ChainLength
         );
 
-        assert(random.getProviderInfo(provider1).currentCommitmentSequenceNumber != 0);
+        assert(
+            random.getProviderInfo(provider1).currentCommitmentSequenceNumber !=
+                0
+        );
     }
 
     // Test helper method for requesting a random value as user from provider.
@@ -72,7 +75,12 @@ contract EntropyGasBenchmark is Test, EntropyTestUtils {
 
     function testBenchmarkBasicFlow() public {
         uint userRandom = 42;
-        uint64 sequenceNumber = requestHelper(user1, provider1, userRandom, true);
+        uint64 sequenceNumber = requestHelper(
+            user1,
+            provider1,
+            userRandom,
+            true
+        );
 
         random.reveal(
             provider1,

--- a/target_chains/ethereum/contracts/forge-test/EntropyGasBenchmark.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/EntropyGasBenchmark.t.sol
@@ -86,7 +86,7 @@ contract EntropyGasBenchmark is Test, EntropyTestUtils {
             provider1,
             sequenceNumber,
             bytes32(userRandom),
-            provider1Proofs[sequenceNumber]
+            provider1Proofs[sequenceNumber - random.getProviderInfo(provider1).originalCommitmentSequenceNumber]
         );
     }
 }

--- a/target_chains/ethereum/contracts/forge-test/EntropyGasBenchmark.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/EntropyGasBenchmark.t.sol
@@ -50,6 +50,9 @@ contract EntropyGasBenchmark is Test, EntropyTestUtils {
             provider1ChainLength
         );
 
+        // Make a request as well to increment the various counters
+        requestHelper(user1, provider1, 100, true);
+
         assert(
             random.getProviderInfo(provider1).currentCommitmentSequenceNumber !=
                 0

--- a/target_chains/ethereum/contracts/forge-test/EntropyGasBenchmark.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/EntropyGasBenchmark.t.sol
@@ -23,7 +23,7 @@ contract EntropyGasBenchmark is Test, EntropyTestUtils {
     address public user1 = address(3);
 
     function setUp() public {
-        random = new Entropy(pythFeeInWei, true);
+        random = new Entropy(pythFeeInWei, provider1, true);
 
         bytes32[] memory hashChain1 = generateHashChain(
             provider1,
@@ -36,7 +36,8 @@ contract EntropyGasBenchmark is Test, EntropyTestUtils {
             provider1FeeInWei,
             provider1Proofs[0],
             hex"0100",
-            provider1ChainLength
+            provider1ChainLength,
+            ""
         );
 
         // Register twice so the commitment sequence number is nonzero. Zero values can be misleading
@@ -46,7 +47,8 @@ contract EntropyGasBenchmark is Test, EntropyTestUtils {
             provider1FeeInWei,
             provider1Proofs[0],
             hex"0100",
-            provider1ChainLength
+            provider1ChainLength,
+            ""
         );
 
         assert(

--- a/target_chains/ethereum/contracts/forge-test/EntropyGasBenchmark.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/EntropyGasBenchmark.t.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "@pythnetwork/entropy-sdk-solidity/EntropyStructs.sol";
+import "../contracts/entropy/Entropy.sol";
+import "./utils/EntropyTestUtils.t.sol";
+
+// TODO
+// - what's the impact of # of in-flight requests on gas usage? More requests => more hashes to
+//   verify the provider's value.
+// - fuzz test?
+contract EntropyGasBenchmark is Test, EntropyTestUtils {
+    Entropy public random;
+
+    uint pythFeeInWei = 7;
+
+    address public provider1 = address(1);
+    bytes32[] provider1Proofs;
+    uint provider1FeeInWei = 8;
+    uint64 provider1ChainLength = 100;
+
+    address public user1 = address(3);
+
+    function setUp() public {
+        random = new Entropy(pythFeeInWei);
+
+        bytes32[] memory hashChain1 = generateHashChain(
+            provider1,
+            0,
+            provider1ChainLength
+        );
+        provider1Proofs = hashChain1;
+        vm.prank(provider1);
+        random.register(
+            provider1FeeInWei,
+            provider1Proofs[0],
+            hex"0100",
+            provider1ChainLength
+        );
+    }
+
+    // Test helper method for requesting a random value as user from provider.
+    function request(
+        address user,
+        address provider,
+        uint randomNumber,
+        bool useBlockhash
+    ) public returns (uint64 sequenceNumber) {
+        uint fee = random.getFee(provider);
+        vm.deal(user, fee);
+        vm.prank(user);
+        sequenceNumber = random.request{value: fee}(
+            provider,
+            random.constructUserCommitment(bytes32(randomNumber)),
+            useBlockhash
+        );
+    }
+
+    function testBenchmarkBasicFlow() public {
+        uint userRandom = 42;
+        uint64 sequenceNumber = request(user1, provider1, userRandom, false);
+
+        random.reveal(
+            provider1,
+            sequenceNumber,
+            bytes32(userRandom),
+            provider1Proofs[sequenceNumber]
+        );
+    }
+}

--- a/target_chains/ethereum/contracts/forge-test/EntropyGasBenchmark.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/EntropyGasBenchmark.t.sol
@@ -10,7 +10,6 @@ import "./utils/EntropyTestUtils.t.sol";
 // TODO
 // - what's the impact of # of in-flight requests on gas usage? More requests => more hashes to
 //   verify the provider's value.
-// - fuzz test?
 contract EntropyGasBenchmark is Test, EntropyTestUtils {
     Entropy public random;
 
@@ -24,7 +23,7 @@ contract EntropyGasBenchmark is Test, EntropyTestUtils {
     address public user1 = address(3);
 
     function setUp() public {
-        random = new Entropy(pythFeeInWei);
+        random = new Entropy(pythFeeInWei, true);
 
         bytes32[] memory hashChain1 = generateHashChain(
             provider1,
@@ -49,14 +48,6 @@ contract EntropyGasBenchmark is Test, EntropyTestUtils {
             hex"0100",
             provider1ChainLength
         );
-
-        vm.roll(2);
-        // uint64 sequenceNumber = requestHelper(user1, 1000, true);
-        // Make a request as well to increment the various counters
-        // for (uint8 i = 0; i < 10; i++) {
-        // uint64 sequenceNumber = requestHelper(user1, 100, true);
-        // revealHelper(sequenceNumber, 100);
-        // }
 
         assert(
             random.getProviderInfo(provider1).currentCommitmentSequenceNumber !=
@@ -97,8 +88,7 @@ contract EntropyGasBenchmark is Test, EntropyTestUtils {
         );
     }
 
-    function testBenchmarkBasicFlow() public {
-        vm.roll(3);
+    function testBasicFlow() public {
         uint userRandom = 42;
         uint64 sequenceNumber = requestHelper(user1, userRandom, true);
 

--- a/target_chains/ethereum/contracts/forge-test/EntropyGasBenchmark.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/EntropyGasBenchmark.t.sol
@@ -39,10 +39,22 @@ contract EntropyGasBenchmark is Test, EntropyTestUtils {
             hex"0100",
             provider1ChainLength
         );
+
+        // Register twice so the commitment sequence number is nonzero. Zero values can be misleading
+        // when gas benchmarking.
+        vm.prank(provider1);
+        random.register(
+            provider1FeeInWei,
+            provider1Proofs[0],
+            hex"0100",
+            provider1ChainLength
+        );
+
+        assert(random.getProviderInfo(provider1).currentCommitmentSequenceNumber != 0);
     }
 
     // Test helper method for requesting a random value as user from provider.
-    function request(
+    function requestHelper(
         address user,
         address provider,
         uint randomNumber,
@@ -60,7 +72,7 @@ contract EntropyGasBenchmark is Test, EntropyTestUtils {
 
     function testBenchmarkBasicFlow() public {
         uint userRandom = 42;
-        uint64 sequenceNumber = request(user1, provider1, userRandom, false);
+        uint64 sequenceNumber = requestHelper(user1, provider1, userRandom, true);
 
         random.reveal(
             provider1,

--- a/target_chains/ethereum/contracts/forge-test/EntropyGasBenchmark.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/EntropyGasBenchmark.t.sol
@@ -14,11 +14,11 @@ import "./utils/EntropyTestUtils.t.sol";
 contract EntropyGasBenchmark is Test, EntropyTestUtils {
     Entropy public random;
 
-    uint pythFeeInWei = 7;
+    uint128 pythFeeInWei = 7;
 
     address public provider1 = address(1);
     bytes32[] provider1Proofs;
-    uint provider1FeeInWei = 8;
+    uint128 provider1FeeInWei = 8;
     uint64 provider1ChainLength = 100;
 
     address public user1 = address(3);
@@ -86,7 +86,12 @@ contract EntropyGasBenchmark is Test, EntropyTestUtils {
             provider1,
             sequenceNumber,
             bytes32(userRandom),
-            provider1Proofs[sequenceNumber - random.getProviderInfo(provider1).originalCommitmentSequenceNumber]
+            provider1Proofs[
+                sequenceNumber -
+                    random
+                        .getProviderInfo(provider1)
+                        .originalCommitmentSequenceNumber
+            ]
         );
     }
 }

--- a/target_chains/ethereum/contracts/forge-test/utils/EntropyTestUtils.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/utils/EntropyTestUtils.t.sol
@@ -6,6 +6,7 @@ import "forge-std/Test.sol";
 import "@pythnetwork/entropy-sdk-solidity/EntropyStructs.sol";
 
 abstract contract EntropyTestUtils is Test {
+    // Generate a hash chain for a provider that can be used for test purposes.
     function generateHashChain(
         address provider,
         uint64 startSequenceNumber,

--- a/target_chains/ethereum/contracts/forge-test/utils/EntropyTestUtils.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/utils/EntropyTestUtils.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "@pythnetwork/entropy-sdk-solidity/EntropyStructs.sol";
+
+abstract contract EntropyTestUtils is Test {
+    function generateHashChain(
+        address provider,
+        uint64 startSequenceNumber,
+        uint64 size
+    ) public pure returns (bytes32[] memory hashChain) {
+        bytes32 initialValue = keccak256(
+            abi.encodePacked(provider, startSequenceNumber)
+        );
+        hashChain = new bytes32[](size);
+        for (uint64 i = 0; i < size; i++) {
+            hashChain[size - (i + 1)] = initialValue;
+            initialValue = keccak256(bytes.concat(initialValue));
+        }
+    }
+}

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyErrors.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyErrors.sol
@@ -16,6 +16,7 @@ library EntropyErrors {
     // The transaction fee was not sufficient
     error InsufficientFee();
     // The user's revealed random value did not match their commitment.
+    // FIXME rename and delete the one below
     error IncorrectUserRevelation();
     // The provider's revealed random value did not match their commitment.
     error IncorrectProviderRevelation();

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyErrors.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyErrors.sol
@@ -6,18 +6,16 @@ library EntropyErrors {
     // An invariant of the contract failed to hold. This error indicates a software logic bug.
     error AssertionFailure();
     // The provider being registered has already registered
-    // Signature: TODO
     error ProviderAlreadyRegistered();
     // The requested provider does not exist.
     error NoSuchProvider();
+    // The specified request does not exist.
+    error NoSuchRequest();
     // The randomness provider is out of commited random numbers. The provider needs to
     // rotate their on-chain commitment to resolve this error.
     error OutOfRandomness();
     // The transaction fee was not sufficient
     error InsufficientFee();
-    // The user's revealed random value did not match their commitment.
-    // FIXME rename and delete the one below
-    error IncorrectUserRevelation();
-    // The provider's revealed random value did not match their commitment.
-    error IncorrectProviderRevelation();
+    // Either the user's or the provider's revealed random values did not match their commitment.
+    error IncorrectRevelation();
 }

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyEvents.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyEvents.sol
@@ -6,7 +6,7 @@ import "./EntropyStructs.sol";
 interface EntropyEvents {
     event Registered(EntropyStructs.ProviderInfo provider);
 
-    event Requested(EntropyStructs.Request request);
+    event Requested(address provider, EntropyStructs.Request request);
 
     event Revealed(
         EntropyStructs.Request request,

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyEvents.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyEvents.sol
@@ -6,7 +6,7 @@ import "./EntropyStructs.sol";
 interface EntropyEvents {
     event Registered(EntropyStructs.ProviderInfo provider);
 
-    event Requested(address provider, EntropyStructs.Request request);
+    event Requested(EntropyStructs.Request request);
 
     event Revealed(
         EntropyStructs.Request request,

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
@@ -31,16 +31,21 @@ contract EntropyStructs {
     }
 
     struct Request {
+        // Storage slot 1 //
         address provider;
         uint64 sequenceNumber;
         // The number of hashes required to verify the provider revelation.
         uint32 numHashes;
+        // Storage slot 2 //
         // The commitment is keccak256(userCommitment, providerCommitment). Storing the hash instead of both saves 20k gas by
         // eliminating 1 store.
         bytes32 commitment;
+        // Storage slot 3 //
         // If nonzero, the randomness requester wants the blockhash of this block to be incorporated into the random number.
-        // Note that we're using a uint128 such that this field fits into the same storage slot as numHashes above.
-        // Although block.number returns a uint256, 128 bits should be plenty to index all of the blocks ever generated.
-        uint128 blockNumber;
+        // Note that we're using a uint96 such that we have an additional 20 bytes of storage afterward for an address.
+        // Although block.number returns a uint256, 96 bits should be plenty to index all of the blocks ever generated.
+        uint96 blockNumber;
+
+        // TODO: store the calling contract address here and authenticate the reveal method
     }
 }

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
@@ -3,13 +3,6 @@
 pragma solidity ^0.8.0;
 
 contract EntropyStructs {
-    struct State {
-        uint128 pythFeeInWei;
-        uint128 accruedPythFeesInWei;
-        mapping(address => ProviderInfo) providers;
-        mapping(bytes32 => Request) requests;
-    }
-
     struct ProviderInfo {
         uint128 feeInWei;
         uint128 accruedFeesInWei;

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
@@ -38,11 +38,11 @@ contract EntropyStructs {
     }
 
     struct Request {
-        address provider;
+        // address provider;
         uint64 sequenceNumber;
+        uint64 providerCommitmentSequenceNumber;
         bytes32 userCommitment;
         bytes32 providerCommitment;
-        uint64 providerCommitmentSequenceNumber;
         // If nonzero, the randomness requester wants the blockhash of this block to be incorporated into the random number.
         uint256 blockNumber;
     }

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
@@ -41,8 +41,9 @@ contract EntropyStructs {
         // address provider;
         uint64 sequenceNumber;
         uint64 providerCommitmentSequenceNumber;
-        bytes32 userCommitment;
-        bytes32 providerCommitment;
+        // The commitment is keccak256(userCommitment, providerCommitment). Storing the hash saves 20k gas by
+        // eliminating 1 store.
+        bytes32 commitment;
         // If nonzero, the randomness requester wants the blockhash of this block to be incorporated into the random number.
         uint256 blockNumber;
     }

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
@@ -33,15 +33,14 @@ contract EntropyStructs {
     struct Request {
         address provider;
         uint64 sequenceNumber;
-        // The sequence number of the provider's commitment. This determines the number of hashes required to verify
-        // the provider revelation.
-        uint64 providerCommitmentSequenceNumber;
+        // The number of hashes required to verify the provider revelation.
+        uint32 numHashes;
+        // The commitment is keccak256(userCommitment, providerCommitment). Storing the hash instead of both saves 20k gas by
+        // eliminating 1 store.
+        bytes32 commitment;
         // If nonzero, the randomness requester wants the blockhash of this block to be incorporated into the random number.
         // Note that we're using a uint128 such that this field fits into the same storage slot as numHashes above.
         // Although block.number returns a uint256, 128 bits should be plenty to index all of the blocks ever generated.
         uint128 blockNumber;
-        // The commitment is keccak256(userCommitment, providerCommitment). Storing the hash instead of both saves 20k gas by
-        // eliminating 1 store.
-        bytes32 commitment;
     }
 }

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
@@ -38,13 +38,14 @@ contract EntropyStructs {
     }
 
     struct Request {
-        // address provider;
-        uint64 sequenceNumber;
-        uint64 providerCommitmentSequenceNumber;
-        // The commitment is keccak256(userCommitment, providerCommitment). Storing the hash saves 20k gas by
+        // The number of hashes
+        uint64 numHashes;
+        // If nonzero, the randomness requester wants the blockhash of this block to be incorporated into the random number.
+        // Note that we're using a uint128 such that this field fits into the same storage slot as numHashes above.
+        // Although block.number returns a uint256, 128 bits should be plenty to index all of the blocks ever generated.
+        uint128 blockNumber;
+        // The commitment is keccak256(userCommitment, providerCommitment). Storing the hash instead of both saves 20k gas by
         // eliminating 1 store.
         bytes32 commitment;
-        // If nonzero, the randomness requester wants the blockhash of this block to be incorporated into the random number.
-        uint256 blockNumber;
     }
 }

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
@@ -33,8 +33,9 @@ contract EntropyStructs {
     struct Request {
         address provider;
         uint64 sequenceNumber;
-        // The number of hashes
-        uint64 numHashes;
+        // The sequence number of the provider's commitment. This determines the number of hashes required to verify
+        // the provider revelation.
+        uint64 providerCommitmentSequenceNumber;
         // If nonzero, the randomness requester wants the blockhash of this block to be incorporated into the random number.
         // Note that we're using a uint128 such that this field fits into the same storage slot as numHashes above.
         // Although block.number returns a uint256, 128 bits should be plenty to index all of the blocks ever generated.

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
@@ -4,15 +4,15 @@ pragma solidity ^0.8.0;
 
 contract EntropyStructs {
     struct State {
-        uint pythFeeInWei;
-        uint accruedPythFeesInWei;
+        uint128 pythFeeInWei;
+        uint128 accruedPythFeesInWei;
         mapping(address => ProviderInfo) providers;
         mapping(bytes32 => Request) requests;
     }
 
     struct ProviderInfo {
-        uint feeInWei;
-        uint accruedFeesInWei;
+        uint128 feeInWei;
+        uint128 accruedFeesInWei;
         // The commitment that the provider posted to the blockchain, and the sequence number
         // where they committed to this. This value is not advanced after the provider commits,
         // and instead is stored to help providers track where they are in the hash chain.

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
@@ -31,6 +31,8 @@ contract EntropyStructs {
     }
 
     struct Request {
+        address provider;
+        uint64 sequenceNumber;
         // The number of hashes
         uint64 numHashes;
         // If nonzero, the randomness requester wants the blockhash of this block to be incorporated into the random number.

--- a/target_chains/ethereum/entropy_sdk/solidity/IEntropy.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/IEntropy.sol
@@ -65,7 +65,7 @@ interface IEntropy is EntropyEvents {
     function getAccruedPythFees()
         external
         view
-        returns (uint accruedPythFeesInWei);
+        returns (uint128 accruedPythFeesInWei);
 
     function constructUserCommitment(
         bytes32 userRandomness

--- a/target_chains/ethereum/entropy_sdk/solidity/IEntropy.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/IEntropy.sol
@@ -60,7 +60,7 @@ interface IEntropy is EntropyEvents {
         uint64 sequenceNumber
     ) external view returns (EntropyStructs.Request memory req);
 
-    function getFee(address provider) external view returns (uint feeAmount);
+    function getFee(address provider) external view returns (uint128 feeAmount);
 
     function getAccruedPythFees()
         external

--- a/target_chains/ethereum/entropy_sdk/solidity/IEntropy.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/IEntropy.sol
@@ -10,7 +10,7 @@ interface IEntropy is EntropyEvents {
     //
     // chainLength is the number of values in the hash chain *including* the commitment, that is, chainLength >= 1.
     function register(
-        uint feeInWei,
+        uint128 feeInWei,
         bytes32 commitment,
         bytes calldata commitmentMetadata,
         uint64 chainLength
@@ -19,7 +19,7 @@ interface IEntropy is EntropyEvents {
     // Withdraw a portion of the accumulated fees for the provider msg.sender.
     // Calling this function will transfer `amount` wei to the caller (provided that they have accrued a sufficient
     // balance of fees in the contract).
-    function withdraw(uint256 amount) external;
+    function withdraw(uint128 amount) external;
 
     // As a user, request a random number from `provider`. Prior to calling this method, the user should
     // generate a random number x and keep it secret. The user should then compute hash(x) and pass that


### PR DESCRIPTION
Working on gas optimizations for entropy. This PR got a little out of hand but I'm glad I did it before the audit because the gas optimizations turned out to be nontrivial.

This PR adds a very basic gas benchmark for entropy, then does some code optimizations to bring down the gas usage. There are three main optimizations. Two of these are easy and one is less easy.
* (easy) use uint128 for fees instead of uint256
* (easy) Reduce the size of the Request struct. Store `hash(providerCommitment, userCommitment)` instead of both values, and store the number of hashes instead of the provider's sequence number.
* (less easy) store requests in a 2 level hash table (an array and a mapping) instead of just a mapping. There's an extensive code comment explaining this design, but basically it allows you to reuse nonzero memory for multiple requests, which lets you pay 5k gas to write instead of 21k gas each time. 

The upshot of all of these optimizations is something like this:

Code before any of these changes
request: 157k
reveal: 11k
total: 168k 

After the 2 easy optimizations
request: 65k
reveal: 10k
total: 75k

With all three optimizations
request: 37k
reveal: 11k
total: 48k (72% savings over original, 36% over the two easy versions only)

One issue with the third optimization is that it creates an unlucky case where a new request needs to be stored in the same slot as another concurrent request. This case comes in at 104k + 11k = 115k if it occurs. However, this case should be rare. If there are N active requests, you have an N/32 chance of the next concurrent request (i.e., a new request before any of the existing ones complete) hitting this case. Furthermore, we can always increase 32 to a larger number.

Reviewer guide: start by looking at EntropyStructs and EntropyState, then read the new functions at the end of Entropy.sol. The rest of the changes are pretty straightforward from there.