### PR TITLE
fix(hermes): update build.rs to fix Docker build

### DIFF
--- a/hermes/build.rs
+++ b/hermes/build.rs
@@ -14,7 +14,7 @@ fn main() {
     // directory as a mini-repo with wormhole and googleapis as remotes, so we can copy out the
     // TREEISH paths we want.
     let protobuf_setup = r#"
-        set -euo pipefail
+        set -e
         git init .
         git clean -df
         git remote add wormhole https://github.com/wormhole-foundation/wormhole.git || true


### PR DESCRIPTION
The `set -o pipefail` in the shell snippet in the build script is a bash feature and is not supported in all shells and failed Docker build. Removing it this along with the `-u` because that is also not used in the small shell snippet here but keeping `-e` to abort the script on errors.

Triggered a manual workflow to verify it works. ([link](https://github.com/pyth-network/pyth-crosschain/actions/runs/7883606305))