### PR TITLE
chore: bump toolchain for solana target chain

### DIFF
--- a/target_chains/solana/rust-toolchain.toml
+++ b/target_chains/solana/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.69.0"
+channel = "1.73.0"


### PR DESCRIPTION
This should fix an issue in `cargo publish`