### PR TITLE
fix(sui): add missing Movement deploy address

### DIFF
--- a/target_chains/sui/contracts/Move.movement_devnet_m2.toml
+++ b/target_chains/sui/contracts/Move.movement_devnet_m2.toml
@@ -1,6 +1,7 @@
 [package]
 name = "Pyth"
 version = "0.0.2"
+published-at = "0x46522b54385efa424e0582ea4886bb5cfbe11d5c2a6a19ac0c82c2c81c73f9c5"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"


### PR DESCRIPTION
Accidentally left off the published-at address for Movement devnet deployment. The deployment can be inspected [here](https://explorer.devnet.m2.movementlabs.xyz/object/0x46522b54385efa424e0582ea4886bb5cfbe11d5c2a6a19ac0c82c2c81c73f9c5?network=devnet).