### PR TITLE
fix: get finalized slots

### DIFF
--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/apps/price_pusher/src/solana/solana.ts
+++ b/apps/price_pusher/src/solana/solana.ts
@@ -31,7 +31,7 @@ export class SolanaPriceListener extends ChainPriceListener {
   // Checking the health of the Solana connection by checking the last block time
   // and ensuring it is not older than 30 seconds.
   private async checkHealth() {
-    const slot = await this.pythSolanaReceiver.connection.getSlot();
+    const slot = await this.pythSolanaReceiver.connection.getSlot("finalized");
     const blockTime = await this.pythSolanaReceiver.connection.getBlockTime(
       slot
     );


### PR DESCRIPTION
This health check fails sometimes because the slot it queries hasn't become a block yet and has no timestamp. To fix this I will instead query a finalized slots which should always have a timestamp
