### PR TITLE
fix(governance/xc_admin): fix price store instruction parsing

### DIFF
--- a/governance/xc_admin/packages/xc_admin_common/src/__tests__/PriceStoreProgramInstruction.test.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/__tests__/PriceStoreProgramInstruction.test.ts
@@ -35,6 +35,10 @@ test("Price store instruction parse: roundtrip", (done) => {
     const instruction = createPriceStoreInstruction(data);
     const parsed = parsePriceStoreInstruction(instruction);
     expect(parsed).toStrictEqual(data);
+
+    instruction.programId = new PublicKey(instruction.programId.toBuffer());
+    const parsed2 = parsePriceStoreInstruction(instruction);
+    expect(parsed2).toStrictEqual(data);
   }
   done();
 });

--- a/governance/xc_admin/packages/xc_admin_common/src/price_store.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/price_store.ts
@@ -149,7 +149,7 @@ export function createPriceStoreInstruction(
 export function parsePriceStoreInstruction(
   instruction: TransactionInstruction
 ): PriceStoreInstruction {
-  if (instruction.programId != PRICE_STORE_PROGRAM_ID) {
+  if (!instruction.programId.equals(PRICE_STORE_PROGRAM_ID)) {
     throw new Error("program ID mismatch");
   }
   if (instruction.data.length < 1) {


### PR DESCRIPTION
Fixes `Error: program ID mismatch`.