### PR TITLE
feat(target_chains/ethereum): remove getPrice from IPyth

### DIFF
--- a/apps/api-reference/src/apis/evm/get-price.ts
+++ b/apps/api-reference/src/apis/evm/get-price.ts
@@ -2,7 +2,7 @@ import { readApi, solidity, ethersJS } from "./common";
 import { ParameterType } from "../../components/EvmApi";
 
 export const getPrice = readApi<"id">({
-  name: "getPrice",
+  name: "getPrice (deprecated)",
   summary: "Get the **latest** price object for the requested price feed ID.",
   description: `
 This method returns the latest price object for the requested price feed ID.

--- a/apps/api-reference/src/apis/evm/get-valid-time-period.ts
+++ b/apps/api-reference/src/apis/evm/get-valid-time-period.ts
@@ -1,7 +1,7 @@
 import { readApi, solidity, ethersJS } from "./common";
 
 export const getValidTimePeriod = readApi<never>({
-  name: "getValidTimePeriod",
+  name: "getValidTimePeriod (deprecated)",
   summary: "Get the default valid time period of price freshness in seconds.",
   description: `
   This method returns the default valid time period of price freshness in **seconds**.

--- a/apps/api-reference/src/apis/evm/parse-price-feed-updates-unique.tsx
+++ b/apps/api-reference/src/apis/evm/parse-price-feed-updates-unique.tsx
@@ -33,7 +33,7 @@ export const parsePriceFeedUpdatesUnique = writeApi<
 
   Use this function if you want to use a Pyth price for a fixed time and not the most
   recent price; otherwise, consider using [updatePriceFeeds](update-price-feeds)
-  followed by [getPrice](get-price) or one of its variants.
+  followed by [getPriceNoOlderThan](get-price-no-older-than) or one of its variants.
 
   Unlike [updatePriceFeeds](updatePriceFeeds), calling this function will **not** update the on-chain price.
 

--- a/apps/api-reference/src/components/Home/index.tsx
+++ b/apps/api-reference/src/components/Home/index.tsx
@@ -21,7 +21,7 @@ export const Home = () => (
           <li className="contents">
             <ProductLink
               icon={PriceFeeds}
-              href="/price-feeds/evm/getPrice"
+              href="/price-feeds/evm/getPriceNoOlderThan"
               name="Price Feeds"
             >
               Fetch real-time low-latency market data, on 50+ chains or off

--- a/express_relay/examples/easy_lend/contracts/EasyLend.sol
+++ b/express_relay/examples/easy_lend/contracts/EasyLend.sol
@@ -85,7 +85,7 @@ contract EasyLend is IExpressRelayFeeReceiver {
      */
     function _getPrice(bytes32 id) internal view returns (uint256) {
         IPyth oracle = IPyth(payable(_oracle));
-        return convertToUint(oracle.getPrice(id), 18);
+        return convertToUint(oracle.getPriceNoOlderThan(id, 60), 18);
     }
 
     function getAllowUndercollateralized() public view returns (bool) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
         version: 2.1.1
       connectkit:
         specifier: ^1.8.2
-        version: 1.8.2(m5fu6jwi7nvuqo5lp7m3jyfehy)
+        version: 1.8.2(@babel/core@7.24.7)(@tanstack/react-query@5.45.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.5.2)(utf-8-validate@5.0.10)(zod@3.23.8))(wagmi@2.10.4(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@18.3.1))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1))(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.5.2)(utf-8-validate@5.0.10)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.5.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8))
       cryptocurrency-icons:
         specifier: ^0.18.1
         version: 0.18.1
@@ -1288,8 +1288,8 @@ importers:
         specifier: workspace:*
         version: link:../entropy_sdk/solidity
       '@pythnetwork/pyth-sdk-solidity':
-        specifier: ^3.0.0
-        version: 3.1.0
+        specifier: workspace:*
+        version: link:../sdk/solidity
       '@pythnetwork/xc-admin-common':
         specifier: workspace:*
         version: link:../../../governance/xc_admin/packages/xc_admin_common
