### PR TITLE
chore: no star dependency

### DIFF
--- a/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
+++ b/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
@@ -14,6 +14,6 @@ name = "pyth_solana_receiver_sdk"
 
 [dependencies]
 anchor-lang = ">=0.28.0"
-hex = "*"
+hex = ">=0.4.3"
 pythnet-sdk = { path = "../../../pythnet/pythnet_sdk", version = "2.0.0"}
-solana-program = "*"
+solana-program = ">=1.16.0"


### PR DESCRIPTION
Remove star dependency to publish `pyth-solana-receiver-sdk`