### PR TITLE
feat(target_chains/solana): relax rust sdk dependencies

### DIFF
--- a/target_chains/solana/Cargo.lock
+++ b/target_chains/solana/Cargo.lock
@@ -1030,7 +1030,7 @@ dependencies = [
  "pyth-sdk",
  "pyth-sdk-solana",
  "pyth-solana-receiver",
- "pyth-solana-receiver-sdk 0.3.0",
+ "pyth-solana-receiver-sdk 0.4.0",
  "pythnet-sdk 2.1.0",
  "rand 0.8.5",
  "serde_wormhole",
@@ -3023,7 +3023,7 @@ dependencies = [
  "common-test-utils",
  "program-simulator",
  "pyth-solana-receiver",
- "pyth-solana-receiver-sdk 0.3.0",
+ "pyth-solana-receiver-sdk 0.4.0",
  "pythnet-sdk 2.1.0",
  "serde_wormhole",
  "solana-program",
@@ -3071,7 +3071,7 @@ dependencies = [
  "byteorder",
  "common-test-utils",
  "program-simulator",
- "pyth-solana-receiver-sdk 0.3.0",
+ "pyth-solana-receiver-sdk 0.4.0",
  "pythnet-sdk 2.1.0",
  "rand 0.8.5",
  "serde_wormhole",
@@ -3094,7 +3094,7 @@ dependencies = [
  "clap 3.2.23",
  "hex",
  "pyth-solana-receiver",
- "pyth-solana-receiver-sdk 0.3.0",
+ "pyth-solana-receiver-sdk 0.4.0",
  "pythnet-sdk 2.1.0",
  "serde_wormhole",
  "shellexpand",
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-solana-receiver-sdk"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anchor-lang",
  "hex",

--- a/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
+++ b/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-solana-receiver-sdk"
-version = "0.3.0"
+version = "0.4.0"
 description = "SDK for the Pyth Solana Receiver program"
 authors = ["Pyth Data Association"]
 repository = "https://github.com/pyth-network/pyth-crosschain"
@@ -13,7 +13,7 @@ name = "pyth_solana_receiver_sdk"
 
 
 [dependencies]
-anchor-lang = ">=0.28.0"
+anchor-lang = ">=0.26.0"
 hex = ">=0.4.3"
 pythnet-sdk = { path = "../../../pythnet/pythnet_sdk", version = "2.1.0", features = ["solana-program"]}
-solana-program = ">=1.16.0"
+solana-program = ">=1.14.0"


### PR DESCRIPTION
Some downstream consumers are using older versions of anchor and solana and cannot easily upgrade their code. Downgrading the requirement on the SDK won't have no impact on us as our lock file is unchanged and previous versions are being used. (To be more precise, we use anchor 0.28.0 because the main program depends on Wormhole which is locked to it)