### PR TITLE
feat(price_pusher): add more options to evm pusher

### DIFF
--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "6.6.3",
+  "version": "6.7.0",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/apps/price_pusher/src/evm/command.ts
+++ b/apps/price_pusher/src/evm/command.ts
@@ -52,6 +52,20 @@ export default {
       required: false,
       default: 5,
     } as Options,
+    "gas-limit": {
+      description: "Gas limit for the transaction",
+      type: "number",
+      required: false,
+    } as Options,
+    "update-fee-multiplier": {
+      description:
+        "Multiplier for the fee to update the price. It is useful in networks " +
+        "such as Hedera where setting on-chain getUpdateFee as the transaction value " +
+        "won't work. Default to 1",
+      type: "number",
+      required: false,
+      default: 1,
+    } as Options,
     ...options.priceConfigFile,
     ...options.priceServiceEndpoint,
     ...options.mnemonicFile,
@@ -73,6 +87,8 @@ export default {
       txSpeed,
       overrideGasPriceMultiplier,
       overrideGasPriceMultiplierCap,
+      gasLimit,
+      updateFeeMultiplier,
     } = argv;
 
     const priceConfigs = readPriceConfigFile(priceConfigFile);
@@ -119,6 +135,8 @@ export default {
       pythContractFactory,
       overrideGasPriceMultiplier,
       overrideGasPriceMultiplierCap,
+      updateFeeMultiplier,
+      gasLimit,
       gasStation
     );
 

--- a/apps/price_pusher/src/evm/evm.ts
+++ b/apps/price_pusher/src/evm/evm.ts
@@ -130,6 +130,8 @@ export class EvmPricePusher implements IPricePusher {
     pythContractFactory: PythContractFactory,
     private overrideGasPriceMultiplier: number,
     private overrideGasPriceMultiplierCap: number,
+    private updateFeeMultiplier: number,
+    private gasLimit?: number,
     customGasStation?: CustomGasStation
   ) {
     this.customGasStation = customGasStation;
@@ -168,6 +170,7 @@ export class EvmPricePusher implements IPricePusher {
       updateFee = await this.pythContract.methods
         .getUpdateFee(priceFeedUpdateData)
         .call();
+      updateFee = Number(updateFee) * (this.updateFeeMultiplier || 1);
       console.log(`Update fee: ${updateFee}`);
     } catch (e: any) {
       console.error(
@@ -217,7 +220,12 @@ export class EvmPricePusher implements IPricePusher {
         priceIdsWith0x,
         pubTimesToPush
       )
-      .send({ value: updateFee, gasPrice, nonce: txNonce })
+      .send({
+        value: updateFee,
+        gasPrice,
+        nonce: txNonce,
+        gasLimit: this.gasLimit,
+      })
       .on("transactionHash", (hash: string) => {
         console.log(`Successful. Tx hash: ${hash}`);
       })


### PR DESCRIPTION
This change makes gasLimit configurable and also adds an updateFeeMultiplier which is useful in Hedera as they have an inconsistency between the `value` passed in tx and the `value` on-chain.