### PR TITLE
feat: enable pda wallets

### DIFF
--- a/governance/pyth_staking_sdk/src/pyth-staking-client.ts
+++ b/governance/pyth_staking_sdk/src/pyth-staking-client.ts
@@ -11,7 +11,7 @@ import {
   createAssociatedTokenAccountInstruction,
   createTransferInstruction,
   getAccount,
-  getAssociatedTokenAddress,
+  getAssociatedTokenAddressSync,
   getMint,
   type Mint,
 } from "@solana/spl-token";
@@ -210,9 +210,10 @@ export class PythStakingClient {
     const globalConfig = await this.getGlobalConfig();
     return getAccount(
       this.connection,
-      await getAssociatedTokenAddress(
+      getAssociatedTokenAddressSync(
         globalConfig.pythTokenMint,
         this.wallet.publicKey,
+        true
       ),
     );
   }
@@ -446,9 +447,10 @@ export class PythStakingClient {
   public async createStakeAccountAndDeposit(amount: bigint) {
     const globalConfig = await this.getGlobalConfig();
 
-    const senderTokenAccount = await getAssociatedTokenAddress(
+    const senderTokenAccount = getAssociatedTokenAddressSync(
       globalConfig.pythTokenMint,
       this.wallet.publicKey,
+      true
     );
 
     const nonce = crypto.randomBytes(16).toString("hex");
@@ -528,9 +530,10 @@ export class PythStakingClient {
     const globalConfig = await this.getGlobalConfig();
     const mint = globalConfig.pythTokenMint;
 
-    const senderTokenAccount = await getAssociatedTokenAddress(
+    const senderTokenAccount = getAssociatedTokenAddressSync(
       mint,
       this.wallet.publicKey,
+      true
     );
 
     const instruction = createTransferInstruction(
@@ -551,9 +554,10 @@ export class PythStakingClient {
     const mint = globalConfig.pythTokenMint;
     const instructions = [];
 
-    const receiverTokenAccount = await getAssociatedTokenAddress(
+    const receiverTokenAccount = getAssociatedTokenAddressSync(
       mint,
       this.wallet.publicKey,
+      true
     );
 
     // Edge case: if the user doesn't have an ATA, create one

--- a/governance/pyth_staking_sdk/src/pyth-staking-client.ts
+++ b/governance/pyth_staking_sdk/src/pyth-staking-client.ts
@@ -213,7 +213,7 @@ export class PythStakingClient {
       getAssociatedTokenAddressSync(
         globalConfig.pythTokenMint,
         this.wallet.publicKey,
-        true
+        true,
       ),
     );
   }
@@ -450,7 +450,7 @@ export class PythStakingClient {
     const senderTokenAccount = getAssociatedTokenAddressSync(
       globalConfig.pythTokenMint,
       this.wallet.publicKey,
-      true
+      true,
     );
 
     const nonce = crypto.randomBytes(16).toString("hex");
@@ -533,7 +533,7 @@ export class PythStakingClient {
     const senderTokenAccount = getAssociatedTokenAddressSync(
       mint,
       this.wallet.publicKey,
-      true
+      true,
     );
 
     const instruction = createTransferInstruction(
@@ -557,7 +557,7 @@ export class PythStakingClient {
     const receiverTokenAccount = getAssociatedTokenAddressSync(
       mint,
       this.wallet.publicKey,
-      true
+      true,
     );
 
     // Edge case: if the user doesn't have an ATA, create one


### PR DESCRIPTION
By default getAssociatedTokenAddress fails if the owner of the token account is a Program Derived Address. This causes problems when for example a program multisig owns a stake account. 