### PR TITLE
Bug: correct fill rate in ER Limo simple searcher example

### DIFF
--- a/express_relay/sdk/js/package.json
+++ b/express_relay/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/express-relay-js",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Utilities for interacting with the express relay protocol",
   "homepage": "https://github.com/pyth-network/pyth-crosschain/tree/main/express_relay/sdk/js",
   "author": "Douro Labs",

--- a/express_relay/sdk/js/package.json
+++ b/express_relay/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/express-relay-js",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Utilities for interacting with the express relay protocol",
   "homepage": "https://github.com/pyth-network/pyth-crosschain/tree/main/express_relay/sdk/js",
   "author": "Douro Labs",

--- a/express_relay/sdk/js/src/examples/simpleSearcherLimo.ts
+++ b/express_relay/sdk/js/src/examples/simpleSearcherLimo.ts
@@ -83,7 +83,7 @@ class SimpleSearcherLimo {
       order.state.outputMint
     );
     const inputAmountDecimals = new Decimal(
-      order.state.remainingInputAmount.toNumber()
+      order.state.initialInputAmount.toNumber()
     )
       .div(new Decimal(10).pow(inputMintDecimals))
       .mul(this.fillRate)
@@ -218,7 +218,8 @@ const argv = yargs(hideBin(process.argv))
     demandOption: true,
   })
   .option("fill-rate", {
-    description: "How much of the order to fill in percentage. Default is 100%",
+    description:
+      "How much of the initial order size to fill in percentage. Default is 100%",
     type: "number",
     default: 100,
   })

--- a/express_relay/sdk/js/src/examples/simpleSearcherLimo.ts
+++ b/express_relay/sdk/js/src/examples/simpleSearcherLimo.ts
@@ -98,7 +98,7 @@ class SimpleSearcherLimo {
       order.state.expectedOutputAmount.toNumber()
     )
       .div(new Decimal(10).pow(outputMintDecimals))
-      .mul(effectiveFillRate + 1)
+      .mul(effectiveFillRate)
       .div(100);
 
     console.log("Order address", order.address.toBase58());

