### PR TITLE
chore: release solana pull oracle packages

### DIFF
--- a/target_chains/solana/sdk/js/pyth_solana_receiver/package.json
+++ b/target_chains/solana/sdk/js/pyth_solana_receiver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-solana-receiver",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pyth solana receiver SDK",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/target_chains/solana/sdk/js/solana_utils/package.json
+++ b/target_chains/solana/sdk/js/solana_utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/solana-utils",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Utility functions for Solana",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",


### PR DESCRIPTION
`0.1.0` got already published. I want the latest version to be published so bumping.