### PR TITLE
fix(fortuna): Refactor and improve timestamp lag gauge

### DIFF
--- a/apps/fortuna/Cargo.lock
+++ b/apps/fortuna/Cargo.lock
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "fortuna"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/fortuna/Cargo.toml
+++ b/apps/fortuna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "fortuna"
-version = "6.0.0"
+version = "6.0.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Set INF value for gauge if RPC is not accessible.
This would trigger the alerts on the monitoring service. We will not do the same for other gauges (e.g. set balance to 0) since that's just duplicate alerts for the same underlying symptom.