### PR TITLE
feat: add anchor to pythnet sdk

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,13 +80,13 @@ repos:
       - id: cargo-fmt-pythnet-sdk
         name: Cargo format for pythnet SDK
         language: "rust"
-        entry: cargo +nightly-2023-07-23 fmt --manifest-path ./pythnet/pythnet_sdk/Cargo.toml --all -- --config-path rustfmt.toml
+        entry: cargo +nightly-2024-03-26 fmt --manifest-path ./pythnet/pythnet_sdk/Cargo.toml --all -- --config-path rustfmt.toml
         pass_filenames: false
         files: pythnet/pythnet_sdk
       - id: cargo-clippy-pythnet-sdk
         name: Cargo clippy for pythnet SDK
         language: "rust"
-        entry: cargo +nightly-2023-07-23 clippy --manifest-path ./pythnet/pythnet_sdk/Cargo.toml --tests --fix --allow-dirty --allow-staged -- -D warnings
+        entry: cargo +nightly-2024-03-26 clippy --manifest-path ./pythnet/pythnet_sdk/Cargo.toml --tests --fix --allow-dirty --allow-staged -- -D warnings
         pass_filenames: false
         files: pythnet/pythnet_sdk
       # Hooks for solana receiver contract

--- a/pythnet/pythnet_sdk/Cargo.toml
+++ b/pythnet/pythnet_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pythnet-sdk"
-version = "2.0.0"
+version = "2.1.0"
 description = "Pyth Runtime for Solana"
 authors = ["Pyth Data Association"]
 repository = "https://github.com/pyth-network/pythnet"
@@ -39,8 +39,8 @@ anchor-lang  = {version = ">=0.28.0", optional = true}
 base64 = "0.21.0"
 rand = "0.7.0"
 serde_json = "1.0.96"
-solana-client = ">1.13.6"
-solana-sdk = ">1.13.6"
+solana-client = ">=1.13.6"
+solana-sdk = ">=1.13.6"
 proptest = "1.1.0"
 
 [package.metadata.docs.rs]

--- a/pythnet/pythnet_sdk/Cargo.toml
+++ b/pythnet/pythnet_sdk/Cargo.toml
@@ -13,7 +13,7 @@ name = "pythnet_sdk"
 
 [features]
 test-utils = ["dep:wormhole-vaas-serde", "dep:serde_wormhole", "dep:libsecp256k1", "dep:rand"]
-solana-program = ["dep:solana-program", "dep:anchor-lang"]
+solana-program = ["dep:solana-program", "dep:anchor-lang", "dep:proc-macro2"]
 
 [dependencies]
 bincode = "1.3.1"
@@ -34,6 +34,7 @@ libsecp256k1 = {version ="0.7.1", optional = true}
 rand = {version = "0.8.5", optional = true}
 solana-program = {version = ">=1.13.6", optional = true}
 anchor-lang  = {version = ">=0.28.0", optional = true}
+proc-macro2 = {version = "=1.0.79", optional = true}
 
 [dev-dependencies]
 base64 = "0.21.0"

--- a/pythnet/pythnet_sdk/Cargo.toml
+++ b/pythnet/pythnet_sdk/Cargo.toml
@@ -13,7 +13,7 @@ name = "pythnet_sdk"
 
 [features]
 test-utils = ["dep:wormhole-vaas-serde", "dep:serde_wormhole", "dep:libsecp256k1", "dep:rand"]
-solana-program = ["dep:solana-program"]
+solana-program = ["dep:solana-program", "dep:anchor-lang"]
 
 [dependencies]
 bincode = "1.3.1"
@@ -33,13 +33,14 @@ wormhole-vaas-serde = {version = "0.1.0", optional = true}
 libsecp256k1 = {version ="0.7.1", optional = true}
 rand = {version = "0.8.5", optional = true}
 solana-program = {version = ">=1.13.6", optional = true}
+anchor-lang  = {version = ">=0.28.0", optional = true}
 
 [dev-dependencies]
 base64 = "0.21.0"
 rand = "0.7.0"
 serde_json = "1.0.96"
-solana-client = "=1.13.6"
-solana-sdk = "=1.13.6"
+solana-client = ">1.13.6"
+solana-sdk = ">1.13.6"
 proptest = "1.1.0"
 
 [package.metadata.docs.rs]

