### PR TITLE
fix(solana_pusher): use processed to poll

### DIFF
--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "6.6.3",
+  "version": "6.6.2",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "6.6.1",
+  "version": "6.6.3",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/apps/price_pusher/src/solana/command.ts
+++ b/apps/price_pusher/src/solana/command.ts
@@ -117,7 +117,7 @@ export default {
     );
 
     const pythSolanaReceiver = new PythSolanaReceiver({
-      connection: new Connection(endpoint),
+      connection: new Connection(endpoint, "processed"),
       wallet,
       pushOracleProgramId: new PublicKey(pythContractAddress),
     });


### PR DESCRIPTION
By using "processed" to poll, we have a more recent view of the blockchain.