### PR TITLE
feat: added gas multiplier arg for injective

### DIFF
--- a/apps/price_pusher/README.md
+++ b/apps/price_pusher/README.md
@@ -105,7 +105,7 @@ pnpm run start injective --grpc-endpoint https://grpc-endpoint.com \
     --price-config-file "path/to/price-config.beta.sample.yaml" \
     --mnemonic-file "path/to/mnemonic.txt" \
     --network testnet \
-    [--gas-price 500000000] \
+    [--gas-price 160000000] \
     [--gas-multiplier 1.1] \
     [--pushing-frequency 10] \
     [--polling-frequency 5]

--- a/apps/price_pusher/README.md
+++ b/apps/price_pusher/README.md
@@ -106,6 +106,7 @@ pnpm run start injective --grpc-endpoint https://grpc-endpoint.com \
     --mnemonic-file "path/to/mnemonic.txt" \
     --network testnet \
     [--gas-price 500000000] \
+    [--gas-multiplier 1.1] \
     [--pushing-frequency 10] \
     [--polling-frequency 5]
 

--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "8.0.4",
+  "version": "8.1.0",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/apps/price_pusher/src/injective/command.ts
+++ b/apps/price_pusher/src/injective/command.ts
@@ -30,6 +30,10 @@ export default {
       description: "Gas price to be used for each transasction",
       type: "number",
     } as Options,
+    "gas-multiplier": {
+      description: "Gas multiplier to be used for each transasction",
+      type: "number",
+    } as Options,
     ...options.priceConfigFile,
     ...options.priceServiceEndpoint,
     ...options.mnemonicFile,
@@ -44,6 +48,7 @@ export default {
     // FIXME: type checks for this
     const {
       gasPrice,
+      gasMultiplier,
       grpcEndpoint,
       priceConfigFile,
       priceServiceEndpoint,
@@ -101,6 +106,7 @@ export default {
       {
         chainId: getNetworkInfo(network).chainId,
         gasPrice,
+        gasMultiplier
       }
     );
 

--- a/apps/price_pusher/src/injective/command.ts
+++ b/apps/price_pusher/src/injective/command.ts
@@ -106,7 +106,7 @@ export default {
       {
         chainId: getNetworkInfo(network).chainId,
         gasPrice,
-        gasMultiplier
+        gasMultiplier,
       }
     );
 

--- a/apps/price_pusher/src/injective/injective.ts
+++ b/apps/price_pusher/src/injective/injective.ts
@@ -23,6 +23,8 @@ import { Logger } from "pino";
 import { Account } from "@injectivelabs/sdk-ts/dist/cjs/client/chain/types/auth";
 
 const DEFAULT_GAS_PRICE = 500000000;
+const DEFAULT_GAS_MULTIPLIER = 1.05
+const INJECTIVE_TESTNET_CHAIN_ID = "injective-888"
 
 type PriceQueryResponse = {
   price_feed: {
@@ -108,8 +110,8 @@ export class InjectivePricePusher implements IPricePusher {
     this.wallet = PrivateKey.fromMnemonic(mnemonic);
 
     this.chainConfig = {
-      chainId: chainConfig?.chainId ?? "injective-888",
-      gasMultiplier: chainConfig?.gasMultiplier ?? 1.2,
+      chainId: chainConfig?.chainId ?? INJECTIVE_TESTNET_CHAIN_ID,
+      gasMultiplier: chainConfig?.gasMultiplier ?? DEFAULT_GAS_MULTIPLIER,
       gasPrice: chainConfig?.gasPrice ?? DEFAULT_GAS_PRICE,
     };
   }

--- a/apps/price_pusher/src/injective/injective.ts
+++ b/apps/price_pusher/src/injective/injective.ts
@@ -23,8 +23,8 @@ import { Logger } from "pino";
 import { Account } from "@injectivelabs/sdk-ts/dist/cjs/client/chain/types/auth";
 
 const DEFAULT_GAS_PRICE = 160000000;
-const DEFAULT_GAS_MULTIPLIER = 1.05
-const INJECTIVE_TESTNET_CHAIN_ID = "injective-888"
+const DEFAULT_GAS_MULTIPLIER = 1.05;
+const INJECTIVE_TESTNET_CHAIN_ID = "injective-888";
 
 type PriceQueryResponse = {
   price_feed: {

--- a/apps/price_pusher/src/injective/injective.ts
+++ b/apps/price_pusher/src/injective/injective.ts
@@ -22,7 +22,7 @@ import {
 import { Logger } from "pino";
 import { Account } from "@injectivelabs/sdk-ts/dist/cjs/client/chain/types/auth";
 
-const DEFAULT_GAS_PRICE = 500000000;
+const DEFAULT_GAS_PRICE = 160000000;
 const DEFAULT_GAS_MULTIPLIER = 1.05
 const INJECTIVE_TESTNET_CHAIN_ID = "injective-888"
 

--- a/target_chains/cosmwasm/tools/src/chains-manager/injective.ts
+++ b/target_chains/cosmwasm/tools/src/chains-manager/injective.ts
@@ -34,7 +34,7 @@ import {
 } from "@injectivelabs/networks";
 import * as net from "net";
 
-const DEFAULT_GAS_PRICE = 500000000;
+const DEFAULT_GAS_PRICE = 160000000;
 
 export class InjectiveExecutor implements ChainExecutor {
   private readonly gasMultiplier = 2;

--- a/target_chains/cosmwasm/tools/src/ci/deployer/injective.ts
+++ b/target_chains/cosmwasm/tools/src/ci/deployer/injective.ts
@@ -87,12 +87,12 @@ export class InjectiveDeployer implements Deployer {
     const txResponse = await this.signAndBroadcastMsg(store_code, {
       amount: [
         {
-          // gas = 5000000 & gasPrice = 500000000
-          amount: String(500000000 * 5000000),
+          // gas = 5000000 & gasPrice = 160000000
+          amount: String(160000000 * 5000000),
           denom: "inj",
         },
       ],
-      // DEFAULT STD FEE that we use has gas = 400000 and gasPrice = 500000000
+      // DEFAULT STD FEE that we use has gas = 400000 and gasPrice = 160000000
       // But this transaction was taking gas around 3000000. Which is a lot more
       // Keeping the gasPrice same as in default std fee as seen above in amount.
       // Changing the gasLimit to 5000000


### PR DESCRIPTION
Hey, we'd like to be able to specify the `gasMultiplier` config. Currently, the Pyth price pusher is spending around `14inj` per day more than needed, which ends up at around $9k at current prices. This is why we'd like to optimize. 

I've also updated the `DEFAULT_GAS_PRICE` to `160000000` which is the new default on chain.