### PR TITLE
fix(governance/xc_admin): add complete dependencies to the dockerfile

### DIFF
--- a/governance/xc_admin/Dockerfile
+++ b/governance/xc_admin/Dockerfile
@@ -9,6 +9,7 @@ USER 1000
 COPY --chown=1000:1000 target_chains/solana/sdk/js target_chains/solana/sdk/js
 COPY --chown=1000:1000 governance/xc_admin governance/xc_admin
 COPY --chown=1000:1000 pythnet/message_buffer pythnet/message_buffer
+COPY --chown=1000:1000 price_service/sdk/js price_service/sdk/js
 
 RUN npx lerna run build --scope="{crank_executor,crank_pythnet_relayer,proposer_server}" --include-dependencies
 

--- a/governance/xc_admin/packages/xc_admin_frontend/Dockerfile
+++ b/governance/xc_admin/packages/xc_admin_frontend/Dockerfile
@@ -9,6 +9,7 @@ USER 1000
 COPY --chown=1000:1000 target_chains/solana/sdk/js target_chains/solana/sdk/js
 COPY --chown=1000:1000 governance/xc_admin governance/xc_admin
 COPY --chown=1000:1000 pythnet/message_buffer pythnet/message_buffer
+COPY --chown=1000:1000 price_service/sdk/js price_service/sdk/js
 
 ENV NODE_ENV production
 ENV NEXT_TELEMETRY_DISABLED 1


### PR DESCRIPTION
Apparently xc-admin now also needs price service SDK because the Solana receiver depends on it.