### PR TITLE
fix(xc-admin): fix ui footer placement

### DIFF
--- a/governance/xc_admin/packages/xc_admin_frontend/components/layout/Layout.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/layout/Layout.tsx
@@ -4,9 +4,9 @@ import Header from './Header'
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <div className="relative overflow-hidden">
+    <div className="flex flex-col min-h-screen relative overflow-hidden">
       <Header />
-      <main>{children}</main>
+      <main className="flex-grow">{children}</main>
       <Footer />
     </div>
   )


### PR DESCRIPTION
fix ui footer where it doesnt show on the bottom of the screen when screen size is relatively huge, this change makes the layout takes 100% of the view height so that layout will be on the bottom of the screen relative of the size