### PR TITLE
[xc-admin] Revert 64 publishers

### DIFF
--- a/governance/xc_admin/packages/xc_admin_common/src/cluster.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/cluster.ts
@@ -37,11 +37,11 @@ export function getMaximumNumberOfPublishers(cluster: PythCluster) {
     case "testnet":
       return 32;
     case "pythnet":
-      return 64;
+      return 32;
     case "pythtest-conformance":
-      return 64;
+      return 32;
     case "pythtest-crosschain":
-      return 64;
+      return 32;
     case "localnet":
       return 32;
   }

--- a/governance/xc_admin/packages/xc_admin_frontend/components/tabs/General.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/tabs/General.tsx
@@ -126,12 +126,16 @@ const General = ({ proposerServerUrl }: { proposerServerUrl: string }) => {
             metadata: {
               ...product.metadata,
             },
-            priceAccounts: product.priceAccounts.map((p) => ({
-              address: p.address.toBase58(),
-              publishers: p.publishers.map((p) => p.toBase58()),
-              expo: p.expo,
-              minPub: p.minPub,
-            })),
+            priceAccounts: product.priceAccounts.map((p) => {
+              return {
+                address: p.address.toBase58(),
+                publishers: p.publishers
+                  .map((p) => p.toBase58())
+                  .slice(0, getMaximumNumberOfPublishers(cluster)),
+                expo: p.expo,
+                minPub: p.minPub,
+              }
+            }),
           }
           // these fields are immutable and should not be updated
           delete symbolToData[product.metadata.symbol].metadata.symbol


### PR DESCRIPTION
Revert xc-admin to support only 32 publishers until pyth-agent can handle 64 publishers.