### PR TITLE
 chore(hermes): use stable rust toolchain in precommit formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
       - id: cargo-fmt-fortuna
         name: Cargo format for Fortuna
         language: "rust"
-        entry: cargo +nightly-2023-07-23 fmt --manifest-path ./apps/fortuna/Cargo.toml --all -- --config-path rustfmt.toml
+        entry: cargo +1.82.0 fmt --manifest-path ./apps/fortuna/Cargo.toml --all -- --config-path rustfmt.toml
         pass_filenames: false
         files: apps/fortuna
       - id: cargo-clippy-fortuna

--- a/apps/hermes/server/src/api/rest/v2/sse.rs
+++ b/apps/hermes/server/src/api/rest/v2/sse.rs
@@ -1,19 +1,34 @@
 use {
     crate::{
         api::{
-            rest::{validate_price_ids, RestError},
+            rest::{
+                validate_price_ids,
+                RestError,
+            },
             types::{
-                BinaryUpdate, EncodingType, ParsedPriceUpdate, PriceIdInput, PriceUpdate,
+                BinaryUpdate,
+                EncodingType,
+                ParsedPriceUpdate,
+                PriceIdInput,
+                PriceUpdate,
                 RpcPriceIdentifier,
             },
             ApiState,
         },
-        state::aggregate::{Aggregates, AggregationEvent, RequestTime},
+        state::aggregate::{
+            Aggregates,
+            AggregationEvent,
+            RequestTime,
+        },
     },
     anyhow::Result,
     axum::{
         extract::State,
-        response::sse::{Event, KeepAlive, Sse},
+        response::sse::{
+            Event,
+            KeepAlive,
+            Sse,
+        },
     },
     futures::Stream,
     pyth_sdk::PriceIdentifier,
@@ -21,7 +36,10 @@ use {
     serde_qs::axum::QsQuery,
     std::convert::Infallible,
     tokio::sync::broadcast,
-    tokio_stream::{wrappers::BroadcastStream, StreamExt as _},
+    tokio_stream::{
+        wrappers::BroadcastStream,
+        StreamExt as _,
+    },
     utoipa::IntoParams,
 };
 


### PR DESCRIPTION
Fix a mismatch between the Hermes toolchain (stable) and the `cargo fmt` command run by precommit in CI (nightly). Reformat the `sse.rs` touched by #2102 to make it pass precommit.