--- a/pythnet/pythnet_sdk/Cargo.toml
+++ b/pythnet/pythnet_sdk/Cargo.toml
@@ -34,7 +34,7 @@ libsecp256k1 = {version ="0.7.1", optional = true}
 rand = {version = "0.8.5", optional = true}
 solana-program = {version = ">=1.13.6", optional = true}
 anchor-lang  = {version = ">=0.28.0", optional = true}
-proc-macro2 = {version = "=1.0.79", optional = true}
+proc-macro2 = {version = "=1.0.79", optional = true} # pinned to 1.0.79 to compilation errors with newer versions, remove this if it compiles fine without
 
 [dev-dependencies]
 base64 = "0.21.0"

--- a/pythnet/pythnet_sdk/src/messages.rs
+++ b/pythnet/pythnet_sdk/src/messages.rs
@@ -1,11 +1,17 @@
+#[cfg(feature = "solana-program")]
+use anchor_lang::{
+    AnchorDeserialize,
+    AnchorSerialize,
+};
+#[cfg(not(feature = "solana-program"))]
+use borsh::{
+    BorshDeserialize,
+    BorshSerialize,
+};
 #[cfg(feature = "quickcheck")]
 use quickcheck::Arbitrary;
 use {
-    borsh::{
-        BorshDeserialize,
-        BorshSchema,
-        BorshSerialize,
-    },
+    borsh::BorshSchema,
     serde::{
         Deserialize,
         Serialize,
@@ -40,6 +46,7 @@ use {
         Deserialize
     ))
 )]
+
 pub enum Message {
     PriceFeedMessage(PriceFeedMessage),
     TwapMessage(TwapMessage),
@@ -75,17 +82,13 @@ impl Arbitrary for Message {
 pub type FeedId = [u8; 32];
 
 #[repr(C)]
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Serialize,
-    Deserialize,
-    BorshDeserialize,
-    BorshSerialize,
-    BorshSchema,
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize, BorshSchema)]
+#[cfg_attr(feature = "solana-program", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(
+    not(feature = "solana-program"),
+    derive(BorshSerialize, BorshDeserialize)
 )]
