### PR TITLE
[doc] Provide installation directions for Foundry

### DIFF
--- a/target_chains/ethereum/entropy_sdk/solidity/README.md
+++ b/target_chains/ethereum/entropy_sdk/solidity/README.md
@@ -9,8 +9,28 @@ Use this protocol at your own risk.
 
 ## Install
 
-```shell
+####Truffle/Hardhat
+
+If you are using Truffle or Hardhat, simply install the NPM package:
+
+```bash
 npm install @pythnetwork/entropy-sdk-solidity
+```
+
+####Foundry
+
+If you are using Foundry, you will need to create an NPM project if you don't already have one.
+From the root directory of your project, run:
+
+```bash
+npm init -y
+npm install @pythnetwork/entropy-sdk-solidity
+```
+
+Then add the following line to your `remappings.txt` file:
+
+```text
+@pythnetwork/entropy-sdk-solidity/=node_modules/@pythnetwork/entropy-sdk-solidity
 ```
 
 ## Setup

--- a/target_chains/ethereum/sdk/solidity/README.md
+++ b/target_chains/ethereum/sdk/solidity/README.md
@@ -7,8 +7,28 @@ It is **strongly recommended** to follow the [consumer best practices](https://d
 
 ## Installation
 
+####Truffle/Hardhat
+
+If you are using Truffle or Hardhat, simply install the NPM package:
+
 ```bash
 npm install @pythnetwork/pyth-sdk-solidity
+```
+
+####Foundry
+
+If you are using Foundry, you will need to create an NPM project if you don't already have one.
+From the root directory of your project, run:
+
+```bash
+npm init -y
+npm install @pythnetwork/pyth-sdk-solidity
+```
+
+Then add the following line to your `remappings.txt` file:
+
+```text
+@pythnetwork/pyth-sdk-solidity/=node_modules/@pythnetwork/pyth-sdk-solidity
 ```
 
 ## Example Usage


### PR DESCRIPTION
By default, foundry expects every library to be a git project. This approach does not work well with SDKs in monorepos (like ours). However, you can also install the dependencies using NPM and then use remappings.txt to point to the SDK. This is a little janky, but it seems to be the recommended approach for this case 🤷  

see issue here https://github.com/foundry-rs/foundry/issues/1847 