### PR TITLE
[pythnet-sdk] Bump borsh add borsh to MerklePriceUpdate

### DIFF
--- a/pythnet/pythnet_sdk/Cargo.toml
+++ b/pythnet/pythnet_sdk/Cargo.toml
@@ -12,7 +12,7 @@ name = "pythnet_sdk"
 
 [dependencies]
 bincode = "1.3.1"
-borsh = "0.9.1"
+borsh = {version = "1.2.1", features = ["derive"]}
 bytemuck = { version = "1.11.0", features = ["derive"] }
 byteorder = "1.4.3"
 fast-math = "0.1"

--- a/pythnet/pythnet_sdk/Cargo.toml
+++ b/pythnet/pythnet_sdk/Cargo.toml
@@ -12,7 +12,7 @@ name = "pythnet_sdk"
 
 [dependencies]
 bincode = "1.3.1"
-borsh = {version = "1.2.1", features = ["derive"]}
+borsh = {version = "0.10.3"}
 bytemuck = { version = "1.11.0", features = ["derive"] }
 byteorder = "1.4.3"
 fast-math = "0.1"

--- a/pythnet/pythnet_sdk/Cargo.toml
+++ b/pythnet/pythnet_sdk/Cargo.toml
@@ -12,7 +12,7 @@ name = "pythnet_sdk"
 
 [dependencies]
 bincode = "1.3.1"
-borsh = {version = "0.10.3"}
+borsh = "0.10.3"
 bytemuck = { version = "1.11.0", features = ["derive"] }
 byteorder = "1.4.3"
 fast-math = "0.1"

--- a/pythnet/pythnet_sdk/src/accumulators/merkle.rs
+++ b/pythnet/pythnet_sdk/src/accumulators/merkle.rs
@@ -245,6 +245,7 @@ mod test {
             mem::size_of,
         },
     };
+
     #[derive(Default, Clone, Debug, borsh::BorshSerialize)]
     struct PriceAccount {
         pub id:         u64,
@@ -331,11 +332,11 @@ mod test {
             ema:        50,
             ema_expo:   1,
         };
-        let item_a = borsh::to_vec(&price_account_a).unwrap();
+        let item_a = borsh::BorshSerialize::try_to_vec(&price_account_a).unwrap();
 
         let mut price_only_b = PriceOnly::from(price_account_a);
         price_only_b.price = 200;
-        let item_b = borsh::to_vec(&price_only_b).unwrap();
+        let item_b = BorshSerialize::try_to_vec(&price_only_b).unwrap();
         let item_c = 2usize.to_be_bytes();
         let item_d = 88usize.to_be_bytes();
 

--- a/pythnet/pythnet_sdk/src/accumulators/merkle.rs
+++ b/pythnet/pythnet_sdk/src/accumulators/merkle.rs
@@ -73,7 +73,7 @@ pub struct MerkleTree<H: Hasher = Keccak256> {
     pub root: MerkleRoot<H>,
 
     #[serde(skip)]
-    #[borsh(skip)]
+    #[borsh_skip]
     pub nodes: Vec<H::Hash>,
 }
 

--- a/pythnet/pythnet_sdk/src/accumulators/merkle.rs
+++ b/pythnet/pythnet_sdk/src/accumulators/merkle.rs
@@ -73,7 +73,7 @@ pub struct MerkleTree<H: Hasher = Keccak256> {
     pub root: MerkleRoot<H>,
 
     #[serde(skip)]
-    #[borsh_skip]
+    #[borsh(skip)]
     pub nodes: Vec<H::Hash>,
 }
 
@@ -245,7 +245,6 @@ mod test {
             mem::size_of,
         },
     };
