### PR TITLE
[xc-admin-frontend] Unify publisher keys file schema with observer and balance tracker

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,4 @@
+nodejs 18.19.1
+pnpm 9.3.0
+rust 1.78.0
+python 3.12.4

--- a/governance/xc_admin/packages/xc_admin_frontend/package.json
+++ b/governance/xc_admin/packages/xc_admin_frontend/package.json
@@ -35,7 +35,8 @@
     "react-hot-toast": "^2.4.0",
     "sharp": "^0.33.4",
     "use-debounce": "^9.0.2",
-    "web3": "^4.8.0"
+    "web3": "^4.8.0",
+    "yaml": "^2.1.1"
   },
   "devDependencies": {
     "@svgr/webpack": "^6.3.1",

--- a/governance/xc_admin/packages/xc_admin_frontend/package.json
+++ b/governance/xc_admin/packages/xc_admin_frontend/package.json
@@ -36,7 +36,8 @@
     "sharp": "^0.33.4",
     "use-debounce": "^9.0.2",
     "web3": "^4.8.0",
-    "yaml": "^2.1.1"
+    "yaml": "^2.1.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@svgr/webpack": "^6.3.1",

--- a/governance/xc_admin/packages/xc_admin_frontend/pages/index.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/pages/index.tsx
@@ -16,12 +16,15 @@ import '../mappings/signers.json'
 
 const readPublisherKeyToNameMapping = (filename: string) => {
   if (fs.existsSync(filename)) {
-    return YAML.parse(fs.readFileSync(filename, 'utf8')).reduce((acc, rec) => {
-      acc[rec.key] = rec.name
-      return acc
-    })
+    return YAML.parse(fs.readFileSync(filename, 'utf8')).reduce(
+      (acc: { [key: string]: string }, rec: { key: string; name: string }) => {
+        acc[rec.key] = rec.name
+        return acc
+      },
+      {}
+    )
   } else {
-    return {} as { string: string }
+    return {}
   }
 }
 

--- a/governance/xc_admin/packages/xc_admin_frontend/pages/index.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/pages/index.tsx
@@ -14,13 +14,14 @@ import { StatusFilterProvider } from '../contexts/StatusFilterContext'
 import { classNames } from '../utils/classNames'
 import '../mappings/signers.json'
 
-const readPublisherKeyToNameMapping = (filename: string) => {
-  if (fs.existsSync(filename)) {
-    const arr = YAML.parse(fs.readFileSync(filename, 'utf8')).map(
+const readPublisherKeyToNameMapping = async (filename: string) => {
+  try {
+    await fs.promises.access(filename)
+    const arr = YAML.parse(await fs.promises.readFile(filename, 'utf8')).map(
       (key: string, name: string) => [key, name]
     )
     return Object.fromEntries(arr)
-  } else {
+  } catch {
     return {}
   }
 }
@@ -31,8 +32,12 @@ export const getServerSideProps: GetServerSideProps = async () => {
   const PUBLISHER_PYTHTEST_MAPPING_PATH = `${MAPPINGS_BASE_PATH}/pythtest/publishers.yaml`
 
   const publisherKeyToNameMapping = {
-    pythnet: readPublisherKeyToNameMapping(PUBLISHER_PYTHNET_MAPPING_PATH),
-    pythtest: readPublisherKeyToNameMapping(PUBLISHER_PYTHTEST_MAPPING_PATH),
+    pythnet: await readPublisherKeyToNameMapping(
+      PUBLISHER_PYTHNET_MAPPING_PATH
+    ),
+    pythtest: await readPublisherKeyToNameMapping(
+      PUBLISHER_PYTHTEST_MAPPING_PATH
+    ),
   }
   const MULTISIG_SIGNER_MAPPING_PATH = `${MAPPINGS_BASE_PATH}/signers.json`
   const multisigSignerKeyToNameMapping = fs.existsSync(

--- a/governance/xc_admin/packages/xc_admin_frontend/pages/index.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/pages/index.tsx
@@ -31,8 +31,8 @@ export const getServerSideProps: GetServerSideProps = async () => {
   const PUBLISHER_PYTHTEST_MAPPING_PATH = `${MAPPINGS_BASE_PATH}/pythtest/publishers.yaml`
 
   const publisherKeyToNameMapping = {
-    pythnet: readPublisherKeyToNameMapping(PUBLISHER_PYTHNET_MAPPING_PATH)
-    pythtest: readPublisherKeyToNameMapping(PUBLISHER_PYTHNET_MAPPING_PATH)
+    pythnet: readPublisherKeyToNameMapping(PUBLISHER_PYTHNET_MAPPING_PATH),
+    pythtest: readPublisherKeyToNameMapping(PUBLISHER_PYTHNET_MAPPING_PATH),
   }
   const MULTISIG_SIGNER_MAPPING_PATH = `${MAPPINGS_BASE_PATH}/signers.json`
   const multisigSignerKeyToNameMapping = fs.existsSync(

--- a/governance/xc_admin/packages/xc_admin_frontend/pages/index.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/pages/index.tsx
@@ -16,13 +16,10 @@ import '../mappings/signers.json'
 
 const readPublisherKeyToNameMapping = (filename: string) => {
   if (fs.existsSync(filename)) {
-    return YAML.parse(fs.readFileSync(filename, 'utf8')).reduce(
-      (acc: { [key: string]: string }, rec: { key: string; name: string }) => {
-        acc[rec.key] = rec.name
-        return acc
-      },
-      {}
+    const arr = YAML.parse(fs.readFileSync(filename, 'utf8')).map(
+      (key: string, name: string) => [key, name]
     )
+    return Object.fromEntries(arr)
   } else {
     return {}
   }

--- a/governance/xc_admin/packages/xc_admin_frontend/pages/index.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/pages/index.tsx
@@ -32,7 +32,7 @@ export const getServerSideProps: GetServerSideProps = async () => {
 
   const publisherKeyToNameMapping = {
     pythnet: readPublisherKeyToNameMapping(PUBLISHER_PYTHNET_MAPPING_PATH),
-    pythtest: readPublisherKeyToNameMapping(PUBLISHER_PYTHNET_MAPPING_PATH),
+    pythtest: readPublisherKeyToNameMapping(PUBLISHER_PYTHTEST_MAPPING_PATH),
   }
   const MULTISIG_SIGNER_MAPPING_PATH = `${MAPPINGS_BASE_PATH}/signers.json`
   const multisigSignerKeyToNameMapping = fs.existsSync(

--- a/governance/xc_admin/packages/xc_admin_frontend/pages/index.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/pages/index.tsx
@@ -1,4 +1,5 @@
 import YAML from 'yaml'
+import { z } from 'zod'
 import { Tab } from '@headlessui/react'
 import * as fs from 'fs'
 import type { GetServerSideProps, NextPage } from 'next'
@@ -14,12 +15,16 @@ import { StatusFilterProvider } from '../contexts/StatusFilterContext'
 import { classNames } from '../utils/classNames'
 import '../mappings/signers.json'
 
+const keyToNameMappingSchema = z.array(
+  z.object({ key: z.string(), name: z.string() })
+)
+
 const readPublisherKeyToNameMapping = async (filename: string) => {
   try {
     await fs.promises.access(filename)
-    const arr = YAML.parse(await fs.promises.readFile(filename, 'utf8')).map(
-      (key: string, name: string) => [key, name]
-    )
+    const arr = keyToNameMappingSchema
+      .parse(YAML.parse(await fs.promises.readFile(filename, 'utf8')))
+      .map((key, name) => [key, name])
     return Object.fromEntries(arr)
   } catch {
     return {}

--- a/governance/xc_admin/packages/xc_admin_frontend/pages/index.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/pages/index.tsx
@@ -21,7 +21,7 @@ const readPublisherKeyToNameMapping = (filename: string) => {
       return acc
     })
   } else {
-    return {}
+    return {} as { string: string }
   }
 }
 

--- a/governance/xc_admin/packages/xc_admin_frontend/pages/index.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/pages/index.tsx
@@ -1,3 +1,4 @@
+import YAML from 'yaml'
 import { Tab } from '@headlessui/react'
 import * as fs from 'fs'
 import type { GetServerSideProps, NextPage } from 'next'
@@ -13,26 +14,25 @@ import { StatusFilterProvider } from '../contexts/StatusFilterContext'
 import { classNames } from '../utils/classNames'
 import '../mappings/signers.json'
 
+const readPublisherKeyToNameMapping = (filename: string) => {
+  if (fs.existsSync(filename)) {
+    return YAML.parse(fs.readFileSync(filename, 'utf8')).reduce((acc, rec) => {
+      acc[rec.key] = rec.name
+      return acc
+    })
+  } else {
+    return {}
+  }
+}
+
 export const getServerSideProps: GetServerSideProps = async () => {
   const MAPPINGS_BASE_PATH = process.env.MAPPINGS_BASE_PATH || 'mappings'
-  const PUBLISHER_PYTHNET_MAPPING_PATH = `${MAPPINGS_BASE_PATH}/publishers-pythnet.json`
-  const PUBLISHER_PYTHTEST_MAPPING_PATH = `${MAPPINGS_BASE_PATH}/publishers-pythtest.json`
+  const PUBLISHER_PYTHNET_MAPPING_PATH = `${MAPPINGS_BASE_PATH}/pythnet/publishers.yaml`
+  const PUBLISHER_PYTHTEST_MAPPING_PATH = `${MAPPINGS_BASE_PATH}/pythtest/publishers.yaml`
 
   const publisherKeyToNameMapping = {
-    pythnet: fs.existsSync(PUBLISHER_PYTHNET_MAPPING_PATH)
-      ? JSON.parse(
-          (
-            await fs.promises.readFile(PUBLISHER_PYTHNET_MAPPING_PATH)
-          ).toString()
-        )
-      : {},
-    pythtest: fs.existsSync(PUBLISHER_PYTHTEST_MAPPING_PATH)
-      ? JSON.parse(
-          (
-            await fs.promises.readFile(PUBLISHER_PYTHTEST_MAPPING_PATH)
-          ).toString()
-        )
-      : {},
+    pythnet: readPublisherKeyToNameMapping(PUBLISHER_PYTHNET_MAPPING_PATH)
+    pythtest: readPublisherKeyToNameMapping(PUBLISHER_PYTHNET_MAPPING_PATH)
   }
   const MULTISIG_SIGNER_MAPPING_PATH = `${MAPPINGS_BASE_PATH}/signers.json`
   const multisigSignerKeyToNameMapping = fs.existsSync(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -677,6 +677,9 @@ importers:
       yaml:
         specifier: ^2.1.1
         version: 2.4.5
+      zod:
+        specifier: ^3.23.8
+        version: 3.23.8
     devDependencies:
       '@svgr/webpack':
         specifier: ^6.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -674,6 +674,9 @@ importers:
       web3:
         specifier: ^4.8.0
         version: 4.8.0(bufferutil@4.0.8)(encoding@0.1.13)(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.23.8)
+      yaml:
+        specifier: ^2.1.1
+        version: 2.4.5
     devDependencies:
       '@svgr/webpack':
         specifier: ^6.3.1
@@ -32436,7 +32439,7 @@ snapshots:
 
   openapi3-ts@3.1.0:
     dependencies:
-      yaml: 2.4.3
+      yaml: 2.4.5
 
   optimism@0.16.2:
     dependencies:
@@ -33265,7 +33268,7 @@ snapshots:
       unicode-properties: 1.4.1
       urijs: 1.19.11
       wordwrap: 1.0.0
-      yaml: 2.4.3
+      yaml: 2.4.5
     transitivePeerDependencies:
       - encoding
 


### PR DESCRIPTION
Deployment of this in the k8s node needs to be coordinated with observer, [balance tracker](https://github.com/pyth-network/balance-tracker/pull/4) and the deduplication of key files in the deployment repo.