### PR TITLE
fix(near): match Price interface from pyth-sdk

### DIFF
--- a/target_chains/near/receiver/src/lib.rs
+++ b/target_chains/near/receiver/src/lib.rs
@@ -469,7 +469,7 @@ impl Pyth {
             // - If Price older than STALENESS_THRESHOLD, set status to Unknown.
             // - If Price newer than now by more than STALENESS_THRESHOLD, set status to Unknown.
             // - Any other price around the current time is considered valid.
-            if u64::abs_diff(block_timestamp, price_timestamp) > age {
+            if u64::abs_diff(block_timestamp, price_timestamp.into()) > age {
                 return None;
             }
 
@@ -500,7 +500,7 @@ impl Pyth {
             // - If Price older than STALENESS_THRESHOLD, set status to Unknown.
             // - If Price newer than now by more than STALENESS_THRESHOLD, set status to Unknown.
             // - Any other price around the current time is considered valid.
-            if u64::abs_diff(block_timestamp, price_timestamp) > age {
+            if u64::abs_diff(block_timestamp, price_timestamp.into()) > age {
                 return None;
             }
 

--- a/target_chains/near/receiver/src/state.rs
+++ b/target_chains/near/receiver/src/state.rs
@@ -5,6 +5,10 @@ use {
             BorshDeserialize,
             BorshSerialize,
         },
+        json_types::{
+            I64,
+            U64,
+        },
         serde::{
             Deserialize,
             Serialize,
@@ -84,13 +88,13 @@ impl near_sdk::serde::Serialize for PriceIdentifier {
 #[derive(BorshDeserialize, BorshSerialize, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(crate = "near_sdk::serde")]
 pub struct Price {
-    pub price:     i64,
+    pub price:     I64,
     /// Confidence interval around the price
-    pub conf:      u64,
+    pub conf:      U64,
     /// The exponent
     pub expo:      i32,
     /// Unix timestamp of when this price was computed
-    pub timestamp: u64,
+    pub timestamp: U64,
 }
 
 /// The PriceFeed structure is stored in the contract under a Price Feed Identifier.
@@ -113,16 +117,20 @@ impl From<&PriceAttestation> for PriceFeed {
         Self {
             id:        PriceIdentifier(price_attestation.price_id.to_bytes()),
             price:     Price {
-                price:     price_attestation.price,
-                conf:      price_attestation.conf,
+                price:     price_attestation.price.into(),
+                conf:      price_attestation.conf.into(),
                 expo:      price_attestation.expo,
-                timestamp: price_attestation.publish_time.try_into().unwrap(),
+                timestamp: TryInto::<u64>::try_into(price_attestation.publish_time)
+                    .unwrap()
+                    .into(),
             },
             ema_price: Price {
-                price:     price_attestation.ema_price,
-                conf:      price_attestation.ema_conf,
+                price:     price_attestation.ema_price.into(),
+                conf:      price_attestation.ema_conf.into(),
                 expo:      price_attestation.expo,
-                timestamp: price_attestation.publish_time.try_into().unwrap(),
+                timestamp: TryInto::<u64>::try_into(price_attestation.publish_time)
+                    .unwrap()
+                    .into(),
             },
         }
     }
@@ -133,16 +141,20 @@ impl From<&PriceFeedMessage> for PriceFeed {
         Self {
             id:        PriceIdentifier(price_feed_message.feed_id),
             price:     Price {
-                price:     price_feed_message.price,
-                conf:      price_feed_message.conf,
+                price:     price_feed_message.price.into(),
+                conf:      price_feed_message.conf.into(),
                 expo:      price_feed_message.exponent,
-                timestamp: price_feed_message.publish_time.try_into().unwrap(),
+                timestamp: TryInto::<u64>::try_into(price_feed_message.publish_time)
+                    .unwrap()
+                    .into(),
             },
             ema_price: Price {
-                price:     price_feed_message.ema_price,
-                conf:      price_feed_message.ema_conf,
+                price:     price_feed_message.ema_price.into(),
+                conf:      price_feed_message.ema_conf.into(),
                 expo:      price_feed_message.exponent,
-                timestamp: price_feed_message.publish_time.try_into().unwrap(),
+                timestamp: TryInto::<u64>::try_into(price_feed_message.publish_time)
+                    .unwrap()
+                    .into(),
             },
         }
     }

--- a/target_chains/near/receiver/tests/workspaces.rs
+++ b/target_chains/near/receiver/tests/workspaces.rs
@@ -500,10 +500,10 @@ async fn test_stale_threshold() {
     // timestamp and price should be unchanged.
     assert_eq!(
         Price {
-            price:     100,
-            conf:      1,
+            price:     100.into(),
+            conf:      1.into(),
             expo:      8,
-            timestamp: now,
+            timestamp: now.into(),
         },
         serde_json::from_slice::<Price>(
             &contract
@@ -560,10 +560,10 @@ async fn test_stale_threshold() {
     // [ref:failed_price_check]
     assert_eq!(
         Some(Price {
-            price:     100,
-            conf:      1,
+            price:     100.into(),
+            conf:      1.into(),
             expo:      8,
-            timestamp: now,
+            timestamp: now.into(),
         }),
         serde_json::from_slice::<Option<Price>>(
             &contract
@@ -1128,10 +1128,10 @@ async fn test_accumulator_updates() {
 
     assert_eq!(
         Some(Price {
-            price:     100,
-            conf:      100,
+            price:     100.into(),
+            conf:      100.into(),
             expo:      100,
-            timestamp: 100,
+            timestamp: 100.into(),
         }),
         serde_json::from_slice::<Option<Price>>(
             &contract


### PR DESCRIPTION
Doesn't require migration, state is already storing the right values. Just changes the `Price` type to use NEAR's U64/I64 types to make sure the result from contract calls serializes correctly. The reason we don't use pyth_sdk directly is because NEAR requires overriding serde which can't be done on imported types.