### PR TITLE
fix: display bigint properly

### DIFF
--- a/governance/xc_admin/packages/xc_admin_frontend/components/tabs/Proposals/Proposal.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/tabs/Proposals/Proposal.tsx
@@ -550,6 +550,8 @@ export const Proposal = ({
                                 ? instruction.args[key]
                                 : instruction.args[key] instanceof Uint8Array
                                 ? instruction.args[key].toString('hex')
+                                : typeof instruction.args[key] === 'bigint'
+                                ? instruction.args[key].toString()
                                 : JSON.stringify(instruction.args[key])}
                             </div>
                           )}


### PR DESCRIPTION
Found this bug in prod:
https://proposals.pyth.network/?tab=proposals&proposal=D77X2ZX93eW9Ss5k2xRLhwgEnhMh195YVrXQ7w1teU9s