### PR TITLE
refactor(hermes): state->cache downcasting

### DIFF
--- a/hermes/src/aggregate.rs
+++ b/hermes/src/aggregate.rs
@@ -23,7 +23,7 @@ use {
         state::{
             benchmarks::Benchmarks,
             cache::{
-                AggregateCache,
+                Cache,
                 MessageState,
                 MessageStateFilter,
             },
@@ -336,7 +336,7 @@ async fn get_verified_price_feeds<S>(
     request_time: RequestTime,
 ) -> Result<PriceFeedsWithUpdateData>
 where
-    S: AggregateCache,
+    S: Cache,
 {
     let messages = state
         .fetch_message_states(
@@ -396,7 +396,7 @@ pub async fn get_price_feeds_with_update_data<S>(
     request_time: RequestTime,
 ) -> Result<PriceFeedsWithUpdateData>
 where
-    S: AggregateCache,
+    S: Cache,
     S: Benchmarks,
 {
     match get_verified_price_feeds(state, price_ids, request_time.clone()).await {
@@ -412,7 +412,7 @@ where
 
 pub async fn get_price_feed_ids<S>(state: &S) -> HashSet<PriceIdentifier>
 where
-    S: AggregateCache,
+    S: Cache,
 {
     state
         .message_state_keys()
@@ -468,10 +468,7 @@ mod test {
                 Accumulator,
             },
             hashers::keccak256_160::Keccak160,
-            messages::{
-                Message,
-                PriceFeedMessage,
-            },
+            messages::PriceFeedMessage,
             wire::v1::{
                 AccumulatorUpdateData,
                 Proof,

--- a/hermes/src/aggregate/wormhole_merkle.rs
+++ b/hermes/src/aggregate/wormhole_merkle.rs
@@ -7,7 +7,7 @@ use {
     crate::{
         network::wormhole::VaaBytes,
         state::cache::{
-            AggregateCache,
+            Cache,
             MessageState,
         },
     },
@@ -70,14 +70,14 @@ impl From<MessageState> for RawMessageWithMerkleProof {
 }
 
 pub async fn store_wormhole_merkle_verified_message<S>(
-    store: &S,
+    state: &S,
     root: WormholeMerkleRoot,
     vaa: VaaBytes,
 ) -> Result<()>
 where
-    S: AggregateCache,
+    S: Cache,
 {
-    store
+    state
         .store_wormhole_merkle_state(WormholeMerkleState { root, vaa })
         .await?;
     Ok(())

--- a/hermes/src/state.rs
+++ b/hermes/src/state.rs
@@ -1,7 +1,7 @@
 //! This module contains the global state of the application.
 
 use {
-    self::cache::Cache,
+    self::cache::CacheState,
     crate::{
         aggregate::{
             AggregateState,
@@ -31,7 +31,7 @@ pub mod cache;
 pub struct State {
     /// Storage is a short-lived cache of the state of all the updates that have been passed to the
     /// store.
-    pub cache: Cache,
+    pub cache: CacheState,
 
     /// Sequence numbers of lately observed Vaas. Store uses this set
     /// to ignore the previously observed Vaas as a performance boost.
@@ -64,7 +64,7 @@ impl State {
     ) -> Arc<Self> {
         let mut metrics_registry = Registry::default();
         Arc::new(Self {
-            cache: Cache::new(cache_size),
+            cache: CacheState::new(cache_size),
             observed_vaa_seqs: RwLock::new(Default::default()),
             guardian_set: RwLock::new(Default::default()),
             api_update_tx: update_tx,


### PR DESCRIPTION
First commit of several for moving services behind an abstraction of `State` under `src/state/*`. Does a few drive by cleanups:

- Renames to `Cache` as it caches multiple things, and eventually might be good to replace with a generic store.
- Type aliases some of the more complex types, also leads to a cleaner rust doc.
- Implements down-casting from `State` to `Cache` to introduce better service separation.