### PR TITLE
[fortuna] Add confirmation delay before responding

### DIFF
--- a/fortuna/config.yaml
+++ b/fortuna/config.yaml
@@ -2,13 +2,17 @@ chains:
   optimism-goerli:
     geth_rpc_addr: https://goerli.optimism.io
     contract_addr: 0x28F16Af4D87523910b843a801454AEde5F9B0459
+    confirmation_blocks: 0
   avalanche-fuji:
     geth_rpc_addr: https://api.avax-test.network/ext/bc/C/rpc
     contract_addr: 0xD42c7a708E74AD19401D907a14146F006c851Ee3
+    confirmation_blocks: 0
   eos-evm-testnet:
     geth_rpc_addr: https://api.testnet.evm.eosnetwork.com/
     contract_addr: 0xD42c7a708E74AD19401D907a14146F006c851Ee3
+    confirmation_blocks: 0
     legacy_tx: true
   arbitrum-goerli:
     geth_rpc_addr: https://arbitrum-goerli.publicnode.com
     contract_addr: 0xd9eAcfFB8e80b7193042499485EF8369b08E85B6
+    confirmation_blocks: 0

--- a/fortuna/src/abi.json
+++ b/fortuna/src/abi.json
@@ -1,19 +1,29 @@
 [
   {
-    "type": "constructor",
-    "inputs": [
+    "type": "function",
+    "name": "NUM_REQUESTS",
+    "inputs": [],
+    "outputs": [
       {
-        "name": "pythFeeInWei",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "defaultProvider",
-        "type": "address",
-        "internalType": "address"
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
       }
     ],
-    "stateMutability": "nonpayable"
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "NUM_REQUESTS_MASK",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes1",
+        "internalType": "bytes1"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
     "type": "function",
@@ -70,8 +80,8 @@
     "outputs": [
       {
         "name": "accruedPythFeesInWei",
-        "type": "uint256",
-        "internalType": "uint256"
+        "type": "uint128",
+        "internalType": "uint128"
       }
     ],
     "stateMutability": "view"
@@ -102,8 +112,8 @@
     "outputs": [
       {
         "name": "feeAmount",
-        "type": "uint256",
-        "internalType": "uint256"
+        "type": "uint128",
+        "internalType": "uint128"
       }
     ],
     "stateMutability": "view"
@@ -126,13 +136,13 @@
         "components": [
           {
             "name": "feeInWei",
-            "type": "uint256",
-            "internalType": "uint256"
+            "type": "uint128",
+            "internalType": "uint128"
           },
           {
             "name": "accruedFeesInWei",
-            "type": "uint256",
-            "internalType": "uint256"
+            "type": "uint128",
+            "internalType": "uint128"
           },
           {
             "name": "originalCommitment",
@@ -181,6 +191,19 @@
   },
   {
     "type": "function",
+    "name": "getPythFee",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "feeAmount",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "getRequest",
     "inputs": [
       {
@@ -211,24 +234,24 @@
             "internalType": "uint64"
           },
           {
-            "name": "userCommitment",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            "name": "numHashes",
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            "name": "providerCommitment",
+            "name": "commitment",
             "type": "bytes32",
             "internalType": "bytes32"
-          },
-          {
-            "name": "providerCommitmentSequenceNumber",
-            "type": "uint64",
-            "internalType": "uint64"
           },
           {
             "name": "blockNumber",
-            "type": "uint256",
-            "internalType": "uint256"
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
+            "name": "requester",
+            "type": "address",
+            "internalType": "address"
           }
         ]
       }
@@ -241,8 +264,8 @@
     "inputs": [
       {
         "name": "feeInWei",
-        "type": "uint256",
-        "internalType": "uint256"
+        "type": "uint128",
+        "internalType": "uint128"
       },
       {
         "name": "commitment",
@@ -337,8 +360,8 @@
     "inputs": [
       {
         "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
+        "type": "uint128",
+        "internalType": "uint128"
       }
     ],
     "outputs": [],
@@ -356,13 +379,13 @@
         "components": [
           {
             "name": "feeInWei",
-            "type": "uint256",
-            "internalType": "uint256"
+            "type": "uint128",
+            "internalType": "uint128"
           },
           {
             "name": "accruedFeesInWei",
-            "type": "uint256",
-            "internalType": "uint256"
+            "type": "uint128",
+            "internalType": "uint128"
           },
           {
             "name": "originalCommitment",
@@ -430,24 +453,24 @@
             "internalType": "uint64"
           },
           {
-            "name": "userCommitment",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            "name": "numHashes",
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            "name": "providerCommitment",
+            "name": "commitment",
             "type": "bytes32",
             "internalType": "bytes32"
-          },
-          {
-            "name": "providerCommitmentSequenceNumber",
-            "type": "uint64",
-            "internalType": "uint64"
           },
           {
             "name": "blockNumber",
-            "type": "uint256",
-            "internalType": "uint256"
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
+            "name": "requester",
+            "type": "address",
+            "internalType": "address"
           }
         ]
       }
@@ -475,24 +498,24 @@
             "internalType": "uint64"
           },
           {
-            "name": "userCommitment",
-            "type": "bytes32",
-            "internalType": "bytes32"
+            "name": "numHashes",
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            "name": "providerCommitment",
+            "name": "commitment",
             "type": "bytes32",
             "internalType": "bytes32"
-          },
-          {
-            "name": "providerCommitmentSequenceNumber",
-            "type": "uint64",
-            "internalType": "uint64"
           },
           {
             "name": "blockNumber",
-            "type": "uint256",
-            "internalType": "uint256"
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
+            "name": "requester",
+            "type": "address",
+            "internalType": "address"
           }
         ]
       },
@@ -530,12 +553,7 @@
   },
   {
     "type": "error",
-    "name": "IncorrectProviderRevelation",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "IncorrectUserRevelation",
+    "name": "IncorrectRevelation",
     "inputs": []
   },
   {
@@ -550,7 +568,17 @@
   },
   {
     "type": "error",
+    "name": "NoSuchRequest",
+    "inputs": []
+  },
+  {
+    "type": "error",
     "name": "OutOfRandomness",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Unauthorized",
     "inputs": []
   }
 ]

