### PR TITLE
Fix pythnet-sdk ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,13 +89,13 @@ repos:
       - id: cargo-fmt-pythnet-sdk
         name: Cargo format for pythnet SDK
         language: "rust"
-        entry: cargo +nightly-2023-03-01 fmt --manifest-path ./pythnet/pythnet_sdk/Cargo.toml --all -- --config-path rustfmt.toml
+        entry: cargo +nightly-2023-07-23 fmt --manifest-path ./pythnet/pythnet_sdk/Cargo.toml --all -- --config-path rustfmt.toml
         pass_filenames: false
         files: pythnet/pythnet_sdk
       - id: cargo-clippy-pythnet-sdk
         name: Cargo clippy for pythnet SDK
         language: "rust"
-        entry: cargo +nightly-2023-03-01 clippy --manifest-path ./pythnet/pythnet_sdk/Cargo.toml --tests --fix --allow-dirty --allow-staged -- -D warnings
+        entry: cargo +nightly-2023-07-23 clippy --manifest-path ./pythnet/pythnet_sdk/Cargo.toml --tests --fix --allow-dirty --allow-staged -- -D warnings
         pass_filenames: false
         files: pythnet/pythnet_sdk
       # Hooks for solana receiver contract

--- a/pythnet/pythnet_sdk/src/messages.rs
+++ b/pythnet/pythnet_sdk/src/messages.rs
@@ -3,6 +3,7 @@ use quickcheck::Arbitrary;
 use {
     borsh::{
         BorshDeserialize,
+        BorshSchema,
         BorshSerialize,
     },
     serde::{
@@ -75,7 +76,15 @@ pub type FeedId = [u8; 32];
 
 #[repr(C)]
 #[derive(
-    Debug, Copy, Clone, PartialEq, Serialize, Deserialize, BorshDeserialize, BorshSerialize,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    BorshDeserialize,
+    BorshSerialize,
+    BorshSchema,
 )]
 pub struct PriceFeedMessage {
     pub feed_id:           FeedId,


### PR DESCRIPTION
pythnet-sdk CI has been failing for a bit.
Bumping nightly version in the pre-commits worked.
I think the error was caused by a new version of `ahash` that our `nightly-2023-03-01` didn't like 