### PR TITLE
Add entropy error signatures for easier access and debugging

### DIFF
--- a/target_chains/ethereum/contracts/contracts/executor/ExecutorErrors.sol
+++ b/target_chains/ethereum/contracts/contracts/executor/ExecutorErrors.sol
@@ -3,19 +3,27 @@ pragma solidity ^0.8.0;
 
 library ExecutorErrors {
     // The provided message is not a valid Wormhole VAA.
+    // Signature: 0x2acbe915
     error InvalidWormholeVaa();
     // The message is coming from an emitter that is not authorized to use this contract.
+    // Signature: 0x4c79d142
     error UnauthorizedEmitter();
     // The sequence number of the provided message is before the last executed message.
+    // Signature: 0xc75415f9
     error MessageOutOfOrder();
     // The call to the provided contract executed without providing its own error.
+    // Signature: 0xf21e646b
     error ExecutionReverted();
     // The message could not be deserialized into an instruction
+    // Signature: 0xfbab86cf
     error DeserializationError();
     // The message is not intended for this contract.
+    // Signature: 0x63daeb77
     error InvalidGovernanceTarget();
     // The target address for the contract call is not a contract
+    // Signature: 0xd30c1cb5
     error InvalidContractTarget();
     // The governance message is not valid
+    // Signature: 0x4ed848c1
     error InvalidMagicValue();
 }

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyErrors.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyErrors.sol
@@ -4,24 +4,34 @@ pragma solidity ^0.8.0;
 
 library EntropyErrors {
     // An invariant of the contract failed to hold. This error indicates a software logic bug.
+    // Signature: 0xd82dd966
     error AssertionFailure();
     // The provider being registered has already registered
+    // Signature: 0xda041bdf
     error ProviderAlreadyRegistered();
     // The requested provider does not exist.
+    // Signature: 0xdf51c431
     error NoSuchProvider();
     // The specified request does not exist.
+    // Signature: 0xc4237352
     error NoSuchRequest();
     // The randomness provider is out of commited random numbers. The provider needs to
     // rotate their on-chain commitment to resolve this error.
+    // Signature: 0x3e515085
     error OutOfRandomness();
     // The transaction fee was not sufficient
+    // Signature: 0x025dbdd4
     error InsufficientFee();
     // Either the user's or the provider's revealed random values did not match their commitment.
+    // Signature: 0xb8be1a8d
     error IncorrectRevelation();
     // Governance message is invalid (e.g., deserialization error).
+    // Signature: 0xb463ce7a
     error InvalidUpgradeMagic();
     // The msg.sender is not allowed to invoke this call.
+    // Signature: 0x82b42900
     error Unauthorized();
     // The blockhash is 0.
+    // Signature: 0x92555c0e
     error BlockhashUnavailable();
 }


### PR DESCRIPTION
Used the same format existing in PythErrors.sol
This website was very handy:
https://abi.hashex.org/