### PR TITLE
[hermes] Add deprecation notices to old API methods

### DIFF
--- a/apps/hermes/Cargo.lock
+++ b/apps/hermes/Cargo.lock
@@ -1796,7 +1796,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/hermes/Cargo.toml
+++ b/apps/hermes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "hermes"
-version     = "0.5.8"
+version     = "0.5.9"
 description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
 edition     = "2021"
 

--- a/apps/hermes/src/api.rs
+++ b/apps/hermes/src/api.rs
@@ -124,6 +124,7 @@ pub async fn run(opts: RunOptions, state: ApiState) -> Result<()> {
     // Initialize Axum Router. Note the type here is a `Router<State>` due to the use of the
     // `with_state` method which replaces `Body` with `State` in the type signature.
     let app = Router::new();
+    #[allow(deprecated)]
     let app = app
         .merge(SwaggerUi::new("/docs").url("/docs/openapi.json", ApiDoc::openapi()))
         .route("/", get(rest::index))

--- a/apps/hermes/src/api/rest/get_price_feed.rs
+++ b/apps/hermes/src/api/rest/get_price_feed.rs
@@ -62,6 +62,7 @@ pub struct GetPriceFeedQueryParams {
         GetPriceFeedQueryParams
     )
 )]
+#[deprecated]
 pub async fn get_price_feed<S>(
     State(state): State<ApiState<S>>,
     QsQuery(params): QsQuery<GetPriceFeedQueryParams>,

--- a/apps/hermes/src/api/rest/get_price_feed.rs
+++ b/apps/hermes/src/api/rest/get_price_feed.rs
@@ -49,6 +49,8 @@ pub struct GetPriceFeedQueryParams {
     binary: bool,
 }
 
+/// **Deprecated: use /v2/updates/price/{publish_time} instead**
+///
 /// Get a price update for a price feed with a specific timestamp
 ///
 /// Given a price feed id and timestamp, retrieve the Pyth price update closest to that timestamp.

--- a/apps/hermes/src/api/rest/get_vaa.rs
+++ b/apps/hermes/src/api/rest/get_vaa.rs
@@ -55,6 +55,8 @@ pub struct GetVaaResponse {
     publish_time: UnixTimestamp,
 }
 
+/// **Deprecated: use /v2/updates/price/{publish_time} instead**
+///
 /// Get a VAA for a price feed with a specific timestamp
 ///
 /// Given a price feed id and timestamp, retrieve the Pyth price update closest to that timestamp.

--- a/apps/hermes/src/api/rest/get_vaa.rs
+++ b/apps/hermes/src/api/rest/get_vaa.rs
@@ -69,6 +69,7 @@ pub struct GetVaaResponse {
         GetVaaQueryParams
     )
 )]
+#[deprecated]
 pub async fn get_vaa<S>(
     State(state): State<ApiState<S>>,
     QsQuery(params): QsQuery<GetVaaQueryParams>,

--- a/apps/hermes/src/api/rest/get_vaa_ccip.rs
+++ b/apps/hermes/src/api/rest/get_vaa_ccip.rs
@@ -46,6 +46,8 @@ pub struct GetVaaCcipResponse {
     data: String, // TODO: Use a typed wrapper for the hex output with leading 0x.
 }
 
+/// **Deprecated: use /v2/updates/price/{publish_time} instead**
+///
 /// Get a VAA for a price feed using CCIP
 ///
 /// This endpoint accepts a single argument which is a hex-encoded byte string of the following form:

--- a/apps/hermes/src/api/rest/get_vaa_ccip.rs
+++ b/apps/hermes/src/api/rest/get_vaa_ccip.rs
@@ -60,6 +60,7 @@ pub struct GetVaaCcipResponse {
         GetVaaCcipQueryParams
     )
 )]
+#[deprecated]
 pub async fn get_vaa_ccip<S>(
     State(state): State<ApiState<S>>,
     QsQuery(params): QsQuery<GetVaaCcipQueryParams>,

--- a/apps/hermes/src/api/rest/latest_price_feeds.rs
+++ b/apps/hermes/src/api/rest/latest_price_feeds.rs
@@ -63,6 +63,7 @@ pub struct LatestPriceFeedsQueryParams {
         LatestPriceFeedsQueryParams
     )
 )]
+#[deprecated]
 pub async fn latest_price_feeds<S>(
     State(state): State<ApiState<S>>,
     QsQuery(params): QsQuery<LatestPriceFeedsQueryParams>,

--- a/apps/hermes/src/api/rest/latest_price_feeds.rs
+++ b/apps/hermes/src/api/rest/latest_price_feeds.rs
@@ -50,6 +50,8 @@ pub struct LatestPriceFeedsQueryParams {
     binary: bool,
 }
 
+/// **Deprecated: use /v2/updates/price/latest instead**
+///
 /// Get the latest price updates by price feed id.
 ///
 /// Given a collection of price feed ids, retrieve the latest Pyth price for each price feed.

--- a/apps/hermes/src/api/rest/latest_vaas.rs
+++ b/apps/hermes/src/api/rest/latest_vaas.rs
@@ -43,6 +43,8 @@ pub struct LatestVaasQueryParams {
 }
 
 
+/// **Deprecated: use /v2/updates/price/latest instead**
+///
 /// Get VAAs for a set of price feed ids.
 ///
 /// Given a collection of price feed ids, retrieve the latest VAA for each. The returned VAA(s) can

--- a/apps/hermes/src/api/rest/latest_vaas.rs
+++ b/apps/hermes/src/api/rest/latest_vaas.rs
@@ -58,6 +58,7 @@ pub struct LatestVaasQueryParams {
         (status = 200, description = "VAAs retrieved successfully", body = Vec<String>, example=json!([doc_examples::vaa_example()]))
     ),
 )]
+#[deprecated]
 pub async fn latest_vaas<S>(
     State(state): State<ApiState<S>>,
     QsQuery(params): QsQuery<LatestVaasQueryParams>,

--- a/apps/hermes/src/api/rest/price_feed_ids.rs
+++ b/apps/hermes/src/api/rest/price_feed_ids.rs
@@ -25,6 +25,7 @@ use {
         (status = 200, description = "Price feed ids retrieved successfully", body = Vec<RpcPriceIdentifier>)
     ),
 )]
+#[deprecated]
 pub async fn price_feed_ids<S>(
     State(state): State<ApiState<S>>,
 ) -> Result<Json<Vec<RpcPriceIdentifier>>, RestError>

--- a/apps/hermes/src/api/rest/price_feed_ids.rs
+++ b/apps/hermes/src/api/rest/price_feed_ids.rs
@@ -14,6 +14,8 @@ use {
     },
 };
 
+/// **Deprecated: use /v2/price_feeds instead**
+///
 /// Get the set of price feed IDs.
 ///
 /// This endpoint fetches all of the price feed IDs for which price updates can be retrieved.


### PR DESCRIPTION
This change makes the methods show up as deprecated in the API docs and points users to the /v2/ alternative


![Screen Shot 2024-04-25 at 2 13 03 PM](https://github.com/pyth-network/pyth-crosschain/assets/541339/ac25bf28-bf60-47fa-889d-e759d2d8e84d)
