### PR TITLE
fix(target_chains/ethereum): update MockPyth to address Pyth

### DIFF
--- a/target_chains/ethereum/sdk/solidity/MockPyth.sol
+++ b/target_chains/ethereum/sdk/solidity/MockPyth.sol
@@ -98,8 +98,12 @@ contract MockPyth is AbstractPyth {
                     (PythStructs.PriceFeed, uint64)
                 );
 
+                uint publishTime = feeds[i].price.publishTime;
+                if (priceFeeds[feeds[i].id].price.publishTime < publishTime) {
+                    priceFeeds[feeds[i].id] = feeds[i];
+                }
+
                 if (feeds[i].id == priceIds[i]) {
-                    uint publishTime = feeds[i].price.publishTime;
                     if (
                         minPublishTime <= publishTime &&
                         publishTime <= maxPublishTime &&

--- a/target_chains/ethereum/sdk/solidity/package.json
+++ b/target_chains/ethereum/sdk/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Read prices from the Pyth oracle",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We've recently changed Pyth to store the feeds on parse* methods if the updateData provided contains fresh prices. This change adds the same feature to the MockPyth.