### PR TITLE
fix(apps/price_pusher/solana): make priceUpdates per bundle configurable

### DIFF
--- a/apps/price_pusher/config.solana.mainnet.sample.json
+++ b/apps/price_pusher/config.solana.mainnet.sample.json
@@ -6,6 +6,7 @@
   "jito-keypair-file": "./jito.json",
   "jito-tip-lamports": "100000",
   "jito-bundle-size": "5",
+  "updates-per-jito-bundle": "6",
   "price-config-file": "./price-config.yaml",
   "price-service-endpoint": "https://hermes.pyth.network/",
   "pyth-contract-address": "pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT",

--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/apps/price_pusher/src/solana/command.ts
+++ b/apps/price_pusher/src/solana/command.ts
@@ -66,6 +66,11 @@ export default {
       type: "number",
       default: 2,
     } as Options,
+    "updates-per-jito-bundle": {
+      description: "Number of transactions in each bundle",
+      type: "number",
+      default: 6,
+    } as Options,
     ...options.priceConfigFile,
     ...options.priceServiceEndpoint,
     ...options.pythContractAddress,
@@ -90,6 +95,7 @@ export default {
       jitoKeypairFile,
       jitoTipLamports,
       jitoBundleSize,
+      updatesPerJitoBundle,
       logLevel,
       priceServiceConnectionLogLevel,
       controllerLogLevel,
@@ -143,7 +149,8 @@ export default {
         shardId,
         jitoTipLamports,
         jitoClient,
-        jitoBundleSize
+        jitoBundleSize,
+        updatesPerJitoBundle
       );
 
       onBundleResult(jitoClient, logger.child({ module: "JitoClient" }));

--- a/apps/price_pusher/src/solana/solana.ts
+++ b/apps/price_pusher/src/solana/solana.ts
@@ -130,8 +130,6 @@ export class SolanaPricePusher implements IPricePusher {
   }
 }
 
-const UPDATES_PER_JITO_BUNDLE = 7;
-
 export class SolanaPricePusherJito implements IPricePusher {
   constructor(
     private pythSolanaReceiver: PythSolanaReceiver,
@@ -140,7 +138,8 @@ export class SolanaPricePusherJito implements IPricePusher {
     private shardId: number,
     private jitoTipLamports: number,
     private searcherClient: SearcherClient,
-    private jitoBundleSize: number
+    private jitoBundleSize: number,
+    private updatesPerJitoBundle: number
   ) {}
 
   async updatePriceFeed(
@@ -158,7 +157,7 @@ export class SolanaPricePusherJito implements IPricePusher {
       return;
     }
 
-    for (let i = 0; i < priceIds.length; i += UPDATES_PER_JITO_BUNDLE) {
+    for (let i = 0; i < priceIds.length; i += this.updatesPerJitoBundle) {
       const transactionBuilder = this.pythSolanaReceiver.newTransactionBuilder({
         closeUpdateAccounts: true,
       });
@@ -167,7 +166,7 @@ export class SolanaPricePusherJito implements IPricePusher {
           return sliceAccumulatorUpdateData(
             Buffer.from(x, "base64"),
             i,
-            i + UPDATES_PER_JITO_BUNDLE
+            i + this.updatesPerJitoBundle
           ).toString("base64");
         }),
         this.shardId


### PR DESCRIPTION
We are using a fixed priceUpdate per bundle constant but it might need to be changed as the price proof size increases. This change makes it configurable.