### PR TITLE
chore(target_chains/sui): redeploy testnet contract

### DIFF
--- a/contract_manager/store/chains/SuiChains.yaml
+++ b/contract_manager/store/chains/SuiChains.yaml
@@ -3,11 +3,6 @@
   mainnet: false
   rpcUrl: https://fullnode.testnet.sui.io:443
   type: SuiChain
-- id: sui_devnet
-  wormholeChainName: sui
-  mainnet: false
-  rpcUrl: https://fullnode.devnet.sui.io:443
-  type: SuiChain
 - id: sui_mainnet
   wormholeChainName: sui
   mainnet: true

--- a/contract_manager/store/contracts/SuiPriceFeedContracts.yaml
+++ b/contract_manager/store/contracts/SuiPriceFeedContracts.yaml
@@ -3,8 +3,8 @@
   wormholeStateId: "0xaeab97f96cf9877fee2883315d459552b2b921edc16d7ceac6eab944dd88919c"
   type: SuiPriceFeedContract
 - chain: sui_testnet
-  stateId: "0x2d82612a354f0b7e52809fc2845642911c7190404620cec8688f68808f8800d8"
-  wormholeStateId: "0xebba4cc4d614f7a7cdbe883acc76d1cc767922bc96778e7b68be0d15fce27c02"
+  stateId: "0x243759059f4c3111179da5878c12f68d612c21a8d54d85edc86164bb18be1c7c"
+  wormholeStateId: "0x31358d198147da50db32eda2562951d53973a0c0ad5ed738e9b17d88b213d790"
   type: SuiPriceFeedContract
 - chain: movement_devnet_m2
   stateId: "0xa2b4997fe170d5d7d622d5f43e54880ccdf69716df4ac4d215a69c35a0a1831f"

--- a/target_chains/sui/contracts/Move.testnet.toml
+++ b/target_chains/sui/contracts/Move.testnet.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Pyth"
 version = "0.0.2"
-published-at = "0xf7114cc10266d90c0c9e4b84455bddf29b40bd78fe56832c7ac98682c3daa95b"
+published-at = "0xabf837e98c26087cba0883c0a7a28326b1fa3c5e1e2c5abdb486f9e8f594c837"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"


### PR DESCRIPTION
The updated wh dependency had a redeployment of contract and that resulted in dependency mismatch. Because of that we needed to do a redeployment.