@@ -5680,9 +5680,6 @@ packages:
 
   '@pythnetwork/price-service-sdk@1.7.1':
     resolution: {integrity: sha512-xr2boVXTyv1KUt/c6llUTfbv2jpud99pWlMJbFaHGUBoygQsByuy7WbjIJKZ+0Blg1itLZl0Lp/pJGGg8SdJoQ==}
-
-  '@pythnetwork/pyth-sdk-solidity@3.1.0':
-    resolution: {integrity: sha512-NgtEPUTL9r0qqMpIOEtSdUVjrF08fHK6wa7eM8hdjhjzMOti4o053B9oFqpm4lkzJW6eELXuP4sRJOABGmNTUg==}
 
   '@pythnetwork/pyth-starknet-js@0.2.1':
     resolution: {integrity: sha512-hLPmWUkLJxYI/f1nGvhk37Hp76uYL+8g12PuJSSH7GIdN9V3ts/wgL4TdI55FbC2Ypnx3WXjVQgTpQyOhhrpyg==}
@@ -26144,8 +26141,6 @@ snapshots:
     dependencies:
       bn.js: 5.2.1
 
-  '@pythnetwork/pyth-sdk-solidity@3.1.0': {}
-
   '@pythnetwork/pyth-starknet-js@0.2.1': {}
 
   '@radix-ui/primitive@1.0.0':
@@ -29696,8 +29691,8 @@ snapshots:
 
   '@vue/shared@3.4.34': {}
 
-  '@wagmi/connectors@5.0.16(mehtb7r3xxh3anmscqllj3vxmi)':
-    dependencies:
+  ? '@wagmi/connectors@5.0.16(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.3)(@wagmi/core@2.11.4(@tanstack/query-core@5.45.0)(@types/react@18.3.3)(bufferutil@4.0.8)(immer@9.0.21)(react@18.3.1)(typescript@5.5.2)(utf-8-validate@5.0.10)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.5.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8))(bufferutil@4.0.8)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1))(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.5.2)(utf-8-validate@5.0.10)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.5.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8)'
+  : dependencies:
       '@coinbase/wallet-sdk': 4.0.3
       '@metamask/sdk': 0.26.0(bufferutil@4.0.8)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1))(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(utf-8-validate@5.0.10)
       '@safe-global/safe-apps-provider': 0.18.1(bufferutil@4.0.8)(typescript@5.5.2)(utf-8-validate@5.0.10)(zod@3.23.8)
@@ -32268,8 +32263,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  connectkit@1.8.2(m5fu6jwi7nvuqo5lp7m3jyfehy):
-    dependencies:
+  ? connectkit@1.8.2(@babel/core@7.24.7)(@tanstack/react-query@5.45.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.5.2)(utf-8-validate@5.0.10)(zod@3.23.8))(wagmi@2.10.4(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@18.3.1))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1))(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.5.2)(utf-8-validate@5.0.10)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.5.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8))
+  : dependencies:
       '@tanstack/react-query': 5.45.1(react@18.3.1)
       buffer: 6.0.3
       detect-browser: 5.3.0
@@ -44117,7 +44112,7 @@ snapshots:
   wagmi@2.10.4(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.45.0)(@tanstack/react-query@5.45.1(react@18.3.1))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1))(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.5.2)(utf-8-validate@5.0.10)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.5.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8):
     dependencies:
       '@tanstack/react-query': 5.45.1(react@18.3.1)
