### PR TITLE
fix: create token owner record on stake

### DIFF
--- a/governance/pyth_staking_sdk/src/pyth-staking-client.ts
+++ b/governance/pyth_staking_sdk/src/pyth-staking-client.ts
@@ -250,7 +250,20 @@ export class PythStakingClient {
     stakeAccountPositions: PublicKey,
     amount: bigint,
   ) {
-    const instructions = [];
+    const globalConfig = await this.getGlobalConfig();
+    const instructions: TransactionInstruction[] = [];
+
+    if (!(await this.hasGovernanceRecord(globalConfig))) {
+      await withCreateTokenOwnerRecord(
+        instructions,
+        GOVERNANCE_ADDRESS,
+        PROGRAM_VERSION_V2,
+        globalConfig.pythGovernanceRealm,
+        this.wallet.publicKey,
+        globalConfig.pythTokenMint,
+        this.wallet.publicKey,
+      );
+    }
 
     if (!(await this.hasJoinedDaoLlc(stakeAccountPositions))) {
       instructions.push(


### PR DESCRIPTION
For locked accounts, which aren't created from the UI, we need to create the token owner record here.