### PR TITLE
[price_pusher] Option to ignore gas objects

### DIFF
--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "6.7.1",
+  "version": "6.7.2",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/apps/price_pusher/src/index.ts
+++ b/apps/price_pusher/src/index.ts
@@ -9,6 +9,9 @@ import near from "./near/command";
 import solana from "./solana/command";
 
 yargs(hideBin(process.argv))
+  .parserConfiguration({
+    "parse-numbers": false,
+  })
   .config("config")
   .global("config")
   .command(evm)

--- a/apps/price_pusher/src/sui/command.ts
+++ b/apps/price_pusher/src/sui/command.ts
@@ -45,7 +45,8 @@ export default {
       default: 30,
     } as Options,
     "ignore-gas-objects": {
-      description: "Gas objects to ignore when merging gas objects on startup -- use this for locked objects.",
+      description:
+        "Gas objects to ignore when merging gas objects on startup -- use this for locked objects.",
       type: "array",
       required: false,
       default: [],

--- a/apps/price_pusher/src/sui/command.ts
+++ b/apps/price_pusher/src/sui/command.ts
@@ -44,6 +44,12 @@ export default {
       required: true,
       default: 30,
     } as Options,
+    "ignore-gas-objects": {
+      description: "Gas objects to ignore when merging gas objects on startup -- use this for locked objects.",
+      type: "array",
+      required: false,
+      default: [],
+    } as Options,
     "gas-budget": {
       description: "Gas budget for each price update",
       type: "number",
@@ -73,6 +79,7 @@ export default {
       pythStateId,
       wormholeStateId,
       numGasObjects,
+      ignoreGasObjects,
       gasBudget,
       accountIndex,
     } = argv;
@@ -126,7 +133,8 @@ export default {
       endpoint,
       keypair,
       gasBudget,
-      numGasObjects
+      numGasObjects,
+      ignoreGasObjects
     );
 
     const controller = new Controller(

--- a/apps/price_pusher/src/sui/sui.ts
+++ b/apps/price_pusher/src/sui/sui.ts
@@ -162,7 +162,8 @@ export class SuiPricePusher implements IPricePusher {
     endpoint: string,
     keypair: Ed25519Keypair,
     gasBudget: number,
-    numGasObjects: number
+    numGasObjects: number,
+    ignoreGasObjects: string[],
   ): Promise<SuiPricePusher> {
     if (numGasObjects > MAX_NUM_OBJECTS_IN_ARGUMENT) {
       throw new Error(
@@ -183,7 +184,8 @@ export class SuiPricePusher implements IPricePusher {
     const gasPool = await SuiPricePusher.initializeGasPool(
       keypair,
       provider,
-      numGasObjects
+      numGasObjects,
+      ignoreGasObjects,
     );
 
     const pythClient = new SuiPythClient(
@@ -318,17 +320,26 @@ export class SuiPricePusher implements IPricePusher {
 
   // This function will smash all coins owned by the signer into one, and then
   // split them equally into numGasObjects.
+  // ignoreGasObjects is a list of gas objects that will be ignored during the
+  // merging -- use this to store any locked objects on initialization.
   private static async initializeGasPool(
     signer: Ed25519Keypair,
     provider: SuiClient,
-    numGasObjects: number
+    numGasObjects: number,
+    ignoreGasObjects: string[],
   ): Promise<SuiObjectRef[]> {
     const signerAddress = await signer.toSuiAddress();
+
+    if (ignoreGasObjects.length > 0) {
+      console.log("Ignoring some gas objects for coin merging:")
+      console.log(ignoreGasObjects);
+    }
 
     const consolidatedCoin = await SuiPricePusher.mergeGasCoinsIntoOne(
       signer,
       provider,
-      signerAddress
+      signerAddress,
+      ignoreGasObjects
     );
     const coinResult = await provider.getObject({
       id: consolidatedCoin.objectId,
@@ -458,7 +469,8 @@ export class SuiPricePusher implements IPricePusher {
   private static async mergeGasCoinsIntoOne(
     signer: Ed25519Keypair,
     provider: SuiClient,
-    owner: SuiAddress
+    owner: SuiAddress,
+    initialLockedAddresses: string[],
   ): Promise<SuiObjectRef> {
     const gasCoins = await SuiPricePusher.getAllGasCoins(provider, owner);
     // skip merging if there is only one coin
@@ -472,6 +484,7 @@ export class SuiPricePusher implements IPricePusher {
     );
     let finalCoin;
     const lockedAddresses: Set<string> = new Set();
+    initialLockedAddresses.forEach((value) => lockedAddresses.add(value));
     for (let i = 0; i < gasCoinsChunks.length; i++) {
       const mergeTx = new TransactionBlock();
       let coins = gasCoinsChunks[i];
@@ -497,7 +510,6 @@ export class SuiPricePusher implements IPricePusher {
             "quorum of validators because of locked objects. Retried a conflicting transaction"
           )
         ) {
-          /*
           Object.values((e as any).data).forEach((lockedObjects: any) => {
             lockedObjects.forEach((lockedObject: [string, number, string]) => {
               lockedAddresses.add(lockedObject[0]);
@@ -505,7 +517,6 @@ export class SuiPricePusher implements IPricePusher {
           });
           // retry merging without the locked coins
           i--;
-           */
           continue;
         }
         throw e;

--- a/apps/price_pusher/src/sui/sui.ts
+++ b/apps/price_pusher/src/sui/sui.ts
@@ -163,7 +163,7 @@ export class SuiPricePusher implements IPricePusher {
     keypair: Ed25519Keypair,
     gasBudget: number,
     numGasObjects: number,
-    ignoreGasObjects: string[],
+    ignoreGasObjects: string[]
   ): Promise<SuiPricePusher> {
     if (numGasObjects > MAX_NUM_OBJECTS_IN_ARGUMENT) {
       throw new Error(
@@ -185,7 +185,7 @@ export class SuiPricePusher implements IPricePusher {
       keypair,
       provider,
       numGasObjects,
-      ignoreGasObjects,
+      ignoreGasObjects
     );
 
     const pythClient = new SuiPythClient(
@@ -326,12 +326,12 @@ export class SuiPricePusher implements IPricePusher {
     signer: Ed25519Keypair,
     provider: SuiClient,
     numGasObjects: number,
-    ignoreGasObjects: string[],
+    ignoreGasObjects: string[]
   ): Promise<SuiObjectRef[]> {
     const signerAddress = await signer.toSuiAddress();
 
     if (ignoreGasObjects.length > 0) {
-      console.log("Ignoring some gas objects for coin merging:")
+      console.log("Ignoring some gas objects for coin merging:");
       console.log(ignoreGasObjects);
     }
 
@@ -470,7 +470,7 @@ export class SuiPricePusher implements IPricePusher {
     signer: Ed25519Keypair,
     provider: SuiClient,
     owner: SuiAddress,
-    initialLockedAddresses: string[],
+    initialLockedAddresses: string[]
   ): Promise<SuiObjectRef> {
     const gasCoins = await SuiPricePusher.getAllGasCoins(provider, owner);
     // skip merging if there is only one coin


### PR DESCRIPTION
We have a bunch of locked gas objects on Sui for some reason. These are usually returned in the error message of the failed tx, but they aren't being returned currently for some reason. Add a command line option so we can manually ignore them to get the process started again.