### PR TITLE
refactor: extract transaction batching logic

### DIFF
--- a/.github/workflows/ci-solana-contract.yml
+++ b/.github/workflows/ci-solana-contract.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Run tests
         run: cargo-test-sbf
       - name: Run sdk tests
-        run: cargo test --p pyth-solana-sdk
+        run: cargo test --package pyth-solana-receiver-state

--- a/governance/xc_admin/packages/xc_admin_common/package.json
+++ b/governance/xc_admin/packages/xc_admin_common/package.json
@@ -29,7 +29,8 @@
     "bigint-buffer": "^1.1.5",
     "ethers": "^5.7.2",
     "lodash": "^4.17.21",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.4",
+    "@pythnetwork/solana-utils": "*"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.1",

--- a/governance/xc_admin/packages/xc_admin_common/src/__tests__/TransactionSize.test.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/__tests__/TransactionSize.test.ts
@@ -18,8 +18,10 @@ import {
   getSizeOfExecutorInstructions,
   MAX_EXECUTOR_PAYLOAD_SIZE,
 } from "..";
-import { getSizeOfTransaction } from "@pythnetwork/solana-utils";
-import { TransactionBuilder } from "@pythnetwork/solana-utils/src";
+import {
+  getSizeOfTransaction,
+  TransactionBuilder,
+} from "@pythnetwork/solana-utils";
 
 it("Unit test for getSizeOfTransaction", async () => {
   jest.setTimeout(60000);

--- a/governance/xc_admin/packages/xc_admin_common/src/__tests__/TransactionSize.test.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/__tests__/TransactionSize.test.ts
@@ -18,18 +18,8 @@ import {
   getSizeOfExecutorInstructions,
   MAX_EXECUTOR_PAYLOAD_SIZE,
 } from "..";
-import {
-  getSizeOfTransaction,
-  getSizeOfCompressedU16,
-} from "@pythnetwork/solana-utils";
+import { getSizeOfTransaction } from "@pythnetwork/solana-utils";
 import { TransactionBuilder } from "@pythnetwork/solana-utils/src";
-
-it("Unit test compressed u16 size", async () => {
-  expect(getSizeOfCompressedU16(127)).toBe(1);
-  expect(getSizeOfCompressedU16(128)).toBe(2);
-  expect(getSizeOfCompressedU16(16383)).toBe(2);
-  expect(getSizeOfCompressedU16(16384)).toBe(3);
-});
 
 it("Unit test for getSizeOfTransaction", async () => {
   jest.setTimeout(60000);
@@ -118,7 +108,7 @@ it("Unit test for getSizeOfTransaction", async () => {
   }
 
   const txToSend: Transaction[] =
-    await TransactionBuilder.batchIntoLegacyTransactions(ixsToSend);
+    TransactionBuilder.batchIntoLegacyTransactions(ixsToSend);
   expect(
     txToSend.map((tx) => tx.instructions.length).reduce((a, b) => a + b)
   ).toBe(ixsToSend.length);

--- a/governance/xc_admin/packages/xc_admin_common/src/propose.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/propose.ts
@@ -257,9 +257,7 @@ export class MultisigVault {
     ixToSend.push(await this.activateProposalIx(proposalAddress));
     ixToSend.push(await this.approveProposalIx(proposalAddress));
 
-    const txToSend = await TransactionBuilder.batchIntoLegacyTransactions(
-      ixToSend
-    );
+    const txToSend = TransactionBuilder.batchIntoLegacyTransactions(ixToSend);
     await this.sendAllTransactions(txToSend);
     return proposalAddress;
   }

--- a/governance/xc_admin/packages/xc_admin_frontend/hooks/usePyth.ts
+++ b/governance/xc_admin/packages/xc_admin_frontend/hooks/usePyth.ts
@@ -74,9 +74,11 @@ const usePyth = (): PythHookData => {
     connectionRef.current = connection
     ;(async () => {
       try {
-        const allPythAccounts = await connection.getProgramAccounts(
-          getPythProgramKeyForCluster(cluster)
-        )
+        const allPythAccounts = [
+          ...(await connection.getProgramAccounts(
+            getPythProgramKeyForCluster(cluster)
+          )),
+        ]
         if (cancelled) return
         const priceRawConfigs: { [key: string]: PriceRawConfig } = {}
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "target_chains/ethereum/examples/oracle_swap/app",
     "target_chains/sui/sdk/js",
     "target_chains/sui/cli",
+    "target_chains/solana/sdk/js/solana_utils",
     "contract_manager"
   ],
   "dependencies": {

--- a/target_chains/solana/sdk/js/solana_utils/.eslintrc.js
+++ b/target_chains/solana/sdk/js/solana_utils/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  root: true,
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint"],
+  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  rules: {
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/ban-ts-comment": "off",
+  },
+};

--- a/target_chains/solana/sdk/js/solana_utils/.gitignore
+++ b/target_chains/solana/sdk/js/solana_utils/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+lib

--- a/target_chains/solana/sdk/js/solana_utils/jest.config.js
+++ b/target_chains/solana/sdk/js/solana_utils/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+};

--- a/target_chains/solana/sdk/js/solana_utils/package.json
+++ b/target_chains/solana/sdk/js/solana_utils/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@pythnetwork/solana-utils",
+  "version": "0.1.0",
+  "description": "Utility function for Solana",
+  "homepage": "https://pyth.network",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib/**/*"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pyth-network/pyth-crosschain.git",
+    "directory": "target_chains/solana/sdk/js"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "test": "jest",
+    "build": "tsc",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "lint": "eslint src/",
+    "prepublishOnly": "npm run build && npm test && npm run lint",
+    "preversion": "npm run lint",
+    "version": "npm run format && git add -A src"
+  },
+  "keywords": [
+    "pyth",
+    "oracle"
+  ],
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@types/jest": "^29.4.0",
+    "@typescript-eslint/eslint-plugin": "^5.20.0",
+    "@typescript-eslint/parser": "^5.20.0",
+    "eslint": "^8.13.0",
+    "jest": "^29.4.0",
+    "prettier": "^2.6.2",
+    "quicktype": "^23.0.76",
+    "ts-jest": "^29.0.5",
+    "typescript": "^4.6.3"
+  },
+  "dependencies": {
+    "@coral-xyz/anchor": "^0.29.0",
+    "@solana/web3.js": "^1.90.0"
+  }
+}

--- a/target_chains/solana/sdk/js/solana_utils/package.json
+++ b/target_chains/solana/sdk/js/solana_utils/package.json
@@ -42,7 +42,6 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "^0.29.0",
     "@solana/web3.js": "^1.90.0"
   }
 }

--- a/target_chains/solana/sdk/js/solana_utils/package.json
+++ b/target_chains/solana/sdk/js/solana_utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pythnetwork/solana-utils",
   "version": "0.1.0",
-  "description": "Utility function for Solana",
+  "description": "Utility functions for Solana",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/target_chains/solana/sdk/js/solana_utils/package.json
+++ b/target_chains/solana/sdk/js/solana_utils/package.json
@@ -11,7 +11,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/pyth-network/pyth-crosschain.git",
-    "directory": "target_chains/solana/sdk/js"
+    "directory": "target_chains/solana/sdk/js/solana_utils"
   },
   "publishConfig": {
     "access": "public"

--- a/target_chains/solana/sdk/js/solana_utils/src/__tests__/TransactionSize.test.ts
+++ b/target_chains/solana/sdk/js/solana_utils/src/__tests__/TransactionSize.test.ts
@@ -9,7 +9,6 @@ import {
   VersionedTransaction,
 } from "@solana/web3.js";
 import { getSizeOfCompressedU16, getSizeOfTransaction } from "..";
-import { TOKEN_PROGRAM_ID } from "@coral-xyz/anchor/dist/cjs/utils/token";
 
 it("Unit test compressed u16 size", async () => {
   expect(getSizeOfCompressedU16(127)).toBe(1);
@@ -50,7 +49,7 @@ it("Unit test for getSizeOfTransaction", async () => {
   ixsToSend.push(
     new TransactionInstruction({
       keys: [{ pubkey: PublicKey.unique(), isSigner: true, isWritable: true }],
-      programId: TOKEN_PROGRAM_ID,
+      programId: PublicKey.unique(),
       data: Buffer.from([1, 2, 3]),
     })
   );

--- a/target_chains/solana/sdk/js/solana_utils/src/__tests__/TransactionSize.test.ts
+++ b/target_chains/solana/sdk/js/solana_utils/src/__tests__/TransactionSize.test.ts
@@ -61,7 +61,7 @@ it("Unit test for getSizeOfTransaction", async () => {
   );
 
   const transaction = new Transaction();
-  for (let ix of ixsToSend) {
+  for (const ix of ixsToSend) {
     transaction.add(ix);
   }
 

--- a/target_chains/solana/sdk/js/solana_utils/src/__tests__/TransactionSize.test.ts
+++ b/target_chains/solana/sdk/js/solana_utils/src/__tests__/TransactionSize.test.ts
@@ -1,0 +1,85 @@
+import {
+  ComputeBudgetProgram,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import { getSizeOfCompressedU16, getSizeOfTransaction } from "..";
+import { TOKEN_PROGRAM_ID } from "@coral-xyz/anchor/dist/cjs/utils/token";
+
+it("Unit test compressed u16 size", async () => {
+  expect(getSizeOfCompressedU16(127)).toBe(1);
+  expect(getSizeOfCompressedU16(128)).toBe(2);
+  expect(getSizeOfCompressedU16(16383)).toBe(2);
+  expect(getSizeOfCompressedU16(16384)).toBe(3);
+});
+
+it("Unit test for getSizeOfTransaction", async () => {
+  jest.setTimeout(60000);
+
+  const payer = new Keypair();
+
+  const ixsToSend: TransactionInstruction[] = [];
+
+  ixsToSend.push(
+    SystemProgram.createAccount({
+      fromPubkey: payer.publicKey,
+      newAccountPubkey: PublicKey.unique(),
+      space: 100,
+      lamports: 1000000000,
+      programId: SystemProgram.programId,
+    })
+  );
+
+  ixsToSend.push(
+    SystemProgram.createAccountWithSeed({
+      fromPubkey: PublicKey.unique(),
+      basePubkey: PublicKey.unique(),
+      seed: "seed",
+      newAccountPubkey: PublicKey.unique(),
+      space: 100,
+      lamports: 1000000000,
+      programId: SystemProgram.programId,
+    })
+  );
+
+  ixsToSend.push(
+    new TransactionInstruction({
+      keys: [{ pubkey: PublicKey.unique(), isSigner: true, isWritable: true }],
+      programId: TOKEN_PROGRAM_ID,
+      data: Buffer.from([1, 2, 3]),
+    })
+  );
+
+  ixsToSend.push(ComputeBudgetProgram.setComputeUnitLimit({ units: 69 }));
+
+  ixsToSend.push(
+    ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 1000000 })
+  );
+
+  const transaction = new Transaction();
+  for (let ix of ixsToSend) {
+    transaction.add(ix);
+  }
+
+  transaction.recentBlockhash = "GqdFtdM7zzWw33YyHtBNwPhyBsdYKcfm9gT47bWnbHvs"; // Mock blockhash from devnet
+  transaction.feePayer = payer.publicKey;
+  expect(transaction.serialize({ requireAllSignatures: false }).length).toBe(
+    getSizeOfTransaction(ixsToSend, false)
+  );
+
+  const versionedTransaction = new VersionedTransaction(
+    new TransactionMessage({
+      recentBlockhash: transaction.recentBlockhash,
+      payerKey: payer.publicKey,
+      instructions: ixsToSend,
+    }).compileToV0Message()
+  );
+  expect(versionedTransaction.serialize().length).toBe(
+    getSizeOfTransaction(ixsToSend)
+  );
+});

--- a/target_chains/solana/sdk/js/solana_utils/src/index.ts
+++ b/target_chains/solana/sdk/js/solana_utils/src/index.ts
@@ -1,0 +1,5 @@
+export {
+  getSizeOfTransaction,
+  getSizeOfCompressedU16,
+  TransactionBuilder,
+} from "./transaction";

--- a/target_chains/solana/sdk/js/solana_utils/src/transaction.ts
+++ b/target_chains/solana/sdk/js/solana_utils/src/transaction.ts
@@ -1,0 +1,143 @@
+import {
+  Connection,
+  PACKET_DATA_SIZE,
+  PublicKey,
+  Signer,
+  Transaction,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+
+/**
+ * Get the size of a transaction that would contain the provided array of instructions
+ */
+export function getSizeOfTransaction(
+  instructions: TransactionInstruction[],
+  versionedTransaction = true
+): number {
+  const signers = new Set<string>();
+  const accounts = new Set<string>();
+
+  instructions.map((ix) => {
+    accounts.add(ix.programId.toBase58()),
+      ix.keys.map((key) => {
+        if (key.isSigner) {
+          signers.add(key.pubkey.toBase58());
+        }
+        accounts.add(key.pubkey.toBase58());
+      });
+  });
+
+  const instruction_sizes: number = instructions
+    .map(
+      (ix) =>
+        1 +
+        getSizeOfCompressedU16(ix.keys.length) +
+        ix.keys.length +
+        getSizeOfCompressedU16(ix.data.length) +
+        ix.data.length
+    )
+    .reduce((a, b) => a + b, 0);
+
+  return (
+    1 +
+    signers.size * 64 +
+    3 +
+    getSizeOfCompressedU16(accounts.size) +
+    32 * accounts.size +
+    32 +
+    getSizeOfCompressedU16(instructions.length) +
+    instruction_sizes +
+    (versionedTransaction ? 1 + getSizeOfCompressedU16(0) : 0)
+  );
+}
+
+/**
+ * Get the size of n in bytes when serialized as a CompressedU16
+ */
+export function getSizeOfCompressedU16(n: number) {
+  return 1 + Number(n >= 128) + Number(n >= 16384);
+}
+
+export class TransactionBuilder {
+  readonly transactionInstructions: {
+    instructions: TransactionInstruction[];
+    signers: Signer[];
+  }[] = [];
+  readonly payer: PublicKey;
+  readonly connection: Connection;
+
+  constructor(payer: PublicKey, connection: Connection) {
+    this.payer = payer;
+    this.connection = connection;
+  }
+
+  addInstruction(instruction: TransactionInstruction, signers: Signer[]) {
+    if (this.transactionInstructions.length === 0) {
+      this.transactionInstructions.push({
+        instructions: [instruction],
+        signers: signers,
+      });
+    } else if (
+      getSizeOfTransaction([
+        ...this.transactionInstructions[this.transactionInstructions.length - 1]
+          .instructions,
+        instruction,
+      ]) <= PACKET_DATA_SIZE
+    ) {
+      this.transactionInstructions[
+        this.transactionInstructions.length - 1
+      ].instructions.push(instruction);
+      this.transactionInstructions[
+        this.transactionInstructions.length - 1
+      ].signers.push(...signers);
+    } else
+      this.transactionInstructions.push({
+        instructions: [instruction],
+        signers: signers,
+      });
+  }
+
+  async getVersionedTransactions(): Promise<
+    { tx: VersionedTransaction; signers: Signer[] }[]
+  > {
+    const blockhash = (await this.connection.getLatestBlockhash()).blockhash;
+    return this.transactionInstructions.map(({ instructions, signers }) => {
+      return {
+        tx: new VersionedTransaction(
+          new TransactionMessage({
+            recentBlockhash: blockhash,
+            instructions: instructions,
+            payerKey: this.payer,
+          }).compileToV0Message()
+        ),
+        signers: signers,
+      };
+    });
+  }
+
+  getLegacyTransactions(): { tx: Transaction; signers: Signer[] }[] {
+    return this.transactionInstructions.map(({ instructions, signers }) => {
+      return {
+        tx: new Transaction().add(...instructions),
+        signers: signers,
+      };
+    });
+  }
+
+  static batchIntoLegacyTransactions(
+    instructions: TransactionInstruction[]
+  ): Transaction[] {
+    const transactionBuilder = new TransactionBuilder(
+      PublicKey.unique(),
+      new Connection("http://placeholder.placeholder")
+    ); // We only need wallet and connection for versionedTransaction so we can put placeholders here
+    for (let instruction of instructions) {
+      transactionBuilder.addInstruction(instruction, []);
+    }
+    return transactionBuilder.getLegacyTransactions().map(({ tx }) => {
+      return tx;
+    });
+  }
+}

--- a/target_chains/solana/sdk/js/solana_utils/src/transaction.ts
+++ b/target_chains/solana/sdk/js/solana_utils/src/transaction.ts
@@ -60,6 +60,10 @@ export function getSizeOfCompressedU16(n: number) {
   return 1 + Number(n >= 128) + Number(n >= 16384);
 }
 
+/**
+ * This class is helpful for batching instructions into transactions in an efficient way.
+ * As you add instructions, it adds them to the current transactions until it's full, then it starts a new transaction.
+ */
 export class TransactionBuilder {
   readonly transactionInstructions: {
     instructions: TransactionInstruction[];
@@ -73,6 +77,10 @@ export class TransactionBuilder {
     this.connection = connection;
   }
 
+  /**
+   * Add an instruction to the builder, the signers argument can be used to specify ephemeral signers that need to sign the transaction
+   * where this instruction appears
+   */
   addInstruction(instruction: TransactionInstruction, signers: Signer[]) {
     if (this.transactionInstructions.length === 0) {
       this.transactionInstructions.push({
@@ -99,6 +107,9 @@ export class TransactionBuilder {
       });
   }
 
+  /**
+   * Returns all the added instructions batched into transactions, plus for each transaction the ephemeral signers that need to sign it
+   */
   async getVersionedTransactions(): Promise<
     { tx: VersionedTransaction; signers: Signer[] }[]
   > {
@@ -117,6 +128,9 @@ export class TransactionBuilder {
     });
   }
 
+  /**
+   * Returns all the added instructions batched into transactions, plus for each transaction the ephemeral signers that need to sign it
+   */
   getLegacyTransactions(): { tx: Transaction; signers: Signer[] }[] {
     return this.transactionInstructions.map(({ instructions, signers }) => {
       return {

--- a/target_chains/solana/sdk/js/solana_utils/src/transaction.ts
+++ b/target_chains/solana/sdk/js/solana_utils/src/transaction.ts
@@ -147,7 +147,7 @@ export class TransactionBuilder {
       PublicKey.unique(),
       new Connection("http://placeholder.placeholder")
     ); // We only need wallet and connection for `VersionedTransaction` so we can put placeholders here
-    for (let instruction of instructions) {
+    for (const instruction of instructions) {
       transactionBuilder.addInstruction(instruction, []);
     }
     return transactionBuilder.getLegacyTransactions().map(({ tx }) => {

--- a/target_chains/solana/sdk/js/solana_utils/src/transaction.ts
+++ b/target_chains/solana/sdk/js/solana_utils/src/transaction.ts
@@ -146,7 +146,7 @@ export class TransactionBuilder {
     const transactionBuilder = new TransactionBuilder(
       PublicKey.unique(),
       new Connection("http://placeholder.placeholder")
-    ); // We only need wallet and connection for versionedTransaction so we can put placeholders here
+    ); // We only need wallet and connection for `VersionedTransaction` so we can put placeholders here
     for (let instruction of instructions) {
       transactionBuilder.addInstruction(instruction, []);
     }

--- a/target_chains/solana/sdk/js/solana_utils/tsconfig.json
+++ b/target_chains/solana/sdk/js/solana_utils/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.json"],
+  "exclude": ["node_modules", "**/__tests__/*"],
+  "compilerOptions": {
+    "rootDir": "src/",
+    "outDir": "./lib"
+  }
+}


### PR DESCRIPTION
I wanted to use this batching logic in the pyth receiver sdk for Solana, so I'm moving it to a place where both `xc-admin-common` and `pyth-receiver-solana` can use it