### PR TITLE
[wip] [solidity sdk] Solidity multicall / ergonomics

### DIFF
--- a/target_chains/ethereum/contracts/forge-test/PythMulticall.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/PythMulticall.t.sol
@@ -74,7 +74,8 @@ contract SampleContract is PythMulticall {
         p = address(pyth);
     }
 
-    // FIXME: payable here kind of sucks.
+    // One problem with approach 1 is that this method must be marked payable even though it use msg.value.
+    // It needs to be payable because the multicall's delegatecall passes a nonzero msg.value to it.
     function approach1() external payable returns (int64) {
         counter += pyth.getPriceUnsafe(id).price;
         return counter;

--- a/target_chains/ethereum/contracts/forge-test/PythMulticall.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/PythMulticall.t.sol
@@ -38,15 +38,25 @@ contract PythMulticallTest is Test {
         );
     }
 
-    function testBasic() public {
+    function testApproach1() public {
         bytes[] memory updateData = priceFeedUpdateHelper(123);
-        bytes memory call = abi.encodeCall(SampleContract.incrementCounter, ());
-
         uint fee = pyth.getUpdateFee(updateData);
         vm.deal(address(this), fee);
         console2.log("sending tx");
         console2.log(address(this));
+
+        bytes memory call = abi.encodeCall(SampleContract.approach1, ());
         multicallable.updateFeedsAndCall{value: fee}(updateData, call);
+    }
+
+    function testApproach2() public {
+        bytes[] memory updateData = priceFeedUpdateHelper(123);
+        uint fee = pyth.getUpdateFee(updateData);
+        vm.deal(address(this), fee);
+        console2.log("sending tx");
+        console2.log(address(this));
+
+        multicallable.approach2{value: fee}(updateData);
     }
 }
 
@@ -65,9 +75,14 @@ contract SampleContract is PythMulticall {
     }
 
     // FIXME: payable here kind of sucks.
