### PR TITLE
feat(solana_pusher): wait for confirmation only for multiple jito bun…

### DIFF
--- a/apps/price_pusher/src/solana/solana.ts
+++ b/apps/price_pusher/src/solana/solana.ts
@@ -156,25 +156,28 @@ export class SolanaPricePusherJito implements IPricePusher {
       await this.pythSolanaReceiver.connection.getLatestBlockhashAndContext({
         commitment: "confirmed",
       });
-    await this.pythSolanaReceiver.connection.confirmTransaction(
-      {
-        signature: firstSignature,
-        blockhash: blockhashResult.value.blockhash,
-        lastValidBlockHeight: blockhashResult.value.lastValidBlockHeight,
-      },
-      "confirmed"
-    );
 
-    for (
-      let i = this.jitoBundleSize;
-      i < transactions.length;
-      i += this.jitoBundleSize
-    ) {
-      await sendTransactionsJito(
-        transactions.slice(i, i + this.jitoBundleSize),
-        this.searcherClient,
-        this.pythSolanaReceiver.wallet
+    if (transactions.length > this.jitoBundleSize) {
+      await this.pythSolanaReceiver.connection.confirmTransaction(
+        {
+          signature: firstSignature,
+          blockhash: blockhashResult.value.blockhash,
+          lastValidBlockHeight: blockhashResult.value.lastValidBlockHeight,
+        },
+        "confirmed"
       );
+
+      for (
+        let i = this.jitoBundleSize;
+        i < transactions.length;
+        i += this.jitoBundleSize
+      ) {
+        await sendTransactionsJito(
+          transactions.slice(i, i + this.jitoBundleSize),
+          this.searcherClient,
+          this.pythSolanaReceiver.wallet
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
The first Jito bundle contains the VAA so we need to wait till it lands before sending other bundles.

However, sometimes we only send 1 Jito bundle. 
To accomodate cases where we want high frequency I think it's good to have functionality to just send and not verify whether it has landed or not.