### PR TITLE
fix(xc_admin/crank_pythnet_relayer): increase compute unit limit 

### DIFF
--- a/governance/xc_admin/packages/crank_pythnet_relayer/src/index.ts
+++ b/governance/xc_admin/packages/crank_pythnet_relayer/src/index.ts
@@ -183,7 +183,7 @@ async function run() {
             .postInstructions([
               ComputeBudgetProgram.setComputeUnitLimit({ units: 1000000 }),
             ])
-            .rpc({ skipPreflight: false });
+            .rpc({ skipPreflight: true });
         } catch (e) {
           if (SKIP_FAILED_REMOTE_INSTRUCTIONS) {
             console.error(e);

--- a/governance/xc_admin/packages/crank_pythnet_relayer/src/index.ts
+++ b/governance/xc_admin/packages/crank_pythnet_relayer/src/index.ts
@@ -11,6 +11,7 @@ import {
 import {
   AccountMeta,
   Commitment,
+  ComputeBudgetProgram,
   Connection,
   Keypair,
   PublicKey,
@@ -177,7 +178,12 @@ async function run() {
             })
             .remainingAccounts(extraAccountMetas)
             .preInstructions(preInstructions)
-            .rpc({ skipPreflight: true });
+            // Use a high compute unit limit to avoid running out of compute units
+            // as some operations can use a lot of compute units.
+            .postInstructions([
+              ComputeBudgetProgram.setComputeUnitLimit({ units: 1000000 }),
+            ])
+            .rpc({ skipPreflight: false });
         } catch (e) {
           if (SKIP_FAILED_REMOTE_INSTRUCTIONS) {
             console.error(e);


### PR DESCRIPTION
By default the compute unit limit for a tx is 200k but this is not
enough for all of our instructions. This change adds an instruction
to the pythnet relayer to set it to 1m to make sure all instructions
can be executed without problem.