### PR TITLE
refactor(apps/price_pusher): crash on RPC failures

### DIFF
--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "7.0.0-alpha",
+  "version": "7.0.0",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/apps/price_pusher/src/injective/injective.ts
+++ b/apps/price_pusher/src/injective/injective.ts
@@ -232,7 +232,8 @@ export class InjectivePricePusher implements IPricePusher {
       updateFeeQueryResponse = JSON.parse(json);
     } catch (err) {
       this.logger.error(err, "Error fetching update fee");
-      return;
+      // Throwing an error because it is likely an RPC issue
+      throw err;
     }
 
     try {

--- a/apps/price_pusher/src/solana/solana.ts
+++ b/apps/price_pusher/src/solana/solana.ts
@@ -35,14 +35,14 @@ export class SolanaPriceListener extends ChainPriceListener {
     const blockTime = await this.pythSolanaReceiver.connection.getBlockTime(
       slot
     );
-    if (blockTime !== undefined || blockTime < Date.now() / 1000 - 30) {
+    if (blockTime === null || blockTime < Date.now() / 1000 - 30) {
       throw new Error("Solana connection is unhealthy");
     }
   }
 
   async start() {
     // Frequently check the RPC connection to ensure it is healthy
-    setInterval(() => this.checkHealth.bind(this), 5000);
+    setInterval(this.checkHealth.bind(this), 5000);
 
     await super.start();
   }
@@ -125,6 +125,7 @@ export class SolanaPricePusher implements IPricePusher {
       this.logger.info({ signatures }, "updatePriceFeed successful");
     } catch (err: any) {
       this.logger.error(err, "updatePriceFeed failed");
+      return;
     }
   }
 }

--- a/apps/price_pusher/src/solana/solana.ts
+++ b/apps/price_pusher/src/solana/solana.ts
@@ -28,6 +28,25 @@ export class SolanaPriceListener extends ChainPriceListener {
     super(config.pollingFrequency, priceItems);
   }
 
+  // Checking the health of the Solana connection by checking the last block time
+  // and ensuring it is not older than 30 seconds.
+  private async checkHealth() {
+    const slot = await this.pythSolanaReceiver.connection.getSlot();
+    const blockTime = await this.pythSolanaReceiver.connection.getBlockTime(
+      slot
+    );
+    if (blockTime !== undefined || blockTime < Date.now() / 1000 - 30) {
+      throw new Error("Solana connection is unhealthy");
+    }
+  }
+
+  async start() {
+    // Frequently check the RPC connection to ensure it is healthy
+    setInterval(() => this.checkHealth.bind(this), 5000);
+
+    await super.start();
+  }
+
   async getOnChainPriceInfo(priceId: string): Promise<PriceInfo | undefined> {
     try {
       const priceFeedAccount =
@@ -103,13 +122,9 @@ export class SolanaPricePusher implements IPricePusher {
         this.pythSolanaReceiver.connection,
         this.pythSolanaReceiver.wallet
       );
-      this.logger.info(
-        { signatures },
-        "broadcasted updatePriceFeed transactions"
-      );
+      this.logger.info({ signatures }, "updatePriceFeed successful");
     } catch (err: any) {
       this.logger.error(err, "updatePriceFeed failed");
-      throw err;
     }
   }
 }

--- a/apps/price_pusher/src/solana/solana.ts
+++ b/apps/price_pusher/src/solana/solana.ts
@@ -103,10 +103,13 @@ export class SolanaPricePusher implements IPricePusher {
         this.pythSolanaReceiver.connection,
         this.pythSolanaReceiver.wallet
       );
-      this.logger.info({ signatures }, "updatePriceFeed successful");
+      this.logger.info(
+        { signatures },
+        "broadcasted updatePriceFeed transactions"
+      );
     } catch (err: any) {
       this.logger.error(err, "updatePriceFeed failed");
-      return;
+      throw err;
     }
   }
 }

