### PR TITLE
fix:solana utils single tx

### DIFF
--- a/target_chains/solana/sdk/js/solana_utils/package.json
+++ b/target_chains/solana/sdk/js/solana_utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/solana-utils",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Utility functions for Solana",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/target_chains/solana/sdk/js/solana_utils/src/transaction.ts
+++ b/target_chains/solana/sdk/js/solana_utils/src/transaction.ts
@@ -259,7 +259,7 @@ export class TransactionBuilder {
           );
         }
 
-        // This handles an edge case where a single instruction needs to be by itself without any compute budget instructions or jito tips
+        // This handles an edge case where a single instruction is too big and therefore needs to be by itself without any compute budget instructions or jito tips
         const instructionsToSend: TransactionInstruction[] = [];
         for (const instruction of instructionsWithComputeBudget) {
           const sizeWithInstruction = getSizeOfTransaction(
@@ -324,7 +324,7 @@ export class TransactionBuilder {
           );
         }
 
-        // This handles an edge case where a single instruction needs to be by itself without any compute budget instructions or jito tips
+        // This handles an edge case where a single instruction is too big and therefore needs to be by itself without any compute budget instructions or jito tips
         const instructionsToSend: TransactionInstruction[] = [];
         for (const instruction of instructionsWithComputeBudget) {
           const sizeWithInstruction = getSizeOfTransaction(

--- a/target_chains/solana/sdk/js/solana_utils/src/transaction.ts
+++ b/target_chains/solana/sdk/js/solana_utils/src/transaction.ts
@@ -259,11 +259,25 @@ export class TransactionBuilder {
           );
         }
 
+        // This handles an edge case where a single instruction needs to be by itself without any compute budget instructions or jito tips
+        const instructionsToSend: TransactionInstruction[] = [];
+        for (const instruction of instructionsWithComputeBudget) {
+          const sizeWithInstruction = getSizeOfTransaction(
+            [...instructionsToSend, instruction],
+            true,
+            this.addressLookupTable
+          );
+          if (sizeWithInstruction > PACKET_DATA_SIZE) {
+            break;
+          }
+          instructionsToSend.push(instruction);
+        }
+
         return {
           tx: new VersionedTransaction(
             new TransactionMessage({
               recentBlockhash: blockhash,
-              instructions: instructionsWithComputeBudget,
+              instructions: instructionsToSend,
               payerKey: this.payer,
             }).compileToV0Message(
               this.addressLookupTable ? [this.addressLookupTable] : []
@@ -310,8 +324,21 @@ export class TransactionBuilder {
           );
         }
 
+        // This handles an edge case where a single instruction needs to be by itself without any compute budget instructions or jito tips
+        const instructionsToSend: TransactionInstruction[] = [];
+        for (const instruction of instructionsWithComputeBudget) {
+          const sizeWithInstruction = getSizeOfTransaction(
+            [...instructionsToSend, instruction],
+            false
+          );
+          if (sizeWithInstruction > PACKET_DATA_SIZE) {
+            break;
+          }
+          instructionsToSend.push(instruction);
+        }
+
         return {
-          tx: new Transaction().add(...instructionsWithComputeBudget),
+          tx: new Transaction().add(...instructionsToSend),
           signers: signers,
         };
       }


### PR DESCRIPTION
Most of the time, we want to add compute units to every transaction that we send to improve land rate.
There one edgecase where a instruction is so big that if we add compute units instruction we go over the limit.
This wasn't handled well, I'm pushing a fix.