### PR TITLE
fix(hermes): tune readiness probe

### DIFF
--- a/apps/hermes/server/Cargo.lock
+++ b/apps/hermes/server/Cargo.lock
@@ -1796,7 +1796,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes"
-version = "0.5.14"
+version = "0.5.15"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/hermes/server/Cargo.toml
+++ b/apps/hermes/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "hermes"
-version     = "0.5.14"
+version     = "0.5.15"
 description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
 edition     = "2021"
 

--- a/apps/hermes/server/src/api/rest/ready.rs
+++ b/apps/hermes/server/src/api/rest/ready.rs
@@ -10,6 +10,7 @@ use {
             IntoResponse,
             Response,
         },
+        Json,
     },
 };
 
@@ -19,7 +20,7 @@ where
 {
     let state = &*state.state;
     match Aggregates::is_ready(state).await {
-        true => (StatusCode::OK, "OK").into_response(),
-        false => (StatusCode::SERVICE_UNAVAILABLE, "Service Unavailable").into_response(),
+        (true, _) => (StatusCode::OK, "OK").into_response(),
+        (false, metadata) => (StatusCode::SERVICE_UNAVAILABLE, Json(metadata)).into_response(),
     }
 }

--- a/apps/hermes/server/src/state/aggregate.rs
+++ b/apps/hermes/server/src/state/aggregate.rs
@@ -434,7 +434,7 @@ where
             state_data.latest_observed_slot,
         ) {
             (Some(latest_completed_slot), Some(latest_observed_slot)) => {
-                latest_observed_slot - latest_completed_slot
+                latest_observed_slot.saturating_sub(latest_completed_slot)
                     <= state_data.readiness_max_allowed_slot_lag
             }
             _ => false,


### PR DESCRIPTION
This change modifies the not_behind readiness indicator to use the most recent slot from Pythnet accumulator instead of taking the max because we think that during forks validators might return an absurdly large slot. It also makes it more verbose by returning the indicators and the initial values for them so we can investigate better if the issue persists.