### PR TITLE
Fix pythnet_sdk compatibility with Anchor's idl-build

### DIFF
--- a/pythnet/pythnet_sdk/src/messages.rs
+++ b/pythnet/pythnet_sdk/src/messages.rs
@@ -100,7 +100,8 @@ pub type Pubkey = [u8; 32];
 )]
 
 pub struct PriceFeedMessage {
-    pub feed_id:           FeedId,
+    /// `FeedId` but avoid the type alias because of compatibility issues with Anchor's `idl-build` feature.
+    pub feed_id:           [u8; 32],
     pub price:             i64,
     pub conf:              u64,
     pub exponent:          i32,


### PR DESCRIPTION
A new method for computing the IDL of a smart contract was introduced in Solana's Anchor framework version 0.29. This method relies on the derive of `AnchorSerialize` trait when the feature `idl-build` is activated. However, the derive fails on type aliases like `FeedId`

This PR simply replaces the occurrence of `FeedId` in `PriceFeedMessage` with the underlying type to work around this limitation.