### PR TITLE
refactor(target_chains/starknet): rename ByteArray to ByteBuffer

### DIFF
--- a/target_chains/starknet/contracts/src/byte_buffer.cairo
+++ b/target_chains/starknet/contracts/src/byte_buffer.cairo
@@ -5,7 +5,7 @@ use super::util::one_shift_left_bytes_u256;
 /// A byte array with storage format similar to `core::ByteArray`, but
 /// suitable for reading data from it.
 #[derive(Drop, Clone, Serde)]
-pub struct ByteArray {
+pub struct ByteBuffer {
     // Number of bytes stored in the last item of `self.data` (or 0 if it's empty).
     num_last_bytes: u8,
     // Bytes in big endian. Each item except the last one stores 31 bytes.
@@ -13,9 +13,9 @@ pub struct ByteArray {
     data: Array<felt252>,
 }
 
-impl DebugByteArray of Debug<ByteArray> {
-    fn fmt(self: @ByteArray, ref f: Formatter) -> Result<(), core::fmt::Error> {
-        write!(f, "ByteArray {{ num_last_bytes: {}, data: [", self.num_last_bytes)?;
+impl DebugByteBuffer of Debug<ByteBuffer> {
+    fn fmt(self: @ByteBuffer, ref f: Formatter) -> Result<(), core::fmt::Error> {
+        write!(f, "ByteBuffer {{ num_last_bytes: {}, data: [", self.num_last_bytes)?;
         let mut data = self.data.clone();
         loop {
             match data.pop_front() {
@@ -28,9 +28,9 @@ impl DebugByteArray of Debug<ByteArray> {
 }
 
 #[generate_trait]
-pub impl ByteArrayImpl of ByteArrayTrait {
+pub impl ByteBufferImpl of ByteBufferTrait {
     /// Creates a byte array with the data.
-    fn new(data: Array<felt252>, num_last_bytes: u8) -> ByteArray {
+    fn new(data: Array<felt252>, num_last_bytes: u8) -> ByteBuffer {
         if data.len() == 0 {
             assert!(num_last_bytes == 0);
         } else {
@@ -39,15 +39,15 @@ pub impl ByteArrayImpl of ByteArrayTrait {
             let last: u256 = (*data.at(data.len() - 1)).into();
             assert!(
                 last / one_shift_left_bytes_u256(num_last_bytes) == 0,
-                "ByteArrayImpl::new: last value is too large"
+                "ByteBufferImpl::new: last value is too large"
             );
         }
-        ByteArray { num_last_bytes, data }
+        ByteBuffer { num_last_bytes, data }
     }
 
     /// Removes 31 or less bytes from the start of the array.
     /// Returns the value and the number of bytes.
-    fn pop_front(ref self: ByteArray) -> Option<(felt252, u8)> {
+    fn pop_front(ref self: ByteBuffer) -> Option<(felt252, u8)> {
         let item = self.data.pop_front()?;
         if self.data.is_empty() {
             let num_bytes = self.num_last_bytes;
@@ -58,7 +58,7 @@ pub impl ByteArrayImpl of ByteArrayTrait {
         }
     }
 
-    fn len(self: @ByteArray) -> usize {
+    fn len(self: @ByteBuffer) -> usize {
         if self.data.is_empty() {
             0
         } else {
@@ -69,19 +69,19 @@ pub impl ByteArrayImpl of ByteArrayTrait {
 
 #[cfg(test)]
 mod tests {
-    use super::{ByteArray, ByteArrayImpl};
+    use super::{ByteBuffer, ByteBufferImpl};
     use pyth::util::array_try_into;
 
     #[test]
     fn empty_byte_array() {
-        let mut array = ByteArrayImpl::new(array![], 0);
+        let mut array = ByteBufferImpl::new(array![], 0);
         assert!(array.len() == 0);
         assert!(array.pop_front() == Option::None);
     }
 
     #[test]
     fn byte_array_3_zeros() {
-        let mut array = ByteArrayImpl::new(array![0], 3);
+        let mut array = ByteBufferImpl::new(array![0], 3);
         assert!(array.len() == 3);
         assert!(array.pop_front() == Option::Some((0, 3)));
         assert!(array.len() == 0);
@@ -90,7 +90,7 @@ mod tests {
 
     #[test]
     fn byte_array_3_bytes() {
-        let mut array = ByteArrayImpl::new(array![0x010203], 3);
+        let mut array = ByteBufferImpl::new(array![0x010203], 3);
         assert!(array.len() == 3);
         assert!(array.pop_front() == Option::Some((0x010203, 3)));
         assert!(array.len() == 0);
@@ -100,7 +100,7 @@ mod tests {
     #[test]
     fn byte_array_single_full() {
         let value_31_bytes = 0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f;
-        let mut array = ByteArrayImpl::new(array![value_31_bytes], 31);
+        let mut array = ByteBufferImpl::new(array![value_31_bytes], 31);
         assert!(array.len() == 31);
         assert!(array.pop_front() == Option::Some((value_31_bytes, 31)));
         assert!(array.len() == 0);
@@ -111,7 +111,7 @@ mod tests {
     fn byte_array_two_full() {
         let value_31_bytes = 0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f;
         let value2_31_bytes = 0x2122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f;
-        let mut array = ByteArrayImpl::new(array![value_31_bytes, value2_31_bytes], 31);
+        let mut array = ByteBufferImpl::new(array![value_31_bytes, value2_31_bytes], 31);
         assert!(array.len() == 62);
         assert!(array.pop_front() == Option::Some((value_31_bytes, 31)));
         assert!(array.len() == 31);
@@ -125,7 +125,7 @@ mod tests {
         let value_31_bytes = 0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f;
         let value2_31_bytes = 0x2122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f;
         let value3_5_bytes = 0x4142434445;
-        let mut array = ByteArrayImpl::new(
+        let mut array = ByteBufferImpl::new(
             array![value_31_bytes, value2_31_bytes, value3_5_bytes], 5
         );
         assert!(array.len() == 67);
@@ -140,24 +140,24 @@ mod tests {
     #[test]
     #[should_panic]
     fn byte_array_empty_invalid() {
-        ByteArrayImpl::new(array![], 5);
+        ByteBufferImpl::new(array![], 5);
     }
 
     #[test]
     #[should_panic]
     fn byte_array_last_too_large() {
-        ByteArrayImpl::new(array![1, 2, 3], 35);
+        ByteBufferImpl::new(array![1, 2, 3], 35);
     }
 
     #[test]
     #[should_panic]
     fn byte_array_last_zero_invalid() {
-        ByteArrayImpl::new(array![1, 2, 0], 0);
+        ByteBufferImpl::new(array![1, 2, 0], 0);
     }
 
     #[test]
     #[should_panic]
     fn byte_array_last_too_many_bytes() {
-        ByteArrayImpl::new(array![1, 2, 0x010203], 2);
+        ByteBufferImpl::new(array![1, 2, 0x010203], 2);
     }
 }

--- a/target_chains/starknet/contracts/src/lib.cairo
+++ b/target_chains/starknet/contracts/src/lib.cairo
@@ -1,12 +1,12 @@
 pub mod pyth;
 pub mod wormhole;
-pub mod byte_array;
+pub mod byte_buffer;
 pub mod reader;
 pub mod hash;
 pub mod util;
 pub mod merkle_tree;
 
-pub use byte_array::{ByteArray, ByteArrayTrait};
+pub use byte_buffer::{ByteBuffer, ByteBufferTrait};
 pub use pyth::{
     Event, PriceFeedUpdated, WormholeAddressSet, GovernanceDataSourceSet, ContractUpgraded,
     DataSourcesSet, FeeSet, GetPriceUnsafeError, GovernanceActionError, UpdatePriceFeedsError,

--- a/target_chains/starknet/contracts/src/merkle_tree.cairo
+++ b/target_chains/starknet/contracts/src/merkle_tree.cairo
@@ -1,6 +1,6 @@
 use super::hash::{Hasher, HasherImpl};
 use super::reader::{Reader, ReaderImpl};
-use super::byte_array::ByteArray;
+use super::byte_buffer::ByteBuffer;
 use super::util::ONE_SHIFT_96;
 use core::cmp::{min, max};
 use core::panic_with_felt252;
@@ -49,7 +49,7 @@ fn node_hash(a: u256, b: u256) -> u256 {
     hasher.finalize() / ONE_SHIFT_96
 }
 
-pub fn read_and_verify_proof(root_digest: u256, message: @ByteArray, ref reader: Reader) {
+pub fn read_and_verify_proof(root_digest: u256, message: @ByteBuffer, ref reader: Reader) {
     let mut message_reader = ReaderImpl::new(message.clone());
     let mut current_hash = leaf_hash(message_reader.clone());
 

--- a/target_chains/starknet/contracts/src/pyth.cairo
+++ b/target_chains/starknet/contracts/src/pyth.cairo
@@ -26,7 +26,7 @@ mod pyth {
         parse_wormhole_proof
     };
     use pyth::reader::{Reader, ReaderImpl};
-    use pyth::byte_array::{ByteArray, ByteArrayImpl};
+    use pyth::byte_buffer::{ByteBuffer, ByteBufferImpl};
     use core::panic_with_felt252;
     use core::starknet::{
         ContractAddress, get_caller_address, get_execution_info, ClassHash, SyscallResultTrait,
@@ -260,11 +260,11 @@ mod pyth {
             info.publish_time
         }
 
-        fn update_price_feeds(ref self: ContractState, data: ByteArray) {
+        fn update_price_feeds(ref self: ContractState, data: ByteBuffer) {
             self.update_price_feeds_internal(data, array![], 0, 0, false);
         }
 
-        fn get_update_fee(self: @ContractState, data: ByteArray, token: ContractAddress) -> u256 {
+        fn get_update_fee(self: @ContractState, data: ByteBuffer, token: ContractAddress) -> u256 {
             let single_update_fee = if token == self.fee_token_address1.read() {
                 self.single_update_fee1.read()
             } else if token == self.fee_token_address2.read() {
@@ -283,7 +283,7 @@ mod pyth {
 
         fn update_price_feeds_if_necessary(
             ref self: ContractState,
-            update: ByteArray,
+            update: ByteBuffer,
             required_publish_times: Array<PriceFeedPublishTime>
         ) {
             let mut i = 0;
@@ -305,7 +305,7 @@ mod pyth {
 
         fn parse_price_feed_updates(
             ref self: ContractState,
-            data: ByteArray,
+            data: ByteBuffer,
             price_ids: Array<u256>,
             min_publish_time: u64,
             max_publish_time: u64
@@ -318,7 +318,7 @@ mod pyth {
 
         fn parse_unique_price_feed_updates(
             ref self: ContractState,
-            data: ByteArray,
+            data: ByteBuffer,
             price_ids: Array<u256>,
             publish_time: u64,
             max_staleness: u64,
@@ -383,7 +383,7 @@ mod pyth {
             wormhole.chain_id()
         }
 
-        fn execute_governance_instruction(ref self: ContractState, data: ByteArray) {
+        fn execute_governance_instruction(ref self: ContractState, data: ByteBuffer) {
             let wormhole = IWormholeDispatcher { contract_address: self.wormhole_address.read() };
             let vm = wormhole.parse_and_verify_vm(data.clone());
             self.verify_governance_vm(@vm);
@@ -510,7 +510,7 @@ mod pyth {
         }
 
         fn check_new_wormhole(
-            ref self: ContractState, wormhole_address: ContractAddress, vm: ByteArray
+            ref self: ContractState, wormhole_address: ContractAddress, vm: ByteBuffer
         ) {
             let wormhole = IWormholeDispatcher { contract_address: wormhole_address };
             let vm = wormhole.parse_and_verify_vm(vm);
@@ -545,7 +545,7 @@ mod pyth {
             }
         }
 
-        fn authorize_governance_transfer(ref self: ContractState, claim_vaa: ByteArray) {
+        fn authorize_governance_transfer(ref self: ContractState, claim_vaa: ByteBuffer) {
             let wormhole = IWormholeDispatcher { contract_address: self.wormhole_address.read() };
             let claim_vm = wormhole.parse_and_verify_vm(claim_vaa.clone());
             // Note: no verify_governance_vm() because claim_vaa is signed by the new data source
@@ -604,7 +604,7 @@ mod pyth {
         // for any of the specified feeds.
         fn update_price_feeds_internal(
             ref self: ContractState,
-            data: ByteArray,
+            data: ByteBuffer,
             price_ids: Array<u256>,
             min_publish_time: u64,
             max_publish_time: u64,

--- a/target_chains/starknet/contracts/src/pyth/fake_upgrades.cairo
+++ b/target_chains/starknet/contracts/src/pyth/fake_upgrades.cairo
@@ -11,7 +11,7 @@ pub trait IFakePyth<T> {
 #[starknet::contract]
 mod pyth_fake_upgrade1 {
     use pyth::pyth::{GetPriceUnsafeError, DataSource, Price};
-    use pyth::byte_array::ByteArray;
+    use pyth::byte_buffer::ByteBuffer;
 
     #[storage]
     struct Storage {}
@@ -36,7 +36,7 @@ mod pyth_fake_upgrade1 {
 #[starknet::contract]
 mod pyth_fake_upgrade_wrong_magic {
     use pyth::pyth::{GetPriceUnsafeError, DataSource, Price};
-    use pyth::byte_array::ByteArray;
+    use pyth::byte_buffer::ByteBuffer;
 
     #[storage]
     struct Storage {}

--- a/target_chains/starknet/contracts/src/pyth/governance.cairo
+++ b/target_chains/starknet/contracts/src/pyth/governance.cairo
@@ -1,7 +1,7 @@
 use pyth::reader::ReaderTrait;
 use core::array::ArrayTrait;
 use pyth::reader::{Reader, ReaderImpl};
-use pyth::byte_array::ByteArray;
+use pyth::byte_buffer::ByteBuffer;
 use pyth::pyth::errors::GovernanceActionError;
 use core::panic_with_felt252;
 use core::starknet::{ContractAddress, ClassHash};
@@ -82,7 +82,7 @@ pub struct AuthorizeGovernanceDataSourceTransfer {
     // Transfer governance control over this contract to another data source.
     // The claim_vaa field is a VAA created by the new data source; using a VAA prevents mistakes
     // in the handoff by ensuring that the new data source can send VAAs (i.e., is not an invalid address).
-    pub claim_vaa: ByteArray,
+    pub claim_vaa: ByteBuffer,
 }
 
 #[derive(Drop, Debug)]
@@ -94,7 +94,7 @@ pub struct UpgradeContract {
     pub new_implementation: ClassHash,
 }
 
-pub fn parse_instruction(payload: ByteArray) -> GovernanceInstruction {
+pub fn parse_instruction(payload: ByteBuffer) -> GovernanceInstruction {
     let mut reader = ReaderImpl::new(payload);
     let magic = reader.read_u32();
     if magic != MAGIC {

--- a/target_chains/starknet/contracts/src/pyth/interface.cairo
+++ b/target_chains/starknet/contracts/src/pyth/interface.cairo
@@ -1,5 +1,5 @@
 use super::{GetPriceUnsafeError, GetPriceNoOlderThanError};
-use pyth::byte_array::ByteArray;
+use pyth::byte_buffer::ByteBuffer;
 use pyth::wormhole::VerifiedVM;
 use core::starknet::ContractAddress;
 
@@ -20,21 +20,25 @@ pub trait IPyth<T> {
     fn price_feed_exists(self: @T, price_id: u256) -> bool;
     fn latest_price_info_publish_time(self: @T, price_id: u256) -> u64;
 
-    fn update_price_feeds(ref self: T, data: ByteArray);
+    fn update_price_feeds(ref self: T, data: ByteBuffer);
     fn update_price_feeds_if_necessary(
-        ref self: T, update: ByteArray, required_publish_times: Array<PriceFeedPublishTime>
+        ref self: T, update: ByteBuffer, required_publish_times: Array<PriceFeedPublishTime>
     );
     fn parse_price_feed_updates(
         ref self: T,
-        data: ByteArray,
+        data: ByteBuffer,
         price_ids: Array<u256>,
         min_publish_time: u64,
         max_publish_time: u64
     ) -> Array<PriceFeed>;
     fn parse_unique_price_feed_updates(
-        ref self: T, data: ByteArray, price_ids: Array<u256>, publish_time: u64, max_staleness: u64,
+        ref self: T,
+        data: ByteBuffer,
+        price_ids: Array<u256>,
+        publish_time: u64,
+        max_staleness: u64,
     ) -> Array<PriceFeed>;
-    fn get_update_fee(self: @T, data: ByteArray, token: ContractAddress) -> u256;
+    fn get_update_fee(self: @T, data: ByteBuffer, token: ContractAddress) -> u256;
     fn wormhole_address(self: @T) -> ContractAddress;
     fn fee_token_addresses(self: @T) -> Array<ContractAddress>;
     fn get_single_update_fee(self: @T, token: ContractAddress) -> u256;
@@ -46,7 +50,7 @@ pub trait IPyth<T> {
     fn governance_data_source_index(self: @T) -> u32;
     fn chain_id(self: @T) -> u16;
 
-    fn execute_governance_instruction(ref self: T, data: ByteArray);
+    fn execute_governance_instruction(ref self: T, data: ByteBuffer);
     fn version(self: @T) -> felt252;
     fn pyth_upgradable_magic(self: @T) -> u32;
 }

--- a/target_chains/starknet/contracts/src/pyth/price_update.cairo
+++ b/target_chains/starknet/contracts/src/pyth/price_update.cairo
@@ -1,7 +1,7 @@
 use pyth::reader::{Reader, ReaderImpl};
 use pyth::pyth::{UpdatePriceFeedsError, PriceFeed, Price};
 use core::panic_with_felt252;
-use pyth::byte_array::ByteArray;
+use pyth::byte_buffer::ByteBuffer;
 use pyth::merkle_tree::read_and_verify_proof;
 use pyth::util::{u32_as_i32, u64_as_i64};
 
@@ -88,7 +88,7 @@ pub fn read_and_verify_header(ref reader: Reader) {
     }
 }
 
-pub fn parse_wormhole_proof(payload: ByteArray) -> u256 {
+pub fn parse_wormhole_proof(payload: ByteBuffer) -> u256 {
     let mut reader = ReaderImpl::new(payload);
     if reader.read_u32() != ACCUMULATOR_WORMHOLE_MAGIC {
         panic_with_felt252(UpdatePriceFeedsError::InvalidUpdateData.into());

--- a/target_chains/starknet/contracts/src/reader.cairo
+++ b/target_chains/starknet/contracts/src/reader.cairo
@@ -4,7 +4,7 @@ use core::keccak::cairo_keccak;
 use core::integer::u128_byte_reverse;
 use core::fmt::{Debug, Formatter};
 use pyth::util::{UNEXPECTED_OVERFLOW, UNEXPECTED_ZERO, one_shift_left_bytes_u128};
-use super::byte_array::{ByteArray, ByteArrayImpl};
+use super::byte_buffer::{ByteBuffer, ByteBufferImpl};
 
 #[derive(Copy, Drop, Debug, Serde, PartialEq)]
 pub enum Error {
@@ -25,7 +25,7 @@ impl ErrorIntoFelt252 of Into<Error, felt252> {
 #[derive(Drop, Clone)]
 pub struct Reader {
     // Input array.
-    array: ByteArray,
+    array: ByteBuffer,
     // Current value to read from (in big endian).
     current: u128,
     // Number of remaining bytes in `self.current`.
@@ -37,7 +37,7 @@ pub struct Reader {
 
 #[generate_trait]
 pub impl ReaderImpl of ReaderTrait {
-    fn new(array: ByteArray) -> Reader {
+    fn new(array: ByteBuffer) -> Reader {
         Reader { array, current: 0, num_current_bytes: 0, next: Option::None }
     }
 
@@ -100,7 +100,7 @@ pub impl ReaderImpl of ReaderTrait {
     }
 
     /// Reads the specified number of bytes as a new byte array.
-    fn read_byte_array(ref self: Reader, num_bytes: usize) -> ByteArray {
+    fn read_byte_array(ref self: Reader, num_bytes: usize) -> ByteBuffer {
         let mut array: Array<felt252> = array![];
         let mut num_last_bytes = 0;
         let mut num_remaining_bytes = num_bytes;
@@ -114,7 +114,7 @@ pub impl ReaderImpl of ReaderTrait {
         };
         // num_last_bytes < 31
         let num_last_bytes = num_last_bytes.try_into().expect(UNEXPECTED_OVERFLOW);
-        ByteArrayImpl::new(array, num_last_bytes)
+        ByteBufferImpl::new(array, num_last_bytes)
     }
 
     /// Returns number of remaining bytes to read.

--- a/target_chains/starknet/contracts/src/wormhole.cairo
+++ b/target_chains/starknet/contracts/src/wormhole.cairo
@@ -25,7 +25,7 @@ mod wormhole {
     use super::governance;
     use super::parse_vm::parse_vm;
     use pyth::reader::{Reader, ReaderImpl};
-    use pyth::byte_array::ByteArray;
+    use pyth::byte_buffer::ByteBuffer;
     use core::starknet::{get_block_timestamp, EthAddress};
     use core::starknet::eth_signature::is_eth_signature_valid;
     use core::panic_with_felt252;
@@ -98,7 +98,7 @@ mod wormhole {
 
     #[abi(embed_v0)]
     impl WormholeImpl of IWormhole<ContractState> {
-        fn parse_and_verify_vm(self: @ContractState, encoded_vm: ByteArray) -> VerifiedVM {
+        fn parse_and_verify_vm(self: @ContractState, encoded_vm: ByteBuffer) -> VerifiedVM {
             let vm = parse_vm(encoded_vm);
             let guardian_set = self.guardian_sets.read(vm.guardian_set_index);
             if guardian_set.num_guardians == 0 {
@@ -182,7 +182,7 @@ mod wormhole {
             self.governance_contract.read()
         }
 
-        fn submit_new_guardian_set(ref self: ContractState, encoded_vm: ByteArray) {
+        fn submit_new_guardian_set(ref self: ContractState, encoded_vm: ByteBuffer) {
             let vm = self.parse_and_verify_vm(encoded_vm);
             self.verify_governance_vm(@vm);
             let mut reader = ReaderImpl::new(vm.payload);

--- a/target_chains/starknet/contracts/src/wormhole/interface.cairo
+++ b/target_chains/starknet/contracts/src/wormhole/interface.cairo
@@ -1,5 +1,5 @@
 use super::errors::SubmitNewGuardianSetError;
-use pyth::byte_array::ByteArray;
+use pyth::byte_buffer::ByteBuffer;
 use core::starknet::secp256_trait::Signature;
 use core::starknet::EthAddress;
 
@@ -13,7 +13,7 @@ pub trait IWormhole<T> {
     /// Parses and returns the contents of the message. Panics if there was a
     /// parsing error or if signature verification failed.
     /// `ParseAndVerifyVmError` enumerates possible panic payloads.
-    fn parse_and_verify_vm(self: @T, encoded_vm: ByteArray) -> VerifiedVM;
+    fn parse_and_verify_vm(self: @T, encoded_vm: ByteBuffer) -> VerifiedVM;
 
     /// Returns the list of guardians at the specified index.
     /// `GetGuardianSetError` enumerates possible panic payloads.
@@ -44,7 +44,7 @@ pub trait IWormhole<T> {
     /// Executes a governance instruction to add a new guardian set. The new set becomes
     /// active immediately. The previous guardian set will be available for 24 hours and then expire.
     /// `SubmitNewGuardianSetError` enumerates possible panic payloads.
-    fn submit_new_guardian_set(ref self: T, encoded_vm: ByteArray);
+    fn submit_new_guardian_set(ref self: T, encoded_vm: ByteBuffer);
 }
 
 /// Information about a guardian's signature within a message.
@@ -78,7 +78,7 @@ pub struct VerifiedVM {
     /// Observed consistency level (specific to the sender's chain).
     pub consistency_level: u8,
     /// The data attached to the message.
-    pub payload: ByteArray,
+    pub payload: ByteBuffer,
     /// Double keccak256 hash of all fields of the message, excluding `version`,
     /// `guardian_set_index` and `signatures`.
     pub hash: u256,

--- a/target_chains/starknet/contracts/src/wormhole/parse_vm.cairo
+++ b/target_chains/starknet/contracts/src/wormhole/parse_vm.cairo
@@ -2,7 +2,7 @@ use pyth::reader::{Reader, ReaderImpl};
 use pyth::hash::{Hasher, HasherImpl};
 use super::{VerifiedVM, GuardianSignature, ParseAndVerifyVmError};
 use core::starknet::secp256_trait::Signature;
-use pyth::byte_array::ByteArray;
+use pyth::byte_buffer::ByteBuffer;
 use core::panic_with_felt252;
 
 /// Parses information about a guardian signature within a Wormhole message.
@@ -18,7 +18,7 @@ fn parse_signature(ref reader: Reader) -> GuardianSignature {
 
 /// Parses a Wormhole message.
 /// `ParseAndVerifyVmError` enumerates possible panic payloads.
-pub fn parse_vm(encoded_vm: ByteArray) -> VerifiedVM {
+pub fn parse_vm(encoded_vm: ByteBuffer) -> VerifiedVM {
     let mut reader = ReaderImpl::new(encoded_vm);
     let version = reader.read_u8();
     if version != 1 {

--- a/target_chains/starknet/contracts/tests/data.cairo
+++ b/target_chains/starknet/contracts/tests/data.cairo
@@ -1,10 +1,10 @@
 // Generated with generate_test_data.rs, do not edit
 
-use pyth::byte_array::{ByteArray, ByteArrayImpl};
+use pyth::byte_buffer::{ByteBuffer, ByteBufferImpl};
 use pyth::util::array_try_into;
 
 // A random update pulled from Hermes.
-pub fn good_update1() -> ByteArray {
+pub fn good_update1() -> ByteBuffer {
     let bytes = array![
         141887862745809943100717722154781668316147089807066324001213790862261653767,
         451230040559159019530944948086670994623010697390864133264612902902585665886,
@@ -48,11 +48,11 @@ pub fn good_update1() -> ByteArray {
         226866843267230707879834616967256711063296411939069440476882347301771901839,
         95752383404870925303422787,
     ];
-    ByteArrayImpl::new(bytes, 11)
+    ByteBufferImpl::new(bytes, 11)
 }
 
 // A wormhole VAA from a random update pulled from Hermes.
-pub fn good_vm1() -> ByteArray {
+pub fn good_vm1() -> ByteBuffer {
     let bytes = array![
         1766847066033410293701000231337210964058791470455465385734308943533652138,
         250126301534699068413432844632573953364878937343368310395142095034982913232,
@@ -86,11 +86,11 @@ pub fn good_vm1() -> ByteArray {
         52685537088250779930155363779405986390839624071318818148325576008719597568,
         14615204155786886573933667335033405822686404253588533,
     ];
-    ByteArrayImpl::new(bytes, 22)
+    ByteBufferImpl::new(bytes, 22)
 }
 
 // A first update for a certain timestamp pulled from Hermes.
-pub fn unique_update1() -> ByteArray {
+pub fn unique_update1() -> ByteBuffer {
     let bytes = array![
         141887862745809943100717722154781668656425228150258363002663887732857548075,
         399793171101922163607717906910020156439802651815166374105600343045575931912,
@@ -134,11 +134,11 @@ pub fn unique_update1() -> ByteArray {
         28583007876111384456149499846085318299326698960792831530075402396150538907,
         126290914008245563820443505,
     ];
-    ByteArrayImpl::new(bytes, 11)
+    ByteBufferImpl::new(bytes, 11)
 }
 
 // An actual mainnet wormhole governance VAA from https://github.com/pyth-network/pyth-crosschain/blob/main/contract_manager/src/contracts/wormhole.ts#L32-L37
-pub fn mainnet_guardian_set_upgrade1() -> ByteArray {
+pub fn mainnet_guardian_set_upgrade1() -> ByteBuffer {
     let bytes = array![
         1766847064779994277746302277072294871108550301449637470263976489521154979,
         374953657095152923031303770743522269007103499920836805761143506434463979495,
@@ -159,11 +159,11 @@ pub fn mainnet_guardian_set_upgrade1() -> ByteArray {
         55852237138651071644815135002358067220635692701051811455610533875912981641,
         190413173566657072516608762222993749133,
     ];
-    ByteArrayImpl::new(bytes, 16)
+    ByteBufferImpl::new(bytes, 16)
 }
 
 // An actual mainnet wormhole governance VAA from https://github.com/pyth-network/pyth-crosschain/blob/main/contract_manager/src/contracts/wormhole.ts#L32-L37
-pub fn mainnet_guardian_set_upgrade2() -> ByteArray {
+pub fn mainnet_guardian_set_upgrade2() -> ByteBuffer {
     let bytes = array![
         1766847065210651126944505525521222069599854288126726949998063840465138797,
         39054013088470866893599813322035661048501117089555726788687392536164861911,
@@ -210,11 +210,11 @@ pub fn mainnet_guardian_set_upgrade2() -> ByteArray {
         75218391584551901010047495874303520775865073092730040058902770251005073864,
         13453,
     ];
-    ByteArrayImpl::new(bytes, 2)
+    ByteBufferImpl::new(bytes, 2)
 }
 
 // An actual mainnet wormhole governance VAA from https://github.com/pyth-network/pyth-crosschain/blob/main/contract_manager/src/contracts/wormhole.ts#L32-L37
-pub fn mainnet_guardian_set_upgrade3() -> ByteArray {
+pub fn mainnet_guardian_set_upgrade3() -> ByteBuffer {
     let bytes = array![
         1766847065622031860560134801367788401015571316785630090767859240961980367,
         408239335069601434456324970231880063141100099721451058487412176729277688481,
@@ -261,11 +261,11 @@ pub fn mainnet_guardian_set_upgrade3() -> ByteArray {
         75218391584551901010047495874303520775865073092730040058902770251005073864,
         13453,
     ];
-    ByteArrayImpl::new(bytes, 2)
+    ByteBufferImpl::new(bytes, 2)
 }
 
 // An actual mainnet wormhole governance VAA from https://github.com/pyth-network/pyth-crosschain/blob/main/contract_manager/src/contracts/wormhole.ts#L32-L37
-pub fn mainnet_guardian_set_upgrade4() -> ByteArray {
+pub fn mainnet_guardian_set_upgrade4() -> ByteBuffer {
     let bytes = array![
         1766847066033426987337757245669159273063358729535478806850006662056807068,
         191023158244075433218055661747029015323596061316379687901032561397223546211,
@@ -312,14 +312,14 @@ pub fn mainnet_guardian_set_upgrade4() -> ByteArray {
         75218391584551901010047495874303520775865073092730040058902770251005073864,
         13453,
     ];
-    ByteArrayImpl::new(bytes, 2)
+    ByteBufferImpl::new(bytes, 2)
 }
 
 pub const TEST_GUARDIAN_ADDRESS1: felt252 = 0x686b9ea8e3237110eaaba1f1b7467559a3273819;
 pub const TEST_GUARDIAN_ADDRESS2: felt252 = 0x363598f080a817e633fc2d8f2b92e6e637f8b449;
 
 // An invalid wormhole guardian set upgrade instruction containing no new guardians.
-pub fn empty_set_upgrade() -> ByteArray {
+pub fn empty_set_upgrade() -> ByteBuffer {
     let bytes = array![
         1766847064779992178996580835909277664613661950847933439396875833330622292,
         364268459763994160238907315760635322263304542127720162879870384990884673431,
@@ -328,11 +328,11 @@ pub fn empty_set_upgrade() -> ByteArray {
         1131377253,
         210141960835432704,
     ];
-    ByteArrayImpl::new(bytes, 8)
+    ByteBufferImpl::new(bytes, 8)
 }
 
 // A wormhole guardian set upgrade instruction with emitter not expected by the test.
-pub fn wrong_emitter_upgrade() -> ByteArray {
+pub fn wrong_emitter_upgrade() -> ByteBuffer {
     let bytes = array![
         1766847064779994286935846877901139612104608837038764127758248269325228906,
         418887508807350452965708560347030276949211978189626151402664101079839557558,
@@ -341,11 +341,11 @@ pub fn wrong_emitter_upgrade() -> ByteArray {
         1131377253,
         307122819832911374634462256129025725147663742791077927773782095897,
     ];
-    ByteArrayImpl::new(bytes, 28)
+    ByteBufferImpl::new(bytes, 28)
 }
 
 // A wormhole guardian set upgrade instruction with set index = 3 not expected by the test.
-pub fn wrong_index_upgrade() -> ByteArray {
+pub fn wrong_index_upgrade() -> ByteBuffer {
     let bytes = array![
         1766847064779996028795173168119917022867471281757617479529431178557452389,
         193283302630366040376283958080462867566389017166937293916301423178932756308,
@@ -354,11 +354,11 @@ pub fn wrong_index_upgrade() -> ByteArray {
         1131377253,
         210624583337115497886730203944140689990237281548333499058561169433,
     ];
-    ByteArrayImpl::new(bytes, 28)
+    ByteBufferImpl::new(bytes, 28)
 }
 
 // A wormhole governance guardian set upgrade instruction signed by test guardian #1 containing test guardian #2 as the new guardian set.
-pub fn upgrade_to_test2() -> ByteArray {
+pub fn upgrade_to_test2() -> ByteBuffer {
     let bytes = array![
         1766847064779995287375101177319600239435018729139341591012343354326614060,
         152103705464783935682610402914146418697934830197930803919710856925871578605,
@@ -367,11 +367,11 @@ pub fn upgrade_to_test2() -> ByteArray {
         1131377253,
         210624583337114749311237613435643962969294824395451022190048752713,
     ];
-    ByteArrayImpl::new(bytes, 28)
+    ByteBufferImpl::new(bytes, 28)
 }
 
 // A Pyth governance instruction to set fee signed by the test guardian #1.
-pub fn pyth_set_fee() -> ByteArray {
+pub fn pyth_set_fee() -> ByteBuffer {
     let bytes = array![
         1766847064779993955862540543984267022910717161432209540262366788014689913,
         322968519187498395396360816568387642032723484530650782503164941848016432477,
@@ -379,11 +379,11 @@ pub fn pyth_set_fee() -> ByteArray {
         49565958604199796163020368,
         8072278384728444780182694421117884443886221966887092226,
     ];
-    ByteArrayImpl::new(bytes, 23)
+    ByteBufferImpl::new(bytes, 23)
 }
 
 // A Pyth governance instruction to set data sources signed by the test guardian #1.
-pub fn pyth_set_data_sources() -> ByteArray {
+pub fn pyth_set_data_sources() -> ByteBuffer {
     let bytes = array![
         1766847064779993795984967344618836356750759980724568847727566676204733945,
         319252252405206634291073190903653114488682078063415369176250618646860635118,
@@ -393,11 +393,11 @@ pub fn pyth_set_data_sources() -> ByteArray {
         223938022913800988696085410923418445187967252047785407181969631814277398528,
         301,
     ];
-    ByteArrayImpl::new(bytes, 14)
+    ByteBufferImpl::new(bytes, 14)
 }
 
 // A Pyth governance instruction to set wormhole address signed by the test guardian #1.
-pub fn pyth_set_wormhole() -> ByteArray {
+pub fn pyth_set_wormhole() -> ByteBuffer {
     let bytes = array![
         1766847064779993746734475762358060494055703996306832791834621971457521573,
         304597972750688370688620483915336485865968448355388067310514768529150663948,
@@ -406,11 +406,11 @@ pub fn pyth_set_wormhole() -> ByteArray {
         148907253456057279176930315687485033494639386197985334929728922792833758561,
         3789456330195130818,
     ];
-    ByteArrayImpl::new(bytes, 8)
+    ByteBufferImpl::new(bytes, 8)
 }
 
 // A Pyth governance instruction to request governance data source transfer signed by the test guardian #1.
-pub fn pyth_request_transfer() -> ByteArray {
+pub fn pyth_request_transfer() -> ByteBuffer {
     let bytes = array![
         1766847064779995673162446580588349917525470038054832932592992288867429640,
         324153743158695484170440096219469152425935271630646363385677281984034639103,
@@ -418,11 +418,11 @@ pub fn pyth_request_transfer() -> ByteArray {
         51983810243429054512432720,
         101886477340929157123538945,
     ];
-    ByteArrayImpl::new(bytes, 11)
+    ByteBufferImpl::new(bytes, 11)
 }
 
 // A Pyth governance instruction to authorize governance data source transfer signed by the test guardian #1.
-pub fn pyth_auth_transfer() -> ByteArray {
+pub fn pyth_auth_transfer() -> ByteBuffer {
     let bytes = array![
         1766847064779996877169354131457289870145133774197236214231189828595607612,
         135397929264511926704016137904543076941936590450380629211164830069940259166,
@@ -434,11 +434,11 @@ pub fn pyth_auth_transfer() -> ByteArray {
         721420288,
         20782639266000304984163621011457,
     ];
-    ByteArrayImpl::new(bytes, 18)
+    ByteBufferImpl::new(bytes, 18)
 }
 
 // A Pyth governance instruction to set fee with alternative emitter signed by the test guardian #1.
-pub fn pyth_set_fee_alt_emitter() -> ByteArray {
+pub fn pyth_set_fee_alt_emitter() -> ByteBuffer {
     let bytes = array![
         1766847064779994296698028907175740560793090837330420619723848454331748383,
         249896185465136242775777270873107292725618014836270803491051657047070145541,
@@ -446,11 +446,11 @@ pub fn pyth_set_fee_alt_emitter() -> ByteArray {
         51983810243429054512498256,
         8072278384728444780182694421117884443886221966887092226,
     ];
-    ByteArrayImpl::new(bytes, 23)
+    ByteBufferImpl::new(bytes, 23)
 }
 
 // A Pyth governance instruction to upgrade the contract signed by the test guardian #1.
-pub fn pyth_upgrade_fake1() -> ByteArray {
+pub fn pyth_upgrade_fake1() -> ByteBuffer {
     let bytes = array![
         1766847064779994791169214817472264547450542145364282319310439743685771618,
         175385590228001769706203572954671062839210335359545531991708252078677402742,
@@ -459,11 +459,11 @@ pub fn pyth_upgrade_fake1() -> ByteArray {
         148907253453589022320407306335457538262203456299261498528172020674942501293,
         9624434269354675143,
     ];
-    ByteArrayImpl::new(bytes, 8)
+    ByteBufferImpl::new(bytes, 8)
 }
 
 // A Pyth governance instruction to upgrade the contract signed by the test guardian #1.
-pub fn pyth_upgrade_not_pyth() -> ByteArray {
+pub fn pyth_upgrade_not_pyth() -> ByteBuffer {
     let bytes = array![
         1766847064779994185568390976518139178339359117743780499979078006447412818,
         312550937452923367391560946919832045570249370029901542796468563830775031789,
@@ -472,11 +472,11 @@ pub fn pyth_upgrade_not_pyth() -> ByteArray {
         148907253453589022305803196061110108233921773465491227564264876752079119569,
         6736708290019375278,
     ];
-    ByteArrayImpl::new(bytes, 8)
+    ByteBufferImpl::new(bytes, 8)
 }
 
 // A Pyth governance instruction to upgrade the contract signed by the test guardian #1.
-pub fn pyth_upgrade_wrong_magic() -> ByteArray {
+pub fn pyth_upgrade_wrong_magic() -> ByteBuffer {
     let bytes = array![
         1766847064779993581380818181711092803131812037068363180730038764700119064,
         43179698701133869693008541869474965453366967663087320291846878688486859828,
@@ -485,11 +485,11 @@ pub fn pyth_upgrade_wrong_magic() -> ByteArray {
         148907253453589022340563264373887392414227070562033595690783947835630084766,
         5698494087895763928,
     ];
-    ByteArrayImpl::new(bytes, 8)
+    ByteBufferImpl::new(bytes, 8)
 }
 
 // A Pyth governance instruction to upgrade the contract signed by the test guardian #1.
-pub fn pyth_upgrade_invalid_hash() -> ByteArray {
+pub fn pyth_upgrade_invalid_hash() -> ByteBuffer {
     let bytes = array![
         1766847064779994789591381079184882258862460741769249190705097785479185254,
         41574146205389297059177705721481778703981276127215462116602633512315608382,
@@ -498,11 +498,11 @@ pub fn pyth_upgrade_invalid_hash() -> ByteArray {
         148907253453589022218037939353255655322518022029545083499057126097303896064,
         505,
     ];
-    ByteArrayImpl::new(bytes, 8)
+    ByteBufferImpl::new(bytes, 8)
 }
 
 // An update pulled from Hermes and re-signed by the test guardian #1.
-pub fn test_price_update1() -> ByteArray {
+pub fn test_price_update1() -> ByteBuffer {
     let bytes = array![
         141887862745809943100421399774809552050876420277163116849842965275903806689,
         210740906737592158039211995620336526131859667363627655742687286503264782608,
@@ -520,11 +520,11 @@ pub fn test_price_update1() -> ByteArray {
         87135893730137265929093180553063146337041045646221968026289709394440932141,
         245333243912241114598596888050489286502591033459250287888834,
     ];
-    ByteArrayImpl::new(bytes, 25)
+    ByteBufferImpl::new(bytes, 25)
 }
 
 // An update pulled from Hermes and re-signed by the test guardian #1.
-pub fn test_price_update2() -> ByteArray {
+pub fn test_price_update2() -> ByteBuffer {
     let bytes = array![
         141887862745809943100421399774809552050874823427618844548942380383465221086,
         106893583704677921907497845070624642590618427233243792006390965895909696183,
@@ -542,11 +542,11 @@ pub fn test_price_update2() -> ByteArray {
         370855179649505412564259994413632062925303311800103998016489412083011059699,
         1182295126766215829784496273374889928477877265080355104888778,
     ];
-    ByteArrayImpl::new(bytes, 25)
+    ByteBufferImpl::new(bytes, 25)
 }
 
 // An update pulled from Hermes and re-signed by the test guardian #1 with another emitter address.
-pub fn test_update2_alt_emitter() -> ByteArray {
+pub fn test_update2_alt_emitter() -> ByteBuffer {
     let bytes = array![
         141887862745809943100421399774809552050876183715022494587482285730295850458,
         359963320496358929787450247990998878269668655936959553372924597144593948268,
@@ -564,11 +564,11 @@ pub fn test_update2_alt_emitter() -> ByteArray {
         370855179649505412564259994413632062925303311800103998016489412083011059699,
         1182295126766215829784496273374889928477877265080355104888778,
     ];
-    ByteArrayImpl::new(bytes, 25)
+    ByteBufferImpl::new(bytes, 25)
 }
 
 // An update pulled from Hermes and re-signed by the test guardian #2.
-pub fn test_update2_set2() -> ByteArray {
+pub fn test_update2_set2() -> ByteBuffer {
     let bytes = array![
         141887862745809943100421399774809552391157901121219476151849805356757998433,
         22927445661989480418689320204846867835510434886542566099417398893061382455,
@@ -586,5 +586,5 @@ pub fn test_update2_set2() -> ByteArray {
         370855179649505412564259994413632062925303311800103998016489412083011059699,
         1182295126766215829784496273374889928477877265080355104888778,
     ];
-    ByteArrayImpl::new(bytes, 25)
+    ByteBufferImpl::new(bytes, 25)
 }

--- a/target_chains/starknet/contracts/tests/pyth.cairo
+++ b/target_chains/starknet/contracts/tests/pyth.cairo
@@ -7,7 +7,7 @@ use pyth::pyth::{
     WormholeAddressSet, GovernanceDataSourceSet, ContractUpgraded, DataSourcesSet, FeeSet,
     PriceFeedPublishTime, GetPriceNoOlderThanError, Price, PriceFeed, GetPriceUnsafeError,
 };
-use pyth::byte_array::{ByteArray, ByteArrayImpl};
+use pyth::byte_buffer::{ByteBuffer, ByteBufferImpl};
 use pyth::util::{array_try_into, UnwrapWithFelt252};
 use pyth::wormhole::{IWormholeDispatcher, IWormholeDispatcherTrait};
 use core::starknet::ContractAddress;
@@ -1127,8 +1127,8 @@ fn deploy_pyth(
 
 fn deploy_fee_contract(class: ContractClass, recipient: ContractAddress) -> IERC20CamelDispatcher {
     let mut args = array![];
-    let name: core::byte_array::ByteArray = "eth";
-    let symbol: core::byte_array::ByteArray = "eth";
+    let name: ByteArray = "eth";
+    let symbol: ByteArray = "eth";
     (name, symbol, 100000_u256, recipient).serialize(ref args);
     let contract_address = match class.deploy(@args) {
         Result::Ok(v) => { v },

--- a/target_chains/starknet/contracts/tests/wormhole.cairo
+++ b/target_chains/starknet/contracts/tests/wormhole.cairo
@@ -7,7 +7,7 @@ use pyth::wormhole::{
     GuardianSetAdded
 };
 use pyth::reader::ReaderImpl;
-use pyth::byte_array::{ByteArray, ByteArrayImpl};
+use pyth::byte_buffer::{ByteBuffer, ByteBufferImpl};
 use pyth::util::{UnwrapWithFelt252, array_try_into, one_shift_left_bytes_u256};
 use core::starknet::{ContractAddress, EthAddress};
 use core::panic_with_felt252;
@@ -317,8 +317,8 @@ pub fn deploy_declared_with_test_guardian_at(
 }
 
 pub fn corrupted_vm(
-    mut real_data: ByteArray, pos: usize, random1: usize, random2: usize
-) -> ByteArray {
+    mut real_data: ByteBuffer, pos: usize, random1: usize, random2: usize
+) -> ByteBuffer {
     let mut new_data = array![];
 
     // Make sure we select a position not on the last item because
@@ -346,10 +346,10 @@ pub fn corrupted_vm(
         }
         i += 1;
     };
-    ByteArrayImpl::new(new_data, num_last_bytes)
+    ByteBufferImpl::new(new_data, num_last_bytes)
 }
 
-// Returns an item of ByteArray data with 2 bytes changed. We need to change at least 2 bytes
+// Returns an item of ByteBuffer data with 2 bytes changed. We need to change at least 2 bytes
 // because a single byte can be a recovery id, where only 1 bit matters so
 // a modification of recovery id can result in a valid VM.
 fn corrupted_bytes(input: felt252, index: usize, random1: usize, random2: usize) -> felt252 {

--- a/target_chains/starknet/tools/test_vaas/src/bin/generate_test_data.rs
+++ b/target_chains/starknet/tools/test_vaas/src/bin/generate_test_data.rs
@@ -10,7 +10,7 @@ use wormhole_vaas::{PayloadKind, VaaBody};
 
 fn main() {
     println!("// Generated with generate_test_data.rs, do not edit\n");
-    println!("use pyth::byte_array::{{ByteArray, ByteArrayImpl}};");
+    println!("use pyth::byte_buffer::{{ByteBuffer, ByteBufferImpl}};");
     println!("use pyth::util::array_try_into;");
 
     // A random update pulled from Hermes.

--- a/target_chains/starknet/tools/test_vaas/src/lib.rs
+++ b/target_chains/starknet/tools/test_vaas/src/lib.rs
@@ -9,8 +9,8 @@ use libsecp256k1::{sign, Message, PublicKey, SecretKey};
 use primitive_types::U256;
 use wormhole_vaas::{keccak256, GuardianSetSig, Readable, Vaa, VaaBody, VaaHeader, Writeable};
 
-/// A data format compatible with `pyth::byte_array::ByteArray`.
-struct CairoByteArrayData {
+/// A data format compatible with `pyth::byte_buffer::ByteBuffer`.
+struct CairoByteBufferData {
     // Number of bytes stored in the last item of `self.data` (or 0 if it's empty).
     num_last_bytes: usize,
     // Bytes in big endian. Each item except the last one stores 31 bytes.
@@ -18,8 +18,8 @@ struct CairoByteArrayData {
     data: Vec<U256>,
 }
 
-/// Converts bytes into a format compatible with `pyth::byte_array::ByteArray`.
-fn to_cairo_byte_array_data(data: &[u8]) -> CairoByteArrayData {
+/// Converts bytes into a format compatible with `pyth::byte_buffer::ByteBuffer`.
+fn to_cairo_byte_array_data(data: &[u8]) -> CairoByteBufferData {
     let mut pos = 0;
     let mut r = Vec::new();
     while pos < data.len() {
@@ -32,14 +32,14 @@ fn to_cairo_byte_array_data(data: &[u8]) -> CairoByteArrayData {
             let len = data.len() - pos;
             buf[32 - len..].copy_from_slice(&data[pos..]);
             r.push(U256::from_big_endian(&buf));
-            return CairoByteArrayData {
+            return CairoByteBufferData {
                 num_last_bytes: len,
                 data: r,
             };
         }
         pos += 31;
     }
-    CairoByteArrayData {
+    CairoByteBufferData {
         num_last_bytes: 0,
         data: r,
     }
@@ -60,13 +60,13 @@ pub fn print_as_cairo_fn(data: &[u8], name: impl Display, comment: impl Display)
     println!();
     println!("// {comment}");
     let data = to_cairo_byte_array_data(data);
-    println!("pub fn {name}() -> ByteArray {{");
+    println!("pub fn {name}() -> ByteBuffer {{");
     println!("    let bytes = array![");
     for item in data.data {
         println!("        {item},");
     }
     println!("    ];");
-    println!("    ByteArrayImpl::new(bytes, {})", data.num_last_bytes);
+    println!("    ByteBufferImpl::new(bytes, {})", data.num_last_bytes);
     println!("}}");
 }
 


### PR DESCRIPTION
Using the same name as the core library type (that's even included in prelude) can be confusing to users. It's probably better to use a different name. Naming suggestions are welcome.