### PR TITLE
fix: join llc before delegating

### DIFF
--- a/governance/pyth_staking_sdk/src/pyth-staking-client.ts
+++ b/governance/pyth_staking_sdk/src/pyth-staking-client.ts
@@ -254,17 +254,19 @@ export class PythStakingClient {
       instructions.push(joinDaoLlcInstruction);
     }
 
-    instructions.push(await this.stakingProgram.methods
-      .createPosition(
-        {
-          voting: {},
-        },
-        new BN(amount.toString()),
-      )
-      .accounts({
-        stakeAccountPositions,
-      })
-      .instruction());
+    instructions.push(
+      await this.stakingProgram.methods
+        .createPosition(
+          {
+            voting: {},
+          },
+          new BN(amount.toString()),
+        )
+        .accounts({
+          stakeAccountPositions,
+        })
+        .instruction(),
+    );
 
     return sendTransaction(instructions, this.connection, this.wallet);
   }
@@ -343,7 +345,7 @@ export class PythStakingClient {
       .filter(
         ({ position }) =>
           position.targetWithParameters.integrityPool?.publisher !==
-          undefined &&
+            undefined &&
           position.targetWithParameters.integrityPool.publisher.equals(
             publisher,
           ) &&
@@ -548,14 +550,16 @@ export class PythStakingClient {
       instructions.push(joinDaoLlcInstruction);
     }
 
-    instructions.push(await this.integrityPoolProgram.methods
-      .delegate(convertBigIntToBN(amount))
-      .accounts({
-        owner: this.wallet.publicKey,
-        publisher,
-        stakeAccountPositions,
-      })
-      .instruction());
+    instructions.push(
+      await this.integrityPoolProgram.methods
+        .delegate(convertBigIntToBN(amount))
+        .accounts({
+          owner: this.wallet.publicKey,
+          publisher,
+          stakeAccountPositions,
+        })
+        .instruction(),
+    );
 
     return sendTransaction(instructions, this.connection, this.wallet);
   }
@@ -826,21 +830,20 @@ export class PythStakingClient {
       .remainingAccounts(
         remainingAccount
           ? [
-            {
-              pubkey: remainingAccount,
-              isWritable: false,
-              isSigner: false,
-            },
-          ]
+              {
+                pubkey: remainingAccount,
+                isWritable: false,
+                isSigner: false,
+              },
+            ]
           : [],
       )
       .instruction();
   }
 
   public async getJoinDaoLlcInstructionIfNeeded(
-    stakeAccountPositions: PublicKey
+    stakeAccountPositions: PublicKey,
   ): Promise<TransactionInstruction | undefined> {
-
     const config = await this.getGlobalConfig();
     const stakeAccountMetadataAddress = getStakeAccountMetadataAddress(
       stakeAccountPositions,
@@ -850,15 +853,17 @@ export class PythStakingClient {
         stakeAccountMetadataAddress,
       );
 
-    if (JSON.stringify(stakeAccountMetadata.signedAgreementHash) !== JSON.stringify(config.agreementHash)) {
+    if (
+      JSON.stringify(stakeAccountMetadata.signedAgreementHash) !==
+      JSON.stringify(config.agreementHash)
+    ) {
       return this.stakingProgram.methods
         .joinDaoLlc(config.agreementHash)
         .accounts({
           stakeAccountPositions,
         })
         .instruction();
-    }
-    else {
+    } else {
       return undefined;
     }
   }

--- a/governance/pyth_staking_sdk/src/pyth-staking-client.ts
+++ b/governance/pyth_staking_sdk/src/pyth-staking-client.ts
@@ -249,9 +249,9 @@ export class PythStakingClient {
     const instructions = [];
 
     if (!(await this.hasJoinedDaoLlc(stakeAccountPositions))) {
-      instructions.push(await this.getJoinDaoLlcInstruction(
-        stakeAccountPositions,
-      ));
+      instructions.push(
+        await this.getJoinDaoLlcInstruction(stakeAccountPositions),
+      );
     }
 
     instructions.push(
@@ -545,9 +545,9 @@ export class PythStakingClient {
     const instructions = [];
 
     if (!(await this.hasJoinedDaoLlc(stakeAccountPositions))) {
-      instructions.push(await this.getJoinDaoLlcInstruction(
-        stakeAccountPositions,
-      ));
+      instructions.push(
+        await this.getJoinDaoLlcInstruction(stakeAccountPositions),
+      );
     }
 
     instructions.push(
@@ -841,7 +841,9 @@ export class PythStakingClient {
       .instruction();
   }
 
-  public async hasJoinedDaoLlc(stakeAccountPositions: PublicKey) : Promise<boolean> {
+  public async hasJoinedDaoLlc(
+    stakeAccountPositions: PublicKey,
+  ): Promise<boolean> {
     const config = await this.getGlobalConfig();
     const stakeAccountMetadataAddress = getStakeAccountMetadataAddress(
       stakeAccountPositions,
@@ -851,20 +853,22 @@ export class PythStakingClient {
         stakeAccountMetadataAddress,
       );
 
-    return JSON.stringify(stakeAccountMetadata.signedAgreementHash) ===
+    return (
+      JSON.stringify(stakeAccountMetadata.signedAgreementHash) ===
       JSON.stringify(config.agreementHash)
+    );
   }
 
   public async getJoinDaoLlcInstruction(
     stakeAccountPositions: PublicKey,
   ): Promise<TransactionInstruction> {
     const config = await this.getGlobalConfig();
-      return this.stakingProgram.methods
-        .joinDaoLlc(config.agreementHash)
-        .accounts({
-          stakeAccountPositions,
-        })
-        .instruction();
+    return this.stakingProgram.methods
+      .joinDaoLlc(config.agreementHash)
+      .accounts({
+        stakeAccountPositions,
+      })
+      .instruction();
   }
 
   public async getMainStakeAccount(owner?: PublicKey) {

--- a/governance/pyth_staking_sdk/src/pyth-staking-client.ts
+++ b/governance/pyth_staking_sdk/src/pyth-staking-client.ts
@@ -247,11 +247,11 @@ export class PythStakingClient {
     amount: bigint,
   ) {
     const instructions = [];
-    const joinDaoLlcInstruction = await this.getJoinDaoLlcInstructionIfNeeded(
-      stakeAccountPositions,
-    );
-    if (joinDaoLlcInstruction !== undefined) {
-      instructions.push(joinDaoLlcInstruction);
+
+    if (!(await this.hasJoinedDaoLlc(stakeAccountPositions))) {
+      instructions.push(await this.getJoinDaoLlcInstruction(
+        stakeAccountPositions,
+      ));
     }
 
     instructions.push(
@@ -543,11 +543,11 @@ export class PythStakingClient {
     amount: bigint,
   ) {
     const instructions = [];
-    const joinDaoLlcInstruction = await this.getJoinDaoLlcInstructionIfNeeded(
-      stakeAccountPositions,
-    );
-    if (joinDaoLlcInstruction !== undefined) {
-      instructions.push(joinDaoLlcInstruction);
+
+    if (!(await this.hasJoinedDaoLlc(stakeAccountPositions))) {
+      instructions.push(await this.getJoinDaoLlcInstruction(
+        stakeAccountPositions,
+      ));
     }
 
     instructions.push(
@@ -841,9 +841,7 @@ export class PythStakingClient {
       .instruction();
   }
 
-  public async getJoinDaoLlcInstructionIfNeeded(
-    stakeAccountPositions: PublicKey,
-  ): Promise<TransactionInstruction | undefined> {
+  public async hasJoinedDaoLlc(stakeAccountPositions: PublicKey) : Promise<boolean> {
     const config = await this.getGlobalConfig();
     const stakeAccountMetadataAddress = getStakeAccountMetadataAddress(
       stakeAccountPositions,
@@ -853,19 +851,20 @@ export class PythStakingClient {
         stakeAccountMetadataAddress,
       );
 
-    if (
-      JSON.stringify(stakeAccountMetadata.signedAgreementHash) !==
+    return JSON.stringify(stakeAccountMetadata.signedAgreementHash) ===
       JSON.stringify(config.agreementHash)
-    ) {
+  }
+
+  public async getJoinDaoLlcInstruction(
+    stakeAccountPositions: PublicKey,
+  ): Promise<TransactionInstruction> {
+    const config = await this.getGlobalConfig();
       return this.stakingProgram.methods
         .joinDaoLlc(config.agreementHash)
         .accounts({
           stakeAccountPositions,
         })
         .instruction();
-    } else {
-      return undefined;
-    }
   }
 
   public async getMainStakeAccount(owner?: PublicKey) {

--- a/governance/pyth_staking_sdk/src/pyth-staking-client.ts
+++ b/governance/pyth_staking_sdk/src/pyth-staking-client.ts
@@ -1,6 +1,6 @@
 import * as crypto from "crypto";
 
-import { AnchorProvider, BN, Instruction, Program } from "@coral-xyz/anchor";
+import { AnchorProvider, BN, Program } from "@coral-xyz/anchor";
 import {
   getTokenOwnerRecordAddress,
   PROGRAM_VERSION_V2,


### PR DESCRIPTION
Some stake accounts are not created through the createStakeAccount function.
Therefore they need to call joinDaoLlc when delegating/staking.