### PR TITLE
chore(staking): upgrade recharts

### DIFF
--- a/apps/staking/package.json
+++ b/apps/staking/package.json
@@ -47,7 +47,7 @@
     "react-aria": "^3.34.3",
     "react-aria-components": "^1.3.3",
     "react-dom": "catalog:",
-    "recharts": "^2.13.2",
+    "recharts": "^2.13.3",
     "swr": "^2.2.5",
     "zod": "^3.23.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -627,8 +627,8 @@ importers:
         specifier: 'catalog:'
         version: 19.0.0-rc-603e6108-20241029(react@19.0.0-rc-603e6108-20241029)
       recharts:
-        specifier: ^2.13.2
-        version: 2.13.2(react-dom@19.0.0-rc-603e6108-20241029(react@19.0.0-rc-603e6108-20241029))(react@19.0.0-rc-603e6108-20241029)
+        specifier: ^2.13.3
+        version: 2.13.3(react-dom@19.0.0-rc-603e6108-20241029(react@19.0.0-rc-603e6108-20241029))(react@19.0.0-rc-603e6108-20241029)
       swr:
         specifier: ^2.2.5
         version: 2.2.5(react@19.0.0-rc-603e6108-20241029)
@@ -19930,8 +19930,8 @@ packages:
   recharts-scale@0.4.5:
     resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
 
-  recharts@2.13.2:
-    resolution: {integrity: sha512-UDLGFmnsBluDIPpQb9uty0ejb+jiVI71vkki8vVsR6ZCJdgjBfKQoQfft4re99CKlTy9qjQApxCLG6TrxJkeAg==}
+  recharts@2.13.3:
+    resolution: {integrity: sha512-YDZ9dOfK9t3ycwxgKbrnDlRC4BHdjlY73fet3a0C1+qGMjXVZe6+VXmpOIIhzkje5MMEL8AN4hLIe4AMskBzlA==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0
@@ -56452,7 +56452,7 @@ snapshots:
     dependencies:
       decimal.js-light: 2.5.1
 
-  recharts@2.13.2(react-dom@19.0.0-rc-603e6108-20241029(react@19.0.0-rc-603e6108-20241029))(react@19.0.0-rc-603e6108-20241029):
+  recharts@2.13.3(react-dom@19.0.0-rc-603e6108-20241029(react@19.0.0-rc-603e6108-20241029))(react@19.0.0-rc-603e6108-20241029):
     dependencies:
       clsx: 2.1.1
       eventemitter3: 4.0.7
@@ -56523,7 +56523,7 @@ snapshots:
 
   regenerator-transform@0.15.1:
     dependencies:
-      '@babel/runtime': 7.25.0
+      '@babel/runtime': 7.25.7
 
   regenerator-transform@0.15.2:
     dependencies:


### PR DESCRIPTION
Seems like recharts's ResponsiveContainer component in version 2.13.2 wasn't working with React 19, and the issue has been fixed with recharts 2.13.3