### PR TITLE
refactor(hermes): use broadcast channel for api notifications

### DIFF
--- a/hermes/src/aggregate.rs
+++ b/hermes/src/aggregate.rs
@@ -268,24 +268,17 @@ pub async fn store_update(state: &State, update: Update) -> Result<()> {
     match aggregate_state.latest_completed_slot {
         None => {
             aggregate_state.latest_completed_slot.replace(slot);
-            state
-                .api_update_tx
-                .send(AggregationEvent::New { slot })
-                .await?;
+            state.api_update_tx.send(AggregationEvent::New { slot })?;
         }
         Some(latest) if slot > latest => {
             state.prune_removed_keys(message_state_keys).await;
             aggregate_state.latest_completed_slot.replace(slot);
-            state
-                .api_update_tx
-                .send(AggregationEvent::New { slot })
-                .await?;
+            state.api_update_tx.send(AggregationEvent::New { slot })?;
         }
         _ => {
             state
                 .api_update_tx
-                .send(AggregationEvent::OutOfOrder { slot })
-                .await?;
+                .send(AggregationEvent::OutOfOrder { slot })?;
         }
     }
 
@@ -583,7 +576,7 @@ mod test {
         // Check that the update_rx channel has received a message
         assert_eq!(
             update_rx.recv().await,
-            Some(AggregationEvent::New { slot: 10 })
+            Ok(AggregationEvent::New { slot: 10 })
         );
 
         // Check the price ids are stored correctly
@@ -708,7 +701,7 @@ mod test {
         // Check that the update_rx channel has received a message
         assert_eq!(
             update_rx.recv().await,
-            Some(AggregationEvent::New { slot: 10 })
+            Ok(AggregationEvent::New { slot: 10 })
         );
 
         // Check the price ids are stored correctly
@@ -745,7 +738,7 @@ mod test {
         // Check that the update_rx channel has received a message
         assert_eq!(
             update_rx.recv().await,
-            Some(AggregationEvent::New { slot: 15 })
+            Ok(AggregationEvent::New { slot: 15 })
         );
 
         // Check that price feed 2 does not exist anymore

--- a/hermes/src/main.rs
+++ b/hermes/src/main.rs
@@ -44,8 +44,8 @@ async fn init() -> Result<()> {
         config::Options::Run(opts) => {
             tracing::info!("Starting hermes service...");
 
-            // The update channel is used to send store update notifications to the public API.
-            let (update_tx, update_rx) = tokio::sync::mpsc::channel(1000);
+            // The update broadcast channel is used to send store update notifications to the public API.
+            let (update_tx, _) = tokio::sync::broadcast::channel(1000);
 
             // Initialize a cache store with a 1000 element circular buffer.
             let store = State::new(update_tx.clone(), 1000, opts.benchmarks.endpoint.clone());
@@ -64,7 +64,7 @@ async fn init() -> Result<()> {
                 Box::pin(spawn(network::wormhole::spawn(opts.clone(), store.clone()))),
                 Box::pin(spawn(network::pythnet::spawn(opts.clone(), store.clone()))),
                 Box::pin(spawn(metrics_server::run(opts.clone(), store.clone()))),
-                Box::pin(spawn(api::spawn(opts.clone(), store.clone(), update_rx))),
+                Box::pin(spawn(api::spawn(opts.clone(), store.clone(), update_tx))),
             ])
             .await;
 

--- a/hermes/src/state.rs
+++ b/hermes/src/state.rs
@@ -20,7 +20,7 @@ use {
         sync::Arc,
     },
     tokio::sync::{
-        mpsc::Sender,
+        broadcast::Sender,
         RwLock,
     },
 };
@@ -81,11 +81,11 @@ pub mod test {
     use {
         super::*,
         crate::network::wormhole::update_guardian_set,
-        tokio::sync::mpsc::Receiver,
+        tokio::sync::broadcast::Receiver,
     };
 
     pub async fn setup_state(cache_size: u64) -> (Arc<State>, Receiver<AggregationEvent>) {
-        let (update_tx, update_rx) = tokio::sync::mpsc::channel(1000);
+        let (update_tx, update_rx) = tokio::sync::broadcast::channel(1000);
         let state = State::new(update_tx, cache_size, None);
 
         // Add an initial guardian set with public key 0


### PR DESCRIPTION
This change removes the manual broadcast implementation to send out API notifications to WS subscribers.