### PR TITLE
chore(target_chains/sui): update sui js packages

### DIFF
--- a/contract_manager/package.json
+++ b/contract_manager/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@certusone/wormhole-sdk": "^0.9.8",
     "@injectivelabs/networks": "1.0.68",
-    "@mysten/sui.js": "^0.37.1",
+    "@mysten/sui.js": "^0.49.1",
     "@pythnetwork/cosmwasm-deploy-tools": "*",
     "@pythnetwork/entropy-sdk-solidity": "*",
     "@pythnetwork/price-service-client": "*",
@@ -32,7 +32,7 @@
     "aptos": "^1.5.0",
     "bs58": "^5.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.3"
+    "typescript": "^5.3.3"
   },
   "devDependencies": {
     "prettier": "^2.6.2",

--- a/contract_manager/src/chains.ts
+++ b/contract_manager/src/chains.ts
@@ -20,12 +20,8 @@ import {
   InjectiveExecutor,
 } from "@pythnetwork/cosmwasm-deploy-tools";
 import { Network } from "@injectivelabs/networks";
-import {
-  Connection,
-  Ed25519Keypair,
-  JsonRpcProvider,
-  RawSigner,
-} from "@mysten/sui.js";
+import { SuiClient } from "@mysten/sui.js/client";
+import { Ed25519Keypair } from "@mysten/sui.js/keypairs/ed25519";
 
 export type ChainConfig = Record<string, string> & {
   mainnet: boolean;
@@ -290,17 +286,15 @@ export class SuiChain extends Chain {
     ).encode();
   }
 
-  getProvider(): JsonRpcProvider {
-    return new JsonRpcProvider(new Connection({ fullnode: this.rpcUrl }));
+  getProvider(): SuiClient {
+    return new SuiClient({ url: this.rpcUrl });
   }
 
   async getAccountAddress(privateKey: PrivateKey): Promise<string> {
-    const provider = this.getProvider();
     const keypair = Ed25519Keypair.fromSecretKey(
       Buffer.from(privateKey, "hex")
     );
-    const wallet = new RawSigner(keypair, provider);
-    return await wallet.getAddress();
+    return keypair.toSuiAddress();
   }
 
   async getAccountBalance(privateKey: PrivateKey): Promise<number> {

--- a/contract_manager/src/contracts/sui.ts
+++ b/contract_manager/src/contracts/sui.ts
@@ -1,14 +1,12 @@
-import {
-  Ed25519Keypair,
-  ObjectId,
-  RawSigner,
-  SUI_CLOCK_OBJECT_ID,
-  TransactionBlock,
-} from "@mysten/sui.js";
 import { Chain, SuiChain } from "../chains";
 import { DataSource } from "xc_admin_common";
 import { PriceFeedContract, PrivateKey, TxResult } from "../base";
 import { SuiPythClient } from "@pythnetwork/pyth-sui-js";
+import { SUI_CLOCK_OBJECT_ID } from "@mysten/sui.js/utils";
+import { Ed25519Keypair } from "@mysten/sui.js/keypairs/ed25519";
+import { TransactionBlock } from "@mysten/sui.js/transactions";
+
+type ObjectId = string;
 
 export class SuiPriceFeedContract extends PriceFeedContract {
   static type = "SuiPriceFeedContract";
@@ -96,13 +94,6 @@ export class SuiPriceFeedContract extends PriceFeedContract {
       timestamp: string;
     };
   }) {
-    const packageId = await this.getPythPackageId();
-    const expectedType = `${packageId}::price::Price`;
-    if (priceInfo.type !== expectedType) {
-      throw new Error(
-        `Price type mismatch, expected ${expectedType} but found ${priceInfo.type}`
-      );
-    }
     let expo = priceInfo.fields.expo.fields.magnitude;
     if (priceInfo.fields.expo.fields.negative) expo = "-" + expo;
     let price = priceInfo.fields.price.fields.magnitude;
@@ -135,10 +126,14 @@ export class SuiPriceFeedContract extends PriceFeedContract {
     }
     return {
       emaPrice: await this.parsePrice(
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         priceInfo.data.content.fields.price_info.fields.price_feed.fields
           .ema_price
       ),
       price: await this.parsePrice(
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         priceInfo.data.content.fields.price_info.fields.price_feed.fields.price
       ),
     };
@@ -303,21 +298,25 @@ export class SuiPriceFeedContract extends PriceFeedContract {
     keypair: Ed25519Keypair
   ) {
     const provider = this.getProvider();
-    const txBlock = {
+    tx.setSender(keypair.toSuiAddress());
+    const dryRun = await provider.dryRunTransactionBlock({
+      transactionBlock: await tx.build({ client: provider }),
+    });
+    tx.setGasBudget(BigInt(dryRun.input.gasData.budget.toString()) * BigInt(2));
+    return provider.signAndExecuteTransactionBlock({
+      signer: keypair,
       transactionBlock: tx,
       options: {
         showEffects: true,
         showEvents: true,
       },
-    };
-    const wallet = new RawSigner(keypair, provider);
-    const gasCost = await wallet.getGasCostEstimation(txBlock);
-    tx.setGasBudget(gasCost * BigInt(2));
-    return wallet.signAndExecuteTransactionBlock(txBlock);
+    });
   }
 
   async getValidTimePeriod() {
     const fields = await this.getStateFields();
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     return Number(fields.stale_price_threshold);
   }
 
@@ -338,6 +337,8 @@ export class SuiPriceFeedContract extends PriceFeedContract {
     if (result.data.content.dataType !== "moveObject") {
       throw new Error("Data Sources type mismatch");
     }
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     return result.data.content.fields.value.fields.keys.map(
       ({
         fields,
@@ -359,6 +360,8 @@ export class SuiPriceFeedContract extends PriceFeedContract {
 
   async getGovernanceDataSource(): Promise<DataSource> {
     const fields = await this.getStateFields();
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     const governanceFields = fields.governance_data_source.fields;
     const chainId = governanceFields.emitter_chain;
     const emitterAddress =
@@ -371,11 +374,15 @@ export class SuiPriceFeedContract extends PriceFeedContract {
 
   async getBaseUpdateFee() {
     const fields = await this.getStateFields();
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     return { amount: fields.base_update_fee };
   }
 
   async getLastExecutedGovernanceSequence() {
     const fields = await this.getStateFields();
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     return Number(fields.last_executed_governance_sequence);
   }
 

--- a/contract_manager/store/contracts/SuiPriceFeedContracts.yaml
+++ b/contract_manager/store/contracts/SuiPriceFeedContracts.yaml
@@ -1,14 +1,6 @@
 - chain: sui_mainnet
-  stateId: "0xf9ff3ef935ef6cdfb659a203bf2754cebeb63346e29114a535ea6f41315e5a3f"
-  wormholeStateId: "0xaeab97f96cf9877fee2883315d459552b2b921edc16d7ceac6eab944dd88919c"
-  type: SuiPriceFeedContract
-- chain: sui_mainnet
   stateId: "0x1f9310238ee9298fb703c3419030b35b22bb1cc37113e3bb5007c99aec79e5b8"
   wormholeStateId: "0xaeab97f96cf9877fee2883315d459552b2b921edc16d7ceac6eab944dd88919c"
-  type: SuiPriceFeedContract
-- chain: sui_testnet
-  stateId: "0xb3142a723792001caafc601b7c6fe38f09f3684e360b56d8d90fc574e71e75f3"
-  wormholeStateId: "0xebba4cc4d614f7a7cdbe883acc76d1cc767922bc96778e7b68be0d15fce27c02"
   type: SuiPriceFeedContract
 - chain: sui_testnet
   stateId: "0x2d82612a354f0b7e52809fc2845642911c7190404620cec8688f68808f8800d8"

--- a/price_pusher/package.json
+++ b/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/price_pusher/package.json
+++ b/price_pusher/package.json
@@ -45,14 +45,14 @@
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "@typescript-eslint/parser": "^5.20.0",
     "eslint": "^8.13.0",
-    "jest": "^27.5.1",
+    "jest": "^29.7.0",
     "prettier": "^2.6.2",
-    "ts-jest": "^27.1.4",
-    "typescript": "^4.6.3"
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.3.3"
   },
   "dependencies": {
     "@injectivelabs/sdk-ts": "1.10.72",
-    "@mysten/sui.js": "^0.37.1",
+    "@mysten/sui.js": "^0.49.1",
     "@pythnetwork/price-service-client": "*",
     "@pythnetwork/pyth-sdk-solidity": "*",
     "@pythnetwork/pyth-sui-js": "*",

--- a/price_pusher/src/sui/command.ts
+++ b/price_pusher/src/sui/command.ts
@@ -6,7 +6,7 @@ import { PythPriceListener } from "../pyth-price-listener";
 import { Controller } from "../controller";
 import { Options } from "yargs";
 import { SuiPriceListener, SuiPricePusher } from "./sui";
-import { Ed25519Keypair } from "@mysten/sui.js";
+import { Ed25519Keypair } from "@mysten/sui.js/keypairs/ed25519";
 
 export default {
   command: "sui",

--- a/target_chains/cosmwasm/deploy-scripts/package.json
+++ b/target_chains/cosmwasm/deploy-scripts/package.json
@@ -12,9 +12,10 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "rimraf": "^5.0.0",
     "@pythnetwork/cosmwasm-deploy-tools": "*",
     "contract_manager": "*",
+    "rimraf": "^5.0.0",
+    "typescript": "^5.3.3",
     "yargs": "^17.0.1"
   },
   "devDependencies": {

--- a/target_chains/sui/sdk/js/package.json
+++ b/target_chains/sui/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-sui-js",
-  "version": "1.2.5",
+  "version": "2.0.0",
   "description": "Pyth Network Sui Utilities",
   "homepage": "https://pyth.network",
   "author": {
@@ -48,13 +48,13 @@
     "jest": "^29.4.1",
     "prettier": "^2.6.2",
     "ts-jest": "^29.0.5",
-    "typescript": "^4.6.3",
+    "typescript": "^5.3.3",
     "web3": "^1.8.2",
     "yargs": "^17.0.20"
   },
   "dependencies": {
+    "@mysten/sui.js": "^0.49.1",
     "@pythnetwork/price-service-client": "*",
-    "@mysten/sui.js": "^0.37.1",
     "buffer": "^6.0.3"
   }
 }


### PR DESCRIPTION
Reopening #1294 as Github wasn't smart enough to pick up the rebase.

Upgraded to 0.49.1 which was fully backward incompatible 😭
Some getter functions (like getExecutionStatusError) were removed so replaced them with their internal logic
Upgraded typescript version when needed.
Removed batch attestation support
The typesystem got a lot stricter and had to ignore some errors for now. Otherwise, there would be lots of code for type narrowing.

Left to do:
- [ ] change the sdk to create the new price feed if it doesn't exist instead of throwing error