### PR TITLE
fix(governance/xc_admin): fix Dockerfiles

### DIFF
--- a/governance/xc_admin/Dockerfile
+++ b/governance/xc_admin/Dockerfile
@@ -6,7 +6,7 @@ USER root
 WORKDIR /home/node/
 USER 1000
 
-COPY --chown=1000:1000 target_chains/solana/sdk/js/solana_utils target_chains/solana/sdk/js/solana_utils
+COPY --chown=1000:1000 target_chains/solana/sdk/js target_chains/solana/sdk/js
 COPY --chown=1000:1000 governance/xc_admin governance/xc_admin
 COPY --chown=1000:1000 pythnet/message_buffer pythnet/message_buffer
 

--- a/governance/xc_admin/packages/xc_admin_frontend/Dockerfile
+++ b/governance/xc_admin/packages/xc_admin_frontend/Dockerfile
@@ -6,7 +6,7 @@ USER root
 WORKDIR /home/node/
 USER 1000
 
-COPY --chown=1000:1000 target_chains/solana/sdk/js/solana_utils target_chains/solana/sdk/js/solana_utils
+COPY --chown=1000:1000 target_chains/solana/sdk/js target_chains/solana/sdk/js
 COPY --chown=1000:1000 governance/xc_admin governance/xc_admin
 COPY --chown=1000:1000 pythnet/message_buffer pythnet/message_buffer
 


### PR DESCRIPTION
xc-admin now depends on Solana receiver's SDK and the Dockerfiles should include it in their build.