### PR TITLE
feat(xc-admin): add support for price store in relayer

### DIFF
--- a/governance/xc_admin/packages/crank_pythnet_relayer/src/index.ts
+++ b/governance/xc_admin/packages/crank_pythnet_relayer/src/index.ts
@@ -15,6 +15,7 @@ import {
   Connection,
   Keypair,
   PublicKey,
+  SystemProgram,
   TransactionInstruction,
 } from "@solana/web3.js";
 import * as fs from "fs";
@@ -30,6 +31,11 @@ import {
   mapKey,
   REMOTE_EXECUTOR_ADDRESS,
   envOrErr,
+  PriceStoreMultisigInstruction,
+  findDetermisticPublisherBufferAddress,
+  PRICE_STORE_BUFFER_SPACE,
+  PRICE_STORE_PROGRAM_ID,
+  createDeterministicPublisherBufferAccountInstruction,
 } from "@pythnetwork/xc-admin-common";
 
 const CLUSTER: PythCluster = envOrErr("CLUSTER") as PythCluster;
@@ -163,6 +169,17 @@ async function run() {
             } else {
               throw Error("Product account not found");
             }
+          } else if (
+            parsedInstruction instanceof PriceStoreMultisigInstruction &&
+            parsedInstruction.name == "InitializePublisher"
+          ) {
+            preInstructions.push(
+              await createDeterministicPublisherBufferAccountInstruction(
+                provider.connection,
+                provider.wallet.publicKey,
+                parsedInstruction.args.publisherKey
+              )
+            );
           }
         }
 

--- a/governance/xc_admin/packages/xc_admin_common/src/executor.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/executor.ts
@@ -142,27 +142,6 @@ export async function executeProposal(
       } else {
         throw Error("Product account not found");
       }
-    } else if (
-      parsedInstruction instanceof PriceStoreMultisigInstruction &&
-      parsedInstruction.name == "InitializePublisher"
-    ) {
-      const [bufferKey, bufferSeed] =
-        await findDetermisticPublisherBufferAddress(
-          parsedInstruction.args.publisherKey
-        );
-      transaction.add(
-        SystemProgram.createAccountWithSeed({
-          fromPubkey: squad.wallet.publicKey,
-          basePubkey: squad.wallet.publicKey,
-          newAccountPubkey: bufferKey,
-          seed: bufferSeed,
-          space: PRICE_STORE_BUFFER_SPACE,
-          lamports: await squad.connection.getMinimumBalanceForRentExemption(
-            PRICE_STORE_BUFFER_SPACE
-          ),
-          programId: PRICE_STORE_PROGRAM_ID,
-        })
-      );
     }
 
     TransactionBuilder.addPriorityFee(transaction, priorityFeeConfig);


### PR DESCRIPTION
The executor only runs on Solana and we need to run this account creation on relayer which handles Pythnet messages.