--- a/apps/price_pusher/src/sui/sui.ts
+++ b/apps/price_pusher/src/sui/sui.ts
@@ -112,12 +112,6 @@ export class SuiPricePusher implements IPricePusher {
     private readonly provider: SuiClient,
     private logger: Logger,
     private priceServiceConnection: PriceServiceConnection,
-    private pythPackageId: string,
-    private pythStateId: string,
-    private wormholePackageId: string,
-    private wormholeStateId: string,
-    endpoint: string,
-    keypair: Ed25519Keypair,
     private gasBudget: number,
     private gasPool: SuiObjectRef[],
     private pythClient: SuiPythClient
@@ -180,14 +174,6 @@ export class SuiPricePusher implements IPricePusher {
     }
 
     const provider = new SuiClient({ url: endpoint });
-    const pythPackageId = await SuiPricePusher.getPackageId(
-      provider,
-      pythStateId
-    );
-    const wormholePackageId = await SuiPricePusher.getPackageId(
-      provider,
-      wormholeStateId
-    );
 
     const gasPool = await SuiPricePusher.initializeGasPool(
       keypair,
@@ -208,12 +194,6 @@ export class SuiPricePusher implements IPricePusher {
       provider,
       logger,
       priceServiceConnection,
-      pythPackageId,
-      pythStateId,
-      wormholePackageId,
-      wormholeStateId,
-      endpoint,
-      keypair,
       gasBudget,
       gasPool,
       pythClient
@@ -337,7 +317,7 @@ export class SuiPricePusher implements IPricePusher {
     ignoreGasObjects: string[],
     logger: Logger
   ): Promise<SuiObjectRef[]> {
-    const signerAddress = await signer.toSuiAddress();
+    const signerAddress = signer.toSuiAddress();
 
     if (ignoreGasObjects.length > 0) {
       logger.info(

--- a/apps/price_pusher/src/sui/sui.ts
+++ b/apps/price_pusher/src/sui/sui.ts
@@ -368,19 +368,15 @@ export class SuiPricePusher implements IPricePusher {
     provider: SuiClient,
     ref: SuiObjectRef
   ): Promise<SuiObjectRef> {
-    try {
-      const objectResponse = await provider.getObject({ id: ref.objectId });
-      if (objectResponse.data !== undefined) {
-        return {
-          digest: objectResponse.data!.digest,
-          objectId: objectResponse.data!.objectId,
-          version: objectResponse.data!.version,
-        };
-      } else {
-        throw new Error("Failed to refresh object reference");
-      }
-    } catch (err) {
-      throw err;
+    const objectResponse = await provider.getObject({ id: ref.objectId });
+    if (objectResponse.data !== undefined) {
+      return {
+        digest: objectResponse.data!.digest,
+        objectId: objectResponse.data!.objectId,
+        version: objectResponse.data!.version,
+      };
+    } else {
+      throw new Error("Failed to refresh object reference");
     }
   }
 

--- a/apps/price_pusher/src/sui/sui.ts
+++ b/apps/price_pusher/src/sui/sui.ts
@@ -363,8 +363,7 @@ export class SuiPricePusher implements IPricePusher {
   }
 
   // Attempt to refresh the version of the provided object reference to point to the current version
-  // of the object. Return the provided object reference if an error occurs or the object could not
-  // be retrieved.
+  // of the object. Throws an error if the object cannot be refreshed.
   private static async tryRefreshObjectReference(
     provider: SuiClient,
     ref: SuiObjectRef
@@ -378,10 +377,10 @@ export class SuiPricePusher implements IPricePusher {
           version: objectResponse.data!.version,
         };
       } else {
-        return ref;
+        throw new Error("Failed to refresh object reference");
       }
-    } catch (error) {
-      return ref;
+    } catch (err) {
+      throw err;
     }
   }
 


### PR DESCRIPTION
This PR updates the price pusher code to cause a crash when the RPC has issues. The RPC issues can be either the target network or Hermes.

This also solves #1704.