### PR TITLE
fix(target_chains/ton): fix traling header size interpretation & compute fee calculation

### DIFF
--- a/contract_manager/src/contracts/ton.ts
+++ b/contract_manager/src/contracts/ton.ts
@@ -5,7 +5,7 @@ import { TokenQty } from "../token";
 import { DataSource } from "@pythnetwork/xc-admin-common";
 import { Address, OpenedContract } from "@ton/ton";
 import {
-  BASE_UPDATE_PRICE_FEEDS_FEE,
+  calculateUpdatePriceFeedsFee,
   PythContract,
 } from "@pythnetwork/pyth-ton-js";
 
@@ -237,7 +237,7 @@ export class TonPriceFeedContract extends PriceFeedContract {
       await contract.sendUpdatePriceFeeds(
         sender,
         vaa,
-        BASE_UPDATE_PRICE_FEEDS_FEE + BigInt(fee)
+        calculateUpdatePriceFeedsFee(BigInt(fee)) + BigInt(fee)
       );
     }
 

--- a/target_chains/ton/contracts/contracts/Pyth.fc
+++ b/target_chains/ton/contracts/contracts/Pyth.fc
@@ -26,7 +26,7 @@ slice read_and_verify_header(slice data) {
     throw_if(ERROR_INVALID_MINOR_VERSION, minor_version < MINIMUM_ALLOWED_MINOR_VERSION);
     int trailing_header_size = data~load_uint(8);
     ;; skip trailing headers
-    data~skip_bits(trailing_header_size);
+    data~skip_bits(trailing_header_size * 8);
     int update_type = data~load_uint(8);
     throw_unless(ERROR_INVALID_UPDATE_DATA_TYPE, update_type == WORMHOLE_MERKLE_UPDATE_TYPE);
     return data;

--- a/target_chains/ton/contracts/contracts/Pyth.fc
+++ b/target_chains/ton/contracts/contracts/Pyth.fc
@@ -172,7 +172,10 @@ int parse_pyth_payload_in_wormhole_vm(slice payload) impure {
 
     int num_updates = cs~load_uint(8);
     int update_fee = single_update_fee * num_updates;
-    int compute_fee = get_compute_fee(WORKCHAIN, UPDATE_PRICE_FEEDS_GAS);
+    int compute_fee = get_compute_fee(
+        WORKCHAIN,
+        UPDATE_PRICE_FEEDS_BASE_GAS + (UPDATE_PRICE_FEEDS_PER_UPDATE_GAS * num_updates)
+    );
     throw_unless(ERROR_INSUFFICIENT_GAS, msg_value >= compute_fee);
     int remaining_msg_value = msg_value - compute_fee;
 

--- a/target_chains/ton/contracts/contracts/common/gas.fc
+++ b/target_chains/ton/contracts/contracts/common/gas.fc
@@ -1,4 +1,13 @@
 int get_compute_fee(int workchain, int gas_used) asm(gas_used workchain) "GETGASFEE";
 
-;; The actual gas used for the transaction is 350166 but we add ~10% (385182.6) and round up (390000) to be on the safe side because the amount of gas used can vary based on the current state of the blockchain
-const int UPDATE_PRICE_FEEDS_GAS = 390000;
+;; 1 update:  262,567 gas
+;; 2 updates: 347,791 (+85,224)
+;; 3 updates: 431,504 (+83,713)
+;; 4 updates: 514,442 (+82,938)
+;; 5 updates: 604,247 (+89,805)
+;; 6 updates: 683,113 (+78,866)
+;; 10 updates: 947,594
+;; Upper bound gas increase per additional update: ~90,000
+;; Base cost (1 update): ~262,567 gas
+const UPDATE_PRICE_FEEDS_BASE_GAS = 300000;  ;; Base cost + 10% safety margin rounded up because the amount of gas used can vary based on the current state of the blockchain
+const UPDATE_PRICE_FEEDS_PER_UPDATE_GAS = 90000;  ;; Per update cost

--- a/target_chains/ton/sdk/js/README.md
+++ b/target_chains/ton/sdk/js/README.md
@@ -24,6 +24,7 @@ import { HermesClient } from "@pythnetwork/hermes-client";
 import {
   PythContract,
   PYTH_CONTRACT_ADDRESS_TESTNET,
+  calculateUpdatePriceFeedsFee,
 } from "@pythnetwork/pyth-ton-js";
 
 const BTC_PRICE_FEED_ID =
@@ -73,7 +74,7 @@ async function main() {
   await contract.sendUpdatePriceFeeds(
     provider.sender(key.secretKey),
     updateData,
-    BASE_UPDATE_PRICE_FEEDS_FEE + BigInt(updateFee)
+    calculateUpdatePriceFeedsFee(1n) + BigInt(updateFee)
   );
   console.log("Price feeds updated successfully.");
 

--- a/target_chains/ton/sdk/js/src/index.ts
+++ b/target_chains/ton/sdk/js/src/index.ts
@@ -13,11 +13,10 @@ import { ContractProvider } from "@ton/ton";
 export const PYTH_CONTRACT_ADDRESS_TESTNET =
   "EQDwGkJmcj7MMmWAHmhldnY-lAKI6hcTQ2tAEcapmwCnztQU";
 // This is defined in target_chains/ton/contracts/common/gas.fc
-export const UPDATE_PRICE_FEEDS_GAS = 390000n;
+export const UPDATE_PRICE_FEEDS_BASE_GAS = 300000n;
+export const UPDATE_PRICE_FEEDS_PER_UPDATE_GAS = 90000n;
 // Current settings in basechain are as follows: 1 unit of gas costs 400 nanotons
 export const GAS_PRICE_FACTOR = 400n;
-export const BASE_UPDATE_PRICE_FEEDS_FEE =
-  UPDATE_PRICE_FEEDS_GAS * GAS_PRICE_FACTOR;
 
 export interface DataSource {
   emitterChain: number;
@@ -317,4 +316,12 @@ export function parseGuardianSetKeys(cell: Cell): string[] {
 
   parseCell(cell);
   return keys;
+}
+
+export function calculateUpdatePriceFeedsFee(numUpdates: bigint) {
+  return (
+    (UPDATE_PRICE_FEEDS_BASE_GAS +
+      UPDATE_PRICE_FEEDS_PER_UPDATE_GAS * numUpdates) *
+    GAS_PRICE_FACTOR
+  );
 }


### PR DESCRIPTION
- **Fix Trailing Header Size Interpretation**: Corrects the trailing header size to be interpreted in bytes rather than bits.
- **Fix Compute Fee Calculation**: Adjusts the compute fee calculation to accurately factor in the number of updates, preventing potential exploitation where fees could be bypassed by submitting numerous updates.