-
     #[derive(Default, Clone, Debug, borsh::BorshSerialize)]
     struct PriceAccount {
         pub id:         u64,
@@ -332,11 +331,11 @@ mod test {
             ema:        50,
             ema_expo:   1,
         };
-        let item_a = borsh::BorshSerialize::try_to_vec(&price_account_a).unwrap();
+        let item_a = borsh::to_vec(&price_account_a).unwrap();
 
         let mut price_only_b = PriceOnly::from(price_account_a);
         price_only_b.price = 200;
-        let item_b = BorshSerialize::try_to_vec(&price_only_b).unwrap();
+        let item_b = borsh::to_vec(&price_only_b).unwrap();
         let item_c = 2usize.to_be_bytes();
         let item_d = 88usize.to_be_bytes();
 

--- a/pythnet/pythnet_sdk/src/wire.rs
+++ b/pythnet/pythnet_sdk/src/wire.rs
@@ -40,6 +40,10 @@ pub mod v1 {
             hashers::keccak256_160::Keccak160,
             require,
         },
+        borsh::{
+            BorshDeserialize,
+            BorshSerialize,
+        },
         serde::{
             Deserialize,
             Serialize,
@@ -99,7 +103,9 @@ pub mod v1 {
         },
     }
 
-    #[derive(Clone, Debug, Hash, PartialEq, Serialize, Deserialize)]
+    #[derive(
+        Clone, Debug, Hash, PartialEq, Serialize, Deserialize, BorshDeserialize, BorshSerialize,
+    )]
     pub struct MerklePriceUpdate {
         pub message: PrefixedVec<u16, u8>,
         pub proof:   MerklePath<Keccak160>,

--- a/pythnet/pythnet_sdk/src/wire/prefixed_vec.rs
+++ b/pythnet/pythnet_sdk/src/wire/prefixed_vec.rs
@@ -236,9 +236,8 @@ where
 
 #[test]
 fn test_borsh_roundtrip() {
-    use borsh::BorshSerialize;
     let prefixed_vec = PrefixedVec::<u16, u8>::from(vec![1, 2, 3, 4, 5]);
-    let encoded = prefixed_vec.try_to_vec().unwrap();
+    let encoded = borsh::to_vec(&prefixed_vec).unwrap();
     assert_eq!(encoded, vec![5, 0, 0, 0, 1, 2, 3, 4, 5]);
 
     let decoded_prefixed_vec = PrefixedVec::<u16, u8>::try_from_slice(encoded.as_slice()).unwrap();

--- a/pythnet/pythnet_sdk/src/wormhole.rs
+++ b/pythnet/pythnet_sdk/src/wormhole.rs
@@ -27,12 +27,14 @@ use {
 };
 
 #[repr(transparent)]
-#[derive(Default)]
+#[derive(Default, PartialEq, Debug)]
 pub struct PostedMessageUnreliableData {
     pub message: MessageData,
 }
 
-#[derive(Debug, Default, BorshSerialize, BorshDeserialize, Clone, Serialize, Deserialize)]
+#[derive(
+    Debug, Default, BorshSerialize, BorshDeserialize, Clone, Serialize, Deserialize, PartialEq,
+)]
 pub struct MessageData {
     pub vaa_version:           u8,
     pub consistency_level:     u8,
@@ -95,4 +97,28 @@ impl Clone for PostedMessageUnreliableData {
 #[derive(Default, Clone, Copy, BorshDeserialize, BorshSerialize)]
 pub struct AccumulatorSequenceTracker {
     pub sequence: u64,
+}
+
+#[test]
+fn test_borsh_roundtrip() {
+    let post_message_unreliable_data = PostedMessageUnreliableData {
+        message: MessageData {
+            vaa_version:           1,
+            consistency_level:     2,
+            vaa_time:              3,
+            vaa_signature_account: [4u8; 32],
+            submission_time:       5,
+            nonce:                 6,
+            sequence:              7,
+            emitter_chain:         8,
+            emitter_address:       [9u8; 32],
+            payload:               vec![10u8; 32],
+        },
+    };
+
+
+    let encoded = borsh::to_vec(&post_message_unreliable_data).unwrap();
+
+    let decoded = PostedMessageUnreliableData::try_from_slice(encoded.as_slice()).unwrap();
+    assert_eq!(decoded, post_message_unreliable_data);
 }

--- a/pythnet/pythnet_sdk/src/wormhole.rs
+++ b/pythnet/pythnet_sdk/src/wormhole.rs
@@ -54,7 +54,10 @@ impl BorshSerialize for PostedMessageUnreliableData {
 }
 
 impl BorshDeserialize for PostedMessageUnreliableData {
-    fn deserialize(buf: &mut &[u8]) -> std::io::Result<Self> {
+    fn deserialize_reader<R: std::io::prelude::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let mut vector = vec![];
+        reader.read_to_end(&mut vector)?;
+        let buf: &mut &[u8] = &mut vector.as_slice();
         if buf.len() < 3 {
             return Err(Error::new(InvalidData, "Not enough bytes"));
         }


### PR DESCRIPTION
I want to use `MerklePriceUpdate` in the receiver contract for Solana.
I made two changes :
- Derive `BorshSerialize` and `BorshDeserialize` for `MerklePriceUpdate`
- Bump borsh to 0.10.3