-      '@wagmi/connectors': 5.0.16(mehtb7r3xxh3anmscqllj3vxmi)
+      '@wagmi/connectors': 5.0.16(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.3)(@wagmi/core@2.11.4(@tanstack/query-core@5.45.0)(@types/react@18.3.3)(bufferutil@4.0.8)(immer@9.0.21)(react@18.3.1)(typescript@5.5.2)(utf-8-validate@5.0.10)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.5.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8))(bufferutil@4.0.8)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react-i18next@13.5.0(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1))(react-native@0.74.2(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@types/react@18.3.3)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.5.2)(utf-8-validate@5.0.10)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.5.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8)
       '@wagmi/core': 2.11.4(@tanstack/query-core@5.45.0)(@types/react@18.3.3)(bufferutil@4.0.8)(immer@9.0.21)(react@18.3.1)(typescript@5.5.2)(utf-8-validate@5.0.10)(viem@2.15.1(bufferutil@4.0.8)(typescript@5.5.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8)
       react: 18.3.1
       use-sync-external-store: 1.2.0(react@18.3.1)

--- a/target_chains/ethereum/contracts/forge-test/GasBenchmark.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/GasBenchmark.t.sol
@@ -389,18 +389,18 @@ contract GasBenchmark is Test, WormholeTestUtils, PythTestUtils {
 
     function testBenchmarkGetPrice() public {
         // Set the block timestamp to 0. As prices have < 10 timestamp and staleness
-        // is set to 60 seconds, the getPrice should work as expected.
+        // below is set to 60 seconds, the getPriceNoOlderThan should work as expected.
         vm.warp(0);
 
-        pyth.getPrice(priceIds[0]);
+        pyth.getPriceNoOlderThan(priceIds[0], 60);
     }
 
     function testBenchmarkGetEmaPrice() public {
         // Set the block timestamp to 0. As prices have < 10 timestamp and staleness
-        // is set to 60 seconds, the getPrice should work as expected.
+        // below is set to 60 seconds, the getEmaPriceNoOlderThan should work as expected.
         vm.warp(0);
 
-        pyth.getEmaPrice(priceIds[0]);
+        pyth.getEmaPriceNoOlderThan(priceIds[0], 60);
     }
 
     function testBenchmarkGetUpdateFee1() public view {

--- a/target_chains/ethereum/contracts/forge-test/Pyth.Aave.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pyth.Aave.t.sol
@@ -138,7 +138,10 @@ contract PythAaveTest is PythWormholeMerkleAccumulatorTest {
             uint256 aavePrice = assetPrice / BASE_CURRENCY_UNIT;
 
             bytes32 priceId = priceIds[i];
-            PythStructs.Price memory price = pyth.getPrice(priceId);
+            PythStructs.Price memory price = pyth.getPriceNoOlderThan(
+                priceId,
+                60
+            );
             int64 pythRawPrice = price.price;
             uint pythNormalizer;
             uint pythPrice;

--- a/target_chains/ethereum/contracts/package.json
+++ b/target_chains/ethereum/contracts/package.json
@@ -34,7 +34,7 @@
     "@openzeppelin/contracts": "=4.8.1",
     "@openzeppelin/contracts-upgradeable": "=4.8.1",
     "@openzeppelin/hardhat-upgrades": "^1.22.1",
-    "@pythnetwork/pyth-sdk-solidity": "^3.0.0",
+    "@pythnetwork/pyth-sdk-solidity": "workspace:*",
     "@pythnetwork/entropy-sdk-solidity": "workspace:*",
     "@pythnetwork/contract-manager": "workspace:*",
     "dotenv": "^10.0.0",

--- a/target_chains/ethereum/sdk/js/README.md
+++ b/target_chains/ethereum/sdk/js/README.md
@@ -84,7 +84,8 @@ contract SomeContract {
 
     // Doing other things that uses prices
     bytes32 priceId = 0xf9c0172ba10dfa4d19088d94f5bf61d3b54d5bd7483a322a982e1373ee8ea31b;
-    PythStructs.Price price = pyth.getPrice(priceId);
+    // Get the price if it is not older than 10 seconds from the current time.
+    PythStructs.Price price = pyth.getPriceNoOlderThan(priceId, 10);
   }
 }
 

--- a/target_chains/ethereum/sdk/js/src/examples/EvmRelay.ts
+++ b/target_chains/ethereum/sdk/js/src/examples/EvmRelay.ts
@@ -102,12 +102,12 @@ async function run() {
       receipt = await web3.eth.getTransactionReceipt(txHash);
     }
 
-    // For on-chain use, you will typically perform the getPrice call within the same transaction as updatePriceFeeds.
-    // The call to getPrice below simply demonstrates that the on-chain price was in fact updated.
+    // For on-chain use, you will typically perform the getPriceNoOlderThan call within the same transaction as updatePriceFeeds.
+    // The call to getPriceNoOlderThan below simply demonstrates that the on-chain price was in fact updated.
     // Note that the code above for waiting for tx confirmation is a little flaky -- if so, you may see an old price printed here.
     for (const priceId of priceIds) {
       const [price, conf, expo, publishTime] = await pythContract.methods
-        .getPrice(priceId)
+        .getPriceNoOlderThan(priceId, 60) // 60 seconds staleness tolerance
         .call();
       console.log(
         `Updated ${priceId} to (${price} +- ${conf}) * 10^${expo} at unix timestamp ${publishTime}`

--- a/target_chains/ethereum/sdk/solidity/AbstractPyth.sol
+++ b/target_chains/ethereum/sdk/solidity/AbstractPyth.sol
@@ -19,6 +19,7 @@ abstract contract AbstractPyth is IPyth {
         bytes32 id
     ) public view virtual returns (bool exists);
 
+    /// @notice This function is deprecated and is only kept for backward compatibility.
     function getValidTimePeriod()
         public
         view

--- a/target_chains/ethereum/sdk/solidity/AbstractPyth.sol
+++ b/target_chains/ethereum/sdk/solidity/AbstractPyth.sol
@@ -23,18 +23,19 @@ abstract contract AbstractPyth is IPyth {
         public
         view
         virtual
-        override
         returns (uint validTimePeriod);
 
+    /// @notice This function is deprecated and is only kept for backward compatibility.
     function getPrice(
         bytes32 id
-    ) external view virtual override returns (PythStructs.Price memory price) {
+    ) external view virtual returns (PythStructs.Price memory price) {
         return getPriceNoOlderThan(id, getValidTimePeriod());
     }
 
+    /// @notice This function is deprecated and is only kept for backward compatibility.
     function getEmaPrice(
         bytes32 id
-    ) external view virtual override returns (PythStructs.Price memory price) {
+    ) external view virtual returns (PythStructs.Price memory price) {
         return getEmaPriceNoOlderThan(id, getValidTimePeriod());
     }
 

--- a/target_chains/ethereum/sdk/solidity/IPyth.sol
+++ b/target_chains/ethereum/sdk/solidity/IPyth.sol
@@ -8,32 +8,13 @@ import "./IPythEvents.sol";
 /// @dev Please refer to the guidance at https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices for how to consume prices safely.
 /// @author Pyth Data Association
 interface IPyth is IPythEvents {
-    /// @notice Returns the period (in seconds) that a price feed is considered valid since its publish time
-    function getValidTimePeriod() external view returns (uint validTimePeriod);
-
-    /// @notice Returns the price and confidence interval.
-    /// @dev Reverts if the price has not been updated within the last `getValidTimePeriod()` seconds.
-    /// @param id The Pyth Price Feed ID of which to fetch the price and confidence interval.
-    /// @return price - please read the documentation of PythStructs.Price to understand how to use this safely.
-    function getPrice(
-        bytes32 id
-    ) external view returns (PythStructs.Price memory price);
-
-    /// @notice Returns the exponentially-weighted moving average price and confidence interval.
-    /// @dev Reverts if the EMA price is not available.
-    /// @param id The Pyth Price Feed ID of which to fetch the EMA price and confidence interval.
-    /// @return price - please read the documentation of PythStructs.Price to understand how to use this safely.
-    function getEmaPrice(
-        bytes32 id
-    ) external view returns (PythStructs.Price memory price);
-
     /// @notice Returns the price of a price feed without any sanity checks.
     /// @dev This function returns the most recent price update in this contract without any recency checks.
     /// This function is unsafe as the returned price update may be arbitrarily far in the past.
     ///
     /// Users of this function should check the `publishTime` in the price to ensure that the returned price is
     /// sufficiently recent for their application. If you are considering using this function, it may be
-    /// safer / easier to use either `getPrice` or `getPriceNoOlderThan`.
+    /// safer / easier to use `getPriceNoOlderThan`.
     /// @return price - please read the documentation of PythStructs.Price to understand how to use this safely.
     function getPriceUnsafe(
         bytes32 id

--- a/target_chains/ethereum/sdk/solidity/README.md
+++ b/target_chains/ethereum/sdk/solidity/README.md
@@ -33,9 +33,11 @@ Then add the following line to your `remappings.txt` file:
 
 ## Example Usage
 
-To consume prices you should use the [`IPyth`](IPyth.sol) interface. Please make sure to read the documentation of this interface in order to use the prices safely.
+To consume prices you should use the [`IPyth`](IPyth.sol) interface. Please make sure to read the documentation of this
+interface in order to use the prices safely.
 
-For example, to read the latest price, call [`getPrice`](IPyth.sol) with the Price ID of the price feed you're interested in. The price feeds available on each chain are listed [below](#target-chains).
+For example, to read the latest price, call [`getPriceNoOlderThan`](IPyth.sol) with the Price ID of the price feed
+you're interested in. The price feeds available on each chain are listed [below](#target-chains).
 
 ```solidity
 // SPDX-License-Identifier: MIT
@@ -61,10 +63,9 @@ contract ExampleContract {
     pyth.updatePriceFeeds{ value: fee }(priceUpdateData);
 
     bytes32 priceID = 0xf9c0172ba10dfa4d19088d94f5bf61d3b54d5bd7483a322a982e1373ee8ea31b;
-    // Read the current value of priceID, aborting the transaction if the price has not been updated recently.
-    // Every chain has a default recency threshold which can be retrieved by calling the getValidTimePeriod() function on the contract.
-    // Please see IPyth.sol for variants of this function that support configurable recency thresholds and other useful features.
-    return pyth.getPrice(priceID);
+    // Read the current value of priceID, aborting the transaction if the price has not been updated in the last 10
+    // seconds.
+    return pyth.getPriceNoOlderThan(priceID, 10);
   }
 }
 

--- a/target_chains/ethereum/sdk/solidity/abis/IPyth.json
+++ b/target_chains/ethereum/sdk/solidity/abis/IPyth.json
@@ -36,47 +36,6 @@
         "internalType": "bytes32",
         "name": "id",
         "type": "bytes32"
-      }
-    ],
-    "name": "getEmaPrice",
-    "outputs": [
-      {
-        "components": [
-          {
-            "internalType": "int64",
-            "name": "price",
-            "type": "int64"
-          },
-          {
-            "internalType": "uint64",
-            "name": "conf",
-            "type": "uint64"
-          },
-          {
-            "internalType": "int32",
-            "name": "expo",
-            "type": "int32"
-          },
-          {
-            "internalType": "uint256",
-            "name": "publishTime",
-            "type": "uint256"
-          }
-        ],
-        "internalType": "struct PythStructs.Price",
-        "name": "price",
-        "type": "tuple"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "id",
-        "type": "bytes32"
       },
       {
         "internalType": "uint256",
@@ -126,47 +85,6 @@
       }
     ],
     "name": "getEmaPriceUnsafe",
-    "outputs": [
-      {
-        "components": [
-          {
-            "internalType": "int64",
-            "name": "price",
-            "type": "int64"
-          },
-          {
-            "internalType": "uint64",
-            "name": "conf",
-            "type": "uint64"
-          },
-          {
-            "internalType": "int32",
-            "name": "expo",
-            "type": "int32"
-          },
-          {
-            "internalType": "uint256",
-            "name": "publishTime",
-            "type": "uint256"
-          }
-        ],
-        "internalType": "struct PythStructs.Price",
-        "name": "price",
-        "type": "tuple"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "id",
-        "type": "bytes32"
-      }
-    ],
-    "name": "getPrice",
     "outputs": [
       {
         "components": [
@@ -299,19 +217,6 @@
       {
         "internalType": "uint256",
         "name": "feeAmount",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "getValidTimePeriod",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "validTimePeriod",
         "type": "uint256"
       }
     ],

--- a/target_chains/ethereum/sdk/solidity/package.json
+++ b/target_chains/ethereum/sdk/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Read prices from the Pyth oracle",
   "repository": {
     "type": "git",


### PR DESCRIPTION
getPrice method uses a configured default staleness from the Pyth contract which is normally set to 60 seconds. While this is enough for some types protocols it's very high for latency-sensitive protocols and protocols should use set their own desired staleness. This change removes this method and getEmaPrice and leaves protocols with getPriceUnsafe or getPriceNoOlderThan.

The contract will still support the getPrice method to avoid breaking existing users of it.