### PR TITLE
fix(contract_manager) Throw error on unknown chain type

### DIFF
--- a/contract_manager/src/store.ts
+++ b/contract_manager/src/store.ts
@@ -86,7 +86,11 @@ export class Store {
     this.getYamlFiles(`${this.path}/chains/`).forEach((yamlFile) => {
       const parsedArray = parse(readFileSync(yamlFile, "utf-8"));
       for (const parsed of parsedArray) {
-        if (allChainClasses[parsed.type] === undefined) return;
+        if (allChainClasses[parsed.type] === undefined) {
+          throw new Error(
+            `No chain class found for chain type: ${parsed.type}`
+          );
+        }
         const chain = allChainClasses[parsed.type].fromJson(parsed);
         if (this.chains[chain.getId()])
           throw new Error(`Multiple chains with id ${chain.getId()} found`);

--- a/contract_manager/store/chains/EvmChains.yaml
+++ b/contract_manager/store/chains/EvmChains.yaml
@@ -678,6 +678,7 @@
   mainnet: true
   rpcUrl: https://mainnet-rpc.b3.fun/http
   networkId: 8333
+  type: EvmChain
 - id: cronos_zkevm_mainnet
   mainnet: true
   rpcUrl: https://mainnet.zkevm.cronos.org


### PR DESCRIPTION
b3_mainnet wasn't defined correctly in the yaml file and this was resulting in an inscrutable error downstream. Fix the yaml file, and also add a check to make the failure mode more obvious.