### PR TITLE
fix(hermes): make `ignore_invalid_price_ids` param optional on the stream API

### DIFF
--- a/apps/hermes/server/Cargo.lock
+++ b/apps/hermes/server/Cargo.lock
@@ -1796,7 +1796,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/hermes/server/Cargo.toml
+++ b/apps/hermes/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "hermes"
-version     = "0.7.0"
+version     = "0.7.1"
 description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
 edition     = "2021"
 

--- a/apps/hermes/server/src/api/rest/v2/sse.rs
+++ b/apps/hermes/server/src/api/rest/v2/sse.rs
@@ -1,34 +1,19 @@
 use {
     crate::{
         api::{
-            rest::{
-                validate_price_ids,
-                RestError,
-            },
+            rest::{validate_price_ids, RestError},
             types::{
-                BinaryUpdate,
-                EncodingType,
-                ParsedPriceUpdate,
-                PriceIdInput,
-                PriceUpdate,
+                BinaryUpdate, EncodingType, ParsedPriceUpdate, PriceIdInput, PriceUpdate,
                 RpcPriceIdentifier,
             },
             ApiState,
         },
-        state::aggregate::{
-            Aggregates,
-            AggregationEvent,
-            RequestTime,
-        },
+        state::aggregate::{Aggregates, AggregationEvent, RequestTime},
     },
     anyhow::Result,
     axum::{
         extract::State,
-        response::sse::{
-            Event,
-            KeepAlive,
-            Sse,
-        },
+        response::sse::{Event, KeepAlive, Sse},
     },
     futures::Stream,
     pyth_sdk::PriceIdentifier,
@@ -36,10 +21,7 @@ use {
     serde_qs::axum::QsQuery,
     std::convert::Infallible,
     tokio::sync::broadcast,
-    tokio_stream::{
-        wrappers::BroadcastStream,
-        StreamExt as _,
-    },
+    tokio_stream::{wrappers::BroadcastStream, StreamExt as _},
     utoipa::IntoParams,
 };
 
@@ -74,7 +56,8 @@ pub struct StreamPriceUpdatesQueryParams {
     #[serde(default)]
     benchmarks_only: bool,
 
-    /// If true, invalid price IDs in the `ids` parameter are ignored. Only applicable to the v2 APIs. Default is `false`.    #[serde(default)]
+    /// If true, invalid price IDs in the `ids` parameter are ignored. Only applicable to the v2 APIs. Default is `false`.
+    #[serde(default)]
     ignore_invalid_price_ids: bool,
 }
 
@@ -178,7 +161,6 @@ where
         .into_iter()
         .map(|price_feed| price_feed.into())
         .collect();
-
 
     if benchmarks_only {
         // Remove those with metadata.prev_publish_time != price.publish_time from parsed_price_updates


### PR DESCRIPTION
Caught a bug when testing #2091 on testnet -- the `ignore_invalid_price_ids` param is required on the stream API when it should have been optional. This was raised by @keyvankhademi in the original PR, but it looks like I crossed some wires in my git operations and the commit didn't end up in the branch before I merged it. Thanks to @ayazabbas for the tip on testing the release on testnet first, it helped out here :)