+
 pub struct PriceFeedMessage {
     pub feed_id:           FeedId,
     pub price:             i64,

--- a/target_chains/solana/Cargo.lock
+++ b/target_chains/solana/Cargo.lock
@@ -1031,7 +1031,7 @@ dependencies = [
  "pyth-sdk-solana",
  "pyth-solana-receiver",
  "pyth-solana-receiver-sdk 0.1.0",
- "pythnet-sdk 2.0.0",
+ "pythnet-sdk 2.1.0",
  "rand 0.8.5",
  "serde_wormhole",
  "solana-program",
@@ -3024,7 +3024,7 @@ dependencies = [
  "program-simulator",
  "pyth-solana-receiver",
  "pyth-solana-receiver-sdk 0.1.0",
- "pythnet-sdk 2.0.0",
+ "pythnet-sdk 2.1.0",
  "serde_wormhole",
  "solana-program",
  "solana-sdk",
@@ -3072,7 +3072,7 @@ dependencies = [
  "common-test-utils",
  "program-simulator",
  "pyth-solana-receiver-sdk 0.1.0",
- "pythnet-sdk 2.0.0",
+ "pythnet-sdk 2.1.0",
  "rand 0.8.5",
  "serde_wormhole",
  "solana-program",
@@ -3095,7 +3095,7 @@ dependencies = [
  "hex",
  "pyth-solana-receiver",
  "pyth-solana-receiver-sdk 0.1.0",
- "pythnet-sdk 2.0.0",
+ "pythnet-sdk 2.1.0",
  "serde_wormhole",
  "shellexpand",
  "solana-client",
@@ -3111,7 +3111,7 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "hex",
- "pythnet-sdk 2.0.0",
+ "pythnet-sdk 2.1.0",
  "solana-program",
 ]
 
@@ -3123,31 +3123,8 @@ checksum = "937c8595148fb2a9a90439daf6a371a5b3c9fcd9b636f26d36ae31d6846d4339"
 dependencies = [
  "anchor-lang",
  "hex",
- "pythnet-sdk 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pythnet-sdk 2.0.0",
  "solana-program",
-]
-
-[[package]]
-name = "pythnet-sdk"
-version = "2.0.0"
-dependencies = [
- "anchor-lang",
- "bincode",
- "borsh 0.10.3",
- "bytemuck",
- "byteorder",
- "fast-math",
- "hex",
- "libsecp256k1 0.7.1",
- "rand 0.8.5",
- "rustc_version",
- "serde",
- "serde_wormhole",
- "sha3 0.10.6",
- "slow_primes",
- "solana-program",
- "thiserror",
- "wormhole-vaas-serde",
 ]
 
 [[package]]
@@ -3167,6 +3144,29 @@ dependencies = [
  "sha3 0.10.6",
  "slow_primes",
  "thiserror",
+]
+
+[[package]]
+name = "pythnet-sdk"
+version = "2.1.0"
+dependencies = [
+ "anchor-lang",
+ "bincode",
+ "borsh 0.10.3",
+ "bytemuck",
+ "byteorder",
+ "fast-math",
+ "hex",
+ "libsecp256k1 0.7.1",
+ "rand 0.8.5",
+ "rustc_version",
+ "serde",
+ "serde_wormhole",
+ "sha3 0.10.6",
+ "slow_primes",
+ "solana-program",
+ "thiserror",
+ "wormhole-vaas-serde",
 ]
 
 [[package]]

--- a/target_chains/solana/Cargo.lock
+++ b/target_chains/solana/Cargo.lock
@@ -125,7 +125,7 @@ checksum = "faa5be5b72abea167f87c868379ba3c2be356bfca9e6f474fd055fa0f7eeb4f2"
 dependencies = [
  "anchor-syn",
  "anyhow",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "regex",
  "syn 1.0.107",
@@ -140,7 +140,7 @@ dependencies = [
  "anchor-syn",
  "anyhow",
  "bs58 0.5.0",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "rustversion",
  "syn 1.0.107",
@@ -153,7 +153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59948e7f9ef8144c2aefb3f32a40c5fce2798baeec765ba038389e82301017ef"
 dependencies = [
  "anchor-syn",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "syn 1.0.107",
 ]
 
@@ -164,7 +164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc753c9d1c7981cb8948cf7e162fb0f64558999c0413058e2d43df1df5448086"
 dependencies = [
  "anchor-syn",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -177,7 +177,7 @@ checksum = "f38b4e172ba1b52078f53fdc9f11e3dc0668ad27997838a0aad2d148afac8c97"
 dependencies = [
  "anchor-syn",
  "anyhow",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -190,7 +190,7 @@ checksum = "4eebd21543606ab61e2d83d9da37d24d3886a49f390f9c43a1964735e8c0f0d5"
 dependencies = [
  "anchor-syn",
  "anyhow",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -222,7 +222,7 @@ checksum = "ec4720d899b3686396cced9508f23dab420f1308344456ec78ef76f98fda42af"
 dependencies = [
  "anchor-syn",
  "anyhow",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -233,7 +233,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f495e85480bd96ddeb77b71d499247c7d4e8b501e75ecb234e9ef7ae7bd6552a"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -271,7 +271,7 @@ dependencies = [
  "anyhow",
  "bs58 0.5.0",
  "heck 0.3.3",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "serde",
  "serde_json",
@@ -376,7 +376,7 @@ checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint 0.4.3",
  "num-traits",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -412,7 +412,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -473,7 +473,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
  "synstructure",
@@ -485,7 +485,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -536,7 +536,7 @@ version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 2.0.39",
 ]
@@ -695,7 +695,7 @@ dependencies = [
  "borsh-derive-internal 0.9.3",
  "borsh-schema-derive-internal 0.9.3",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "syn 1.0.107",
 ]
 
@@ -708,7 +708,7 @@ dependencies = [
  "borsh-derive-internal 0.10.3",
  "borsh-schema-derive-internal 0.10.3",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "syn 1.0.107",
 ]
 
@@ -718,7 +718,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -729,7 +729,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -740,7 +740,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -751,7 +751,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -845,7 +845,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aca418a974d83d40a0c1f0c5cba6ff4bc28d8df099109ca459a2118d40b6322"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -981,7 +981,7 @@ checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -1243,7 +1243,7 @@ dependencies = [
  "cc",
  "codespan-reporting",
  "once_cell",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "scratch",
  "syn 1.0.107",
@@ -1261,7 +1261,7 @@ version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357f40d1f06a24b60ae1fe122542c1fb05d28d32acb2aed064e84bc2ad1e252e"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -1284,7 +1284,7 @@ checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "strsim 0.10.0",
  "syn 2.0.39",
@@ -1353,7 +1353,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -1425,7 +1425,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -1507,7 +1507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0188e3c3ba8df5753894d54461f0e39bc91741dc5b22e1c46999ec2c71f4e4"
 dependencies = [
  "enum-ordinalize",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -1548,7 +1548,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 2.0.39",
 ]
@@ -1561,7 +1561,7 @@ checksum = "a62bb1df8b45ecb7ffa78dca1c17a438fb193eb083db0b1b494d2a61bcb5096a"
 dependencies = [
  "num-bigint 0.4.3",
  "num-traits",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "rustc_version",
  "syn 1.0.107",
@@ -1720,7 +1720,7 @@ version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 2.0.39",
 ]
@@ -2491,7 +2491,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -2580,7 +2580,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -2591,7 +2591,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 2.0.39",
 ]
@@ -2673,7 +2673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate 1.3.0",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 2.0.39",
 ]
@@ -2685,7 +2685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
 dependencies = [
  "proc-macro-crate 1.3.0",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 2.0.39",
 ]
@@ -2775,7 +2775,7 @@ checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -2866,7 +2866,7 @@ version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -2966,7 +2966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
  "version_check",
@@ -2978,7 +2978,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "version_check",
 ]
@@ -2994,9 +2994,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -3158,6 +3158,7 @@ dependencies = [
  "fast-math",
  "hex",
  "libsecp256k1 0.7.1",
+ "proc-macro2 1.0.79",
  "rand 0.8.5",
  "rustc_version",
  "serde",
@@ -3243,7 +3244,7 @@ version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
 ]
 
 [[package]]
@@ -3680,7 +3681,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f188d036977451159430f3b8dc82ec76364a42b7e289c2b18a9a18f4470058e9"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "serde_derive_internals",
  "syn 1.0.107",
@@ -3713,7 +3714,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -3790,7 +3791,7 @@ version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 2.0.39",
 ]
@@ -3801,7 +3802,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -3846,7 +3847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
  "darling",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 2.0.39",
 ]
@@ -4268,7 +4269,7 @@ version = "1.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "992b866b9f0510fd3c290afe6a37109ae8d15b74fa24e3fb6d164be2971ee94f"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "rustc_version",
  "syn 2.0.39",
@@ -4754,7 +4755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fe4363d2503a75325ec94aa18b063574edb3454d38840e01c5af477b3b0689d"
 dependencies = [
  "bs58 0.4.0",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "rustversion",
  "syn 2.0.39",
@@ -5086,7 +5087,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e5f2044ca42c8938d54d1255ce599c79a1ffd86b677dfab695caa20f9ffc3f2"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "sha2 0.10.6",
  "syn 2.0.39",
@@ -5134,7 +5135,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5269c8e868da17b6552ef35a51355a017bd8e0eae269c201fef830d35fa52c"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "sha2 0.10.6",
  "syn 2.0.39",
@@ -5268,7 +5269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.0",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "rustversion",
  "syn 1.0.107",
@@ -5303,7 +5304,7 @@ version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "unicode-ident",
 ]
@@ -5314,7 +5315,7 @@ version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "unicode-ident",
 ]
@@ -5325,7 +5326,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
  "unicode-xid 0.2.4",
@@ -5393,7 +5394,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee42b4e559f17bce0385ebf511a7beb67d5cc33c12c96b7f4e9789919d9c10f"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -5450,7 +5451,7 @@ version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 2.0.39",
 ]
@@ -5552,7 +5553,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 2.0.39",
 ]
@@ -5701,7 +5702,7 @@ version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
 ]
