### PR TITLE
chore(target_chains/sui): update sui and wormhole dependency

### DIFF
--- a/.github/workflows/ci-sui-contract.yml
+++ b/.github/workflows/ci-sui-contract.yml
@@ -24,7 +24,7 @@ jobs:
         run: rustup update stable
 
       - name: Install Sui CLI
-        run: cargo install --locked --git https://github.com/MystenLabs/sui.git --rev 09b2081498366df936abae26eea4b2d5cafb2788 sui
+        run: cargo install --locked --git https://github.com/MystenLabs/sui.git --rev 041c5f2bae2fe52079e44b70514333532d69f4e6 sui
 
       - name: Run tests
         run: sui move test

--- a/target_chains/sui/contracts/Move.lock
+++ b/target_chains/sui/contracts/Move.lock
@@ -2,6 +2,8 @@
 
 [move]
 version = 0
+manifest_digest = "320300697C11C4D84BF6ED32C1DB48A4EE830B6B44F4DFDA4E89345875C5EA11"
+deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 
 dependencies = [
   { name = "Sui" },
@@ -10,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 name = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "09b2081498366df936abae26eea4b2d5cafb2788", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "041c5f2bae2fe52079e44b70514333532d69f4e6", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 name = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "09b2081498366df936abae26eea4b2d5cafb2788", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "041c5f2bae2fe52079e44b70514333532d69f4e6", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { name = "MoveStdlib" },
@@ -22,8 +24,13 @@ dependencies = [
 
 [[move.package]]
 name = "Wormhole"
-source = { git = "https://github.com/wormhole-foundation/wormhole.git", rev = "d050ad1d67a5b7da9fb65030aad12ef5d774ccad", subdir = "sui/wormhole" }
+source = { git = "https://github.com/wormhole-foundation/wormhole.git", rev = "82d82bffd5a8566e4b5d94be4e4678ad55ab1f4f", subdir = "sui/wormhole" }
 
 dependencies = [
   { name = "Sui" },
 ]
+
+[move.toolchain-version]
+compiler-version = "1.19.1"
+edition = "legacy"
+flavor = "sui"

--- a/target_chains/sui/contracts/Move.mainnet.toml
+++ b/target_chains/sui/contracts/Move.mainnet.toml
@@ -6,10 +6,12 @@ published-at = "0x04e20ddf36af412a4096f9014f4a565af9e812db9a05cc40254846cf6ed0ad
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
 subdir = "crates/sui-framework/packages/sui-framework"
-rev = "09b2081498366df936abae26eea4b2d5cafb2788"
+rev = "041c5f2bae2fe52079e44b70514333532d69f4e6"
 
 [dependencies.Wormhole]
-local = "../../../../wormhole/sui/wormhole"
+git = "https://github.com/wormhole-foundation/wormhole.git"
+subdir = "sui/wormhole"
+rev = "sui-upgrade-mainnet"
 
 [addresses]
 pyth = "0x0"

--- a/target_chains/sui/contracts/Move.testnet.toml
+++ b/target_chains/sui/contracts/Move.testnet.toml
@@ -6,10 +6,12 @@ published-at = "0xf7114cc10266d90c0c9e4b84455bddf29b40bd78fe56832c7ac98682c3daa9
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
 subdir = "crates/sui-framework/packages/sui-framework"
-rev = "09b2081498366df936abae26eea4b2d5cafb2788"
+rev = "041c5f2bae2fe52079e44b70514333532d69f4e6"
 
 [dependencies.Wormhole]
-local = "../../../../wormhole/sui/wormhole"
+git = "https://github.com/wormhole-foundation/wormhole.git"
+subdir = "sui/wormhole"
+rev = "sui-upgrade-testnet"
 
 [addresses]
 pyth = "0x0"

--- a/target_chains/sui/contracts/Move.toml
+++ b/target_chains/sui/contracts/Move.toml
@@ -5,12 +5,12 @@ version = "0.0.2"
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
 subdir = "crates/sui-framework/packages/sui-framework"
-rev = "09b2081498366df936abae26eea4b2d5cafb2788"
+rev = "041c5f2bae2fe52079e44b70514333532d69f4e6"
 
 [dependencies.Wormhole]
 git = "https://github.com/wormhole-foundation/wormhole.git"
 subdir = "sui/wormhole"
-rev = "d050ad1d67a5b7da9fb65030aad12ef5d774ccad"
+rev = "82d82bffd5a8566e4b5d94be4e4678ad55ab1f4f"
 
 [addresses]
 pyth = "0x00b53b0f4174108627fbee72e2498b58d6a2714cded53fac537034c220d26302"

--- a/target_chains/sui/contracts/sources/governance/contract_upgrade.move
+++ b/target_chains/sui/contracts/sources/governance/contract_upgrade.move
@@ -27,11 +27,6 @@ module pyth::contract_upgrade {
     const E_GOVERNANCE_CONTRACT_UPGRADE_CHAIN_ID_ZERO: u64 = 2;
     const E_CANNOT_EXECUTE_GOVERNANCE_ACTION_WITH_OBSOLETE_SEQUENCE_NUMBER: u64 = 3;
 
-    /// Specific governance payload ID (action) to complete upgrading the
-    /// contract.
-    /// TODO: is it okay for the contract upgrade action for Pyth to be 0? Or should it be 1?
-    const CONTRACT_UPGRADE: u8 = 0;
-
     // Event reflecting package upgrade.
     struct ContractUpgraded has drop, copy {
         old_contract: ID,
@@ -130,6 +125,13 @@ module pyth::contract_upgrade {
         cursor::take_rest(cur);
         UpgradeContract { digest }
     }
+
+    #[test_only]
+    /// Specific governance payload ID (action) to complete upgrading the
+    /// contract.
+    /// TODO: is it okay for the contract upgrade action for Pyth to be 0? Or should it be 1?
+    const CONTRACT_UPGRADE: u8 = 0;
+
 
     #[test_only]
     public fun action(): u8 {

--- a/target_chains/sui/contracts/sources/governance/governance.move
+++ b/target_chains/sui/contracts/sources/governance/governance.move
@@ -14,7 +14,6 @@ module pyth::governance {
     const E_INVALID_GOVERNANCE_ACTION: u64 = 0;
     const E_MUST_USE_CONTRACT_UPGRADE_MODULE_TO_DO_UPGRADES: u64 = 1;
     const E_CANNOT_EXECUTE_GOVERNANCE_ACTION_WITH_OBSOLETE_SEQUENCE_NUMBER: u64 = 2;
-    const E_OLD_GUARDIAN_SET_GOVERNANCE: u64 = 3;
     const E_INVALID_GOVERNANCE_DATA_SOURCE: u64 = 4;
 
     // this struct does not have the store or key ability so it must be

--- a/target_chains/sui/contracts/sources/governance/set_data_sources.move
+++ b/target_chains/sui/contracts/sources/governance/set_data_sources.move
@@ -76,7 +76,7 @@ module pyth::set_data_sources_tests {
         test_scenario::next_tx(&mut scenario, DEPLOYER);
         let (pyth_state, worm_state) = take_wormhole_and_pyth_states(&scenario);
 
-        let verified_vaa = wormhole::vaa::parse_and_verify(&mut worm_state, SET_DATA_SOURCES_VAA, &clock);
+        let verified_vaa = wormhole::vaa::parse_and_verify(&worm_state, SET_DATA_SOURCES_VAA, &clock);
 
         let receipt = pyth::governance::verify_vaa(&pyth_state, verified_vaa);
 

--- a/target_chains/sui/contracts/sources/governance/set_stale_price_threshold.move
+++ b/target_chains/sui/contracts/sources/governance/set_stale_price_threshold.move
@@ -51,7 +51,7 @@ module pyth::set_stale_price_threshold_test {
         test_scenario::next_tx(&mut scenario, DEPLOYER);
         let (pyth_state, worm_state) = take_wormhole_and_pyth_states(&scenario);
 
-        let verified_vaa = wormhole::vaa::parse_and_verify(&mut worm_state, SET_STALE_PRICE_THRESHOLD_VAA, &clock);
+        let verified_vaa = wormhole::vaa::parse_and_verify(&worm_state, SET_STALE_PRICE_THRESHOLD_VAA, &clock);
 
         let receipt = pyth::governance::verify_vaa(&pyth_state, verified_vaa);
 

--- a/target_chains/sui/contracts/sources/governance/set_update_fee.move
+++ b/target_chains/sui/contracts/sources/governance/set_update_fee.move
@@ -8,7 +8,6 @@ module pyth::set_update_fee {
 
     friend pyth::governance;
 
-    const MAX_U64: u128 = (1 << 64) - 1;
     const E_EXPONENT_DOES_NOT_FIT_IN_U8: u64 = 0;
 
     struct UpdateFee {
@@ -65,7 +64,7 @@ module pyth::set_update_fee_tests {
         test_scenario::next_tx(&mut scenario, DEPLOYER);
         let (pyth_state, worm_state) = take_wormhole_and_pyth_states(&scenario);
 
-        let verified_vaa = wormhole::vaa::parse_and_verify(&mut worm_state, SET_FEE_VAA, &clock);
+        let verified_vaa = wormhole::vaa::parse_and_verify(&worm_state, SET_FEE_VAA, &clock);
 
         let receipt = pyth::governance::verify_vaa(&pyth_state, verified_vaa);
 

--- a/target_chains/sui/contracts/sources/hot_potato_vector.move
+++ b/target_chains/sui/contracts/sources/hot_potato_vector.move
@@ -3,8 +3,6 @@
 module pyth::hot_potato_vector {
     use std::vector;
 
-    const E_EMPTY_HOT_POTATO: u64 = 0;
-
     friend pyth::pyth;
     #[test_only]
     friend pyth::pyth_tests;

--- a/target_chains/sui/contracts/sources/merkle_tree.move
+++ b/target_chains/sui/contracts/sources/merkle_tree.move
@@ -4,8 +4,11 @@ module pyth::merkle_tree {
     use std::vector::{Self};
     use sui::hash::{keccak256};
     use wormhole::bytes20::{Self, Bytes20, data};
-    use wormhole::cursor::{Self, Cursor};
+    use wormhole::cursor::Cursor;
     use pyth::deserialize::{Self};
+
+    #[test_only]
+    use wormhole::cursor::{Self};
 
     const MERKLE_LEAF_PREFIX: u8 = 0;
     const MERKLE_NODE_PREFIX: u8 = 1;

--- a/target_chains/sui/contracts/sources/pyth.move
+++ b/target_chains/sui/contracts/sources/pyth.move
@@ -30,9 +30,6 @@ module pyth::pyth {
     const E_STALE_PRICE_UPDATE: u64 = 3;
     const E_UPDATE_AND_PRICE_INFO_OBJECT_MISMATCH: u64 = 4;
     const E_PRICE_UPDATE_NOT_FOUND_FOR_PRICE_INFO_OBJECT: u64 = 5;
-    const E_INVALID_ACCUMULATOR_MAGIC: u64 = 7;
-
-    const PYTHNET_ACCUMULATOR_UPDATE_MAGIC: u64 = 1347305813;
 
     #[test_only]
     friend pyth::pyth_tests;
@@ -160,6 +157,7 @@ module pyth::pyth {
         vector::destroy_empty(verified_vaas);
     }
 
+    #[allow(lint(share_owned))]
     // create_and_share_price_feeds_using_verified_price_infos is a private function used by
     // 1) create_price_feeds
     // 2) create_price_feeds_using_accumulator
@@ -456,12 +454,6 @@ module pyth::pyth_tests{
     fun ACCUMULATOR_TESTS_DATA_SOURCE(): vector<DataSource> {
         vector[data_source::new(1, external_address::new(bytes32::from_bytes(ACCUMULATOR_TESTS_EMITTER_ADDRESS)))]
     }
-
-    // /// A vector containing a single VAA with:
-    // /// - emitter chain ID 17
-    // /// - emitter address 0x71f8dcb863d176e2c420ad6610cf687359612b6fb392e0642b0ca6b1f186aa3b
-    // /// - payload corresponding to the batch price attestation of the prices returned by get_mock_price_infos()
-    const TEST_VAAS: vector<vector<u8>> = vector[x"0100000000010036eb563b80a24f4253bee6150eb8924e4bdf6e4fa1dfc759a6664d2e865b4b134651a7b021b7f1ce3bd078070b688b6f2e37ce2de0d9b48e6a78684561e49d5201527e4f9b00000001001171f8dcb863d176e2c420ad6610cf687359612b6fb392e0642b0ca6b1f186aa3b0000000000000001005032574800030000000102000400951436e0be37536be96f0896366089506a59763d036728332d3e3038047851aea7c6c75c89f14810ec1c54c03ab8f1864a4c4032791f05747f560faec380a695d1000000000000049a0000000000000008fffffffb00000000000005dc0000000000000003000000000100000001000000006329c0eb000000006329c0e9000000006329c0e400000000000006150000000000000007215258d81468614f6b7e194c5d145609394f67b041e93e6695dcc616faadd0603b9551a68d01d954d6387aff4df1529027ffb2fee413082e509feb29cc4904fe000000000000041a0000000000000003fffffffb00000000000005cb0000000000000003010000000100000001000000006329c0eb000000006329c0e9000000006329c0e4000000000000048600000000000000078ac9cf3ab299af710d735163726fdae0db8465280502eb9f801f74b3c1bd190333832fad6e36eb05a8972fe5f219b27b5b2bb2230a79ce79beb4c5c5e7ecc76d00000000000003f20000000000000002fffffffb00000000000005e70000000000000003010000000100000001000000006329c0eb000000006329c0e9000000006329c0e40000000000000685000000000000000861db714e9ff987b6fedf00d01f9fea6db7c30632d6fc83b7bc9459d7192bc44a21a28b4c6619968bd8c20e95b0aaed7df2187fd310275347e0376a2cd7427db800000000000006cb0000000000000001fffffffb00000000000005e40000000000000003010000000100000001000000006329c0eb000000006329c0e9000000006329c0e400000000000007970000000000000001"];
 
     fun get_verified_test_vaas(worm_state: &WormState, clock: &Clock): vector<VAA> {
         let test_vaas_: vector<vector<u8>> = vector[x"0100000000010036eb563b80a24f4253bee6150eb8924e4bdf6e4fa1dfc759a6664d2e865b4b134651a7b021b7f1ce3bd078070b688b6f2e37ce2de0d9b48e6a78684561e49d5201527e4f9b00000001001171f8dcb863d176e2c420ad6610cf687359612b6fb392e0642b0ca6b1f186aa3b0000000000000001005032574800030000000102000400951436e0be37536be96f0896366089506a59763d036728332d3e3038047851aea7c6c75c89f14810ec1c54c03ab8f1864a4c4032791f05747f560faec380a695d1000000000000049a0000000000000008fffffffb00000000000005dc0000000000000003000000000100000001000000006329c0eb000000006329c0e9000000006329c0e400000000000006150000000000000007215258d81468614f6b7e194c5d145609394f67b041e93e6695dcc616faadd0603b9551a68d01d954d6387aff4df1529027ffb2fee413082e509feb29cc4904fe000000000000041a0000000000000003fffffffb00000000000005cb0000000000000003010000000100000001000000006329c0eb000000006329c0e9000000006329c0e4000000000000048600000000000000078ac9cf3ab299af710d735163726fdae0db8465280502eb9f801f74b3c1bd190333832fad6e36eb05a8972fe5f219b27b5b2bb2230a79ce79beb4c5c5e7ecc76d00000000000003f20000000000000002fffffffb00000000000005e70000000000000003010000000100000001000000006329c0eb000000006329c0e9000000006329c0e40000000000000685000000000000000861db714e9ff987b6fedf00d01f9fea6db7c30632d6fc83b7bc9459d7192bc44a21a28b4c6619968bd8c20e95b0aaed7df2187fd310275347e0376a2cd7427db800000000000006cb0000000000000001fffffffb00000000000005e40000000000000003010000000100000001000000006329c0eb000000006329c0e9000000006329c0e400000000000007970000000000000001"];
@@ -809,7 +801,7 @@ module pyth::pyth_tests{
 
         let fee_coins = coin::split(&mut test_coins, DEFAULT_BASE_UPDATE_FEE, ctx(&mut scenario));
         vec = update_single_price_feed(
-            &mut pyth_state,
+            &pyth_state,
             vec,
             &mut price_info_object_1,
             fee_coins,
@@ -891,7 +883,7 @@ module pyth::pyth_tests{
 
         test_scenario::next_tx(&mut scenario, DEPLOYER);
         auth_price_infos = update_single_price_feed(
-            &mut pyth_state,
+            &pyth_state,
             auth_price_infos,
             &mut price_info_object_1,
             coins,
@@ -1162,7 +1154,7 @@ module pyth::pyth_tests{
             let coin_split = coin::split(&mut coins, 1000, ctx(&mut scenario));
             let price_info_object = take_shared<PriceInfoObject>(&scenario);
             auth_price_infos = update_single_price_feed(
-                &mut pyth_state,
+                &pyth_state,
                 auth_price_infos,
                 &mut price_info_object,
                 coin_split,
@@ -1239,7 +1231,7 @@ module pyth::pyth_tests{
 
         test_scenario::next_tx(&mut scenario, DEPLOYER);
         vec = update_single_price_feed(
-            &mut pyth_state,
+            &pyth_state,
             vec,
             &mut price_info_object_1,
             test_coins,
@@ -1453,7 +1445,8 @@ module pyth::pyth_tests{
 
         // append some extra garbage bytes at the end of the accumulator message, and make sure
         // that parse_and_verify_accumulator_message does not error out
-        vector::append(&mut TEST_ACCUMULATOR_3_MSGS, x"1234123412341234");
+        let test_accumulator_3_msgs_modified = TEST_ACCUMULATOR_3_MSGS;
+        vector::append(&mut test_accumulator_3_msgs_modified, x"1234123412341234");
 
         let cur = cursor::new(TEST_ACCUMULATOR_3_MSGS);
 

--- a/target_chains/sui/contracts/sources/pyth_accumulator.move
+++ b/target_chains/sui/contracts/sources/pyth_accumulator.move
@@ -9,7 +9,7 @@ module pyth::accumulator {
     use pyth::price_feed::{Self};
     use pyth::merkle_tree::{Self};
 
-    const PRICE_FEED_MESSAGE_TYPE: u64 = 0;
+    const PRICE_FEED_MESSAGE_TYPE: u8 = 0;
     const E_INVALID_UPDATE_DATA: u64 = 245;
     const E_INVALID_PROOF: u64 = 345;
     const E_INVALID_WORMHOLE_MESSAGE: u64 = 454;
@@ -77,7 +77,7 @@ module pyth::accumulator {
     fun parse_price_feed_message(message_cur: &mut Cursor<u8>, clock: &Clock): PriceInfo {
         let message_type = deserialize::deserialize_u8(message_cur);
 
-        assert!(message_type == 0, 0); // PriceFeedMessage variant
+        assert!(message_type == PRICE_FEED_MESSAGE_TYPE, E_INVALID_UPDATE_DATA);
         let price_identifier = price_identifier::from_byte_vec(deserialize::deserialize_vector(message_cur, 32));
         let price = deserialize::deserialize_i64(message_cur);
         let conf = deserialize::deserialize_u64(message_cur);

--- a/target_chains/sui/contracts/sources/setup.move
+++ b/target_chains/sui/contracts/sources/setup.move
@@ -7,11 +7,6 @@ module pyth::setup {
     use pyth::state::{Self};
     use pyth::data_source::{DataSource};
 
-    /// `UpgradeCap` is not as expected when initializing `State`.
-    const E_INVALID_UPGRADE_CAP: u64 = 0;
-    /// Build version for setup must only be `1`.
-    const E_INVALID_BUILD_VERSION: u64 = 1;
-
     friend pyth::pyth;
     #[test_only]
     friend pyth::pyth_tests;
@@ -44,6 +39,7 @@ module pyth::setup {
         );
     }
 
+    #[allow(lint(share_owned))]
     /// Only the owner of the `DeployerCap` can call this method. This
     /// method destroys the capability and shares the `State` object.
     public(friend) fun init_and_share_state(

--- a/target_chains/sui/contracts/sources/state.move
+++ b/target_chains/sui/contracts/sources/state.move
@@ -30,11 +30,6 @@ module pyth::state {
 
     /// Build digest does not agree with current implementation.
     const E_INVALID_BUILD_DIGEST: u64 = 0;
-    /// Specified version does not match this build's version.
-    const E_VERSION_MISMATCH: u64 = 1;
-
-    /// Sui's chain ID is hard-coded to one value.
-    const CHAIN_ID: u16 = 21;
 
     /// Capability reflecting that the current build version is used to invoke
     /// state methods.


### PR DESCRIPTION
Developers on Sui need to pin the same Sui version as their dependencies and it enforces everyone to use the same Sui version.

Pyth and Wormhole Sui versions have been old and this change updates them to the latest testnet version (1.19.1) to make integrations with us easier. Wormhole has undergone a similar change and thereforce its version has changed as well.

No contract deployment is needed for this change as it only unblocks downstream consumers for compiling their contracts.