### PR TITLE
fix: Specify sender address on reveal simulations

### DIFF
--- a/apps/fortuna/Cargo.lock
+++ b/apps/fortuna/Cargo.lock
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "fortuna"
-version = "6.5.3"
+version = "6.5.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/fortuna/Cargo.toml
+++ b/apps/fortuna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "fortuna"
-version = "6.5.3"
+version = "6.5.4"
 edition = "2021"
 
 [dependencies]

--- a/apps/fortuna/src/chain/ethereum.rs
+++ b/apps/fortuna/src/chain/ethereum.rs
@@ -379,6 +379,7 @@ impl<T: JsonRpcClient + 'static> EntropyReader for PythRandom<Provider<T>> {
 
     async fn estimate_reveal_with_callback_gas(
         &self,
+        sender: Address,
         provider: Address,
         sequence_number: u64,
         user_random_number: [u8; 32],
@@ -391,6 +392,7 @@ impl<T: JsonRpcClient + 'static> EntropyReader for PythRandom<Provider<T>> {
                 user_random_number,
                 provider_revelation,
             )
+            .from(sender)
             .estimate_gas()
             .await;
 

--- a/apps/fortuna/src/chain/reader.rs
+++ b/apps/fortuna/src/chain/reader.rs
@@ -60,6 +60,7 @@ pub trait EntropyReader: Send + Sync {
     /// Estimate the gas required to reveal a random number with a callback.
     async fn estimate_reveal_with_callback_gas(
         &self,
+        sender: Address,
         provider: Address,
         sequence_number: u64,
         user_random_number: [u8; 32],
@@ -184,6 +185,7 @@ pub mod mock {
 
         async fn estimate_reveal_with_callback_gas(
             &self,
+            sender: Address,
             provider: Address,
             sequence_number: u64,
             user_random_number: [u8; 32],

--- a/apps/fortuna/src/keeper.rs
+++ b/apps/fortuna/src/keeper.rs
@@ -444,6 +444,7 @@ pub async fn process_event(
     let gas_estimate_res = chain_config
         .contract
         .estimate_reveal_with_callback_gas(
+            contract.wallet().address(),
             event.provider_address,
             event.sequence_number,
             event.user_random_number,


### PR DESCRIPTION
abstract chain was not able to simulate these calls since the default from address was not a valid account