### PR TITLE
fix: specify only channel and date for the toolchain

### DIFF
--- a/apps/fortuna/Cargo.lock
+++ b/apps/fortuna/Cargo.lock
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "fortuna"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/fortuna/rust-toolchain
+++ b/apps/fortuna/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2023-07-23-x86_64-unknown-linux-gnu
+nightly-2023-07-23


### PR DESCRIPTION
also it has a minor update to cargo.lock file. 