### PR TITLE
[entropy] Add authorization for reveal method

### DIFF
--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyErrors.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyErrors.sol
@@ -18,4 +18,6 @@ library EntropyErrors {
     error InsufficientFee();
     // Either the user's or the provider's revealed random values did not match their commitment.
     error IncorrectRevelation();
+    // The msg.sender is not allowed to invoke this call.
+    error Unauthorized();
 }

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
@@ -49,7 +49,7 @@ contract EntropyStructs {
         // Note that we're using a uint96 such that we have an additional 20 bytes of storage afterward for an address.
         // Although block.number returns a uint256, 96 bits should be plenty to index all of the blocks ever generated.
         uint96 blockNumber;
-
-        // TODO: store the calling contract address here and authenticate the reveal method
+        // The address that requested this random number.
+        address requester;
     }
 }


### PR DESCRIPTION
Require the reveal method to be called by the same msg.sender that called request. This prevents a denial of service attack (see inline comment)