### PR TITLE
Implementation of parsePriceFeedUpdates from ethereum pyth.sol in Pyth's Aptos contract

### DIFF
--- a/target_chains/aptos/contracts/sources/pyth.move
+++ b/target_chains/aptos/contracts/sources/pyth.move
@@ -521,6 +521,9 @@ module pyth::pyth {
         state::get_base_update_fee() * total_updates
     }
 
+    ///////////////////////////////////////////////////////
+    //Parse Pyth Benchmark Prices
+    ///////////////////////////////////////////////////////
     struct ParsePriceFeed has copy, drop {
         price_identifier: PriceIdentifier,
         price: u64,

--- a/target_chains/aptos/contracts/sources/pyth.move
+++ b/target_chains/aptos/contracts/sources/pyth.move
@@ -529,6 +529,17 @@ module pyth::pyth {
         publish_time: u64
     }
 
+    fun parse_updates(
+        data: vector<u8>, 
+        price_ids: &vector<PriceIdentifier>, 
+        min_publish_time: u64, 
+        max_publish_time: u64
+    ): vector<ParsePriceFeed> {
+        // Create an empty vector to store ParsePriceFeed structs
+        let updates: vector<ParsePriceFeed> = vector::empty<ParsePriceFeed>();
+        
+        updates
+    }
 
     fun parse_price_feed_updates_internal(
         update_data: vector<vector<u8>>,

--- a/target_chains/aptos/contracts/sources/pyth.move
+++ b/target_chains/aptos/contracts/sources/pyth.move
@@ -521,6 +521,14 @@ module pyth::pyth {
         state::get_base_update_fee() * total_updates
     }
 
+    struct ParsePriceFeed has copy, drop {
+        price_identifier: PriceIdentifier,
+        price: u64,
+        conf: u64,
+        expo: u64,
+        publish_time: u64
+    }
+
     public fun parse_price_feed_updates(
         update_data: vector<vector<u8>>,
         price_ids: vector<PriceIdentifier>,

--- a/target_chains/aptos/contracts/sources/pyth.move
+++ b/target_chains/aptos/contracts/sources/pyth.move
@@ -529,6 +529,25 @@ module pyth::pyth {
         publish_time: u64
     }
 
+
+    fun parse_price_feed_updates_internal(
+        update_data: vector<vector<u8>>,
+        price_ids: vector<PriceIdentifier>,
+        min_publish_time: u64,
+        max_publish_time: u64,
+        fee: Coin<AptosCoin>
+    ): vector<ParsePriceFeed> {
+        //if fee provided is sufficient then proceed
+        //else give insufficient_fee error message
+        let required_fee = get_update_fee(&update_data);
+        assert!(coin::value(&fee) <= required_fee, error::insufficient_fee());
+
+        let price_feeds = vector::empty<ParsePriceFeed>();
+
+        coin::deposit(@pyth, fee);
+        price_feeds
+    }
+
     public fun parse_price_feed_updates(
         update_data: vector<vector<u8>>,
         price_ids: vector<PriceIdentifier>,

--- a/target_chains/aptos/contracts/sources/pyth.move
+++ b/target_chains/aptos/contracts/sources/pyth.move
@@ -520,6 +520,23 @@ module pyth::pyth {
         };
         state::get_base_update_fee() * total_updates
     }
+
+    public fun parse_price_feed_updates(
+        update_data: vector<vector<u8>>,
+        price_ids: vector<PriceIdentifier>,
+        min_publish_time: u64,
+        max_publish_time: u64,
+        fee: Coin<AptosCoin>
+    ): vector<ParsePriceFeed> {
+        parse_price_feed_updates_internal(
+            update_data,
+            price_ids,
+            min_publish_time,
+            max_publish_time,
+            fee
+        )
+    }
+
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
**Description**
This pull request adds the parse_price_feed_updates function in Aptos contracts. This is an implementation of parsePriceFeedUpdates from ethereum's contract pyth.sol.

**Changes Made**
- Added a new function parse_price_feed_updates to the Pyth Aptos contract.
- The function takes the following parameters similar to its ethereum's counterpart:
  - update_data: a vector of vectors containing update data.
  - price_ids: a vector of containing PriceIdentifiers.
  - min_publish_time: the minimum publish time as a u64.
  - max_publish_time: the maximum publish time as a u64.
  - fee: fee provided to transaction
- The function processes the price feed updates and returns a vector of ParsePriceFeed objects.
- PasePriceFeed struct is defined as:
 ```
struct ParsePriceFeed has copy, drop {
        price_identifier: PriceIdentifier,
        price: u64,
        conf: u64,
        expo: u64,
        publish_time: u64
    }
```
- The function parse_price_feed_updates is public and calls an internal function for further execution parse_price_feed_updates_internal
- This implementation successfully compiles without throwing any errors
![Screenshot 2024-06-18 at 5 03 49 AM](https://github.com/pyth-network/pyth-crosschain/assets/43104299/da3325b1-bcc8-47bc-8634-70f90cb1bd88)
