### PR TITLE
fix(price-pusher): randomize price feed ids

### DIFF
--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/apps/price_pusher/src/solana/solana.ts
+++ b/apps/price_pusher/src/solana/solana.ts
@@ -93,7 +93,12 @@ export class SolanaPricePusher implements IPricePusher {
       return;
     }
 
-    const shuffledPriceIds = priceIds.sort(() => Math.random() - 0.5);
+    const shuffledPriceIds = priceIds
+      .map((x) => {
+        return { element: x, key: Math.random() };
+      })
+      .sort((a, b) => a.key - b.key)
+      .map((x) => x.element);
     let priceFeedUpdateData;
     try {
       priceFeedUpdateData = await this.priceServiceConnection.getLatestVaas(

--- a/apps/price_pusher/src/solana/solana.ts
+++ b/apps/price_pusher/src/solana/solana.ts
@@ -99,6 +99,7 @@ export class SolanaPricePusher implements IPricePusher {
       })
       .sort((a, b) => a.key - b.key)
       .map((x) => x.element);
+
     let priceFeedUpdateData;
     try {
       priceFeedUpdateData = await this.priceServiceConnection.getLatestVaas(

--- a/apps/price_pusher/src/solana/solana.ts
+++ b/apps/price_pusher/src/solana/solana.ts
@@ -93,10 +93,11 @@ export class SolanaPricePusher implements IPricePusher {
       return;
     }
 
+    const shuffledPriceIds = priceIds.sort(() => Math.random() - 0.5);
     let priceFeedUpdateData;
     try {
       priceFeedUpdateData = await this.priceServiceConnection.getLatestVaas(
-        priceIds
+        shuffledPriceIds
       );
     } catch (err: any) {
       this.logger.error(err, "getPriceFeedsUpdateData failed:");


### PR DESCRIPTION
Solana devnet pusher doesn't work great.
Since we have no Jito, we need to land many transactions sequentially. And until now it sequentially follows the order in `price-config.yaml`. In periods of bad landing rate it crashes before getting to the end of the sequence. Therefore price feeds towards the end of the list never get updated.

By randomizing the order of price updates to avoid the imbalance between the top of the list and the bottom of the list in terms of frequency of updates.


