### PR TITLE
refactor(target_chains/ethereum): fix forge warnings

### DIFF
--- a/.github/workflows/ci-ethereum-contract.yml
+++ b/.github/workflows/ci-ethereum-contract.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm run install-forge-deps
 
       - name: Run tests
-        run: forge test -vvv
+        run: forge test -vvv --deny-warnings
 
       - name: Run snapshot
         run: NO_COLOR=1 forge snapshot --match-contract GasBenchmark >> $GITHUB_STEP_SUMMARY

--- a/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
@@ -812,7 +812,6 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             provider1,
             assignedSequenceNumber
         );
-        bytes32 blockHash = bytes32(uint256(0));
 
         vm.expectEmit(false, false, false, true, address(random));
         emit RevealedWithCallback(
@@ -866,7 +865,6 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             provider1,
             assignedSequenceNumber
         );
-        bytes32 blockHash = bytes32(uint256(0));
 
         vm.expectEmit(false, false, false, true, address(random));
         emit RevealedWithCallback(
@@ -943,10 +941,10 @@ contract EntropyConsumer is IEntropyConsumer {
     function requestEntropy(
         bytes32 randomNumber
     ) public payable returns (uint64 sequenceNumber) {
-        address provider = IEntropy(entropy).getDefaultProvider();
+        address _provider = IEntropy(entropy).getDefaultProvider();
         sequenceNumber = IEntropy(entropy).requestWithCallback{
             value: msg.value
-        }(provider, randomNumber);
+        }(_provider, randomNumber);
     }
 
     function getEntropy() internal view override returns (address) {
@@ -977,11 +975,7 @@ contract EntropyConsumerFails is IEntropyConsumer {
         return entropy;
     }
 
-    function entropyCallback(
-        uint64 _sequence,
-        address _provider,
-        bytes32 _randomness
-    ) internal override {
+    function entropyCallback(uint64, address, bytes32) internal pure override {
         revert("Callback failed");
     }
 }

--- a/target_chains/ethereum/contracts/forge-test/Executor.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Executor.t.sol
@@ -70,7 +70,7 @@ contract ExecutorTest is Test, WormholeTestUtils {
     function getTestUpgradeVaa(
         address newImplementation,
         uint value
-    ) internal returns (bytes memory vaa) {
+    ) internal view returns (bytes memory vaa) {
         bytes memory payload = abi.encodePacked(
             uint32(0x5054474d),
             PythGovernanceInstructions.GovernanceModule.EvmExecutor,
@@ -637,7 +637,7 @@ contract TestCallable is ICallable {
         lastCaller = msg.sender;
     }
 
-    function reverts() external override {
+    function reverts() external pure override {
         revert("call should revert");
     }
 }

--- a/target_chains/ethereum/contracts/forge-test/Pyth.WormholeMerkleAccumulator.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pyth.WormholeMerkleAccumulator.t.sol
@@ -618,7 +618,7 @@ contract PythWormholeMerkleAccumulatorTest is
         (
             bytes[] memory updateData,
             uint updateFee,
-            bytes32[] memory priceIds
+
         ) = createAndForgeWormholeMerkleUpdateData("");
 
         pyth.updatePriceFeeds{value: updateFee}(updateData);

--- a/target_chains/ethereum/contracts/forge-test/VerificationExperiments.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/VerificationExperiments.t.sol
@@ -286,7 +286,6 @@ contract VerificationExperiments is Test, WormholeTestUtils, PythTestUtils {
         ) = generateMerkleProof(priceId, price, depth);
 
         data = generateMessagePayload(priceId, price);
-        bytes32 hash = keccak256(data);
 
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(THRESHOLD_KEY, root);
         bytes memory signature = abi.encodePacked(r, s, v - 27);
@@ -592,7 +591,7 @@ contract PythExperimental is Pyth {
         bytes32 expectedRoot,
         bytes memory data,
         bytes32[] memory proof
-    ) public returns (bool) {
+    ) public pure returns (bool) {
         bytes32 curNodeHash = keccak256(data);
         for (uint i = 0; i < proof.length; ) {
             curNodeHash = keccak256(abi.encode(curNodeHash, proof[i]));

--- a/target_chains/ethereum/contracts/forge-test/utils/PythTestUtils.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/utils/PythTestUtils.t.sol
@@ -56,7 +56,7 @@ abstract contract PythTestUtils is Test, WormholeTestUtils, RandTestUtils {
         return address(pyth);
     }
 
-    function singleUpdateFeeInWei() public view returns (uint) {
+    function singleUpdateFeeInWei() public pure returns (uint) {
         return SINGLE_UPDATE_FEE_IN_WEI;
     }
 
@@ -182,7 +182,7 @@ abstract contract PythTestUtils is Test, WormholeTestUtils, RandTestUtils {
         uint8 numSigners,
         uint8 minorVersion,
         bytes memory trailingHeaderData
-    ) internal returns (bytes memory whMerkleUpdateData) {
+    ) internal view returns (bytes memory whMerkleUpdateData) {
         bytes[] memory encodedPriceFeedMessages = encodePriceFeedMessages(
             priceFeedMessages
         );
@@ -222,7 +222,7 @@ abstract contract PythTestUtils is Test, WormholeTestUtils, RandTestUtils {
     function generateForwardCompatibleWormholeMerkleUpdateHeader(
         uint8 minorVersion,
         bytes memory trailingHeaderData
-    ) private returns (bytes memory whMerkleUpdateHeader) {
+    ) private pure returns (bytes memory whMerkleUpdateHeader) {
         whMerkleUpdateHeader = abi.encodePacked(
             uint32(0x504e4155), // PythAccumulator.ACCUMULATOR_MAGIC
             uint8(1), // major version
@@ -237,7 +237,7 @@ abstract contract PythTestUtils is Test, WormholeTestUtils, RandTestUtils {
         bytes20 rootDigest,
         bytes memory futureData,
         uint8 numSigners
-    ) internal returns (bytes memory wormholeMerkleVaa) {
+    ) internal view returns (bytes memory wormholeMerkleVaa) {
         wormholeMerkleVaa = generateVaa(
             0,
             SOURCE_EMITTER_CHAIN_ID,

--- a/target_chains/ethereum/contracts/forge-test/utils/WormholeTestUtils.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/utils/WormholeTestUtils.t.sol
@@ -96,7 +96,7 @@ abstract contract WormholeTestUtils is Test {
         uint64 sequence,
         bytes memory payload,
         uint8 numSigners
-    ) public returns (bytes memory vaa) {
+    ) public view returns (bytes memory vaa) {
         bytes memory body = abi.encodePacked(
             timestamp,
             uint32(0), // Nonce. It is zero for single VAAs.
@@ -141,7 +141,7 @@ abstract contract WormholeTestUtils is Test {
         bytes memory payload,
         uint8 numSigners,
         bytes memory forgeItem
-    ) public returns (bytes memory vaa) {
+    ) public view returns (bytes memory vaa) {
         bytes memory body = abi.encodePacked(
             timestamp,
             uint32(0), // Nonce. It is zero for single VAAs.
@@ -201,7 +201,6 @@ abstract contract WormholeTestUtils is Test {
             // encodePacked uses padding for arrays and we don't want it, so we manually concat them.
             newGuardians = abi.encodePacked(newGuardians, vm.addr(i + 1 + 10));
         }
-        uint32 newGuardianSetIndex = uint32(1);
         bytes memory upgradeGuardianSetPayload = abi.encodePacked(
             bytes32(
                 0x00000000000000000000000000000000000000000000000000000000436f7265
@@ -327,9 +326,6 @@ contract WormholeTestUtilsTest is Test, WormholeTestUtils {
         uint8 numGuardians = 5;
         address whAddr = setUpWormholeReceiver(numGuardians);
         IWormhole wormhole = IWormhole(whAddr);
-        ReceiverImplementation whReceiverImpl = ReceiverImplementation(
-            payable(whAddr)
-        );
         // generate the vaa and sign with the initial wormhole guardian set
         bytes memory vaa = forgeVaa(
             TEST_VAA_TIMESTAMP,
@@ -351,9 +347,6 @@ contract WormholeTestUtilsTest is Test, WormholeTestUtils {
         uint8 numGuardians = 5;
         address whAddr = setUpWormholeReceiver(numGuardians);
         IWormhole wormhole = IWormhole(whAddr);
-        ReceiverImplementation whReceiverImpl = ReceiverImplementation(
-            payable(whAddr)
-        );
         // generate the vaa and sign with the initial wormhole guardian set
         bytes memory vaa = forgeVaa(
             TEST_VAA_TIMESTAMP,
@@ -375,9 +368,6 @@ contract WormholeTestUtilsTest is Test, WormholeTestUtils {
         uint8 numGuardians = 5;
         address whAddr = setUpWormholeReceiver(numGuardians);
         IWormhole wormhole = IWormhole(whAddr);
-        ReceiverImplementation whReceiverImpl = ReceiverImplementation(
-            payable(whAddr)
-        );
         upgradeGuardianSet(5);
         // generate the vaa and sign with the new wormhole guardian set
         bytes memory vaa = generateVaa(
@@ -388,7 +378,6 @@ contract WormholeTestUtilsTest is Test, WormholeTestUtils {
             TEST_PAYLOAD,
             TEST_NUM_SIGNERS
         );
-        uint32 guardianSetIdx = wormhole.getCurrentGuardianSetIndex();
         vm.warp(block.timestamp + 5 days);
 
         (Structs.VM memory vm, bool valid, string memory reason) = wormhole
@@ -402,9 +391,6 @@ contract WormholeTestUtilsTest is Test, WormholeTestUtils {
         uint8 numGuardians = 5;
         address whAddr = setUpWormholeReceiver(numGuardians);
         IWormhole wormhole = IWormhole(whAddr);
-        ReceiverImplementation whReceiverImpl = ReceiverImplementation(
-            payable(whAddr)
-        );
         // generate the vaa and sign with the initial wormhole guardian set
         bytes memory vaa = generateVaa(
             TEST_VAA_TIMESTAMP,
@@ -416,7 +402,6 @@ contract WormholeTestUtilsTest is Test, WormholeTestUtils {
         );
 
         upgradeGuardianSet(numGuardians);
-        uint32 guardianSetIdx = wormhole.getCurrentGuardianSetIndex();
         uint previousGuardianSetExpiration = wormhole
             .getGuardianSet(0)
             .expirationTime;
@@ -431,9 +416,6 @@ contract WormholeTestUtilsTest is Test, WormholeTestUtils {
         uint8 numGuardians = 5;
         address whAddr = setUpWormholeReceiver(numGuardians);
         IWormhole wormhole = IWormhole(whAddr);
-        ReceiverImplementation whReceiverImpl = ReceiverImplementation(
-            payable(whAddr)
-        );
         // generate the vaa and sign with the current wormhole guardian set
         bytes memory vaa = generateVaa(
             TEST_VAA_TIMESTAMP,
@@ -445,7 +427,6 @@ contract WormholeTestUtilsTest is Test, WormholeTestUtils {
         );
 
         upgradeGuardianSet(numGuardians);
-        uint32 guardianSetIdx = wormhole.getCurrentGuardianSetIndex();
         vm.warp(block.timestamp + 5 days);
         (, bool valid, string memory reason) = wormhole.parseAndVerifyVM(vaa);
         assertEq(valid, false);
@@ -456,9 +437,6 @@ contract WormholeTestUtilsTest is Test, WormholeTestUtils {
         uint8 numGuardians = 5;
         address whAddr = setUpWormholeReceiver(numGuardians);
         IWormhole wormhole = IWormhole(whAddr);
-        ReceiverImplementation whReceiverImpl = ReceiverImplementation(
-            payable(whAddr)
-        );
         // generate the vaa and sign with the current wormhole guardian set
         bytes memory vaa = forgeVaa(
             TEST_VAA_TIMESTAMP,
@@ -479,9 +457,6 @@ contract WormholeTestUtilsTest is Test, WormholeTestUtils {
         uint8 numGuardians = 5;
         address whAddr = setUpWormholeReceiver(numGuardians);
         IWormhole wormhole = IWormhole(whAddr);
-        ReceiverImplementation whReceiverImpl = ReceiverImplementation(
-            payable(whAddr)
-        );
         // generate the vaa and sign with the current wormhole guardian set
         bytes memory vaa = forgeVaa(
             TEST_VAA_TIMESTAMP,

--- a/target_chains/ethereum/contracts/foundry.toml
+++ b/target_chains/ethereum/contracts/foundry.toml
@@ -11,3 +11,14 @@ libs = [
     'lib',
     '../../../node_modules',
 ]
+
+# This doesn't work on ../../../node_modules alone because the sources from
+# parent directories are also represented as absolute paths and won't doesn't
+# match the relative paths in the source files. Therefore, we are adding
+# the absolute path for the node_modules directory in the github CI to
+# make sure that the CI runs successfully.
+ignored_warnings_from = [
+    "lib",
+    "../../../node_modules/",
+    "/home/runner/work/pyth-crosschain/pyth-crosschain/node_modules"
+]


### PR DESCRIPTION
This change modifies the tests so the warnings go away. However, there are some warnings in the dependencies and they couldn't be resolved.