### PR TITLE
refactor(solana): separate anchor state to another crate

### DIFF
--- a/target_chains/solana/Cargo.lock
+++ b/target_chains/solana/Cargo.lock
@@ -3033,6 +3033,7 @@ dependencies = [
  "program-simulator",
  "pyth-sdk",
  "pyth-sdk-solana",
+ "pyth-solana-receiver-state",
  "pythnet-sdk",
  "rand 0.8.5",
  "serde_wormhole",
@@ -3041,7 +3042,7 @@ dependencies = [
  "solana-sdk",
  "tokio",
  "wormhole-core-bridge-solana",
- "wormhole-raw-vaas 0.0.1-alpha.2",
+ "wormhole-raw-vaas",
  "wormhole-sdk",
 ]
 
@@ -3056,6 +3057,7 @@ dependencies = [
  "clap 3.2.23",
  "hex",
  "pyth-solana-receiver",
+ "pyth-solana-receiver-state",
  "pythnet-sdk",
  "serde_wormhole",
  "shellexpand",
@@ -3064,6 +3066,15 @@ dependencies = [
  "wormhole-core-bridge-solana",
  "wormhole-sdk",
  "wormhole-solana",
+]
+
+[[package]]
+name = "pyth-solana-receiver-state"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "pythnet-sdk",
+ "solana-program",
 ]
 
 [[package]]
@@ -6169,7 +6180,7 @@ dependencies = [
  "ruint",
  "solana-program",
  "wormhole-io",
- "wormhole-raw-vaas 0.1.3",
+ "wormhole-raw-vaas",
 ]
 
 [[package]]
@@ -6177,16 +6188,6 @@ name = "wormhole-io"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4965f46f7a99debe3c2cf9337c6e3eb7068da348aecf074a3e35686937f25c65"
-
-[[package]]
-name = "wormhole-raw-vaas"
-version = "0.0.1-alpha.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb59754ad91d99c0e3d7d159fffcbb4087c18a1c13b1b2a945775635ef9bd03"
-dependencies = [
- "ruint",
- "ruint-macro",
-]
 
 [[package]]
 name = "wormhole-raw-vaas"

--- a/target_chains/solana/Cargo.toml
+++ b/target_chains/solana/Cargo.toml
@@ -1,7 +1,9 @@
 [workspace]
 members = [
     "programs/*",
-    "cli/"
+    "cli/",
+    "program_simulator/",
+    "pyth_solana_receiver_state/"
 ]
 
 [profile.release]

--- a/target_chains/solana/cli/Cargo.toml
+++ b/target_chains/solana/cli/Cargo.toml
@@ -19,3 +19,4 @@ serde_wormhole = { workspace = true }
 hex = "0.4.3"
 borsh = "0.9.3" # Old version of borsh needed for wormhole-solana
 wormhole-core-bridge-solana = {workspace = true}
+pyth-solana-receiver-state = {path = "../pyth_solana_receiver_state"}

--- a/target_chains/solana/cli/src/main.rs
+++ b/target_chains/solana/cli/src/main.rs
@@ -21,10 +21,10 @@ use {
             get_treasury_address,
             DEFAULT_TREASURY_ID,
         },
-        state::config::DataSource,
         PostUpdateAtomicParams,
         PostUpdateParams,
     },
