### PR TITLE
[fortuna] Adjust gas oracle logic to eliminate ethers.rs priority fee lower bound

### DIFF
--- a/apps/fortuna/Cargo.lock
+++ b/apps/fortuna/Cargo.lock
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "fortuna"
-version = "5.3.2"
+version = "5.3.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/fortuna/Cargo.toml
+++ b/apps/fortuna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "fortuna"
-version = "5.3.2"
+version = "5.3.3"
 edition = "2021"
 
 [dependencies]

--- a/apps/fortuna/src/chain.rs
+++ b/apps/fortuna/src/chain.rs
@@ -1,3 +1,3 @@
+pub(crate) mod eth_gas_oracle;
 pub(crate) mod ethereum;
 pub(crate) mod reader;
-pub(crate) mod eth_gas_oracle;

--- a/apps/fortuna/src/chain.rs
+++ b/apps/fortuna/src/chain.rs
@@ -1,2 +1,3 @@
 pub(crate) mod ethereum;
 pub(crate) mod reader;
+pub(crate) mod eth_gas_oracle;

--- a/apps/fortuna/src/chain/eth_gas_oracle.rs
+++ b/apps/fortuna/src/chain/eth_gas_oracle.rs
@@ -149,11 +149,11 @@ fn estimate_priority_fee(rewards: Vec<Vec<U256>>) -> U256 {
 }
 
 fn base_fee_surged(base_fee_per_gas: U256) -> U256 {
-    if base_fee_per_gas <= U256::from(40_000u64) {
+    if base_fee_per_gas <= U256::from(SURGE_THRESHOLD_1) {
         base_fee_per_gas * 2
-    } else if base_fee_per_gas <= U256::from(100_000u64) {
+    } else if base_fee_per_gas <= U256::from(SURGE_THRESHOLD_2) {
         base_fee_per_gas * 16 / 10
-    } else if base_fee_per_gas <= U256::from(200_000u64) {
+    } else if base_fee_per_gas <= U256::from(SURGE_THRESHOLD_3) {
         base_fee_per_gas * 14 / 10
     } else {
         base_fee_per_gas * 12 / 10

--- a/apps/fortuna/src/chain/eth_gas_oracle.rs
+++ b/apps/fortuna/src/chain/eth_gas_oracle.rs
@@ -20,7 +20,7 @@ use {
 // work well in layer 2 networks because it lower bounds the priority fee at 3 gwei.
 // Unfortunately this logic is not configurable in ethers.rs.
 //
-// Thus, this file is copy-pasted from places in ethers.rs with all of the fee constants divided by 100000.
+// Thus, this file is copy-pasted from places in ethers.rs with all of the fee constants divided by 1000000.
 // See original logic here:
 // https://github.com/gakonst/ethers-rs/blob/master/ethers-providers/src/rpc/provider.rs#L452
 

--- a/apps/fortuna/src/chain/eth_gas_oracle.rs
+++ b/apps/fortuna/src/chain/eth_gas_oracle.rs
@@ -1,0 +1,129 @@
+use ethers::types::{U256, I256};
+use ethers::providers::Middleware;
+use ethers::prelude::GasOracle;
+use ethers::prelude::gas_oracle::GasOracleError;
+use ethers::prelude::gas_oracle::Result;
+use axum::async_trait;
+
+
+/// Gas oracle from a [`Middleware`] implementation such as an
+/// Ethereum RPC provider.
+#[derive(Clone, Debug)]
+#[must_use]
+pub struct EthProviderOracle<M: Middleware> {
+    provider: M,
+}
+
+impl<M: Middleware> EthProviderOracle<M> {
+    pub fn new(provider: M) -> Self {
+        Self { provider }
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl<M: Middleware> GasOracle for EthProviderOracle<M>
+    where
+        M::Error: 'static,
+{
+    async fn fetch(&self) -> Result<U256> {
+        self.provider
+            .get_gas_price()
+            .await
+            .map_err(|err| GasOracleError::ProviderError(Box::new(err)))
+    }
+
+    async fn estimate_eip1559_fees(&self) -> Result<(U256, U256)> {
+        self.provider
+            .estimate_eip1559_fees(Some(eip1559_default_estimator))
+            .await
+            .map_err(|err| GasOracleError::ProviderError(Box::new(err)))
+    }
+}
+
+/// The default max priority fee per gas, used in case the base fee is within a threshold.
+pub const EIP1559_FEE_ESTIMATION_DEFAULT_PRIORITY_FEE: u64 = 3_000;
+/// The threshold for base fee below which we use the default priority fee, and beyond which we
+/// estimate an appropriate value for priority fee.
+pub const EIP1559_FEE_ESTIMATION_PRIORITY_FEE_TRIGGER: u64 = 100_000;
+/// The threshold max change/difference (in %) at which we will ignore the fee history values
+/// under it.
+pub const EIP1559_FEE_ESTIMATION_THRESHOLD_MAX_CHANGE: i64 = 200;
+
+/// The default EIP-1559 fee estimator which is based on the work by [MyCrypto](https://github.com/MyCryptoHQ/MyCrypto/blob/master/src/services/ApiService/Gas/eip1559.ts)
+fn eip1559_default_estimator(base_fee_per_gas: U256, rewards: Vec<Vec<U256>>) -> (U256, U256) {
+    let max_priority_fee_per_gas =
+        if base_fee_per_gas < U256::from(EIP1559_FEE_ESTIMATION_PRIORITY_FEE_TRIGGER) {
+            U256::from(EIP1559_FEE_ESTIMATION_DEFAULT_PRIORITY_FEE)
+        } else {
+            std::cmp::max(
+                estimate_priority_fee(rewards),
+                U256::from(EIP1559_FEE_ESTIMATION_DEFAULT_PRIORITY_FEE),
+            )
+        };
+    let potential_max_fee = base_fee_surged(base_fee_per_gas);
+    let max_fee_per_gas = if max_priority_fee_per_gas > potential_max_fee {
+        max_priority_fee_per_gas + potential_max_fee
+    } else {
+        potential_max_fee
+    };
+    (max_fee_per_gas, max_priority_fee_per_gas)
+}
+
+fn estimate_priority_fee(rewards: Vec<Vec<U256>>) -> U256 {
+    let mut rewards: Vec<U256> =
+        rewards.iter().map(|r| r[0]).filter(|r| *r > U256::zero()).collect();
+    if rewards.is_empty() {
+        return U256::zero()
+    }
+    if rewards.len() == 1 {
+        return rewards[0]
+    }
+    // Sort the rewards as we will eventually take the median.
+    rewards.sort();
+
+    // A copy of the same vector is created for convenience to calculate percentage change
+    // between subsequent fee values.
+    let mut rewards_copy = rewards.clone();
+    rewards_copy.rotate_left(1);
+
+    let mut percentage_change: Vec<I256> = rewards
+        .iter()
+        .zip(rewards_copy.iter())
+        .map(|(a, b)| {
+            let a = I256::try_from(*a).expect("priority fee overflow");
+            let b = I256::try_from(*b).expect("priority fee overflow");
+            ((b - a) * 100) / a
+        })
+        .collect();
+    percentage_change.pop();
+
+    // Fetch the max of the percentage change, and that element's index.
+    let max_change = percentage_change.iter().max().unwrap();
+    let max_change_index = percentage_change.iter().position(|&c| c == *max_change).unwrap();
+
+    // If we encountered a big change in fees at a certain position, then consider only
+    // the values >= it.
+    let values = if *max_change >= EIP1559_FEE_ESTIMATION_THRESHOLD_MAX_CHANGE.into() &&
+        (max_change_index >= (rewards.len() / 2))
+    {
+        rewards[max_change_index..].to_vec()
+    } else {
+        rewards
+    };
+
+    // Return the median.
+    values[values.len() / 2]
+}
+
+fn base_fee_surged(base_fee_per_gas: U256) -> U256 {
+    if base_fee_per_gas <= U256::from(40_000u64) {
+        base_fee_per_gas * 2
+    } else if base_fee_per_gas <= U256::from(100_000u64) {
+        base_fee_per_gas * 16 / 10
+    } else if base_fee_per_gas <= U256::from(200_000u64) {
+        base_fee_per_gas * 14 / 10
+    } else {
+        base_fee_per_gas * 12 / 10
+    }
+}

--- a/apps/fortuna/src/chain/ethereum.rs
+++ b/apps/fortuna/src/chain/ethereum.rs
@@ -7,6 +7,9 @@ use {
             EntropyReader,
             RequestedWithCallbackEvent,
         },
+        chain::eth_gas_oracle::{
+            EthProviderOracle,
+        },
         config::EthereumConfig,
     },
     anyhow::{
@@ -26,7 +29,6 @@ use {
         middleware::{
             gas_oracle::{
                 GasOracleMiddleware,
-                ProviderOracle,
             },
             transformer::{
                 Transformer,
@@ -72,7 +74,7 @@ pub type SignablePythContract = PythRandom<
             NonceManagerMiddleware<SignerMiddleware<Provider<Http>, LocalWallet>>,
             LegacyTxTransformer,
         >,
-        ProviderOracle<Provider<Http>>,
+        EthProviderOracle<Provider<Http>>,
     >,
 >;
 pub type PythContract = PythRandom<Provider<Http>>;
@@ -103,7 +105,7 @@ impl SignablePythContract {
         let provider = Provider::<Http>::try_from(&chain_config.geth_rpc_addr)?;
         let chain_id = provider.get_chainid().await?;
 
-        let gas_oracle = ProviderOracle::new(provider.clone());
+        let gas_oracle = EthProviderOracle::new(provider.clone());
 
         let transformer = LegacyTxTransformer {
             use_legacy_tx: chain_config.legacy_tx,

--- a/apps/fortuna/src/chain/ethereum.rs
+++ b/apps/fortuna/src/chain/ethereum.rs
@@ -1,14 +1,14 @@
 use {
     crate::{
-        chain::reader::{
-            self,
-            BlockNumber,
-            BlockStatus,
-            EntropyReader,
-            RequestedWithCallbackEvent,
-        },
-        chain::eth_gas_oracle::{
-            EthProviderOracle,
+        chain::{
+            eth_gas_oracle::EthProviderOracle,
+            reader::{
+                self,
+                BlockNumber,
+                BlockStatus,
+                EntropyReader,
+                RequestedWithCallbackEvent,
+            },
         },
         config::EthereumConfig,
     },
@@ -27,9 +27,7 @@ use {
         },
         core::types::Address,
         middleware::{
-            gas_oracle::{
-                GasOracleMiddleware,
-            },
+            gas_oracle::GasOracleMiddleware,
             transformer::{
                 Transformer,
                 TransformerError,

--- a/apps/fortuna/src/keeper.rs
+++ b/apps/fortuna/src/keeper.rs
@@ -223,7 +223,7 @@ pub async fn run_keeper_threads(
             .await
             .expect("Chain config should be valid"),
     );
-    let keeper_address = contract.client().inner().inner().signer().address();
+    let keeper_address = contract.client().inner().inner().inner().signer().address();
 
     let fulfilled_requests_cache = Arc::new(RwLock::new(HashMap::<u64, RequestState>::new()));
 
@@ -428,6 +428,7 @@ pub async fn process_event(
                                         chain_id: chain_config.id.clone(),
                                         address:  contract
                                             .client()
+                                            .inner()
                                             .inner()
                                             .inner()
                                             .signer()

--- a/apps/fortuna/src/main.rs
+++ b/apps/fortuna/src/main.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
             .finish(),
     )?;
 
-    match config::Options::parse() {
+    let result = match config::Options::parse() {
         config::Options::GetRequest(opts) => command::get_request(&opts).await,
         config::Options::Generate(opts) => command::generate(&opts).await,
         config::Options::Run(opts) => command::run(&opts).await,
@@ -43,5 +43,7 @@ async fn main() -> Result<()> {
         config::Options::SetupProvider(opts) => command::setup_provider(&opts).await,
         config::Options::RequestRandomness(opts) => command::request_randomness(&opts).await,
         config::Options::Inspect(opts) => command::inspect(&opts).await,
-    }
+    };
+
+    result
 }

--- a/apps/fortuna/src/main.rs
+++ b/apps/fortuna/src/main.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
             .finish(),
     )?;
 
-    config::Options::parse() {
+    match config::Options::parse() {
         config::Options::GetRequest(opts) => command::get_request(&opts).await,
         config::Options::Generate(opts) => command::generate(&opts).await,
         config::Options::Run(opts) => command::run(&opts).await,

--- a/apps/fortuna/src/main.rs
+++ b/apps/fortuna/src/main.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
             .finish(),
     )?;
 
-    let result = match config::Options::parse() {
+    config::Options::parse() {
         config::Options::GetRequest(opts) => command::get_request(&opts).await,
         config::Options::Generate(opts) => command::generate(&opts).await,
         config::Options::Run(opts) => command::run(&opts).await,
@@ -43,7 +43,5 @@ async fn main() -> Result<()> {
         config::Options::SetupProvider(opts) => command::setup_provider(&opts).await,
         config::Options::RequestRandomness(opts) => command::request_randomness(&opts).await,
         config::Options::Inspect(opts) => command::inspect(&opts).await,
-    };
-
-    result
+    }
 }


### PR DESCRIPTION
So this was a fun one. It turns out that the default fee estimation logic in ethers.rs has a lower bound on the priority fee of 3 gwei. This value is way too high for the L2s that entropy is deployed on.

(see this logic here https://github.com/gakonst/ethers-rs/blob/master/ethers-providers/src/rpc/provider.rs#L452
which calls this to estimate the fee https://github.com/gakonst/ethers-rs/blob/master/ethers-core/src/utils/mod.rs#L496
which uses this constant as a lower bound https://github.com/gakonst/ethers-rs/blob/master/ethers-core/src/utils/mod.rs#L88 )

Unfortunately, there isn't a way to configure this behavior in ethers.rs , so I've ended up copy/pasting the relevant bits and dividing the constants by 100k which puts them more in the range of l2 behavior. 




