### PR TITLE
fix: solana audit 3

### DIFF
--- a/target_chains/solana/programs/pyth-solana-receiver/src/sdk.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/src/sdk.rs
@@ -238,6 +238,17 @@ impl instruction::RequestGovernanceAuthorityTransfer {
     }
 }
 
+impl instruction::CancelGovernanceAuthorityTransfer {
+    pub fn populate(payer: Pubkey) -> Instruction {
+        let governance_accounts = accounts::Governance::populate(payer).to_account_metas(None);
+        Instruction {
+            program_id: ID,
+            accounts:   governance_accounts,
+            data:       instruction::CancelGovernanceAuthorityTransfer.data(),
+        }
+    }
+}
+
 impl instruction::AcceptGovernanceAuthorityTransfer {
     pub fn populate(payer: Pubkey) -> Instruction {
         let governance_accounts =

--- a/target_chains/solana/programs/pyth-solana-receiver/tests/test_governance.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/tests/test_governance.rs
@@ -384,7 +384,10 @@ async fn test_governance() {
         .await
         .unwrap();
 
-
+    current_config = program_simulator
+        .get_anchor_account_data::<Config>(get_config_address())
+        .await
+        .unwrap();
     assert_eq!(
         current_config.governance_authority,
         initial_config.governance_authority
@@ -408,14 +411,20 @@ async fn test_governance() {
     // Redo the request
     program_simulator
         .process_ix_with_default_compute_limit(
-            CancelGovernanceAuthorityTransfer::populate(governance_authority.pubkey()),
+            RequestGovernanceAuthorityTransfer::populate(
+                governance_authority.pubkey(),
+                new_governance_authority.pubkey(),
+            ),
             &vec![&governance_authority],
             None,
         )
         .await
         .unwrap();
 
-
+    current_config = program_simulator
+        .get_anchor_account_data::<Config>(get_config_address())
+        .await
+        .unwrap();
     assert_eq!(
         current_config.governance_authority,
         initial_config.governance_authority

--- a/target_chains/solana/programs/pyth-solana-receiver/tests/test_governance.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/tests/test_governance.rs
@@ -9,6 +9,7 @@ use {
         error::ReceiverError,
         instruction::{
             AcceptGovernanceAuthorityTransfer,
+            CancelGovernanceAuthorityTransfer,
             RequestGovernanceAuthorityTransfer,
             SetDataSources,
             SetFee,
@@ -371,6 +372,72 @@ async fn test_governance() {
             .unwrap(),
         into_transaction_error(ReceiverError::TargetGovernanceAuthorityMismatch)
     );
+
+
+    // Undo the request
+    program_simulator
+        .process_ix_with_default_compute_limit(
+            CancelGovernanceAuthorityTransfer::populate(governance_authority.pubkey()),
+            &vec![&governance_authority],
+            None,
+        )
+        .await
+        .unwrap();
+
+
+    assert_eq!(
+        current_config.governance_authority,
+        initial_config.governance_authority
+    );
+    assert_eq!(current_config.target_governance_authority, None);
+    assert_eq!(current_config.wormhole, new_config.wormhole);
+    assert_eq!(
+        current_config.valid_data_sources,
+        new_config.valid_data_sources
+    );
+    assert_eq!(
+        current_config.single_update_fee_in_lamports,
+        new_config.single_update_fee_in_lamports
+    );
+    assert_eq!(
+        current_config.minimum_signatures,
+        new_config.minimum_signatures
+    );
+
+
+    // Redo the request
+    program_simulator
+        .process_ix_with_default_compute_limit(
+            CancelGovernanceAuthorityTransfer::populate(governance_authority.pubkey()),
+            &vec![&governance_authority],
+            None,
+        )
+        .await
+        .unwrap();
+
+
+    assert_eq!(
+        current_config.governance_authority,
+        initial_config.governance_authority
+    );
+    assert_eq!(
+        current_config.target_governance_authority,
+        Some(new_governance_authority.pubkey())
+    );
+    assert_eq!(current_config.wormhole, new_config.wormhole);
+    assert_eq!(
+        current_config.valid_data_sources,
+        new_config.valid_data_sources
+    );
+    assert_eq!(
+        current_config.single_update_fee_in_lamports,
+        new_config.single_update_fee_in_lamports
+    );
+    assert_eq!(
+        current_config.minimum_signatures,
+        new_config.minimum_signatures
+    );
+
 
     // New authority can accept
     program_simulator

--- a/target_chains/solana/programs/pyth-solana-receiver/tests/test_post_price_update_from_vaa.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/tests/test_post_price_update_from_vaa.rs
@@ -34,6 +34,7 @@ use {
             create_accumulator_message,
             create_dummy_price_feed_message,
             create_dummy_twap_message,
+            trim_vaa_signatures,
             DEFAULT_DATA_SOURCE,
             SECONDARY_DATA_SOURCE,
         },
@@ -348,7 +349,7 @@ async fn test_post_price_update_from_vaa() {
     assert_eq!(price_update_account.write_authority, poster.pubkey());
     assert_eq!(
         price_update_account.verification_level,
-        VerificationLevel::Partial { num_signatures: 13 }
+        VerificationLevel::Full
     );
     assert_eq!(
         Message::PriceFeedMessage(price_update_account.price_message),
@@ -366,6 +367,12 @@ async fn test_post_price_update_from_vaa() {
         .await
         .unwrap();
 
+    // Change number of signatures too
+    let vaa = serde_wormhole::to_vec(&trim_vaa_signatures(
+        serde_wormhole::from_slice(&vaa).unwrap(),
+        12,
+    ))
+    .unwrap();
 
     assert_eq!(
         program_simulator
@@ -402,7 +409,7 @@ async fn test_post_price_update_from_vaa() {
     assert_eq!(price_update_account.write_authority, poster.pubkey());
     assert_eq!(
         price_update_account.verification_level,
-        VerificationLevel::Partial { num_signatures: 13 }
+        VerificationLevel::Full
     );
     assert_eq!(
         Message::PriceFeedMessage(price_update_account.price_message),
@@ -455,7 +462,7 @@ async fn test_post_price_update_from_vaa() {
     assert_eq!(price_update_account.write_authority, poster.pubkey());
     assert_eq!(
         price_update_account.verification_level,
-        VerificationLevel::Partial { num_signatures: 13 },
+        VerificationLevel::Partial { num_signatures: 12 }
     );
     assert_eq!(
         Message::PriceFeedMessage(price_update_account.price_message),

--- a/target_chains/solana/programs/pyth-solana-receiver/tests/test_post_price_update_from_vaa.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/tests/test_post_price_update_from_vaa.rs
@@ -402,6 +402,7 @@ async fn test_post_price_update_from_vaa() {
     )
     .await;
 
+    // Transaction failed, so the account should not have been updated
     price_update_account = program_simulator
         .get_anchor_account_data::<PriceUpdateV1>(price_update_keypair.pubkey())
         .await


### PR DESCRIPTION
- allow post_update_atomic to return VerificationLevel::Full if it meets guardian quorum
- add cancel_governance_authority_transfer instruction