+    pyth_solana_receiver_state::config::DataSource,
     pythnet_sdk::wire::v1::MerklePriceUpdate,
     serde_wormhole::RawMessage,
     solana_client::{
@@ -184,7 +184,7 @@ fn main() -> Result<()> {
                 program_id: pyth_solana_receiver::ID,
                 accounts:   initialize_pyth_receiver_accounts,
                 data:       pyth_solana_receiver::instruction::Initialize {
-                    initial_config: pyth_solana_receiver::state::config::Config {
+                    initial_config: pyth_solana_receiver_state::config::Config {
                         governance_authority: payer.pubkey(),
                         target_governance_authority: None,
                         wormhole,

--- a/target_chains/solana/programs/pyth-solana-receiver/Cargo.toml
+++ b/target_chains/solana/programs/pyth-solana-receiver/Cargo.toml
@@ -21,7 +21,8 @@ pythnet-sdk = { path = "../../../../pythnet/pythnet_sdk" }
 solana-program = "1.16.20"
 byteorder = "1.4.3"
 wormhole-core-bridge-solana = {workspace = true}
-wormhole-raw-vaas = {version = "0.0.1-alpha.1", features = ["ruint", "on-chain"], default-features = false }
+wormhole-raw-vaas = {version = "0.1.3", features = ["ruint", "on-chain"], default-features = false }
+pyth-solana-receiver-state = { path = "../../pyth_solana_receiver_state"}
 
 [dev-dependencies]
 pyth-sdk = "0.8.0"

--- a/target_chains/solana/programs/pyth-solana-receiver/src/lib.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/src/lib.rs
@@ -1,6 +1,16 @@
 use {
     crate::error::ReceiverError,
     anchor_lang::prelude::*,
+    pyth_solana_receiver_state::{
+        config::{
+            Config,
+            DataSource,
+        },
+        price_update::{
+            PriceUpdateV1,
+            VerificationLevel,
+        },
+    },
     pythnet_sdk::{
         accumulators::merkle::MerkleRoot,
         hashers::keccak256_160::Keccak160,
@@ -20,16 +30,6 @@ use {
         secp256k1_recover::secp256k1_recover,
         system_instruction,
     },
-    state::{
-        config::{
-            Config,
-            DataSource,
-        },
-        price_update::{
-            PriceUpdateV1,
-            VerificationLevel,
-        },
-    },
     wormhole_core_bridge_solana::{
         sdk::{
             legacy::AccountVariant,
@@ -45,7 +45,6 @@ use {
 
 pub mod error;
 pub mod sdk;
-pub mod state;
 
 declare_id!("rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ");
 

--- a/target_chains/solana/programs/pyth-solana-receiver/src/lib.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/src/lib.rs
@@ -46,7 +46,7 @@ use {
 pub mod error;
 pub mod sdk;
 
-declare_id!("rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ");
+declare_id!(pyth_solana_receiver_state::ID);
 
 #[program]
 pub mod pyth_solana_receiver {

--- a/target_chains/solana/programs/pyth-solana-receiver/src/sdk.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/src/sdk.rs
@@ -2,10 +2,6 @@ use {
     crate::{
         accounts,
         instruction,
-        state::config::{
-            Config,
-            DataSource,
-        },
         PostUpdateAtomicParams,
         PostUpdateParams,
         CONFIG_SEED,
@@ -16,6 +12,10 @@ use {
         prelude::*,
         system_program,
         InstructionData,
+    },
+    pyth_solana_receiver_state::config::{
+        Config,
+        DataSource,
     },
     pythnet_sdk::wire::v1::{
         AccumulatorUpdateData,

--- a/target_chains/solana/programs/pyth-solana-receiver/src/state/mod.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/src/state/mod.rs
@@ -1,2 +1,0 @@
-pub mod config;
-pub mod price_update;

--- a/target_chains/solana/programs/pyth-solana-receiver/tests/common/mod.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/tests/common/mod.rs
@@ -11,11 +11,11 @@ use {
             DEFAULT_TREASURY_ID,
             SECONDARY_TREASURY_ID,
         },
-        state::config::{
-            Config,
-            DataSource,
-        },
         ID,
+    },
+    pyth_solana_receiver_state::config::{
+        Config,
+        DataSource,
     },
     pythnet_sdk::test_utils::{
         dummy_guardians,

--- a/target_chains/solana/programs/pyth-solana-receiver/tests/test_governance.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/tests/test_governance.rs
@@ -16,10 +16,10 @@ use {
             SetWormholeAddress,
         },
         sdk::get_config_address,
-        state::config::{
-            Config,
-            DataSource,
-        },
+    },
+    pyth_solana_receiver_state::config::{
+        Config,
+        DataSource,
     },
     pythnet_sdk::test_utils::SECONDARY_DATA_SOURCE,
     solana_program::{

--- a/target_chains/solana/programs/pyth-solana-receiver/tests/test_post_price_update_from_vaa.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/tests/test_post_price_update_from_vaa.rs
@@ -20,12 +20,12 @@ use {
             deserialize_accumulator_update_data,
             DEFAULT_TREASURY_ID,
         },
-        state::{
-            config::DataSource,
-            price_update::{
-                PriceUpdateV1,
-                VerificationLevel,
-            },
+    },
+    pyth_solana_receiver_state::{
+        config::DataSource,
+        price_update::{
+            PriceUpdateV1,
+            VerificationLevel,
         },
     },
     pythnet_sdk::{

--- a/target_chains/solana/programs/pyth-solana-receiver/tests/test_post_updates.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/tests/test_post_updates.rs
@@ -18,10 +18,10 @@ use {
             deserialize_accumulator_update_data,
             DEFAULT_TREASURY_ID,
         },
-        state::price_update::{
-            PriceUpdateV1,
-            VerificationLevel,
-        },
+    },
+    pyth_solana_receiver_state::price_update::{
+        PriceUpdateV1,
+        VerificationLevel,
     },
     pythnet_sdk::{
         messages::Message,

--- a/target_chains/solana/programs/pyth-solana-receiver/tests/test_post_updates_atomic.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/tests/test_post_updates_atomic.rs
@@ -18,10 +18,10 @@ use {
             DEFAULT_TREASURY_ID,
             SECONDARY_TREASURY_ID,
         },
-        state::price_update::{
-            PriceUpdateV1,
-            VerificationLevel,
-        },
+    },
+    pyth_solana_receiver_state::price_update::{
+        PriceUpdateV1,
+        VerificationLevel,
     },
     pythnet_sdk::{
         messages::Message,

--- a/target_chains/solana/pyth_solana_receiver_state/Cargo.toml
+++ b/target_chains/solana/pyth_solana_receiver_state/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "pyth-solana-receiver-state"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["lib"]
+name = "pyth_solana_receiver_state"
+
+
+[dependencies]
+anchor-lang = ">=0.28.0"
+pythnet-sdk = { path = "../../../pythnet/pythnet_sdk"}
+solana-program = "*"

--- a/target_chains/solana/pyth_solana_receiver_state/src/config.rs
+++ b/target_chains/solana/pyth_solana_receiver_state/src/config.rs
@@ -28,7 +28,7 @@ impl Config {
 pub mod tests {
     use {
         super::DataSource,
-        crate::state::config::Config,
+        crate::config::Config,
         anchor_lang::{
             AnchorSerialize,
             Discriminator,

--- a/target_chains/solana/pyth_solana_receiver_state/src/lib.rs
+++ b/target_chains/solana/pyth_solana_receiver_state/src/lib.rs
@@ -1,0 +1,6 @@
+use anchor_lang::declare_id;
+
+pub mod config;
+pub mod price_update;
+
+declare_id!("rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ");

--- a/target_chains/solana/pyth_solana_receiver_state/src/price_update.rs
+++ b/target_chains/solana/pyth_solana_receiver_state/src/price_update.rs
@@ -11,7 +11,9 @@ use {
 /**
  * This enum represents how many guardian signatures were checked for a Pythnet price update
  * If full, guardian quorum has been attained
- * If partial, at least config.minimum signatures have been verified, but in the case config.minimum_signatures changes in the future we also include the number of signatures that were checked */
+ * If partial, at least config.minimum signatures have been verified, but in the case config.minimum_signatures changes in the future we also include the number of signatures that were checked
+ */
+
 #[derive(AnchorSerialize, AnchorDeserialize, Copy, Clone, PartialEq, BorshSchema, Debug)]
 pub enum VerificationLevel {
     Partial { num_signatures: u8 },

--- a/target_chains/solana/pyth_solana_receiver_state/src/price_update.rs
+++ b/target_chains/solana/pyth_solana_receiver_state/src/price_update.rs
@@ -32,7 +32,7 @@ impl PriceUpdateV1 {
 #[cfg(test)]
 pub mod tests {
     use {
-        crate::state::price_update::PriceUpdateV1,
+        crate::price_update::PriceUpdateV1,
         anchor_lang::Discriminator,
         solana_program::borsh0_10,
     };


### PR DESCRIPTION
In the smart contract we are pinning anchor to 0.28.0 because of a Wormhole dependency.
I want consumers to be able to import our types in their code, but it's not great if they have to pin anchor to that version.
The compromise is moving the structs to a different crate that doesn't pin anchor and that can be imported both by the on-chain program and by consumer programs.