--- a/express_relay/sdk/js/src/examples/simpleSearcherLimo.ts
+++ b/express_relay/sdk/js/src/examples/simpleSearcherLimo.ts
@@ -82,22 +82,27 @@ class SimpleSearcherLimo {
     const outputMintDecimals = await this.getMintDecimalsCached(
       order.state.outputMint
     );
+    const effectiveFillRate = Math.min(
+      this.fillRate,
+      (100 * order.state.remainingInputAmount.toNumber()) /
+        order.state.initialInputAmount.toNumber()
+    );
     const inputAmountDecimals = new Decimal(
       order.state.initialInputAmount.toNumber()
     )
       .div(new Decimal(10).pow(inputMintDecimals))
-      .mul(this.fillRate)
+      .mul(effectiveFillRate)
       .div(100);
 
     const outputAmountDecimals = new Decimal(
       order.state.expectedOutputAmount.toNumber()
     )
       .div(new Decimal(10).pow(outputMintDecimals))
-      .mul(this.fillRate)
+      .mul(effectiveFillRate + 1)
       .div(100);
 
     console.log("Order address", order.address.toBase58());
-    console.log("Fill rate", this.fillRate);
+    console.log("Fill rate", effectiveFillRate);
     console.log(
       "Sell token",
       order.state.inputMint.toBase58(),

--- a/express_relay/sdk/python/express_relay/searcher/examples/simple_searcher_svm.py
+++ b/express_relay/sdk/python/express_relay/searcher/examples/simple_searcher_svm.py
@@ -109,11 +109,17 @@ class SimpleSearcherSvm:
         order: OrderStateAndAddress = {"address": opp.order_address, "state": opp.order}
         input_mint_decimals = await self.get_mint_decimals(order["state"].input_mint)
         output_mint_decimals = await self.get_mint_decimals(order["state"].output_mint)
-        input_amount_decimals = Decimal(
-            order["state"].remaining_input_amount
-        ) / Decimal(10**input_mint_decimals)
+        effective_fill_rate = min(
+            self.fill_rate,
+            100
+            * order["state"].remaining_input_amount
+            / order["state"].initial_input_amount,
+        )
+        input_amount_decimals = Decimal(order["state"].initial_input_amount) / Decimal(
+            10**input_mint_decimals
+        )
         input_amount_decimals = (
-            input_amount_decimals * Decimal(self.fill_rate) / Decimal(100)
+            input_amount_decimals * Decimal(effective_fill_rate) / Decimal(100)
         )
         output_amount_decimals = Decimal(
             order["state"].expected_output_amount
@@ -127,7 +133,9 @@ class SimpleSearcherSvm:
             self.private_key.pubkey(),
             order,
             input_amount_decimals,
+            output_amount_decimals,
             input_mint_decimals,
+            output_mint_decimals,
             self.svm_config["express_relay_program"],
         )
         router = self.limo_client.get_pda_authority(

--- a/express_relay/sdk/python/express_relay/searcher/examples/simple_searcher_svm.py
+++ b/express_relay/sdk/python/express_relay/searcher/examples/simple_searcher_svm.py
@@ -223,7 +223,7 @@ async def main():
         "--fill-rate",
         type=int,
         default=100,
-        help="How much of the order to fill in percentage. Default is 100%",
+        help="How much of the initial order size to fill in percentage. Default is 100%",
     )
 
     args = parser.parse_args()

--- a/express_relay/sdk/python/express_relay/svm/generated/limo/instructions/take_order.py
+++ b/express_relay/sdk/python/express_relay/svm/generated/limo/instructions/take_order.py
@@ -8,9 +8,10 @@ from ..program_id import PROGRAM_ID
 
 class TakeOrderArgs(typing.TypedDict):
     input_amount: int
+    output_amount: int
 
 
-layout = borsh.CStruct("input_amount" / borsh.U64)
+layout = borsh.CStruct("input_amount" / borsh.U64, "output_amount" / borsh.U64)
 
 
 class TakeOrderAccounts(typing.TypedDict):
@@ -90,6 +91,7 @@ def take_order(
     encoded_args = layout.build(
         {
             "input_amount": args["input_amount"],
+            "output_amount": args["output_amount"],
         }
     )
     data = identifier + encoded_args

--- a/express_relay/sdk/python/express_relay/svm/limo_client.py
+++ b/express_relay/sdk/python/express_relay/svm/limo_client.py
@@ -199,8 +199,8 @@ class LimoClient:
         Args:
             taker: The taker's public key
             order: The order to fulfill
-            input_amount_decimals: The amount of input tokens to take multiplied by 10 ** input_mint_decimals
-            output_amount_decimals: The amount of output tokens to take multiplied by 10 ** output_mint_decimals
+            input_amount_decimals: The amount of input tokens to take. Will be multiplied by 10 ** input_mint_decimals in this method.
+            output_amount_decimals: The amount of output tokens to provide. Will be multiplied by 10 ** output_mint_decimals in this method.
             input_mint_decimals: input mint decimals (can be fetched via get_mint_decimals)
             output_mint_decimals: output mint decimals (can be fetched via get_mint_decimals)
             express_relay_program_id: Express relay program id

--- a/express_relay/sdk/python/express_relay/svm/limo_client.py
+++ b/express_relay/sdk/python/express_relay/svm/limo_client.py
@@ -189,7 +189,9 @@ class LimoClient:
         taker: Pubkey,
         order: OrderStateAndAddress,
         input_amount_decimals: Decimal,
+        output_amount_decimals: Decimal,
         input_mint_decimals: int,
+        output_mint_decimals: int,
         express_relay_program_id: Pubkey,
     ) -> List[Instruction]:
         """
@@ -198,7 +200,9 @@ class LimoClient:
             taker: The taker's public key
             order: The order to fulfill
             input_amount_decimals: The amount of input tokens to take multiplied by 10 ** input_mint_decimals
+            output_amount_decimals: The amount of output tokens to take multiplied by 10 ** output_mint_decimals
             input_mint_decimals: input mint decimals (can be fetched via get_mint_decimals)
+            output_mint_decimals: output mint decimals (can be fetched via get_mint_decimals)
             express_relay_program_id: Express relay program id
 
         Returns:
@@ -260,7 +264,10 @@ class LimoClient:
                 TakeOrderArgs(
                     input_amount=int(
                         input_amount_decimals * (10**input_mint_decimals)
-                    )
+                    ),
+                    output_amount=int(
+                        output_amount_decimals * (10**output_mint_decimals)
+                    ),
                 ),
                 {
                     "taker": taker,

--- a/express_relay/sdk/python/pyproject.toml
+++ b/express_relay/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "express-relay"
-version = "0.10.1"
+version = "0.12.2"
 description = "Utilities for searchers and protocols to interact with the Express Relay protocol."
 authors = ["dourolabs"]
 license = "Apache-2.0"


### PR DESCRIPTION
Prior to the recent Limo updates to include `outputAmount` in the take instruction, `fillRate` could refer to the percentage of the remaining input amount to fill. Now that the client must compute out the `outputAmount` to receive, the `fillRate` computation is a bit easier to do if in terms of the original input amount rather than the remaining amount, since we don't have to recompute the percentage of the original input amount that is being filled.