### PR TITLE
fix(hermes): update cache.rs path in dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,5 +15,4 @@
 
 .git
 
-hermes/wormhole
-!hermes/src/state/cache.rs
+!apps/hermes/src/state/cache.rs


### PR DESCRIPTION
Our dockerignore ignores all the files containing cache in their name and hermes had an exception here. This change was missed in moving Hermes around.