### PR TITLE
chore(price_service): update spy version and bootstrappers

### DIFF
--- a/price_service/server/docker-compose.mainnet.yaml
+++ b/price_service/server/docker-compose.mainnet.yaml
@@ -1,7 +1,7 @@
 services:
   spy:
     # Find latest Guardian images in https://github.com/wormhole-foundation/wormhole/pkgs/container/guardiand
-    image: ghcr.io/wormhole-foundation/guardiand:v2.23.14
+    image: ghcr.io/wormhole-foundation/guardiand:v2.23.28
     restart: on-failure
     command:
       - "spy"
@@ -10,7 +10,7 @@ services:
       - "--spyRPC"
       - "[::]:7072"
       - "--bootstrap"
-      - "/dns4/wormhole-mainnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWQp644DK27fd3d4Km3jr7gHiuJJ5ZGmy8hH4py7fP4FP7"
+      - "/dns4/wormhole-v2-mainnet-bootstrap.xlabs.xyz/udp/8999/quic/p2p/12D3KooWNQ9tVrcb64tw6bNs2CaNrUGPM7yRrKvBBheQ5yCyPHKC,/dns4/wormhole.mcf.rocks/udp/8999/quic/p2p/12D3KooWDZVv7BhZ8yFLkarNdaSWaB43D6UbQwExJ8nnGAEmfHcU,/dns4/wormhole-v2-mainnet-bootstrap.staking.fund/udp/8999/quic/p2p/12D3KooWG8obDX9DNi1KUwZNu9xkGwfKqTp2GFwuuHpWZ3nQruS1"
       - "--network"
       - "/wormhole/mainnet/2"
       - "--logLevel"

--- a/price_service/server/docker-compose.testnet.yaml
+++ b/price_service/server/docker-compose.testnet.yaml
@@ -1,7 +1,7 @@
 services:
   spy:
     # Find latest Guardian images in https://github.com/wormhole-foundation/wormhole/pkgs/container/guardiand
-    image: ghcr.io/wormhole-foundation/guardiand:v2.23.14
+    image: ghcr.io/wormhole-foundation/guardiand:v2.23.28
     restart: on-failure
     command:
       - "spy"
@@ -10,7 +10,7 @@ services:
       - "--spyRPC"
       - "[::]:7072"
       - "--bootstrap"
-      - "/dns4/wormhole-testnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWAkB9ynDur1Jtoa97LBUp8RXdhzS5uHgAfdTquJbrbN7i"
+      - "/dns4/t-guardian-01.nodes.stable.io/udp/8999/quic/p2p/12D3KooWCW3LGUtkCVkHZmVSZHzL3C4WRKWfqAiJPz1NR7dT9Bxh,/dns4/t-guardian-02.nodes.stable.io/udp/8999/quic/p2p/12D3KooWJXA6goBCiWM8ucjzc4jVUBSqL9Rri6UpjHbkMPErz5zK"
       - "--network"
       - "/wormhole/testnet/2/1"
       - "--logLevel"


### PR DESCRIPTION
The new spy has a QUIC upgrade logic for mainnet which happens on January 16. This upgrade is breaking and all the spy runners should upgraded their spies.