### PR TITLE
chore: export getPriceFeedAccountForProgram

### DIFF
--- a/target_chains/solana/sdk/js/pyth_solana_receiver/package.json
+++ b/target_chains/solana/sdk/js/pyth_solana_receiver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-solana-receiver",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Pyth solana receiver SDK",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/target_chains/solana/sdk/js/pyth_solana_receiver/src/PythSolanaReceiver.ts
+++ b/target_chains/solana/sdk/js/pyth_solana_receiver/src/PythSolanaReceiver.ts
@@ -795,7 +795,7 @@ export class PythSolanaReceiver {
  * @param pushOracleProgramId The program ID of the Pyth Push Oracle program. If not provided, the default deployment will be used.
  * @returns The address of the price feed account
  */
-function getPriceFeedAccountForProgram(
+export function getPriceFeedAccountForProgram(
   shardId: number,
   priceFeedId: Buffer | string,
   pushOracleProgramId?: PublicKey

--- a/target_chains/solana/sdk/js/pyth_solana_receiver/src/index.ts
+++ b/target_chains/solana/sdk/js/pyth_solana_receiver/src/index.ts
@@ -1,6 +1,7 @@
 export {
   PythSolanaReceiver,
   PythTransactionBuilder,
+  getPriceFeedAccountForProgram,
 } from "./PythSolanaReceiver";
 export {
   TransactionBuilder,


### PR DESCRIPTION
We forgot to export this method. It's good to export because it can be used to compute price feed account pubkeys.
