### PR TITLE
[solana-receiver] Initialize receiver from CLI

### DIFF
--- a/target_chains/solana/cli/src/cli.rs
+++ b/target_chains/solana/cli/src/cli.rs
@@ -44,4 +44,12 @@ pub enum Action {
         about = "Initialize a wormhole receiver contract by sequentially replaying the guardian set updates"
     )]
     InitializeWormholeReceiver {},
+    InitializePythReceiver {
+        #[clap(short = 'f', long, help = "Fee in lmaports")]
+        fee:     u64,
+        #[clap(short = 'e', long, parse(try_from_str = Pubkey::from_str), help = "Source emitter")]
+        emitter: Pubkey,
+        #[clap(short = 'c', long, help = "Source chain")]
+        chain:   u16,
+    },
 }

--- a/target_chains/solana/cli/src/main.rs
+++ b/target_chains/solana/cli/src/main.rs
@@ -1,6 +1,5 @@
 #![deny(warnings)]
 
-use pyth_solana_receiver::state::config::DataSource;
 
 pub mod cli;
 use {
@@ -15,6 +14,7 @@ use {
         Action,
         Cli,
     },
+    pyth_solana_receiver::state::config::DataSource,
     pythnet_sdk::wire::v1::{
         AccumulatorUpdateData,
         MerklePriceUpdate,
@@ -132,7 +132,6 @@ fn main() -> Result<()> {
             emitter,
             chain,
         } => {
-            let pyth_receiver_id: Pubkey = pyth_solana_receiver::ID;
             let rpc_client = RpcClient::new(url);
             let payer =
                 read_keypair_file(&*shellexpand::tilde(&keypair)).expect("Keypair not found");
@@ -141,7 +140,7 @@ fn main() -> Result<()> {
                 pyth_solana_receiver::accounts::Initialize::populate(&payer.pubkey())
                     .to_account_metas(None);
             let initialize_pyth_receiver_instruction = Instruction {
-                program_id: pyth_receiver_id,
+                program_id: pyth_solana_receiver::ID,
                 accounts:   initialize_pyth_receiver_accounts,
                 data:       pyth_solana_receiver::instruction::Initialize {
                     initial_config: pyth_solana_receiver::state::config::Config {

--- a/target_chains/solana/programs/pyth-solana-receiver/src/lib.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/src/lib.rs
@@ -29,7 +29,7 @@ use {
     },
 };
 
-declare_id!("DvPfMBZJJwKgJsv2WJA8bFwUMn8nFd5Xpioc6foC3rse");
+declare_id!("rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ");
 
 #[program]
 pub mod pyth_solana_receiver {

--- a/target_chains/solana/programs/pyth-solana-receiver/src/lib.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/src/lib.rs
@@ -1,4 +1,7 @@
-use state::config::Config;
+use {
+    anchor_lang::system_program,
+    state::config::Config,
+};
 
 pub mod error;
 pub mod state;
@@ -207,6 +210,16 @@ pub struct PostUpdates<'info> {
     pub posted_vaa: UncheckedAccount<'info>,
 }
 
+impl crate::accounts::Initialize {
+    pub fn populate(payer: &Pubkey) -> Self {
+        let config = Pubkey::find_program_address(&[CONFIG_SEED.as_ref()], &crate::ID).0;
+        crate::accounts::Initialize {
+            payer: *payer,
+            config,
+            system_program: system_program::ID,
+        }
+    }
+}
 
 impl crate::accounts::PostUpdates {
     pub fn populate(payer: &Pubkey, posted_vaa: &Pubkey) -> Self {


### PR DESCRIPTION
Command in the CLI to initialize the Pyth receiver on Solana