### PR TITLE
fix(hermes): ignore no subscriber error on broadcast

### DIFF
--- a/apps/hermes/Cargo.lock
+++ b/apps/hermes/Cargo.lock
@@ -1796,7 +1796,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/hermes/Cargo.toml
+++ b/apps/hermes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "hermes"
-version     = "0.5.6"
+version     = "0.5.7"
 description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
 edition     = "2021"
 


### PR DESCRIPTION
This change ignores the errors appearing when there are no subsribers to price updates. The issue was fixed before and was missed during the refactor.