### PR TITLE
chore(ethereum): add new networks

### DIFF
--- a/contract_manager/src/contracts/evm.ts
+++ b/contract_manager/src/contracts/evm.ts
@@ -269,6 +269,9 @@ export class WormholeEvmContract extends WormholeContract {
       from: address,
       gas: 100000000,
     });
+    // Some networks like Filecoin do not support the normal transaction type and need a type 2 transaction.
+    // To send a type 2 transaction, remove the ``gasPrice`` field and add the `type` field with the value
+    // `0x2` to the transaction configuration parameters.
     const result = await transactionObject.send({
       from: address,
       gas: gasEstiamte * GAS_ESTIMATE_MULTIPLIER,

--- a/contract_manager/store/chains/EvmChains.yaml
+++ b/contract_manager/store/chains/EvmChains.yaml
@@ -408,3 +408,23 @@
   rpcUrl: https://rpc.s2.testblast.io/$ENV_BLAST_S2_TESTNET_API_KEY
   networkId: 168587773
   type: EvmChain
+- id: hedera_testnet
+  mainnet: false
+  rpcUrl: https://testnet.hashio.io/api
+  networkId: 296
+  type: EvmChain
+- id: hedera
+  mainnet: true
+  rpcUrl: https://mainnet.hashio.io/api
+  networkId: 295
+  type: EvmChain
+- id: filecoin_calibration
+  mainnet: false
+  rpcUrl: https://rpc.ankr.com/filecoin_testnet
+  networkId: 314159
+  type: EvmChain
+- id: filecoin
+  mainnet: true
+  rpcUrl: https://rpc.ankr.com/filecoin
+  networkId: 314
+  type: EvmChain

--- a/contract_manager/store/contracts/EvmContracts.yaml
+++ b/contract_manager/store/contracts/EvmContracts.yaml
@@ -244,3 +244,9 @@
 - chain: zkfair
   address: "0xA2aa501b19aff244D90cc15a4Cf739D2725B5729"
   type: EvmContract
+- chain: filecoin_calibration
+  address: "0xA2aa501b19aff244D90cc15a4Cf739D2725B5729"
+  type: EvmContract
+- chain: filecoin
+  address: "0xA2aa501b19aff244D90cc15a4Cf739D2725B5729"
+  type: EvmContract

--- a/governance/xc_admin/packages/xc_admin_common/src/chains.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/chains.ts
@@ -58,6 +58,8 @@ export const RECEIVER_CHAINS = {
   mode: 60039,
   bttc: 60040,
   zkfair: 60041,
+  hedera: 60042,
+  filecoin: 60043,
 
   // Testnets as a separate chain ids (to use stable data sources and governance for them)
   injective_testnet: 60013,
@@ -114,6 +116,8 @@ export const RECEIVER_CHAINS = {
   movement_move_devnet: 50045,
   zkfair_testnet: 50046,
   blast_s2_testnet: 50047,
+  hedera_testnet: 50048,
+  filecoin_calibration: 50049, // Filecoin testnet
 };
 
 // If there is any overlapping value the receiver chain will replace the wormhole

--- a/target_chains/ethereum/contracts/networks/314.json
+++ b/target_chains/ethereum/contracts/networks/314.json
@@ -1,0 +1,16 @@
+[
+  {
+    "contractName": "Migrations",
+    "address": "0xf5BBe9558F4Bf37F1eB82fb2CEdb1C775FA56832"
+  },
+  {
+    "contractName": "WormholeReceiver",
+    "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
+    "transactionHash": "0x8c7c1bbecc72d29e7a025b855a384f685efc3089078a21096dd3157a4fdb5882"
+  },
+  {
+    "contractName": "PythUpgradable",
+    "address": "0xA2aa501b19aff244D90cc15a4Cf739D2725B5729",
+    "transactionHash": "0x8afbfdc3e7669d76d25453bf0c8c6b8f5e1751eb9fc6d35bbd300541fd63b9d3"
+  }
+]

--- a/target_chains/ethereum/contracts/networks/314159.json
+++ b/target_chains/ethereum/contracts/networks/314159.json
@@ -1,0 +1,16 @@
+[
+  {
+    "contractName": "Migrations",
+    "address": "0xf5BBe9558F4Bf37F1eB82fb2CEdb1C775FA56832"
+  },
+  {
+    "contractName": "WormholeReceiver",
+    "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
+    "transactionHash": "0xa504e9db88b136aaed24cc3fdcab56af757f1d7772ea2f7eb029ffaeb8ebb3e8"
+  },
+  {
+    "contractName": "PythUpgradable",
+    "address": "0xA2aa501b19aff244D90cc15a4Cf739D2725B5729",
+    "transactionHash": "0xe8d4788b95f3c6418e4300b7e671f83a0bdc2872bba0ead6daeda1ac7ac45e41"
+  }
+]


### PR DESCRIPTION
This change adds RPC configuration for Filecoin and Hedera and adds the contract addresses for Filecoin.