### PR TITLE
fix: remove alreadySending flag

### DIFF
--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "6.6.2",
+  "version": "6.6.3",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/apps/price_pusher/src/solana/solana.ts
+++ b/apps/price_pusher/src/solana/solana.ts
@@ -59,19 +59,13 @@ export class SolanaPricePusher implements IPricePusher {
     private pythSolanaReceiver: PythSolanaReceiver,
     private priceServiceConnection: PriceServiceConnection,
     private shardId: number,
-    private computeUnitPriceMicroLamports: number,
-    private alreadySending: boolean = false
+    private computeUnitPriceMicroLamports: number
   ) {}
 
   async updatePriceFeed(
     priceIds: string[],
     pubTimesToPush: number[]
   ): Promise<void> {
-    if (this.alreadySending) {
-      console.log(new Date(), "updatePriceFeed already in progress");
-      return;
-    }
-    this.alreadySending = true;
     if (priceIds.length === 0) {
       return;
     }
@@ -106,10 +100,8 @@ export class SolanaPricePusher implements IPricePusher {
         this.pythSolanaReceiver.wallet
       );
       console.log(new Date(), "updatePriceFeed successful");
-      this.alreadySending = false;
     } catch (e: any) {
       console.error(new Date(), "updatePriceFeed failed", e);
-      this.alreadySending = false;
       return;
     }
   }


### PR DESCRIPTION
This behavior is bad because sometimes it causes the pusher to get stuck forever.
Since this pusher is only used on Devnet right now, I am just dropping this feature.