### PR TITLE
fix: lowest epoch calc

### DIFF
--- a/governance/pyth_staking_sdk/src/pyth-staking-client.ts
+++ b/governance/pyth_staking_sdk/src/pyth-staking-client.ts
@@ -48,7 +48,6 @@ import {
   type TargetAccount,
   type VoterWeightAction,
   type VestingSchedule,
-  Position,
 } from "./types";
 import { convertBigIntToBN, convertBNToBigInt } from "./utils/bn";
 import { epochToDate, getCurrentEpoch } from "./utils/clock";
@@ -687,7 +686,7 @@ export class PythStakingClient {
           targetWithParameters.integrityPool?.publisher.equals(publisher.pubkey),
       )
 
-      const lowestEpoch = positionsWithPublisher.reduce((min, position)  => (min === undefined || position.activationEpoch < min) ? position.activationEpoch : min, <bigint| undefined>undefined);
+      const lowestEpoch = positionsWithPublisher.reduce<bigint| undefined>((min, position)  => (min === undefined || position.activationEpoch < min) ? position.activationEpoch : min, undefined);
       return {
         ...publisher,
         lowestEpoch
@@ -713,10 +712,10 @@ export class PythStakingClient {
       return a > b ? a : b;
     }
 
-    const lowestEpoch = publishers.reduce((min, publisher, index) => {
+    const lowestEpoch = publishers.reduce<bigint| undefined>((min, publisher, index) => {
       const maximum = max(publisher.lowestEpoch, delegationRecords[index]?.lastEpoch);
-      return (min === undefined || (maximum !== undefined && maximum < min)) ? publisher.lowestEpoch : min, <bigint| undefined>undefined
-    }, <bigint| undefined>undefined);
+      return (min === undefined || (maximum !== undefined && maximum < min)) ? publisher.lowestEpoch : min, undefined as bigint| undefined
+    }, undefined);
 
     const currentEpoch = await getCurrentEpoch(this.connection);
 

--- a/governance/pyth_staking_sdk/src/pyth-staking-client.ts
+++ b/governance/pyth_staking_sdk/src/pyth-staking-client.ts
@@ -49,7 +49,7 @@ import {
   type VoterWeightAction,
   type VestingSchedule,
 } from "./types";
-import { bigintMax } from "./utils/bigint";
+import { bigintMax, bigintMin } from "./utils/bigint";
 import { convertBigIntToBN, convertBNToBigInt } from "./utils/bn";
 import { epochToDate, getCurrentEpoch } from "./utils/clock";
 import { extractPublisherData } from "./utils/pool";
@@ -693,12 +693,7 @@ export class PythStakingClient {
 
         let lowestEpoch;
         for (const position of positionsWithPublisher) {
-          if (
-            lowestEpoch === undefined ||
-            position.activationEpoch < lowestEpoch
-          ) {
-            lowestEpoch = position.activationEpoch;
-          }
+          lowestEpoch = bigintMin(position.activationEpoch, lowestEpoch);
         }
 
         return {
@@ -720,12 +715,7 @@ export class PythStakingClient {
         publisher.lowestEpoch,
         delegationRecords[index]?.lastEpoch,
       );
-      if (
-        lowestEpoch === undefined ||
-        (maximum !== undefined && maximum < lowestEpoch)
-      ) {
-        lowestEpoch = maximum;
-      }
+      lowestEpoch = bigintMin(lowestEpoch, maximum);
     }
 
     const currentEpoch = await getCurrentEpoch(this.connection);

--- a/governance/pyth_staking_sdk/src/pyth-staking-client.ts
+++ b/governance/pyth_staking_sdk/src/pyth-staking-client.ts
@@ -816,7 +816,7 @@ export class PythStakingClient {
       expiry:
         instructions.lowestEpoch === undefined
           ? undefined
-          : epochToDate(instructions.lowestEpoch + 52n),
+          : epochToDate(instructions.lowestEpoch + 53n),
     };
   }
 

--- a/governance/pyth_staking_sdk/src/pyth-staking-client.ts
+++ b/governance/pyth_staking_sdk/src/pyth-staking-client.ts
@@ -702,7 +702,7 @@ export class PythStakingClient {
       ),
     );
 
-    const max = (a : bigint | undefined, b: bigint | undefined) => {
+    const bigintMax = (a : bigint | undefined, b: bigint | undefined) => {
       if (a === undefined) {
         return b;
       }
@@ -713,8 +713,8 @@ export class PythStakingClient {
     }
 
     const lowestEpoch = publishers.reduce<bigint| undefined>((min, publisher, index) => {
-      const maximum = max(publisher.lowestEpoch, delegationRecords[index]?.lastEpoch);
-      return (min === undefined || (maximum !== undefined && maximum < min)) ? publisher.lowestEpoch : min, undefined as bigint| undefined
+      const maximum = bigintMax(publisher.lowestEpoch, delegationRecords[index]?.lastEpoch);
+      return (min === undefined || (maximum !== undefined && maximum < min)) ? maximum : min;
     }, undefined);
 
     const currentEpoch = await getCurrentEpoch(this.connection);

--- a/governance/pyth_staking_sdk/src/utils/bigint.ts
+++ b/governance/pyth_staking_sdk/src/utils/bigint.ts
@@ -1,0 +1,9 @@
+export const bigintMax = (a: bigint | undefined, b: bigint | undefined) => {
+  if (a === undefined) {
+    return b;
+  }
+  if (b === undefined) {
+    return a;
+  }
+  return a > b ? a : b;
+};

--- a/governance/pyth_staking_sdk/src/utils/bigint.ts
+++ b/governance/pyth_staking_sdk/src/utils/bigint.ts
@@ -7,3 +7,13 @@ export const bigintMax = (a: bigint | undefined, b: bigint | undefined) => {
   }
   return a > b ? a : b;
 };
+
+export const bigintMin = (a: bigint | undefined, b: bigint | undefined) => {
+  if (a === undefined) {
+    return b;
+  }
+  if (b === undefined) {
+    return a;
+  }
+  return a < b ? a : b;
+};


### PR DESCRIPTION
Until now lowest epoch calculation was wrong because it only took into account delegation records, but these don't exist if you have never claimed.
When the delegation record doesn't exist, you need to look at the activationEpoch of the positions to get a sense of the expiry date of the rewards.