### PR TITLE
fix(hermes): add else to select! to loop cleanly

### DIFF
--- a/apps/hermes/src/network/pythnet.rs
+++ b/apps/hermes/src/network/pythnet.rs
@@ -291,7 +291,8 @@ pub async fn spawn(opts: RunOptions, state: Arc<State>) -> Result<()> {
                             tracing::error!("Pythnet listener restarting too quickly. Sleep 1s.");
                             tokio::time::sleep(Duration::from_secs(1)).await;
                         }
-                    }
+                    },
+                    else => {}
                 }
             }
             tracing::info!("Shutting down Pythnet listener...");

--- a/apps/hermes/src/network/wormhole.rs
+++ b/apps/hermes/src/network/wormhole.rs
@@ -162,7 +162,8 @@ pub async fn spawn(opts: RunOptions, state: Arc<State>) -> Result<()> {
             _ = exit.changed() => break,
             Err(err) = run(opts.clone(), state.clone()) => {
                 tracing::error!(error = ?err, "Wormhole gRPC service failed.");
-            }
+            },
+            else => {}
         }
     }
     tracing::info!("Shutting down Wormhole gRPC service...");


### PR DESCRIPTION
The behaviour of `select!` is a little unintuitive, right now some code explicitly matches an `Err(_)` pattern, if the branch returns Ok(()), rather than breaking out of the select it instead just disabled that branch until the loop iterates, blocking forever on our exit flag. This adds a quick fix in the form of `else => {}` to make the select's exhaustive.