--- a/fortuna/src/abi.json
+++ b/fortuna/src/abi.json
@@ -245,8 +245,8 @@
           },
           {
             "name": "blockNumber",
-            "type": "uint96",
-            "internalType": "uint96"
+            "type": "int96",
+            "internalType": "int96"
           },
           {
             "name": "requester",
@@ -464,8 +464,8 @@
           },
           {
             "name": "blockNumber",
-            "type": "uint96",
-            "internalType": "uint96"
+            "type": "int96",
+            "internalType": "int96"
           },
           {
             "name": "requester",
@@ -509,8 +509,8 @@
           },
           {
             "name": "blockNumber",
-            "type": "uint96",
-            "internalType": "uint96"
+            "type": "int96",
+            "internalType": "int96"
           },
           {
             "name": "requester",

--- a/fortuna/src/api.rs
+++ b/fortuna/src/api.rs
@@ -1,6 +1,9 @@
 use {
     crate::{
-        chain::reader::EntropyReader,
+        chain::reader::{
+            BlockNumber,
+            EntropyReader,
+        },
         state::HashChainState,
     },
     axum::{
@@ -68,11 +71,14 @@ impl ApiState {
 #[derive(Clone)]
 pub struct BlockchainState {
     /// The hash chain(s) required to serve random numbers for this blockchain
-    pub state:            Arc<HashChainState>,
+    pub state:               Arc<HashChainState>,
     /// The contract that the server is fulfilling requests for.
-    pub contract:         Arc<dyn EntropyReader>,
+    pub contract:            Arc<dyn EntropyReader>,
     /// The address of the provider that this server is operating for.
-    pub provider_address: Address,
+    pub provider_address:    Address,
+    /// The server will wait for this many block confirmations of a request before revealing
+    /// the random number.
+    pub confirmation_blocks: BlockNumber,
 }
 
 pub struct Metrics {
@@ -217,20 +223,22 @@ mod test {
     }
 
     fn test_server() -> (TestServer, Arc<MockEntropyReader>, Arc<MockEntropyReader>) {
-        let eth_read = Arc::new(MockEntropyReader::with_requests(&[]));
+        let eth_read = Arc::new(MockEntropyReader::with_requests(1, &[]));
 
         let eth_state = BlockchainState {
-            state:            ETH_CHAIN.clone(),
-            contract:         eth_read.clone(),
-            provider_address: PROVIDER,
+            state:               ETH_CHAIN.clone(),
+            contract:            eth_read.clone(),
+            provider_address:    PROVIDER,
+            confirmation_blocks: 0,
         };
 
-        let avax_read = Arc::new(MockEntropyReader::with_requests(&[]));
+        let avax_read = Arc::new(MockEntropyReader::with_requests(1, &[]));
 
         let avax_state = BlockchainState {
-            state:            AVAX_CHAIN.clone(),
-            contract:         avax_read.clone(),
-            provider_address: PROVIDER,
+            state:               AVAX_CHAIN.clone(),
+            contract:            avax_read.clone(),
+            provider_address:    PROVIDER,
+            confirmation_blocks: 0,
         };
 
         let api_state = ApiState::new(&[
@@ -265,7 +273,7 @@ mod test {
         .await;
 
         // Once someone requests the number, then it is accessible
-        eth_contract.insert(PROVIDER, 0);
+        eth_contract.insert(PROVIDER, 0, 1, false);
         let response =
             get_and_assert_status(&server, "/v1/chains/ethereum/revelations/0", StatusCode::OK)
                 .await;
@@ -274,12 +282,12 @@ mod test {
         });
 
         // Each chain and provider has its own set of requests
-        eth_contract.insert(PROVIDER, 100);
-        eth_contract.insert(*OTHER_PROVIDER, 101);
-        eth_contract.insert(PROVIDER, 102);
-        avax_contract.insert(PROVIDER, 102);
-        avax_contract.insert(PROVIDER, 103);
-        avax_contract.insert(*OTHER_PROVIDER, 104);
+        eth_contract.insert(PROVIDER, 100, 1, false);
+        eth_contract.insert(*OTHER_PROVIDER, 101, 1, false);
+        eth_contract.insert(PROVIDER, 102, 1, false);
+        avax_contract.insert(PROVIDER, 102, 1, false);
+        avax_contract.insert(PROVIDER, 103, 1, false);
+        avax_contract.insert(*OTHER_PROVIDER, 104, 1, false);
 
         let response = get_and_assert_status(
             &server,
@@ -372,7 +380,7 @@ mod test {
             StatusCode::FORBIDDEN,
         )
         .await;
-        avax_contract.insert(PROVIDER, 99);
+        avax_contract.insert(PROVIDER, 99, 1, false);
         get_and_assert_status(
             &server,
             "/v1/chains/avalanche/revelations/99",

--- a/fortuna/src/api.rs
+++ b/fortuna/src/api.rs
@@ -115,6 +115,9 @@ pub enum RestError {
     /// The caller requested a random value that can't currently be revealed (because it
     /// hasn't been committed to on-chain)
     NoPendingRequest,
+    /// The request exists, but the server is waiting for more confirmations (more blocks
+    /// to be mined) before revealing the random number.
+    PendingConfirmation,
     /// The server cannot currently communicate with the blockchain, so is not able to verify
     /// which random values have been requested.
     TemporarilyUnavailable,
@@ -136,6 +139,10 @@ impl IntoResponse for RestError {
             RestError::NoPendingRequest => (
                 StatusCode::FORBIDDEN,
                 "The random value cannot currently be retrieved",
+            ).into_response(),
+            RestError::PendingConfirmation => (
+                StatusCode::FORBIDDEN,
+                "The request needs additional confirmations before the random value can be retrieved. Try your request again later.",
             )
                 .into_response(),
             RestError::TemporarilyUnavailable => (

--- a/fortuna/src/api/revelation.rs
+++ b/fortuna/src/api/revelation.rs
@@ -65,8 +65,10 @@ pub async fn revelation(
         .await
         .map_err(|_| RestError::TemporarilyUnavailable)?;
 
+    let current_block_number = state.contract.get_block_number().await;
+
     match maybe_request {
-        Some(_) => {
+        Some(r) if current_block_number - state.reveal_delay >= r.block_number => {
             let value = &state
                 .state
                 .reveal(sequence)
@@ -77,6 +79,7 @@ pub async fn revelation(
                 value: encoded_value,
             }))
         }
+        Some(_) => Err(RestError::PendingConfirmation),
         None => Err(RestError::NoPendingRequest),
     }
 }

--- a/fortuna/src/api/revelation.rs
+++ b/fortuna/src/api/revelation.rs
@@ -65,10 +65,15 @@ pub async fn revelation(
         .await
         .map_err(|_| RestError::TemporarilyUnavailable)?;
 
-    let current_block_number = state.contract.get_block_number().await;
+    // TODO: paralellize requests
+    let current_block_number = state
+        .contract
+        .get_block_number()
+        .await
+        .map_err(|_| RestError::TemporarilyUnavailable)?;
 
     match maybe_request {
-        Some(r) if current_block_number - state.reveal_delay >= r.block_number => {
+        Some(r) if current_block_number - state.confirmation_blocks >= r.block_number => {
             let value = &state
                 .state
                 .reveal(sequence)

--- a/fortuna/src/chain/ethereum.rs
+++ b/fortuna/src/chain/ethereum.rs
@@ -17,7 +17,10 @@ use {
             abigen,
             EthLogDecode,
         },
-        core::types::Address,
+        core::{
+            k256::U256,
+            types::Address,
+        },
         middleware::{
             transformer::{
                 Transformer,
@@ -36,7 +39,10 @@ use {
             LocalWallet,
             Signer,
         },
-        types::transaction::eip2718::TypedTransaction,
+        types::{
+            transaction::eip2718::TypedTransaction,
+            U64,
+        },
     },
     sha3::{
         Digest,
@@ -198,5 +204,9 @@ impl EntropyReader for PythContract {
         } else {
             Ok(None)
         }
+    }
+
+    async fn get_block_number(&self) -> Result<u64> {
+        Ok(self.client().get_block_number().await?.as_u64())
     }
 }

--- a/fortuna/src/chain/ethereum.rs
+++ b/fortuna/src/chain/ethereum.rs
@@ -2,7 +2,10 @@ use {
     crate::{
         chain::{
             reader,
-            reader::EntropyReader,
+            reader::{
+                BlockNumber,
+                EntropyReader,
+            },
         },
         config::EthereumConfig,
     },
@@ -17,10 +20,7 @@ use {
             abigen,
             EthLogDecode,
         },
-        core::{
-            k256::U256,
-            types::Address,
-        },
+        core::types::Address,
         middleware::{
             transformer::{
                 Transformer,
@@ -39,10 +39,7 @@ use {
             LocalWallet,
             Signer,
         },
-        types::{
-            transaction::eip2718::TypedTransaction,
-            U64,
-        },
+        types::transaction::eip2718::TypedTransaction,
     },
     sha3::{
         Digest,
@@ -200,13 +197,15 @@ impl EntropyReader for PythContract {
             Ok(Some(reader::Request {
                 provider:        r.provider,
                 sequence_number: r.sequence_number,
+                block_number:    r.block_number.abs().try_into()?,
+                use_blockhash:   r.block_number >= 0,
             }))
         } else {
             Ok(None)
         }
     }
 
-    async fn get_block_number(&self) -> Result<u64> {
+    async fn get_block_number(&self) -> Result<BlockNumber> {
         Ok(self.client().get_block_number().await?.as_u64())
     }
 }

--- a/fortuna/src/chain/reader.rs
+++ b/fortuna/src/chain/reader.rs
@@ -1,11 +1,10 @@
 use {
     anyhow::Result,
     axum::async_trait,
-    ethers::{
-        core::k256::U256,
-        types::Address,
-    },
+    ethers::types::Address,
 };
+
+pub type BlockNumber = u64;
 
 /// EntropyReader is the read-only interface of the Entropy contract.
 #[async_trait]
@@ -16,7 +15,7 @@ pub trait EntropyReader: Send + Sync {
     async fn get_request(&self, provider: Address, sequence_number: u64)
         -> Result<Option<Request>>;
 
-    async fn get_block_number(&self) -> Result<U256>;
+    async fn get_block_number(&self) -> Result<BlockNumber>;
 }
 
 /// An in-flight request stored in the contract.
@@ -27,7 +26,7 @@ pub struct Request {
     pub provider:        Address,
     pub sequence_number: u64,
     // The block number where this request was created
-    pub block_number:    u128,
+    pub block_number:    BlockNumber,
     pub use_blockhash:   bool,
 }
 
@@ -36,6 +35,7 @@ pub struct Request {
 pub mod mock {
     use {
         crate::chain::reader::{
+            BlockNumber,
             EntropyReader,
             Request,
         },
@@ -49,19 +49,26 @@ pub mod mock {
     /// This class is internally locked to allow tests to modify the in-flight requests while
     /// the API is also holding a pointer to the same data structure.
     pub struct MockEntropyReader {
+        block_number: BlockNumber,
         /// The set of requests that are currently in-flight.
-        requests: RwLock<Vec<Request>>,
+        requests:     RwLock<Vec<Request>>,
     }
 
     impl MockEntropyReader {
-        pub fn with_requests(requests: &[(Address, u64)]) -> MockEntropyReader {
+        pub fn with_requests(
+            block_number: BlockNumber,
+            requests: &[(Address, u64, BlockNumber, bool)],
+        ) -> MockEntropyReader {
             MockEntropyReader {
+                block_number,
                 requests: RwLock::new(
                     requests
                         .iter()
-                        .map(|&(a, s)| Request {
+                        .map(|&(a, s, b, u)| Request {
                             provider:        a,
                             sequence_number: s,
+                            block_number:    b,
+                            use_blockhash:   u,
                         })
                         .collect(),
                 ),
@@ -69,10 +76,18 @@ pub mod mock {
         }
 
         /// Insert a new request into the set of in-flight requests.
-        pub fn insert(&self, provider: Address, sequence: u64) -> &Self {
+        pub fn insert(
+            &self,
+            provider: Address,
+            sequence: u64,
+            block_number: BlockNumber,
+            use_blockhash: bool,
+        ) -> &Self {
             self.requests.write().unwrap().push(Request {
                 provider,
                 sequence_number: sequence,
+                block_number,
+                use_blockhash,
             });
             self
         }
@@ -92,6 +107,10 @@ pub mod mock {
                 .iter()
                 .find(|&r| r.sequence_number == sequence_number && r.provider == provider)
                 .map(|r| (*r).clone()))
+        }
+
+        async fn get_block_number(&self) -> Result<u64> {
+            Ok(self.block_number.try_into()?)
         }
     }
 }

--- a/fortuna/src/chain/reader.rs
+++ b/fortuna/src/chain/reader.rs
@@ -1,7 +1,10 @@
 use {
     anyhow::Result,
     axum::async_trait,
-    ethers::types::Address,
+    ethers::{
+        core::k256::U256,
+        types::Address,
+    },
 };
 
 /// EntropyReader is the read-only interface of the Entropy contract.
@@ -12,6 +15,8 @@ pub trait EntropyReader: Send + Sync {
     /// need to become more generic.
     async fn get_request(&self, provider: Address, sequence_number: u64)
         -> Result<Option<Request>>;
+
+    async fn get_block_number(&self) -> Result<U256>;
 }
 
 /// An in-flight request stored in the contract.
@@ -21,6 +26,9 @@ pub trait EntropyReader: Send + Sync {
 pub struct Request {
     pub provider:        Address,
     pub sequence_number: u64,
+    // The block number where this request was created
+    pub block_number:    u128,
+    pub use_blockhash:   bool,
 }
 
 

--- a/fortuna/src/command/run.rs
+++ b/fortuna/src/command/run.rs
@@ -88,6 +88,7 @@ pub async fn run(opts: &RunOptions) -> Result<()> {
             state: Arc::new(chain_state),
             contract,
             provider_address: opts.provider,
+            confirmation_blocks: chain_config.confirmation_blocks,
         };
 
         chains.insert(chain_id.clone(), state);

--- a/fortuna/src/config.rs
+++ b/fortuna/src/config.rs
@@ -1,5 +1,8 @@
 use {
-    crate::api::ChainId,
+    crate::{
+        api::ChainId,
+        chain::reader::BlockNumber,
+    },
     anyhow::{
         anyhow,
         Result,
@@ -114,6 +117,9 @@ pub struct EthereumConfig {
 
     /// Address of a Pyth Randomness contract to interact with.
     pub contract_addr: Address,
+
+    /// How many blocks to wait before revealing the random number.
+    pub confirmation_blocks: BlockNumber,
 
     /// Use the legacy transaction format (for networks without EIP 1559)
     #[serde(default)]

--- a/fortuna/src/config/register_provider.rs
+++ b/fortuna/src/config/register_provider.rs
@@ -7,7 +7,6 @@ use {
         },
     },
     clap::Args,
-    ethers::types::U256,
 };
 
 #[derive(Args, Clone, Debug)]
@@ -35,7 +34,7 @@ pub struct RegisterProviderOptions {
     /// The fee to charge (in wei) for each requested random number
     #[arg(long = "pyth-contract-fee")]
     #[arg(default_value = "100")]
-    pub fee: U256,
+    pub fee: u128,
 
     /// The URI where clients can retrieve random values from this provider,
     /// i.e., wherever fortuna for this provider will be hosted.

--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -209,9 +209,11 @@ abstract contract Entropy is IEntropy, EntropyState {
         req.requester = msg.sender;
 
         if (useBlockHash) {
-            req.blockNumber = SafeCast.toUint96(block.number);
+            req.blockNumber = SafeCast.toInt96(SafeCast.toInt256(block.number));
         } else {
-            req.blockNumber = 0;
+            req.blockNumber =
+                -1 *
+                SafeCast.toInt96(SafeCast.toInt256(block.number));
         }
 
         emit Requested(req);
@@ -254,8 +256,9 @@ abstract contract Entropy is IEntropy, EntropyState {
         ) revert EntropyErrors.IncorrectRevelation();
 
         bytes32 blockHash = bytes32(uint256(0));
-        if (req.blockNumber != 0) {
-            blockHash = blockhash(req.blockNumber);
+        if (req.blockNumber >= 0) {
+            // Cast is safe because of the >= check above
+            blockHash = blockhash(uint96(req.blockNumber));
         }
 
         randomNumber = combineRandomValues(

--- a/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
@@ -205,8 +205,9 @@ contract EntropyTest is Test, EntropyTestUtils {
     }
 
     function testBasicFlow() public {
+        vm.roll(17);
         uint64 sequenceNumber = request(user2, provider1, 42, false);
-        assertEq(random.getRequest(provider1, sequenceNumber).blockNumber, 0);
+        assertEq(random.getRequest(provider1, sequenceNumber).blockNumber, -17);
 
         assertRevealSucceeds(
             user2,
@@ -229,13 +230,14 @@ contract EntropyTest is Test, EntropyTestUtils {
     }
 
     function testDefaultProvider() public {
+        vm.roll(20);
         uint64 sequenceNumber = request(
             user2,
             random.getDefaultProvider(),
             42,
             false
         );
-        assertEq(random.getRequest(provider1, sequenceNumber).blockNumber, 0);
+        assertEq(random.getRequest(provider1, sequenceNumber).blockNumber, -20);
 
         assertRevealReverts(
             user2,

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
@@ -45,10 +45,12 @@ contract EntropyStructs {
         // eliminating 1 store.
         bytes32 commitment;
         // Storage slot 3 //
-        // If nonzero, the randomness requester wants the blockhash of this block to be incorporated into the random number.
+        // The number of the block where this request was created, using the sign as a boolean.
+        // If positive, the randomness requester wants the blockhash of this block to be incorporated into the random number.
+        // If negative, the randomness requester does not want ^.
         // Note that we're using a uint96 such that we have an additional 20 bytes of storage afterward for an address.
-        // Although block.number returns a uint256, 96 bits should be plenty to index all of the blocks ever generated.
-        uint96 blockNumber;
+        // Although block.number returns a uint256, 95 bits should be plenty to index all of the blocks ever generated.
+        int96 blockNumber;
         // The address that requested this random number.
         address requester;
     }


### PR DESCRIPTION
This PR adds a configurable confirmation delay to fortuna for each blockchain. The purpose of this delay is to ensure that the request has confirmed and will not be rolled back in a chain reorg before revealing the random number.

In order to implement this change, I had to update the entropy contract to store the block number regardless of whether or not the blockhash was used. I did this using 1 bit of the number to save storage slots (sigh).