### PR TITLE
refactor(hermes): match mapping address argument style with the rest

### DIFF
--- a/apps/hermes/Cargo.lock
+++ b/apps/hermes/Cargo.lock
@@ -1796,7 +1796,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/hermes/Cargo.toml
+++ b/apps/hermes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "hermes"
-version     = "0.5.7"
+version     = "0.5.8"
 description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
 edition     = "2021"
 

--- a/apps/hermes/src/config/pythnet.rs
+++ b/apps/hermes/src/config/pythnet.rs
@@ -19,9 +19,9 @@ pub struct Options {
     #[arg(env = "PYTHNET_HTTP_ADDR")]
     pub http_addr: String,
 
-    /// Pyth mapping account address.
-    #[arg(long = "mapping-address")]
+    /// Pyth mapping account address on Pythnet.
+    #[arg(long = "pythnet-mapping-addr")]
     #[arg(default_value = DEFAULT_PYTHNET_MAPPING_ADDR)]
-    #[arg(env = "PYTHNET_MAPPING_ADDRESS")]
+    #[arg(env = "PYTHNET_MAPPING_ADDR")]
     pub mapping_addr: Pubkey,
 }


### PR DESCRIPTION
All arguments in `config/pythnet.rs` have `pythnet` as their prefix. Also they use `addr` instead of `address`. This change makes them consistent.