### PR TITLE
Force Node Version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -79,10 +79,11 @@ Lerna has some common failure modes that you may encounter:
 1. `npm ci` fails with a typescript compilation error about a missing package.
    This error likely means that the failing package has a `prepare` entry compiling the typescript in its `package.json`.
    Fix this error by moving that logic to the `prepublishOnly` entry.
-1. The software builds locally but fails in CI, or vice-versa.
+2. The software builds locally but fails in CI, or vice-versa.
    This error likely means that some local build caches need to be cleaned.
    The build error may not indicate that this is a caching issue, e.g., it may appear that the packages are being built in the wrong order.
    Delete `node_modules/`, `lib/` and `tsconfig.tsbuildinfo` from each package's subdirectory. then try again.
+3. `npm ci` fails due to wrong node version. Make sure to be using `v18`. Node version `v21` is not supported and known to cause issues.
 
 ## Audit / Feature Status
 

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   "devDependencies": {
     "lerna": "^6.4.1"
   },
+  "engines" : { 
+    "node" : ">=16.0.0 <19.0.0"
+  },
   "version": "0.0.1"
 }


### PR DESCRIPTION
I was on node version v21, and nothing was working. It wasn't clear to me which version was required, so I spent maybe an hour trying to hack the dependencies to work.

Finally, I saw a stack overflow suggesting to downgrade the node version.

With this change, the compiler will yell at you that use the proper node version to continue, which would have saved me some time.