### PR TITLE
feat(governance/xc_admin): add initial support for solana receiver

### DIFF
--- a/governance/xc_admin/packages/xc_admin_cli/package.json
+++ b/governance/xc_admin/packages/xc_admin_cli/package.json
@@ -28,6 +28,7 @@
     "@sqds/mesh": "^1.0.6",
     "commander": "^9.5.0",
     "typescript": "^4.9.4",
-    "xc_admin_common": "*"
+    "xc_admin_common": "*",
+    "@pythnetwork/pyth-solana-receiver": "*"
   }
 }

--- a/governance/xc_admin/packages/xc_admin_cli/src/index.ts
+++ b/governance/xc_admin/packages/xc_admin_cli/src/index.ts
@@ -36,6 +36,16 @@ import {
   getMultisigCluster,
   getProposalInstructions,
 } from "xc_admin_common";
+
+import {
+  PythSolanaReceiver as PythSolanaReceiverProgram,
+  IDL as PythSolanaReceiverIdl,
+} from "@pythnetwork/pyth-solana-receiver/lib/idl/pyth_solana_receiver";
+import {
+  getConfigPda,
+  DEFAULT_RECEIVER_PROGRAM_ID,
+} from "@pythnetwork/pyth-solana-receiver";
+
 import { LedgerNodeWallet } from "./ledger";
 
 export async function loadHotWalletOrLedger(
@@ -102,7 +112,7 @@ program
   .version("0.1.0");
 
 multisigCommand(
-  "accept-authority",
+  "escrow-program-accept-authority",
   "Accept authority from the program authority escrow"
 )
   .requiredOption(
@@ -144,6 +154,56 @@ multisigCommand(
         programAccount: programId,
         programDataAccount,
         bpfUpgradableLoader: BPF_UPGRADABLE_LOADER,
+      })
+      .instruction();
+
+    await vault.proposeInstructions([proposalInstruction], targetCluster);
+  });
+
+multisigCommand(
+  "solana-receiver-program-accept-governance-authority-transfer",
+  "Accept governance authority transfer for the solana receiver program"
+).action(async (options: any) => {
+  const vault = await loadVaultFromOptions(options);
+  const targetCluster: PythCluster = options.cluster;
+
+  const programSolanaReceiver = new Program(
+    PythSolanaReceiverIdl as PythSolanaReceiverProgram,
+    DEFAULT_RECEIVER_PROGRAM_ID,
+    vault.getAnchorProvider()
+  );
+
+  const proposalInstruction = await programSolanaReceiver.methods
+    .acceptGovernanceAuthorityTransfer()
+    .accounts({
+      payer: await vault.getVaultAuthorityPDA(targetCluster),
+      config: getConfigPda(DEFAULT_RECEIVER_PROGRAM_ID),
+    })
+    .instruction();
+
+  await vault.proposeInstructions([proposalInstruction], targetCluster);
+});
+
+multisigCommand(
+  "solana-receiver-program-request-governance-authority-transfer",
+  "Request governance authority transfer for the solana receiver program"
+)
+  .requiredOption("-t, --target <pubkey>", "")
+  .action(async (options: any) => {
+    const vault = await loadVaultFromOptions(options);
+    const targetCluster: PythCluster = options.cluster;
+    const target: PublicKey = new PublicKey(options.target);
+
+    const programSolanaReceiver = new Program(
+      PythSolanaReceiverIdl as PythSolanaReceiverProgram,
+      DEFAULT_RECEIVER_PROGRAM_ID,
+      vault.getAnchorProvider()
+    );
+
+    const proposalInstruction = await programSolanaReceiver.methods
+      .requestGovernanceAuthorityTransfer(target)
+      .accounts({
+        config: getConfigPda(DEFAULT_RECEIVER_PROGRAM_ID),
       })
       .instruction();
 

--- a/governance/xc_admin/packages/xc_admin_common/package.json
+++ b/governance/xc_admin/packages/xc_admin_common/package.json
@@ -30,7 +30,8 @@
     "ethers": "^5.7.2",
     "lodash": "^4.17.21",
     "typescript": "^4.9.4",
-    "@pythnetwork/solana-utils": "*"
+    "@pythnetwork/solana-utils": "*",
+    "@pythnetwork/pyth-solana-receiver": "*"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.1",

--- a/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/MessageBufferMultisigInstruction.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/MessageBufferMultisigInstruction.ts
@@ -11,6 +11,8 @@ import { Idl, BorshCoder } from "@coral-xyz/anchor";
 import { MESSAGE_BUFFER_PROGRAM_ID } from "../message_buffer";
 import meshIdl from "@sqds/mesh/lib/mesh-idl/mesh.json";
 import stakingIdl from "./idl/staking.json";
+import { IDL as solanaReciverIdl } from "@pythnetwork/pyth-solana-receiver/lib/idl/pyth_solana_receiver";
+import { DEFAULT_RECEIVER_PROGRAM_ID } from "@pythnetwork/pyth-solana-receiver";
 
 export const MESH_PROGRAM_ID = new PublicKey(
   "SMPLVC8MxZ5Bf5EfF7PaMiTCxoBAcmkbM2vkrvMK8ho"
@@ -54,6 +56,10 @@ export class AnchorMultisigInstruction implements MultisigInstruction {
       case STAKING_PROGRAM_ID.toBase58():
         idl = stakingIdl as Idl;
         program = MultisigInstructionProgram.Staking;
+        break;
+      case DEFAULT_RECEIVER_PROGRAM_ID.toBase58():
+        idl = solanaReciverIdl as Idl;
+        program = MultisigInstructionProgram.SolanaReceiver;
         break;
       default:
         return UnrecognizedProgram.fromTransactionInstruction(instruction);

--- a/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/MessageBufferMultisigInstruction.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/MessageBufferMultisigInstruction.ts
@@ -11,8 +11,10 @@ import { Idl, BorshCoder } from "@coral-xyz/anchor";
 import { MESSAGE_BUFFER_PROGRAM_ID } from "../message_buffer";
 import meshIdl from "@sqds/mesh/lib/mesh-idl/mesh.json";
 import stakingIdl from "./idl/staking.json";
-import { IDL as solanaReciverIdl } from "@pythnetwork/pyth-solana-receiver/lib/idl/pyth_solana_receiver";
-import { DEFAULT_RECEIVER_PROGRAM_ID } from "@pythnetwork/pyth-solana-receiver";
+import {
+  DEFAULT_RECEIVER_PROGRAM_ID,
+  pythSolanaReceiverIdl,
+} from "@pythnetwork/pyth-solana-receiver";
 
 export const MESH_PROGRAM_ID = new PublicKey(
   "SMPLVC8MxZ5Bf5EfF7PaMiTCxoBAcmkbM2vkrvMK8ho"
@@ -58,7 +60,7 @@ export class AnchorMultisigInstruction implements MultisigInstruction {
         program = MultisigInstructionProgram.Staking;
         break;
       case DEFAULT_RECEIVER_PROGRAM_ID.toBase58():
-        idl = solanaReciverIdl as Idl;
+        idl = pythSolanaReceiverIdl as Idl;
         program = MultisigInstructionProgram.SolanaReceiver;
         break;
       default:

--- a/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/index.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/index.ts
@@ -22,6 +22,7 @@ import { BpfUpgradableLoaderInstruction } from "./BpfUpgradableLoaderMultisigIns
 import { BPF_UPGRADABLE_LOADER } from "../bpf_upgradable_loader";
 import { AnchorAccounts } from "./anchor";
 import { SolanaStakingMultisigInstruction } from "./SolanaStakingMultisigInstruction";
+import { DEFAULT_RECEIVER_PROGRAM_ID } from "@pythnetwork/pyth-solana-receiver";
 
 export const UNRECOGNIZED_INSTRUCTION = "unrecognizedInstruction";
 export enum MultisigInstructionProgram {
@@ -33,6 +34,7 @@ export enum MultisigInstructionProgram {
   SystemProgram,
   BpfUpgradableLoader,
   SolanaStakingProgram,
+  SolanaReceiver,
   UnrecognizedProgram,
 }
 
@@ -54,6 +56,8 @@ export function getProgramName(program: MultisigInstructionProgram) {
       return "Mesh Multisig Program";
     case MultisigInstructionProgram.Staking:
       return "Pyth Staking Program";
+    case MultisigInstructionProgram.SolanaReceiver:
+      return "Pyth Solana Receiver";
     case MultisigInstructionProgram.UnrecognizedProgram:
       return "Unknown";
   }
@@ -123,7 +127,8 @@ export class MultisigParser {
     } else if (
       instruction.programId.equals(MESSAGE_BUFFER_PROGRAM_ID) ||
       instruction.programId.equals(MESH_PROGRAM_ID) ||
-      instruction.programId.equals(STAKING_PROGRAM_ID)
+      instruction.programId.equals(STAKING_PROGRAM_ID) ||
+      instruction.programId.equals(DEFAULT_RECEIVER_PROGRAM_ID)
     ) {
       return AnchorMultisigInstruction.fromTransactionInstruction(instruction);
     } else if (instruction.programId.equals(SystemProgram.programId)) {

--- a/target_chains/solana/sdk/js/pyth_solana_receiver/package.json
+++ b/target_chains/solana/sdk/js/pyth_solana_receiver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-solana-receiver",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Pyth solana receiver SDK",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/target_chains/solana/sdk/js/pyth_solana_receiver/src/index.ts
+++ b/target_chains/solana/sdk/js/pyth_solana_receiver/src/index.ts
@@ -6,3 +6,9 @@ export {
   TransactionBuilder,
   InstructionWithEphemeralSigners,
 } from "@pythnetwork/solana-utils";
+
+export {
+  getConfigPda,
+  DEFAULT_RECEIVER_PROGRAM_ID,
+  DEFAULT_WORMHOLE_PROGRAM_ID,
+} from "./address";

--- a/target_chains/solana/sdk/js/pyth_solana_receiver/src/index.ts
+++ b/target_chains/solana/sdk/js/pyth_solana_receiver/src/index.ts
@@ -12,3 +12,13 @@ export {
   DEFAULT_RECEIVER_PROGRAM_ID,
   DEFAULT_WORMHOLE_PROGRAM_ID,
 } from "./address";
+
+export {
+  IDL as pythSolanaReceiverIdl,
+  PythSolanaReceiver as PythSolanaReceiverProgram,
+} from "./idl/pyth_solana_receiver";
+
+export {
+  IDL as wormholeCoreBridgeIdl,
+  WormholeCoreBridgeSolana as WormholeCoreBridgeProgram,
+} from "./idl/wormhole_core_bridge_solana";


### PR DESCRIPTION
This change adds Solana Receiver IDL to xc-admin to support parsing them in the xc-admin Frontend. Also adds two CLI commands to request and accept governance authority transfer.