### PR TITLE
feat: fix solana sdk for benchmarks

### DIFF
--- a/target_chains/solana/sdk/js/pyth_solana_receiver/package.json
+++ b/target_chains/solana/sdk/js/pyth_solana_receiver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-solana-receiver",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Pyth solana receiver SDK",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/target_chains/solana/sdk/js/pyth_solana_receiver/src/PythSolanaReceiver.ts
+++ b/target_chains/solana/sdk/js/pyth_solana_receiver/src/PythSolanaReceiver.ts
@@ -465,15 +465,16 @@ export class PythSolanaReceiver {
     encodedVaaAddress: PublicKey;
     closeInstructions: InstructionWithEphemeralSigners[];
   }> {
+    const trimmedVaa = trimSignatures(vaa, 13);
     const postInstructions: InstructionWithEphemeralSigners[] = [];
     const closeInstructions: InstructionWithEphemeralSigners[] = [];
     const encodedVaaKeypair = new Keypair();
-    const guardianSetIndex = getGuardianSetIndex(vaa);
+    const guardianSetIndex = getGuardianSetIndex(trimmedVaa);
 
     postInstructions.push(
       await buildEncodedVaaCreateInstruction(
         this.wormhole,
-        vaa,
+        trimmedVaa,
         encodedVaaKeypair
       )
     );
@@ -491,7 +492,7 @@ export class PythSolanaReceiver {
     postInstructions.push(
       ...(await buildWriteEncodedVaaWithSplitInstructions(
         this.wormhole,
-        vaa,
+        trimmedVaa,
         encodedVaaKeypair.publicKey
       ))
     );


### PR DESCRIPTION
Benchmarks serves the VAAs with 19 signatures, but we only care about verifying 13 to save compute units
