### PR TITLE
fix: solana audit 2

### DIFF
--- a/target_chains/solana/programs/pyth-solana-receiver/tests/common/mod.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/tests/common/mod.rs
@@ -8,8 +8,6 @@ use {
             get_config_address,
             get_guardian_set_address,
             get_treasury_address,
-            DEFAULT_TREASURY_ID,
-            SECONDARY_TREASURY_ID,
         },
         ID,
     },
@@ -201,22 +199,6 @@ pub async fn setup_pyth_receiver(
         .unwrap();
     assert_eq!(config_account, initial_config);
 
-    program_simulator
-        .airdrop(
-            &get_treasury_address(DEFAULT_TREASURY_ID),
-            Rent::default().minimum_balance(0),
-        )
-        .await
-        .unwrap();
-
-    program_simulator
-        .airdrop(
-            &get_treasury_address(SECONDARY_TREASURY_ID),
-            Rent::default().minimum_balance(0),
-        )
-        .await
-        .unwrap();
-
     ProgramTestFixtures {
         program_simulator,
         encoded_vaa_addresses,
@@ -234,8 +216,5 @@ pub async fn assert_treasury_balance(
         .await
         .unwrap();
 
-    assert_eq!(
-        treasury_balance,
-        expected_balance + Rent::default().minimum_balance(0)
-    );
+    assert_eq!(treasury_balance, expected_balance);
 }

--- a/target_chains/solana/programs/pyth-solana-receiver/tests/test_post_price_update_from_vaa.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/tests/test_post_price_update_from_vaa.rs
@@ -43,6 +43,7 @@ use {
         pubkey::Pubkey,
     },
     solana_sdk::{
+        rent::Rent,
         signature::Keypair,
         signer::Signer,
     },
@@ -332,7 +333,12 @@ async fn test_post_price_update_from_vaa() {
         .await
         .unwrap();
 
-    assert_treasury_balance(&mut program_simulator, 1, DEFAULT_TREASURY_ID).await;
+    assert_treasury_balance(
+        &mut program_simulator,
+        Rent::default().minimum_balance(0),
+        DEFAULT_TREASURY_ID,
+    )
+    .await;
 
     let mut price_update_account = program_simulator
         .get_anchor_account_data::<PriceUpdateV1>(price_update_keypair.pubkey())
@@ -382,7 +388,12 @@ async fn test_post_price_update_from_vaa() {
         into_transaction_error(ReceiverError::InsufficientFunds)
     );
 
-    assert_treasury_balance(&mut program_simulator, 1, DEFAULT_TREASURY_ID).await;
+    assert_treasury_balance(
+        &mut program_simulator,
+        Rent::default().minimum_balance(0),
+        DEFAULT_TREASURY_ID,
+    )
+    .await;
 
     price_update_account = program_simulator
         .get_anchor_account_data::<PriceUpdateV1>(price_update_keypair.pubkey())
@@ -432,7 +443,7 @@ async fn test_post_price_update_from_vaa() {
 
     assert_treasury_balance(
         &mut program_simulator,
-        LAMPORTS_PER_SOL + 1,
+        Rent::default().minimum_balance(0) + LAMPORTS_PER_SOL,
         DEFAULT_TREASURY_ID,
     )
     .await;

--- a/target_chains/solana/programs/pyth-solana-receiver/tests/test_post_updates.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/tests/test_post_updates.rs
@@ -32,6 +32,7 @@ use {
     },
     solana_program::pubkey::Pubkey,
     solana_sdk::{
+        rent::Rent,
         signature::Keypair,
         signer::Signer,
     },
@@ -78,7 +79,12 @@ async fn test_post_update() {
         .await
         .unwrap();
 
-    assert_treasury_balance(&mut program_simulator, 1, DEFAULT_TREASURY_ID).await;
+    assert_treasury_balance(
+        &mut program_simulator,
+        Rent::default().minimum_balance(0),
+        DEFAULT_TREASURY_ID,
+    )
+    .await;
 
     let mut price_update_account = program_simulator
         .get_anchor_account_data::<PriceUpdateV1>(price_update_keypair.pubkey())
@@ -110,7 +116,12 @@ async fn test_post_update() {
         .await
         .unwrap();
 
-    assert_treasury_balance(&mut program_simulator, 2, DEFAULT_TREASURY_ID).await;
+    assert_treasury_balance(
+        &mut program_simulator,
+        Rent::default().minimum_balance(0) + 1,
+        DEFAULT_TREASURY_ID,
+    )
+    .await;
 
     price_update_account = program_simulator
         .get_anchor_account_data::<PriceUpdateV1>(price_update_keypair.pubkey())

--- a/target_chains/solana/programs/pyth-solana-receiver/tests/test_post_updates_atomic.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/tests/test_post_updates_atomic.rs
@@ -33,6 +33,7 @@ use {
     },
     serde_wormhole::RawMessage,
     solana_sdk::{
+        rent::Rent,
         signature::Keypair,
         signer::Signer,
     },
@@ -84,7 +85,12 @@ async fn test_post_update_atomic() {
         .await
         .unwrap();
 
-    assert_treasury_balance(&mut program_simulator, 1, DEFAULT_TREASURY_ID).await;
+    assert_treasury_balance(
+        &mut program_simulator,
+        Rent::default().minimum_balance(0),
+        DEFAULT_TREASURY_ID,
+    )
+    .await;
 
     let mut price_update_account = program_simulator
         .get_anchor_account_data::<PriceUpdateV1>(price_update_keypair.pubkey())
@@ -119,7 +125,12 @@ async fn test_post_update_atomic() {
         .await
         .unwrap();
 
-    assert_treasury_balance(&mut program_simulator, 2, DEFAULT_TREASURY_ID).await;
+    assert_treasury_balance(
+        &mut program_simulator,
+        Rent::default().minimum_balance(0) + 1,
+        DEFAULT_TREASURY_ID,
+    )
+    .await;
     assert_treasury_balance(&mut program_simulator, 0, SECONDARY_TREASURY_ID).await;
 
     price_update_account = program_simulator
@@ -155,8 +166,18 @@ async fn test_post_update_atomic() {
         .await
         .unwrap();
 
-    assert_treasury_balance(&mut program_simulator, 2, DEFAULT_TREASURY_ID).await;
-    assert_treasury_balance(&mut program_simulator, 1, SECONDARY_TREASURY_ID).await;
+    assert_treasury_balance(
+        &mut program_simulator,
+        Rent::default().minimum_balance(0) + 1,
+        DEFAULT_TREASURY_ID,
+    )
+    .await;
+    assert_treasury_balance(
+        &mut program_simulator,
+        Rent::default().minimum_balance(0),
+        SECONDARY_TREASURY_ID,
+    )
+    .await;
 
     price_update_account = program_simulator
         .get_anchor_account_data::<PriceUpdateV1>(price_update_keypair.pubkey())


### PR DESCRIPTION
The big change here to review is the following. Previously during setup we had to pay rent of the treasury accounts otherwise when you send 1 lamport that doesn't cover the rent and it would fail. Now the first person to use a treasury account will pay the rent 0.0009 SOL. It makes it more ergonomic to deploy.

Other changes:
- move minimum signatures check for consistency with the Wormhole codebase
- try_deserialize_unchecked -> try_deserialize for the guardian check
