### PR TITLE
fix(contract_manager) Set HBAR decimals to 18

### DIFF
--- a/contract_manager/store/tokens/Tokens.yaml
+++ b/contract_manager/store/tokens/Tokens.yaml
@@ -36,7 +36,7 @@
   type: token
 - id: HBAR
   pythId: 3728e591097635310e6341af53db8b7ee42da9b3a8d918f9463ce9cca886dfbd
-  decimals: 8
+  decimals: 18
   type: token
 - id: CORE
   pythId: 9b4503710cc8c53f75c30e6e4fda1a7064680ef2e0ee97acd2e3a7c37b3c830c


### PR DESCRIPTION
I added this field initially to account for the fact that the chain has different mapping from "wei" to HBAR than the typical EVM chain. This was a hack though, and it looks like someone has fixed this issue somewhere else.