### PR TITLE
fix: pyth-publish-js workflow

### DIFF
--- a/governance/pyth_staking_sdk/package.json
+++ b/governance/pyth_staking_sdk/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/index.ts"
   },
+  "private": true,
   "scripts": {
     "build": "tsc",
     "test": "pnpm run test:format && pnpm run test:lint && pnpm run test:integration && pnpm run test:types",


### PR DESCRIPTION
the `@pythnetwork/staking-sdk` is causing pyth-publish-js workflow to fail, more info here: https://github.com/pyth-network/pyth-crosschain/actions/runs/10848587703/job/30106315103

specifically it can't figure out if published or not so it assumes it is unpublished, this is blocking fuel release so making it private for now if it's not ready to be published