### PR TITLE
feat(target_chains/starknet): update if necessary and get no older than

### DIFF
--- a/target_chains/starknet/contracts/src/pyth.cairo
+++ b/target_chains/starknet/contracts/src/pyth.cairo
@@ -175,6 +175,16 @@ mod pyth {
             Result::Ok(price)
         }
 
+        fn get_ema_price_no_older_than(
+            self: @ContractState, price_id: u256, age: u64
+        ) -> Result<Price, GetPriceNoOlderThanError> {
+            let info = self.get_ema_price_unsafe(price_id).map_err_into()?;
+            if !is_no_older_than(info.publish_time, age) {
+                return Result::Err(GetPriceNoOlderThanError::StalePrice);
+            }
+            Result::Ok(info)
+        }
+
         fn get_ema_price_unsafe(
             self: @ContractState, price_id: u256
         ) -> Result<Price, GetPriceUnsafeError> {

--- a/target_chains/starknet/contracts/src/pyth/errors.cairo
+++ b/target_chains/starknet/contracts/src/pyth/errors.cairo
@@ -12,6 +12,31 @@ impl GetPriceUnsafeErrorIntoFelt252 of Into<GetPriceUnsafeError, felt252> {
 }
 
 #[derive(Copy, Drop, Debug, Serde, PartialEq)]
+pub enum GetPriceNoOlderThanError {
+    PriceFeedNotFound,
+    StalePrice,
+}
+
+impl GetPriceNoOlderThanErrorIntoFelt252 of Into<GetPriceNoOlderThanError, felt252> {
+    fn into(self: GetPriceNoOlderThanError) -> felt252 {
+        match self {
+            GetPriceNoOlderThanError::PriceFeedNotFound => 'price feed not found',
+            GetPriceNoOlderThanError::StalePrice => 'stale price',
+        }
+    }
+}
+
+impl GetPriceUnsafeErrorIntoGetPriceNoOlderThanError of Into<
+    GetPriceUnsafeError, GetPriceNoOlderThanError
+> {
+    fn into(self: GetPriceUnsafeError) -> GetPriceNoOlderThanError {
+        match self {
+            GetPriceUnsafeError::PriceFeedNotFound => GetPriceNoOlderThanError::PriceFeedNotFound,
+        }
+    }
+}
+
+#[derive(Copy, Drop, Debug, Serde, PartialEq)]
 pub enum GovernanceActionError {
     AccessDenied,
     Wormhole: pyth::wormhole::ParseAndVerifyVmError,

--- a/target_chains/starknet/contracts/src/pyth/errors.cairo
+++ b/target_chains/starknet/contracts/src/pyth/errors.cairo
@@ -81,3 +81,20 @@ impl UpdatePriceFeedsErrorIntoFelt252 of Into<UpdatePriceFeedsError, felt252> {
         }
     }
 }
+
+#[derive(Copy, Drop, Debug, Serde, PartialEq)]
+pub enum UpdatePriceFeedsIfNecessaryError {
+    Update: UpdatePriceFeedsError,
+    NoFreshUpdate,
+}
+
+impl UpdatePriceFeedsIfNecessaryErrorIntoFelt252 of Into<
+    UpdatePriceFeedsIfNecessaryError, felt252
+> {
+    fn into(self: UpdatePriceFeedsIfNecessaryError) -> felt252 {
+        match self {
+            UpdatePriceFeedsIfNecessaryError::Update(err) => err.into(),
+            UpdatePriceFeedsIfNecessaryError::NoFreshUpdate => 'no fresh update',
+        }
+    }
+}