-    function incrementCounter() external payable returns (int64) {
-        console2.log("incrementCounter");
-        console2.log(msg.sender);
+    function approach1() external payable returns (int64) {
+        counter += pyth.getPriceUnsafe(id).price;
+        return counter;
+    }
+
+    function approach2(
+        bytes[] calldata pythPrices
+    ) external payable withPyth(pythPrices) returns (int64) {
         counter += pyth.getPriceUnsafe(id).price;
         return counter;
     }

--- a/target_chains/ethereum/contracts/forge-test/PythMulticall.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/PythMulticall.t.sol
@@ -1,4 +1,3 @@
-
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
@@ -10,13 +9,39 @@ import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
 import "./utils/WormholeTestUtils.t.sol";
 import "./utils/PythTestUtils.t.sol";
 import "./utils/RandTestUtils.t.sol";
-import "../../sdk/solidity/PythMulticall.sol";
+import "@pythnetwork/pyth-sdk-solidity/PythMulticall.sol";
+import "@pythnetwork/pyth-sdk-solidity/MockPyth.sol";
 
-contract PythMulticallTest is Test, WormholeTestUtils, PythTestUtils {
+contract PythMulticallTest is Test {
     IPyth public pyth;
+    SampleContract public multicallable;
 
+    function setUp() public {
+        pyth = new MockPyth(60, 1);
+        multicallable = new SampleContract(address(pyth));
+    }
+
+    function testBasic() public {
+        bytes[] memory updateData = new bytes[](0);
+        bytes memory call = abi.encodeCall(SampleContract.incrementCounter, ());
+        // bytes memory call = bytes.concat(multicallable.incrementCounter.selector);
+        multicallable.updateFeedsAndCall(updateData, call);
+        multicallable.incrementCounter();
+    }
 }
 
 contract SampleContract is PythMulticall {
-    constructor(pythAddress)
+    address pyth;
+
+    constructor(address _pyth) {
+        pyth = _pyth;
+    }
+
+    function pythAddress() internal override returns (address p) {
+        p = pyth;
+    }
+
+    function incrementCounter() external returns (int32 c) {
+        c = 10;
+    }
 }

--- a/target_chains/ethereum/contracts/forge-test/PythMulticall.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/PythMulticall.t.sol
@@ -1,0 +1,22 @@
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "forge-std/Test.sol";
+
+import "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
+import "@pythnetwork/pyth-sdk-solidity/PythErrors.sol";
+import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
+import "./utils/WormholeTestUtils.t.sol";
+import "./utils/PythTestUtils.t.sol";
+import "./utils/RandTestUtils.t.sol";
+import "../../sdk/solidity/PythMulticall.sol";
+
+contract PythMulticallTest is Test, WormholeTestUtils, PythTestUtils {
+    IPyth public pyth;
+
+}
+
+contract SampleContract is PythMulticall {
+    constructor(pythAddress)
+}

--- a/target_chains/ethereum/contracts/foundry.toml
+++ b/target_chains/ethereum/contracts/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc_version = '0.8.4'
+solc_version = '0.8.21'
 optimizer = true
 optimizer_runs = 200
 src = 'contracts'

--- a/target_chains/ethereum/sdk/solidity/PythMulticall.sol
+++ b/target_chains/ethereum/sdk/solidity/PythMulticall.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "./IPyth.sol";
+
+abstract contract PythMulticall {
+    function pythAddress() private returns (address pythAddress);
+
+    function updateFeedsAndCall(
+        bytes[] calldata priceUpdateData,
+        bytes calldata data
+    ) public payable returns (bytes memory result) {
+        updatePythPriceFeeds{value: msg.value}(priceUpdateData);
+        return Address.functionDelegateCall(address(this), data);
+    }
+
+    function updatePythPriceFeeds(
+        bytes[] calldata priceUpdateData
+    ) public payable {
+        IPyth pyth = IPyth(pythAddress());
+
+        // Update the prices to the latest available values and pay the required fee for it. The `priceUpdateData` data
+        // should be retrieved from our off-chain Price Service API using the `pyth-evm-js` package.
+        // See section "How Pyth Works on EVM Chains" below for more information.
+        uint fee = pyth.getUpdateFee(priceUpdateData);
+        pyth.updatePriceFeeds{value: fee}(priceUpdateData);
+    }
+}

--- a/target_chains/ethereum/sdk/solidity/PythMulticall.sol
+++ b/target_chains/ethereum/sdk/solidity/PythMulticall.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "./IPyth.sol";
+import "forge-std/console2.sol";
 
 abstract contract PythMulticall {
     function pythAddress() internal virtual returns (address pyth);
@@ -10,10 +11,14 @@ abstract contract PythMulticall {
         bytes[] calldata priceUpdateData,
         bytes calldata data
     ) public payable returns (bytes memory response) {
+        console2.log(msg.sender);
         updatePythPriceFeeds(priceUpdateData);
 
+        nonPayableSample();
+
         bool success;
-        (success, response) = address(this).delegatecall(data);
+        // (success, response) = address(this).delegatecall{value: 0}(data);
+        (success, response) = address(this).{value: 0}(data);
 
         // Check if the call was successful or not.
         if (!success) {
@@ -33,6 +38,10 @@ abstract contract PythMulticall {
     function updatePythPriceFeeds(
         bytes[] calldata priceUpdateData
     ) public payable {
+        console2.log("updatePythPriceFeeds");
+        console2.log(msg.sender);
+        console2.log(msg.value);
+
         IPyth pyth = IPyth(pythAddress());
 
         // Update the prices to the latest available values and pay the required fee for it. The `priceUpdateData` data
@@ -40,5 +49,10 @@ abstract contract PythMulticall {
         // See section "How Pyth Works on EVM Chains" below for more information.
         uint fee = pyth.getUpdateFee(priceUpdateData);
         pyth.updatePriceFeeds{value: fee}(priceUpdateData);
+    }
+
+    function nonPayableSample() public {
+        console2.log("nonpayableSample");
+        console2.log(msg.sender);
     }
 }


### PR DESCRIPTION
I've been thinking about how to increase adoption amongst lending protocols. One of the obstacles seems to be that people are deploying forks of other protocols (aave, etc) and they do not want to modify the source code. I wanted to experiment with ways to enable these users to integrate Pyth more easily.

My initial thought was that we could put a multicall in front of the unmodified lending protocol's contracts. This however doesn't work because the delegatecall semantics don't quite work the way that you want. Given that, I came up with two approaches that allow for minimal code modification:

1. Make an abstract contract with a multicall function on it that the lending protocol contract inherits from. This works, but has some fallout. In particular, every function that is called from the multicall function must be `payable`, because it will receive the same msg.value as the multicall itself. 
2. Make a solidity guard that performs a pyth price update. This requires a little bit more code modification, but the end result seems nicer and more transparent. 

Both approaches are demonstrated in the snippet below. I think (2) is probably something we could tidy up and ship in the official SDK, but curious what you think.