### PR TITLE
fix(xc_admin_frontend): inject env variable for RPC in docker build

### DIFF
--- a/.github/workflows/push-xc-admin-frontend-image.yml
+++ b/.github/workflows/push-xc-admin-frontend-image.yml
@@ -31,9 +31,8 @@ jobs:
         run: |
           DOCKER_BUILDKIT=1 docker build -t lerna -f Dockerfile.lerna .
           DOCKER_BUILDKIT=1 docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
-            --build-arg NEXT_PUBLIC_RPC_POOL_TOKEN=$NEXT_PUBLIC_RPC_POOL_TOKEN -f governance/xc_admin/packages/xc_admin_frontend/Dockerfile .
-        env:
-          NEXT_PUBLIC_RPC_POOL_TOKEN: ${{ secrets.NEXT_PUBLIC_RPC_POOL_TOKEN }}
+            --build-arg NEXT_PUBLIC_RPC_POOL_TOKEN=${{ secrets.NEXT_PUBLIC_RPC_POOL_TOKEN }} \
+            -f governance/xc_admin/packages/xc_admin_frontend/Dockerfile .
       - name: Push docker image
         if: github.ref == 'refs/heads/main'
         run: |

--- a/.github/workflows/push-xc-admin-frontend-image.yml
+++ b/.github/workflows/push-xc-admin-frontend-image.yml
@@ -1,5 +1,6 @@
 name: xc_admin_frontend Docker Image
 on:
+  pull_request:
   push:
     branches: [main]
     paths: [governance/xc_admin/**]
@@ -29,7 +30,10 @@ jobs:
       - name: Build docker image
         run: |
           DOCKER_BUILDKIT=1 docker build -t lerna -f Dockerfile.lerna .
-          DOCKER_BUILDKIT=1 docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} -f governance/xc_admin/packages/xc_admin_frontend/Dockerfile .
+          DOCKER_BUILDKIT=1 docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
+            --build-arg NEXT_PUBLIC_RPC_POOL_TOKEN=$NEXT_PUBLIC_RPC_POOL_TOKEN -f governance/xc_admin/packages/xc_admin_frontend/Dockerfile .
+        env:
+          NEXT_PUBLIC_RPC_POOL_TOKEN: ${{ secrets.NEXT_PUBLIC_RPC_POOL_TOKEN }}
       - name: Push docker image
         if: github.ref == 'refs/heads/main'
         run: |

--- a/.github/workflows/push-xc-admin-frontend-image.yml
+++ b/.github/workflows/push-xc-admin-frontend-image.yml
@@ -34,6 +34,6 @@ jobs:
             --build-arg NEXT_PUBLIC_RPC_POOL_TOKEN=${{ secrets.NEXT_PUBLIC_RPC_POOL_TOKEN }} \
             -f governance/xc_admin/packages/xc_admin_frontend/Dockerfile .
       - name: Push docker image
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         run: |
           docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/push-xc-admin-frontend-image.yml
+++ b/.github/workflows/push-xc-admin-frontend-image.yml
@@ -1,6 +1,5 @@
 name: xc_admin_frontend Docker Image
 on:
-  pull_request:
   push:
     branches: [main]
     paths: [governance/xc_admin/**]
@@ -34,6 +33,6 @@ jobs:
             --build-arg NEXT_PUBLIC_RPC_POOL_TOKEN=${{ secrets.NEXT_PUBLIC_RPC_POOL_TOKEN }} \
             -f governance/xc_admin/packages/xc_admin_frontend/Dockerfile .
       - name: Push docker image
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         run: |
           docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}

--- a/governance/xc_admin/packages/xc_admin_frontend/Dockerfile
+++ b/governance/xc_admin/packages/xc_admin_frontend/Dockerfile
@@ -6,6 +6,8 @@ USER root
 WORKDIR /home/node/
 USER 1000
 
+ARG NEXT_PUBLIC_RPC_POOL_TOKEN
+
 COPY --chown=1000:1000 target_chains/solana/sdk/js target_chains/solana/sdk/js
 COPY --chown=1000:1000 governance/xc_admin governance/xc_admin
 COPY --chown=1000:1000 pythnet/message_buffer pythnet/message_buffer
@@ -13,6 +15,7 @@ COPY --chown=1000:1000 price_service/sdk/js price_service/sdk/js
 
 ENV NODE_ENV production
 ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_PUBLIC_RPC_POOL_TOKEN $NEXT_PUBLIC_RPC_POOL_TOKEN
 
 RUN npx lerna run build --scope="xc_admin_frontend" --include-dependencies
 


### PR DESCRIPTION
xc-admin-frontend needs to have some environment variables during build time to make them available on the client-side. This PR adds the most important one.