### PR TITLE
chore(target_chains/ethereum): add Blast and Mode gas claim patches

### DIFF
--- a/target_chains/ethereum/contracts/blast-gas-claim-patch.diff
+++ b/target_chains/ethereum/contracts/blast-gas-claim-patch.diff
@@ -1,0 +1,25 @@
+diff --git a/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol b/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
+index 6b08e386..aa34f117 100644
+--- a/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
++++ b/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
+@@ -12,6 +12,10 @@ import "./PythGetters.sol";
+ import "./PythSetters.sol";
+ import "./PythInternalStructs.sol";
+
++interface IBlast {
++    function configureClaimableGas() external;
++}
++
+ abstract contract Pyth is
+     PythGetters,
+     PythSetters,
+@@ -722,4 +726,9 @@ abstract contract Pyth is
+     function version() public pure returns (string memory) {
+         return "1.4.3";
+     }
++
++    function configureClaimableGas() external {
++        IBlast(0x4300000000000000000000000000000000000002)
++            .configureClaimableGas();
++    }
+ }

--- a/target_chains/ethereum/contracts/mode-gas-claim-patch.diff
+++ b/target_chains/ethereum/contracts/mode-gas-claim-patch.diff
@@ -1,0 +1,26 @@
+diff --git a/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol b/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
+index 6b08e386..2c9b4285 100644
+--- a/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
++++ b/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
+@@ -12,6 +12,10 @@ import "./PythGetters.sol";
+ import "./PythSetters.sol";
+ import "./PythInternalStructs.sol";
+
++interface ISFS {
++    function register(address recipient) external returns (uint256 tokenId);
++}
++
+ abstract contract Pyth is
+     PythGetters,
+     PythSetters,
+@@ -722,4 +726,10 @@ abstract contract Pyth is
+     function version() public pure returns (string memory) {
+         return "1.4.3";
+     }
++
++    function configureClaimableGas() external {
++        ISFS(0x8680CEaBcb9b56913c519c069Add6Bc3494B7020).register(
++            address(this)
++        );
++    }
+ }


### PR DESCRIPTION
This change adds the change in our implementation that allowed support for enabling gas claims on Blast and Mode as a reference.