@@ -5964,7 +5965,7 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 2.0.39",
  "wasm-bindgen-shared",
@@ -5998,7 +5999,7 @@ version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 2.0.39",
  "wasm-bindgen-backend",
@@ -6375,7 +6376,7 @@ version = "0.7.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 2.0.39",
 ]
@@ -6395,7 +6396,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.79",
  "quote 1.0.33",
  "syn 1.0.107",
  "synstructure",

--- a/target_chains/solana/Cargo.lock
+++ b/target_chains/solana/Cargo.lock
@@ -1030,7 +1030,7 @@ dependencies = [
  "pyth-sdk",
  "pyth-sdk-solana",
  "pyth-solana-receiver",
- "pyth-solana-receiver-sdk 0.1.0",
+ "pyth-solana-receiver-sdk 0.2.0",
  "pythnet-sdk 2.1.0",
  "rand 0.8.5",
  "serde_wormhole",
@@ -3023,7 +3023,7 @@ dependencies = [
  "common-test-utils",
  "program-simulator",
  "pyth-solana-receiver",
- "pyth-solana-receiver-sdk 0.1.0",
+ "pyth-solana-receiver-sdk 0.2.0",
  "pythnet-sdk 2.1.0",
  "serde_wormhole",
  "solana-program",
@@ -3071,7 +3071,7 @@ dependencies = [
  "byteorder",
  "common-test-utils",
  "program-simulator",
- "pyth-solana-receiver-sdk 0.1.0",
+ "pyth-solana-receiver-sdk 0.2.0",
  "pythnet-sdk 2.1.0",
  "rand 0.8.5",
  "serde_wormhole",
@@ -3094,7 +3094,7 @@ dependencies = [
  "clap 3.2.23",
  "hex",
  "pyth-solana-receiver",
- "pyth-solana-receiver-sdk 0.1.0",
+ "pyth-solana-receiver-sdk 0.2.0",
  "pythnet-sdk 2.1.0",
  "serde_wormhole",
  "shellexpand",
@@ -3108,22 +3108,22 @@ dependencies = [
 [[package]]
 name = "pyth-solana-receiver-sdk"
 version = "0.1.0"
-dependencies = [
- "anchor-lang",
- "hex",
- "pythnet-sdk 2.1.0",
- "solana-program",
-]
-
-[[package]]
-name = "pyth-solana-receiver-sdk"
-version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "937c8595148fb2a9a90439daf6a371a5b3c9fcd9b636f26d36ae31d6846d4339"
 dependencies = [
  "anchor-lang",
  "hex",
  "pythnet-sdk 2.0.0",
+ "solana-program",
+]
+
+[[package]]
+name = "pyth-solana-receiver-sdk"
+version = "0.2.0"
+dependencies = [
+ "anchor-lang",
+ "hex",
+ "pythnet-sdk 2.1.0",
  "solana-program",
 ]
 
@@ -3762,7 +3762,7 @@ name = "send-usd"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "pyth-solana-receiver-sdk 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pyth-solana-receiver-sdk 0.1.0",
  "solana-program",
 ]
 

--- a/target_chains/solana/Cargo.lock
+++ b/target_chains/solana/Cargo.lock
@@ -3131,6 +3131,7 @@ dependencies = [
 name = "pythnet-sdk"
 version = "2.0.0"
 dependencies = [
+ "anchor-lang",
  "bincode",
  "borsh 0.10.3",
  "bytemuck",

--- a/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
+++ b/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-solana-receiver-sdk"
-version = "0.1.0"
+version = "0.2.0"
 description = "SDK for the Pyth Solana Receiver program"
 authors = ["Pyth Data Association"]
 repository = "https://github.com/pyth-network/pyth-crosschain"

--- a/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
+++ b/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
@@ -15,5 +15,5 @@ name = "pyth_solana_receiver_sdk"
 [dependencies]
 anchor-lang = ">=0.28.0"
 hex = ">=0.4.3"
-pythnet-sdk = { path = "../../../pythnet/pythnet_sdk", version = "2.0.0", features = ["solana-program"]}
+pythnet-sdk = { path = "../../../pythnet/pythnet_sdk", version = "2.1.0", features = ["solana-program"]}
 solana-program = ">=1.16.0"

--- a/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
+++ b/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
@@ -15,5 +15,5 @@ name = "pyth_solana_receiver_sdk"
 [dependencies]
 anchor-lang = ">=0.28.0"
 hex = ">=0.4.3"
-pythnet-sdk = { path = "../../../pythnet/pythnet_sdk", version = "2.0.0"}
+pythnet-sdk = { path = "../../../pythnet/pythnet_sdk", version = "2.0.0", features = ["solana-program"]}
 solana-program = ">=1.16.0"


### PR DESCRIPTION
In anchor 0.30.0, it's not enough to implement `BorshSerialize` and `BorshDeserialize` for your structs.
You also need to implement the trait `IdlBuild`.
Thankfully the derive macro for `AnchorSerialize` and `AnchorDeserialize` does this for you automatically. 

I want to add this derive macro in pythnet_sdk when the solana-program feature is on.
This will allow people to use pyth-solana-receiver-sdk with anchor 0.30.0