### PR TITLE
[entropy] Fix doc formatting

### DIFF
--- a/target_chains/ethereum/entropy_sdk/solidity/README.md
+++ b/target_chains/ethereum/entropy_sdk/solidity/README.md
@@ -6,7 +6,7 @@ This SDK can be used for any application that requires random numbers, such as N
 
 ## Install
 
-####Truffle/Hardhat
+###Truffle/Hardhat
 
 If you are using Truffle or Hardhat, simply install the NPM package:
 
@@ -14,7 +14,7 @@ If you are using Truffle or Hardhat, simply install the NPM package:
 npm install @pythnetwork/entropy-sdk-solidity
 ```
 
-####Foundry
+###Foundry
 
 If you are using Foundry, you will need to create an NPM project if you don't already have one.
 From the root directory of your project, run:

--- a/target_chains/ethereum/entropy_sdk/solidity/package.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/entropy-sdk-solidity",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Generate secure random numbers with Pyth Entropy",
   "repository": {
     "type": "git",

--- a/target_chains/ethereum/sdk/solidity/README.md
+++ b/target_chains/ethereum/sdk/solidity/README.md
@@ -7,7 +7,7 @@ It is **strongly recommended** to follow the [consumer best practices](https://d
 
 ## Installation
 
-####Truffle/Hardhat
+###Truffle/Hardhat
 
 If you are using Truffle or Hardhat, simply install the NPM package:
 
@@ -15,7 +15,7 @@ If you are using Truffle or Hardhat, simply install the NPM package:
 npm install @pythnetwork/pyth-sdk-solidity
 ```
 
-####Foundry
+###Foundry
 
 If you are using Foundry, you will need to create an NPM project if you don't already have one.
 From the root directory of your project, run:

--- a/target_chains/ethereum/sdk/solidity/package.json
+++ b/target_chains/ethereum/sdk/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Read prices from the Pyth oracle",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I was checking NPM to see if the other doc fix landed, and I noticed that `####` doesn't render properly over there. Replace with `###` 