### PR TITLE
fix(target_chains/sui): Update addresses in Move.tomls

### DIFF
--- a/target_chains/sui/contracts/Move.lock
+++ b/target_chains/sui/contracts/Move.lock
@@ -31,6 +31,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.19.1"
+compiler-version = "1.27.2"
 edition = "legacy"
 flavor = "sui"

--- a/target_chains/sui/contracts/Move.mainnet.toml
+++ b/target_chains/sui/contracts/Move.mainnet.toml
@@ -14,9 +14,4 @@ subdir = "sui/wormhole"
 rev = "sui-upgrade-mainnet"
 
 [addresses]
-pyth = "0x04e20ddf36af412a4096f9014f4a565af9e812db9a05cc40254846cf6ed0ad91"
-wormhole = "0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a"
-
-[dev-addresses]
-pyth = "0x100"
-wormhole = "0x200"
+pyth = "0x8d97f1cd6ac663735be08d1d2b6d02a159e711586461306ce60a2b7a6a565a9e"

--- a/target_chains/sui/contracts/Move.movement_m2_devnet.toml
+++ b/target_chains/sui/contracts/Move.movement_m2_devnet.toml
@@ -13,8 +13,3 @@ local = "../vendor/wormhole_movement_m2_devnet/wormhole"
 
 [addresses]
 pyth = "0x46522b54385efa424e0582ea4886bb5cfbe11d5c2a6a19ac0c82c2c81c73f9c5"
-wormhole = "0x23a373b70e6e23a39e4846fa6896fa12beb08da061b3d4ec856bc8ead54f1e22"
-
-[dev-addresses]
-pyth = "0x100"
-wormhole = "0x200"

--- a/target_chains/sui/contracts/Move.testnet.toml
+++ b/target_chains/sui/contracts/Move.testnet.toml
@@ -15,8 +15,3 @@ rev = "sui-upgrade-testnet"
 
 [addresses]
 pyth = "0xabf837e98c26087cba0883c0a7a28326b1fa3c5e1e2c5abdb486f9e8f594c837"
-wormhole = "0xf47329f4344f3bf0f8e436e2f7b485466cff300f12a166563995d3888c296a94"
-
-[dev-addresses]
-pyth = "0x100"
-wormhole = "0x200"


### PR DESCRIPTION
Apparently the address of Pyth in the addresses section should be the address of the first published package and only `published-at` should change upon upgrades.

The rest of the changes are cleaning up other addresses as they are not used. The wormhole address gets imported automatically by the dependency.