### PR TITLE
fix(solana-receiver-js): Add test script to make prepublishOnly work

### DIFF
--- a/target_chains/solana/sdk/js/pyth_solana_receiver/package.json
+++ b/target_chains/solana/sdk/js/pyth_solana_receiver/package.json
@@ -20,6 +20,7 @@
     "build": "tsc",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint src/",
+    "test": "jest src/ --passWithNoTests",
     "prepublishOnly": "npm run build && npm test && npm run lint",
     "preversion": "npm run lint",
     "version": "npm run format && git add -A src"


### PR DESCRIPTION
Publish workflow is failing because this package `prepublishOnly` script does not run successfuly.