### PR TITLE
fix: solana health check increase time

### DIFF
--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/apps/price_pusher/src/solana/solana.ts
+++ b/apps/price_pusher/src/solana/solana.ts
@@ -35,7 +35,7 @@ export class SolanaPriceListener extends ChainPriceListener {
     const blockTime = await this.pythSolanaReceiver.connection.getBlockTime(
       slot
     );
-    if (blockTime === null || blockTime < Date.now() / 1000 - 30) {
+    if (blockTime === null || blockTime < Date.now() / 1000 - 50) {
       throw new Error("Solana connection is unhealthy");
     }
   }


### PR DESCRIPTION
With https://github.com/pyth-network/pyth-crosschain/pull/2029 I can see some false positives of Solana being unhealthy that made the pusher crash, because finalized slots are typically 20 seconds in the past (and sometimes it touches 30s).
Let's increase this threshold so that it doesn't crash anymore