### PR TITLE
chore(contract_manager): Rename package to @pythnetwork/contract-manager

### DIFF
--- a/contract_manager/package.json
+++ b/contract_manager/package.json
@@ -6,8 +6,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
-    "lib/**/*",
-    "store/**/*"
+    "lib/**/*"
   ],
   "scripts": {
     "build": "tsc",
@@ -20,9 +19,6 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/pyth-network/pyth-crosschain.git"
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "dependencies": {
     "@certusone/wormhole-sdk": "^0.9.8",

--- a/contract_manager/package.json
+++ b/contract_manager/package.json
@@ -1,12 +1,13 @@
 {
-  "name": "contract_manager",
+  "name": "@pythnetwork/contract-manager",
   "version": "1.0.0",
   "description": "Set of tools to manage pyth contracts",
   "private": true,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
-    "lib/**/*"
+    "lib/**/*",
+    "store/**/*"
   ],
   "scripts": {
     "build": "tsc",
@@ -19,6 +20,9 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/pyth-network/pyth-crosschain.git"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "dependencies": {
     "@certusone/wormhole-sdk": "^0.9.8",

--- a/target_chains/aptos/cli/src/commands/aptos.ts
+++ b/target_chains/aptos/cli/src/commands/aptos.ts
@@ -8,7 +8,7 @@ import {
   AptosChain,
   DefaultStore,
   getDefaultDeploymentConfig,
-} from "contract_manager";
+} from "@pythnetwork/contract-manager";
 
 const NETWORK_CHOICES = Object.entries(DefaultStore.chains)
   .filter(([chain, config]) => {

--- a/target_chains/cosmwasm/deploy-scripts/package.json
+++ b/target_chains/cosmwasm/deploy-scripts/package.json
@@ -13,7 +13,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@pythnetwork/cosmwasm-deploy-tools": "*",
-    "contract_manager": "*",
+    "@pythnetwork/contract-manager": "*",
     "rimraf": "^5.0.0",
     "typescript": "^5.3.3",
     "yargs": "^17.0.1"

--- a/target_chains/cosmwasm/deploy-scripts/src/configs.ts
+++ b/target_chains/cosmwasm/deploy-scripts/src/configs.ts
@@ -1,4 +1,4 @@
-import { getDefaultDeploymentConfig } from "contract_manager";
+import { getDefaultDeploymentConfig } from "@pythnetwork/contract-manager";
 import { DeploymentType } from "./helper";
 
 function getPythSources(deploymentType: DeploymentType) {

--- a/target_chains/cosmwasm/deploy-scripts/src/instantiate-pyth.ts
+++ b/target_chains/cosmwasm/deploy-scripts/src/instantiate-pyth.ts
@@ -8,7 +8,7 @@ import {
   DefaultStore,
   Store,
   toPrivateKey,
-} from "contract_manager";
+} from "@pythnetwork/contract-manager";
 import { CHAINS } from "xc_admin_common";
 import { DeploymentType, getContractBytesDict } from "./helper";
 

--- a/target_chains/cosmwasm/deploy-scripts/src/instantiate-wormhole.ts
+++ b/target_chains/cosmwasm/deploy-scripts/src/instantiate-wormhole.ts
@@ -7,7 +7,7 @@ import {
   DefaultStore,
   toPrivateKey,
   CosmWasmWormholeContract,
-} from "contract_manager";
+} from "@pythnetwork/contract-manager";
 import { CHAINS } from "xc_admin_common";
 import { DeploymentType } from "./helper";
 

--- a/target_chains/ethereum/contracts/package.json
+++ b/target_chains/ethereum/contracts/package.json
@@ -37,7 +37,7 @@
     "@pythnetwork/pyth-multisig-wh-message-builder": "*",
     "@pythnetwork/pyth-sdk-solidity": "^3.0.0",
     "@pythnetwork/entropy-sdk-solidity": "*",
-    "contract_manager": "*",
+    "@pythnetwork/contract-manager": "*",
     "dotenv": "^10.0.0",
     "elliptic": "^6.5.2",
     "ethers": "^5.7.2",

--- a/target_chains/ethereum/contracts/scripts/batchDeployReceivers.ts
+++ b/target_chains/ethereum/contracts/scripts/batchDeployReceivers.ts
@@ -10,7 +10,7 @@ import {
   EvmChain,
   loadHotWallet,
   EvmWormholeContract,
-} from "contract_manager";
+} from "@pythnetwork/contract-manager";
 import Web3 from "web3";
 import { CHAINS } from "xc_admin_common";
 import * as fs from "fs";

--- a/target_chains/sui/cli/package.json
+++ b/target_chains/sui/cli/package.json
@@ -15,7 +15,7 @@
     "@pythnetwork/client": "^2.17.0",
     "@pythnetwork/price-service-client": "^1.4.0",
     "@pythnetwork/price-service-sdk": "^1.2.0",
-    "contract_manager": "*",
+    "@pythnetwork/contract-manager": "*",
     "prettier": "^2.8.7",
     "typescript": "^5.0.4",
     "xc_admin_common": "*"

--- a/target_chains/sui/cli/src/cli.ts
+++ b/target_chains/sui/cli/src/cli.ts
@@ -5,7 +5,7 @@ import {
   getDefaultDeploymentConfig,
   SuiChain,
   SuiPriceFeedContract,
-} from "contract_manager";
+} from "@pythnetwork/contract-manager";
 import { PriceServiceConnection } from "@pythnetwork/price-service-client";
 import { execSync } from "child_process";
 import { initPyth, publishPackage } from "./pyth_deploy";

--- a/target_chains/sui/cli/src/upgrade_pyth.ts
+++ b/target_chains/sui/cli/src/upgrade_pyth.ts
@@ -8,7 +8,7 @@ import { SuiClient } from "@mysten/sui.js/client";
 import { Ed25519Keypair } from "@mysten/sui.js/keypairs/ed25519";
 
 import { execSync } from "child_process";
-import { SuiPriceFeedContract } from "contract_manager";
+import { SuiPriceFeedContract } from "@pythnetwork/contract-manager";
 
 export function buildForBytecodeAndDigest(packagePath: string) {
   const buildOutput: {


### PR DESCRIPTION
This change renames the contract manager package name to @pythnetwork/contract-manager to be consistent with our package names.
