### PR TITLE
fix: add env vars to turbo config

### DIFF
--- a/apps/api-reference/turbo.json
+++ b/apps/api-reference/turbo.json
@@ -4,7 +4,12 @@
   "tasks": {
     "build": {
       "dependsOn": ["pull:env", "^build"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [".next/**", "!.next/cache/**"],
+      "env": [
+        "WALLETCONNECT_PROJECT_ID",
+        "AMPLITUDE_API_KEY",
+        "GOOGLE_ANALYTICS_ID"
+      ]
     },
     "pull:env": {
       "outputs": [".env.local"],

--- a/apps/staking/turbo.json
+++ b/apps/staking/turbo.json
@@ -4,7 +4,17 @@
   "tasks": {
     "build": {
       "dependsOn": ["pull:env", "^build"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [".next/**", "!.next/cache/**"],
+      "env": [
+        "IP_ALLOWLIST",
+        "GOVERNANCE_ONLY_REGIONS",
+        "WALLETCONNECT_PROJECT_ID",
+        "PROXYCHECK_API_KEY",
+        "MAINNET_RPC",
+        "BLOCKED_REGIONS",
+        "AMPLITUDE_API_KEY",
+        "GOOGLE_ANALYTICS_ID"
+      ]
     },
     "pull:env": {
       "outputs": [".env.local"],

--- a/governance/xc_admin/packages/xc_admin_frontend/turbo.json
+++ b/governance/xc_admin/packages/xc_admin_frontend/turbo.json
@@ -5,7 +5,11 @@
     "build": {
       "dependsOn": ["pull:env", "^build"],
       "outputs": [".next/**", "!.next/cache/**"],
-      "env": ["BUILD_STANDALONE"]
+      "env": [
+        "BUILD_STANDALONE",
+        "NEXT_PUBLIC_MAINNET_RPC",
+        "NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID"
+      ]
     },
     "pull:env": {
       "outputs": [".env.local"],


### PR DESCRIPTION
This PR adds environment variables to the turbo configuration, which fixes an issue where they aren't available at build time due to [turbo environment strict
mode](https://turbo.build/repo/docs/crafting-your-repository/using-environment-variables#strict-mode). As a result, statically generated pages do not have correct environment variables and in particular things like the RPC aren't set correctly