--- a/target_chains/starknet/contracts/src/pyth/interface.cairo
+++ b/target_chains/starknet/contracts/src/pyth/interface.cairo
@@ -6,6 +6,9 @@ pub trait IPyth<T> {
     fn get_price_unsafe(self: @T, price_id: u256) -> Result<Price, GetPriceUnsafeError>;
     fn get_ema_price_unsafe(self: @T, price_id: u256) -> Result<Price, GetPriceUnsafeError>;
     fn update_price_feeds(ref self: T, data: ByteArray);
+    fn update_price_feeds_if_necessary(
+        ref self: T, update: ByteArray, required_publish_times: Array<PriceFeedPublishTime>
+    );
     fn get_update_fee(self: @T, data: ByteArray) -> u256;
     fn execute_governance_instruction(ref self: T, data: ByteArray);
     fn pyth_upgradable_magic(self: @T) -> u32;
@@ -22,5 +25,11 @@ pub struct Price {
     pub price: i64,
     pub conf: u64,
     pub expo: i32,
+    pub publish_time: u64,
+}
+
+#[derive(Drop, Clone, Serde)]
+pub struct PriceFeedPublishTime {
+    pub price_id: u256,
     pub publish_time: u64,
 }

--- a/target_chains/starknet/contracts/src/pyth/interface.cairo
+++ b/target_chains/starknet/contracts/src/pyth/interface.cairo
@@ -1,8 +1,11 @@
-use super::GetPriceUnsafeError;
+use super::{GetPriceUnsafeError, GetPriceNoOlderThanError};
 use pyth::byte_array::ByteArray;
 
 #[starknet::interface]
 pub trait IPyth<T> {
+    fn get_price_no_older_than(
+        self: @T, price_id: u256, age: u64
+    ) -> Result<Price, GetPriceNoOlderThanError>;
     fn get_price_unsafe(self: @T, price_id: u256) -> Result<Price, GetPriceUnsafeError>;
     fn get_ema_price_unsafe(self: @T, price_id: u256) -> Result<Price, GetPriceUnsafeError>;
     fn update_price_feeds(ref self: T, data: ByteArray);

--- a/target_chains/starknet/contracts/src/pyth/interface.cairo
+++ b/target_chains/starknet/contracts/src/pyth/interface.cairo
@@ -7,6 +7,9 @@ pub trait IPyth<T> {
         self: @T, price_id: u256, age: u64
     ) -> Result<Price, GetPriceNoOlderThanError>;
     fn get_price_unsafe(self: @T, price_id: u256) -> Result<Price, GetPriceUnsafeError>;
+    fn get_ema_price_no_older_than(
+        self: @T, price_id: u256, age: u64
+    ) -> Result<Price, GetPriceNoOlderThanError>;
     fn get_ema_price_unsafe(self: @T, price_id: u256) -> Result<Price, GetPriceUnsafeError>;
     fn update_price_feeds(ref self: T, data: ByteArray);
     fn update_price_feeds_if_necessary(

--- a/target_chains/starknet/contracts/src/util.cairo
+++ b/target_chains/starknet/contracts/src/util.cairo
@@ -145,6 +145,19 @@ pub fn array_try_into<T, U, +TryInto<T, U>, +Drop<T>, +Drop<U>>(mut input: Array
     output
 }
 
+pub trait ResultMapErrInto<T, E1, E2> {
+    fn map_err_into(self: Result<T, E1>) -> Result<T, E2>;
+}
+
+impl ResultMapErrIntoImpl<T, E1, E2, +Into<E1, E2>> of ResultMapErrInto<T, E1, E2> {
+    fn map_err_into(self: Result<T, E1>) -> Result<T, E2> {
+        match self {
+            Result::Ok(v) => Result::Ok(v),
+            Result::Err(err) => Result::Err(err.into()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{u64_as_i64, u32_as_i32};

--- a/target_chains/starknet/contracts/tests/pyth.cairo
+++ b/target_chains/starknet/contracts/tests/pyth.cairo
@@ -5,6 +5,7 @@ use snforge_std::{
 use pyth::pyth::{
     IPythDispatcher, IPythDispatcherTrait, DataSource, Event as PythEvent, PriceFeedUpdated,
     WormholeAddressSet, GovernanceDataSourceSet, ContractUpgraded, DataSourcesSet, FeeSet,
+    PriceFeedPublishTime,
 };
 use pyth::byte_array::{ByteArray, ByteArrayImpl};
 use pyth::util::{array_try_into, UnwrapWithFelt252};
@@ -130,6 +131,60 @@ fn update_price_feeds_works() {
     assert!(last_ema_price.conf == 4096812700);
     assert!(last_ema_price.expo == -8);
     assert!(last_ema_price.publish_time == 1712589206);
+}
+
+#[test]
+fn test_update_if_necessary_works() {
+    let user = 'user'.try_into().unwrap();
+    let wormhole = super::wormhole::deploy_with_test_guardian();
+    let fee_contract = deploy_fee_contract(user);
+    let pyth = deploy_default(wormhole.contract_address, fee_contract.contract_address);
+
+    start_prank(CheatTarget::One(fee_contract.contract_address), user);
+    fee_contract.approve(pyth.contract_address, 10000);
+    stop_prank(CheatTarget::One(fee_contract.contract_address));
+
+    let mut spy = spy_events(SpyOn::One(pyth.contract_address));
+
+    start_prank(CheatTarget::One(pyth.contract_address), user);
+    pyth.update_price_feeds_if_necessary(data::test_price_update1(), array![]);
+
+    let price_id = 0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43;
+    assert!(pyth.get_price_unsafe(price_id).is_err());
+    spy.fetch_events();
+    assert!(spy.events.len() == 0);
+
+    let times = array![PriceFeedPublishTime { price_id, publish_time: 1715769470 }];
+    pyth.update_price_feeds_if_necessary(data::test_price_update1(), times);
+
+    let last_price = pyth.get_price_unsafe(price_id).unwrap_with_felt252();
+    assert!(last_price.price == 6281060000000);
+    assert!(last_price.publish_time == 1715769470);
+
+    spy.fetch_events();
+    assert!(spy.events.len() == 1);
+
+    let times = array![PriceFeedPublishTime { price_id, publish_time: 1715769470 }];
+    pyth.update_price_feeds_if_necessary(data::test_price_update2(), times);
+
+    let last_price = pyth.get_price_unsafe(price_id).unwrap_with_felt252();
+    assert!(last_price.price == 6281060000000);
+    assert!(last_price.publish_time == 1715769470);
+
+    spy.fetch_events();
+    assert!(spy.events.len() == 1);
+
+    let times = array![PriceFeedPublishTime { price_id, publish_time: 1715769475 }];
+    pyth.update_price_feeds_if_necessary(data::test_price_update2(), times);
+
+    let last_price = pyth.get_price_unsafe(price_id).unwrap_with_felt252();
+    assert!(last_price.price == 6281522520745);
+    assert!(last_price.publish_time == 1715769475);
+
+    spy.fetch_events();
+    assert!(spy.events.len() == 2);
+
+    stop_prank(CheatTarget::One(pyth.contract_address));
 }
 
 #[test]

--- a/target_chains/starknet/contracts/tests/pyth.cairo
+++ b/target_chains/starknet/contracts/tests/pyth.cairo
@@ -196,6 +196,8 @@ fn test_get_no_older_works() {
     let price_id = 0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43;
     let err = pyth.get_price_no_older_than(price_id, 100).unwrap_err();
     assert!(err == GetPriceNoOlderThanError::PriceFeedNotFound);
+    let err = pyth.get_ema_price_no_older_than(price_id, 100).unwrap_err();
+    assert!(err == GetPriceNoOlderThanError::PriceFeedNotFound);
 
     start_prank(CheatTarget::One(fee_contract.contract_address), user.try_into().unwrap());
     fee_contract.approve(pyth.contract_address, 10000);
@@ -208,16 +210,24 @@ fn test_get_no_older_works() {
     start_warp(CheatTarget::One(pyth.contract_address), 1712589210);
     let err = pyth.get_price_no_older_than(price_id, 3).unwrap_err();
     assert!(err == GetPriceNoOlderThanError::StalePrice);
+    let err = pyth.get_ema_price_no_older_than(price_id, 3).unwrap_err();
+    assert!(err == GetPriceNoOlderThanError::StalePrice);
 
     start_warp(CheatTarget::One(pyth.contract_address), 1712589208);
     let val = pyth.get_price_no_older_than(price_id, 3).unwrap_with_felt252();
     assert!(val.publish_time == 1712589206);
     assert!(val.price == 7192002930010);
+    let val = pyth.get_ema_price_no_older_than(price_id, 3).unwrap_with_felt252();
+    assert!(val.publish_time == 1712589206);
+    assert!(val.price == 7181868900000);
 
     start_warp(CheatTarget::One(pyth.contract_address), 1712589204);
     let val = pyth.get_price_no_older_than(price_id, 3).unwrap_with_felt252();
     assert!(val.publish_time == 1712589206);
     assert!(val.price == 7192002930010);
+    let val = pyth.get_ema_price_no_older_than(price_id, 3).unwrap_with_felt252();
+    assert!(val.publish_time == 1712589206);
+    assert!(val.price == 7181868900000);
 
     stop_warp(CheatTarget::One(pyth.contract_address));
 }


### PR DESCRIPTION
The stale check is different from the ethereum contract that essentially does `abs(block_timestamp - publish_time) < age`, which seems incorrect to me. Not sure what's the best way to handle the invalid `block_timestamp < publish_time` case, but it shouldn't depend on `age`.