### PR TITLE
chore: update cosmwasm to used the wormhole published packages

### DIFF
--- a/target_chains/cosmwasm/Cargo.lock
+++ b/target_chains/cosmwasm/Cargo.lock
@@ -1590,7 +1590,7 @@ dependencies = [
  "terraswap",
  "thiserror",
  "wormhole-cosmwasm",
- "wormhole-sdk",
+ "wormhole-vaas-serde",
 ]
 
 [[package]]
@@ -1656,7 +1656,7 @@ dependencies = [
  "sha3 0.10.8",
  "slow_primes",
  "thiserror",
- "wormhole-sdk",
+ "wormhole-vaas-serde",
 ]
 
 [[package]]
@@ -1995,7 +1995,8 @@ dependencies = [
 [[package]]
 name = "serde_wormhole"
 version = "0.1.0"
-source = "git+https://github.com/wormhole-foundation/wormhole?tag=rust-sdk-2024-01-25#55faa9ca1fe456e90e957b33aa7bcc565a33c3fa"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b022bf813578a06341fd453c3fd6e64945d9975191193d5d45e8dbd97d1d84"
 dependencies = [
  "base64",
  "itoa",
@@ -2809,9 +2810,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "wormhole-sdk"
+name = "wormhole-supported-chains"
 version = "0.1.0"
-source = "git+https://github.com/wormhole-foundation/wormhole?tag=rust-sdk-2024-01-25#55faa9ca1fe456e90e957b33aa7bcc565a33c3fa"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f42a80a24212937cc7d7b0ab8115bb87d82f949a1a42f75d500807072c94ba4"
+dependencies = [
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "wormhole-vaas-serde"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240c5a6136dc66ecc65097bb6d159e849b5df4ecbbbb220868d0edbdcc568ed3"
 dependencies = [
  "anyhow",
  "bstr",
@@ -2820,6 +2832,7 @@ dependencies = [
  "serde_wormhole",
  "sha3 0.10.8",
  "thiserror",
+ "wormhole-supported-chains",
 ]
 
 [[package]]

--- a/target_chains/cosmwasm/contracts/pyth/Cargo.toml
+++ b/target_chains/cosmwasm/contracts/pyth/Cargo.toml
@@ -46,5 +46,5 @@ wormhole-cosmwasm =  {git = "https://github.com/wormhole-foundation/wormhole", t
 cosmwasm-vm = { version = "1.0.0", default-features = false }
 serde_json = "1.0"
 pythnet-sdk = { path = "../../../../pythnet/pythnet_sdk", features = ["test-utils"] }
-serde_wormhole = { git = "https://github.com/wormhole-foundation/wormhole", tag="rust-sdk-2024-01-25"}
-wormhole-sdk = { git = "https://github.com/wormhole-foundation/wormhole", tag="rust-sdk-2024-01-25"}
+serde_wormhole = "0.1.0"
+wormhole-vaas-serde = "0.1.0"


### PR DESCRIPTION
This should fix CI failing in `main`