### PR TITLE
fix(apps/hermes/server): use RpcPriceIdentifier instead of PriceIdentifier

### DIFF
--- a/apps/hermes/Cargo.lock
+++ b/apps/hermes/Cargo.lock
@@ -1796,7 +1796,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/hermes/Cargo.toml
+++ b/apps/hermes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "hermes"
-version     = "0.5.11"
+version     = "0.5.12"
 description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
 edition     = "2021"
 

--- a/apps/hermes/src/api/types.rs
+++ b/apps/hermes/src/api/types.rs
@@ -327,7 +327,7 @@ impl TryFrom<PriceUpdate> for PriceFeedsWithUpdateData {
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct PriceFeedMetadata {
-    pub id:         PriceIdentifier,
+    pub id:         RpcPriceIdentifier,
     // BTreeMap is used to automatically sort the keys to ensure consistent ordering of attributes in the JSON response.
     // This enhances user experience by providing a predictable structure, avoiding confusion from varying orders in different responses.
     pub attributes: BTreeMap<String, String>,

--- a/apps/hermes/src/network/pythnet.rs
+++ b/apps/hermes/src/network/pythnet.rs
@@ -442,7 +442,7 @@ async fn fetch_price_feeds_metadata(
                             .expect("Invalid length for PriceIdentifier");
 
                         let price_feed_metadata = PriceFeedMetadata {
-                            id: PriceIdentifier::new(px_pkey_array),
+                            id: RpcPriceIdentifier::new(px_pkey_array),
                             attributes,
                         };
 

--- a/apps/hermes/src/network/pythnet.rs
+++ b/apps/hermes/src/network/pythnet.rs
@@ -4,7 +4,10 @@
 
 use {
     crate::{
-        api::types::PriceFeedMetadata,
+        api::types::{
+            PriceFeedMetadata,
+            RpcPriceIdentifier,
+        },
         config::RunOptions,
         network::wormhole::{
             BridgeData,
@@ -30,7 +33,6 @@ use {
     },
     borsh::BorshDeserialize,
     futures::stream::StreamExt,
-    pyth_sdk::PriceIdentifier,
     pyth_sdk_solana::state::{
         load_mapping_account,
         load_product_account,

--- a/apps/hermes/src/state/aggregate.rs
+++ b/apps/hermes/src/state/aggregate.rs
@@ -870,7 +870,7 @@ mod test {
         // Add a dummy price feeds metadata
         state
             .store_price_feeds_metadata(&[PriceFeedMetadata {
-                id:         PriceIdentifier::new([100; 32]),
+                id:         RpcPriceIdentifier::new([100; 32]),
                 attributes: Default::default(),
             }])
             .await

--- a/apps/hermes/src/state/aggregate.rs
+++ b/apps/hermes/src/state/aggregate.rs
@@ -19,6 +19,7 @@ use {
         WormholeMerkleState,
     },
     crate::{
+        api::types::RpcPriceIdentifier,
         network::wormhole::VaaBytes,
         state::{
             benchmarks::Benchmarks,


### PR DESCRIPTION
I was running `openapi-zod-client https://hermes.pyth.network/docs/openapi.json` and got an error `MissingPointerError: Token "PriceIdentifier" does not exist.` it seems like we have a `RpcPriceIdentifier` which is pretty much similar to `PriceIdentifier` and also allows you to convert to and fro