### PR TITLE
chore(xc_admin/frontend): set pythnet max publishers to 64

### DIFF
--- a/.github/workflows/ci-ethereum-contract.yml
+++ b/.github/workflows/ci-ethereum-contract.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm ci
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@v1.1.1
         with:
           version: nightly
 

--- a/governance/xc_admin/packages/xc_admin_common/src/cluster.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/cluster.ts
@@ -37,7 +37,7 @@ export function getMaximumNumberOfPublishers(cluster: PythCluster) {
     case "testnet":
       return 32;
     case "pythnet":
-      return 32;
+      return 64;
     case "pythtest-conformance":
       return 64;
     case "pythtest-crosschain":

--- a/target_chains/ethereum/contracts/package.json
+++ b/target_chains/ethereum/contracts/package.json
@@ -21,7 +21,7 @@
     "migrate": "truffle migrate",
     "receiver-submit-guardian-sets": "truffle exec scripts/receiverSubmitGuardianSetUpgrades.js",
     "verify": "truffle run verify $npm_config_module@$npm_config_contract_address --network $npm_config_network",
-    "install-forge-deps": "forge install foundry-rs/forge-std@2c7cbfc6fbede6d7c9e6b17afe997e3fdfe22fef --no-git --no-commit",
+    "install-forge-deps": "forge install foundry-rs/forge-std@v1.7.6 --no-git --no-commit",
     "coverage": "./coverage.sh"
   },
   "author": "",


### PR DESCRIPTION
p.s (on the CI fix): Here is my theory: Apparently older forge had some bugs in cloning the dependencies of its own dependencies properly. `ds-test` is a dependency of `forge-std` that has some functionalities for testing were new and not really at the version we were using. Now that they've fixed the issue we are facing a problem as the ds-test doesn't have the new functions. I couldn't find relative PR for this though, it's just a guess. I could fix the CI by pinning foundry to an older version but this one is better.