### PR TITLE
[stacks] Add constants for Stacks

### DIFF
--- a/governance/xc_admin/packages/xc_admin_common/src/chains.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/chains.ts
@@ -54,6 +54,7 @@ export const RECEIVER_CHAINS = {
   astar: 60035,
   coredao: 60036,
   tomochain: 60037,
+  stacks: 60038,
 
   // Testnets as a separate chain ids (to use stable data sources and governance for them)
   injective_testnet: 60013,
@@ -101,8 +102,7 @@ export const RECEIVER_CHAINS = {
   astar_testnet: 50036,
   coredao_testnet: 50037,
   tomochain_testnet: 50038,
-  stacks: 50039,
-  stacks_testnet: 50040,
+  stacks_testnet: 50039,
 };
 
 // If there is any overlapping value the receiver chain will replace the wormhole

--- a/governance/xc_admin/packages/xc_admin_common/src/chains.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/chains.ts
@@ -101,6 +101,8 @@ export const RECEIVER_CHAINS = {
   astar_testnet: 50036,
   coredao_testnet: 50037,
   tomochain_testnet: 50038,
+  stacks: 50039,
+  stacks_testnet: 50040,
 };
 
 // If there is any overlapping value the receiver chain will replace the wormhole

--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
@@ -20,7 +20,9 @@ contract PythGovernanceInstructions {
     enum GovernanceModule {
         Executor, // 0
         Target, // 1
-        EvmExecutor // 2
+        EvmExecutor, // 2
+        // The stacks target chain contract has custom governance instructions and needs its own module.
+        StacksTarget // 3
     }
 
     GovernanceModule constant MODULE = GovernanceModule.Target;


### PR DESCRIPTION
allocate a chain id and governance module for stacks. They need a governance module because they have a bunch of new governance instructions that it doesn't make sense to support under the existing Target module.