### PR TITLE
cap solana-program under 2 and fix warning

### DIFF
--- a/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
+++ b/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
@@ -16,4 +16,4 @@ name = "pyth_solana_receiver_sdk"
 anchor-lang = ">=0.28.0"
 hex = ">=0.4.3"
 pythnet-sdk = { path = "../../../pythnet/pythnet_sdk", version = "2.1.0", features = ["solana-program"]}
-solana-program = ">=1.16.0"
+solana-program = ">=1.16.0,<2"

--- a/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
+++ b/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
@@ -13,7 +13,7 @@ name = "pyth_solana_receiver_sdk"
 
 
 [dependencies]
-anchor-lang = "<0.30"
+anchor-lang = "<=0.30.0"
 hex = ">=0.4.3"
 pythnet-sdk = { path = "../../../pythnet/pythnet_sdk", version = "2.1.0", features = ["solana-program"]}
 solana-program = ">=1.16.0,<2"

--- a/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
+++ b/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
@@ -13,7 +13,7 @@ name = "pyth_solana_receiver_sdk"
 
 
 [dependencies]
-anchor-lang = ">=0.28"
+anchor-lang = "<=0.30.0"
 hex = ">=0.4.3"
 pythnet-sdk = { path = "../../../pythnet/pythnet_sdk", version = "2.1.0", features = ["solana-program"]}
 solana-program = ">=1.16.0,<2"

--- a/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
+++ b/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
@@ -13,7 +13,7 @@ name = "pyth_solana_receiver_sdk"
 
 
 [dependencies]
-anchor-lang = "<=0.30.0"
+anchor-lang = ">=0.28"
 hex = ">=0.4.3"
 pythnet-sdk = { path = "../../../pythnet/pythnet_sdk", version = "2.1.0", features = ["solana-program"]}
 solana-program = ">=1.16.0,<2"

--- a/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
+++ b/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
@@ -13,7 +13,7 @@ name = "pyth_solana_receiver_sdk"
 
 
 [dependencies]
-anchor-lang = ">=0.28.0"
+anchor-lang = "<0.30"
 hex = ">=0.4.3"
 pythnet-sdk = { path = "../../../pythnet/pythnet_sdk", version = "2.1.0", features = ["solana-program"]}
 solana-program = ">=1.16.0,<2"

--- a/target_chains/solana/pyth_solana_receiver_sdk/src/price_update.rs
+++ b/target_chains/solana/pyth_solana_receiver_sdk/src/price_update.rs
@@ -28,7 +28,7 @@ use {
 /// Using partially verified price updates is dangerous, as it lowers the threshold of guardians that need to collude to produce a malicious price update.
 #[derive(AnchorSerialize, AnchorDeserialize, Copy, Clone, PartialEq, BorshSchema, Debug)]
 pub enum VerificationLevel {
-    Partial { num_signatures: u8 },
+    Partial { #[allow(unused)] num_signatures: u8 },
     Full,
 }
 


### PR DESCRIPTION
The receiver SDK (or rather the generated anchor client) does not work with solana-program 2.0. Cargo does not know this though and ends up picking solana-program 2.0 which then blows up the downstream build. 

This PR caps the solana-program dependency to < 2 and fixes a build warning