### PR TITLE
Deny clippy warnings in CI properly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,7 +97,7 @@ repos:
       - id: cargo-clippy-message-buffer
         name: Cargo clippy for message buffer contract
         language: "rust"
-        entry: cargo +1.66.1 clippy --manifest-path ./pythnet/message_buffer/Cargo.toml --tests --fix --allow-dirty --allow-staged --features test-bpf -- -D warnings
+        entry: cargo +1.66.1 clippy --manifest-path ./pythnet/message_buffer/Cargo.toml --tests -- --deny warnings
         pass_filenames: false
         files: pythnet/message_buffer
       # Hooks for pythnet_sdk

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,7 +84,7 @@ repos:
       - id: cargo-clippy-fortuna
         name: Cargo clippy for Fortuna
         language: "rust"
-        entry: cargo +1.82.0 clippy --manifest-path ./apps/fortuna/Cargo.toml --tests --fix --allow-dirty --allow-staged -- -D warnings
+        entry: cargo +1.82.0 clippy --manifest-path ./apps/fortuna/Cargo.toml --tests -- --deny warnings
         pass_filenames: false
         files: apps/fortuna
       # Hooks for message buffer contract

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
       - id: cargo-clippy-cosmwasm
         name: Cargo clippy for cosmwasm contract
         language: "rust"
-        entry: cargo +1.82.0 clippy --manifest-path ./target_chains/cosmwasm/Cargo.toml --tests --fix --allow-dirty --allow-staged -- -D warnings
+        entry: cargo +1.82.0 clippy --manifest-path ./target_chains/cosmwasm/Cargo.toml --tests -- --deny warnings
         pass_filenames: false
         files: target_chains/cosmwasm
       # Hooks for Hermes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,7 @@ repos:
       - id: cargo-clippy-hermes
         name: Cargo clippy for Hermes
         language: "rust"
-        entry: cargo +1.82.0 clippy --manifest-path ./apps/hermes/server/Cargo.toml --tests --fix --allow-dirty --allow-staged -- -D warnings
+        entry: cargo +1.82.0 clippy --manifest-path ./apps/hermes/server/Cargo.toml --tests -- --deny warnings
         pass_filenames: false
         files: apps/hermes
       # Hooks for Fortuna

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -110,7 +110,7 @@ repos:
       - id: cargo-clippy-pythnet-sdk
         name: Cargo clippy for pythnet SDK
         language: "rust"
-        entry: cargo +1.82.0 clippy --manifest-path ./pythnet/pythnet_sdk/Cargo.toml --tests --fix --allow-dirty --allow-staged -- -D warnings
+        entry: cargo +1.82.0 clippy --manifest-path ./pythnet/pythnet_sdk/Cargo.toml --tests -- --deny warnings
         pass_filenames: false
         files: pythnet/pythnet_sdk
       # Hooks for solana receiver contract
@@ -123,7 +123,7 @@ repos:
       - id: cargo-clippy-pyth-solana-receiver
         name: Cargo clippy for solana target chain contract
         language: "rust"
-        entry: cargo +1.73.0 clippy --manifest-path ./target_chains/solana/Cargo.toml --tests --fix --allow-dirty --allow-staged -- -D warnings
+        entry: cargo +1.73.0 clippy --manifest-path ./target_chains/solana/Cargo.toml --tests -- --deny warnings
         pass_filenames: false
         files: target_chains/solana
       # For express relay python files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
       - id: cargo-clippy-remote-executor
         name: Cargo clippy for remote executor
         language: "rust"
-        entry: cargo +1.66.1 clippy --manifest-path ./governance/remote_executor/Cargo.toml --tests --fix --allow-dirty --allow-staged -- -D warnings
+        entry: cargo +1.66.1 clippy --manifest-path ./governance/remote_executor/Cargo.toml --tests -- --deny warnings
         pass_filenames: false
         files: governance/remote_executor
       # Hooks for cosmwasm contract

--- a/apps/fortuna/src/api/revelation.rs
+++ b/apps/fortuna/src/api/revelation.rs
@@ -40,10 +40,6 @@ pub async fn revelation(
         })
         .inc();
 
-    let sequence: u64 = sequence
-        .try_into()
-        .map_err(|_| RestError::InvalidSequenceNumber)?;
-
     let state = state
         .chains
         .get(&chain_id)

--- a/apps/fortuna/src/chain/ethereum.rs
+++ b/apps/fortuna/src/chain/ethereum.rs
@@ -295,7 +295,7 @@ impl<T: JsonRpcClient + 'static> EntropyReader for PythRandom<Provider<T>> {
             Ok(Some(reader::Request {
                 provider: r.provider,
                 sequence_number: r.sequence_number,
-                block_number: r.block_number.try_into()?,
+                block_number: r.block_number,
                 use_blockhash: r.use_blockhash,
             }))
         } else {

--- a/apps/fortuna/src/chain/reader.rs
+++ b/apps/fortuna/src/chain/reader.rs
@@ -157,7 +157,7 @@ pub mod mock {
 
         async fn get_block_number(
             &self,
-            confirmed_block_status: BlockStatus,
+            _confirmed_block_status: BlockStatus,
         ) -> Result<BlockNumber> {
             Ok(*self.block_number.read().unwrap())
         }
@@ -172,11 +172,11 @@ pub mod mock {
 
         async fn estimate_reveal_with_callback_gas(
             &self,
-            sender: Address,
-            provider: Address,
-            sequence_number: u64,
-            user_random_number: [u8; 32],
-            provider_revelation: [u8; 32],
+            _sender: Address,
+            _provider: Address,
+            _sequence_number: u64,
+            _user_random_number: [u8; 32],
+            _provider_revelation: [u8; 32],
         ) -> Result<U256> {
             Ok(U256::from(5))
         }

--- a/apps/fortuna/src/command/run.rs
+++ b/apps/fortuna/src/command/run.rs
@@ -207,7 +207,7 @@ pub async fn run(opts: &RunOptions) -> Result<()> {
 
 async fn setup_chain_state(
     provider: &Address,
-    secret: &String,
+    secret: &str,
     chain_sample_interval: u64,
     chain_id: &ChainId,
     chain_config: &EthereumConfig,

--- a/apps/fortuna/src/state.rs
+++ b/apps/fortuna/src/state.rs
@@ -83,6 +83,7 @@ impl PebbleHashChain {
         Ok(val)
     }
 
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.length
     }
@@ -140,6 +141,8 @@ mod test {
         let chain = PebbleHashChain::new(secret, length, sample_interval);
 
         let mut last_val = chain.reveal_ith(0).unwrap();
+
+        #[allow(clippy::needless_range_loop)]
         for i in 1..length {
             let cur_val = chain.reveal_ith(i).unwrap();
             println!("{}", i);

--- a/apps/hermes/server/src/network/wormhole.rs
+++ b/apps/hermes/server/src/network/wormhole.rs
@@ -75,6 +75,7 @@ pub struct GuardianSetData {
 ///
 /// The following module structure must match the protobuf definitions, so that the generated code
 /// can correctly reference modules from each other.
+#[allow(clippy::enum_variant_names)]
 mod proto {
     pub mod node {
         pub mod v1 {

--- a/governance/remote_executor/programs/remote-executor/src/tests/executor_simulator.rs
+++ b/governance/remote_executor/programs/remote-executor/src/tests/executor_simulator.rs
@@ -123,7 +123,7 @@ impl ExecutorBench {
     pub fn add_vaa_account(
         &mut self,
         emitter: &Pubkey,
-        instructions: &Vec<Instruction>,
+        instructions: &[Instruction],
         validity: VaaAttack,
     ) -> Pubkey {
         let emitter_chain: u16 = match validity {

--- a/governance/remote_executor/programs/remote-executor/src/tests/test_adversarial.rs
+++ b/governance/remote_executor/programs/remote-executor/src/tests/test_adversarial.rs
@@ -28,7 +28,7 @@ async fn test_adversarial() {
     // Setup VAAs
     let vaa_account_valid = bench.add_vaa_account(
         &emitter,
-        &vec![transfer(
+        &[transfer(
             &executor_key,
             &receiver,
             Rent::default().minimum_balance(0),
@@ -37,7 +37,7 @@ async fn test_adversarial() {
     );
     let vaa_account_wrong_data = bench.add_vaa_account(
         &emitter,
-        &vec![transfer(
+        &[transfer(
             &executor_key,
             &receiver,
             Rent::default().minimum_balance(0),
@@ -46,7 +46,7 @@ async fn test_adversarial() {
     );
     let vaa_account_wrong_owner = bench.add_vaa_account(
         &emitter,
-        &vec![transfer(
+        &[transfer(
             &executor_key,
             &receiver,
             Rent::default().minimum_balance(0),
@@ -55,7 +55,7 @@ async fn test_adversarial() {
     );
     let vaa_account_wrong_emitter_chain = bench.add_vaa_account(
         &emitter,
-        &vec![transfer(
+        &[transfer(
             &executor_key,
             &receiver,
             Rent::default().minimum_balance(0),
@@ -65,7 +65,7 @@ async fn test_adversarial() {
 
     let vaa_account_wrong_vaa_magic = bench.add_vaa_account(
         &emitter,
-        &vec![transfer(
+        &[transfer(
             &executor_key,
             &receiver,
             Rent::default().minimum_balance(0),
@@ -75,7 +75,7 @@ async fn test_adversarial() {
 
     // The goal of this account is creating a claim_record that the attacker is going to try to use to impersonate
     // the right claim_record
-    let vaa_account_valid_2 = bench.add_vaa_account(&emitter_2, &vec![], VaaAttack::None);
+    let vaa_account_valid_2 = bench.add_vaa_account(&emitter_2, &[], VaaAttack::None);
 
     let mut sim = bench.start().await;
     sim.airdrop(&executor_key, LAMPORTS_PER_SOL).await.unwrap();

--- a/governance/remote_executor/programs/remote-executor/src/tests/test_basic_instructions.rs
+++ b/governance/remote_executor/programs/remote-executor/src/tests/test_basic_instructions.rs
@@ -57,11 +57,9 @@ async fn test_basic_instructions() {
     );
 
     let vaa_account_create =
-        bench.add_vaa_account(&emitter, &vec![instruction1, instruction2], VaaAttack::None);
-    let vaa_account_transfer1 =
-        bench.add_vaa_account(&emitter, &vec![instruction3], VaaAttack::None);
-    let vaa_account_transfer2 =
-        bench.add_vaa_account(&emitter, &vec![instruction4], VaaAttack::None);
+        bench.add_vaa_account(&emitter, &[instruction1, instruction2], VaaAttack::None);
+    let vaa_account_transfer1 = bench.add_vaa_account(&emitter, &[instruction3], VaaAttack::None);
+    let vaa_account_transfer2 = bench.add_vaa_account(&emitter, &[instruction4], VaaAttack::None);
 
     let mut sim = bench.start().await;
 

--- a/pythnet/message_buffer/programs/message_buffer/src/lib.rs
+++ b/pythnet/message_buffer/programs/message_buffer/src/lib.rs
@@ -1,3 +1,6 @@
+// We can't do much about the size of `anchor_lang::error::Error`.
+#![allow(clippy::result_large_err)]
+
 pub mod instructions;
 mod state;
 

--- a/pythnet/message_buffer/programs/mock-cpi-caller/src/lib.rs
+++ b/pythnet/message_buffer/programs/mock-cpi-caller/src/lib.rs
@@ -1,3 +1,6 @@
+// We can't do much about the size of `anchor_lang::error::Error`.
+#![allow(clippy::result_large_err)]
+
 use {anchor_lang::prelude::*, instructions::*};
 
 pub mod instructions;

--- a/pythnet/message_buffer/programs/mock-cpi-caller/src/state/mod.rs
+++ b/pythnet/message_buffer/programs/mock-cpi-caller/src/state/mod.rs
@@ -18,8 +18,3 @@ pub enum PythAccountType {
     Test = 4,
     Permissions = 5,
 }
-impl PythAccountType {
-    pub(crate) fn to_u32(&self) -> u32 {
-        *self as u32
-    }
-}

--- a/target_chains/cosmwasm/contracts/pyth/src/contract.rs
+++ b/target_chains/cosmwasm/contracts/pyth/src/contract.rs
@@ -1097,7 +1097,7 @@ mod test {
                 assert_eq!(ema_price.expo, feed_msg.exponent);
                 assert_eq!(ema_price.publish_time, feed_msg.publish_time);
             }
-            _ => assert!(false, "invalid message type"),
+            _ => panic!("invalid message type"),
         };
     }
 
@@ -1228,8 +1228,8 @@ mod test {
         let info = mock_info("123", &[]);
         let result = update_price_feeds(deps.as_mut(), env, info, &[msg.into()]);
         assert!(result.is_ok());
-        for i in 100..110 {
-            check_price_match(&deps, all_feeds[i]);
+        for msg in &all_feeds[100..110] {
+            check_price_match(&deps, msg);
         }
     }
 

--- a/target_chains/cosmwasm/sdk/rust/src/testing.rs
+++ b/target_chains/cosmwasm/sdk/rust/src/testing.rs
@@ -4,7 +4,7 @@ use {
         from_binary, to_binary, Binary, Coin, ContractResult, QuerierResult, SystemError,
         SystemResult,
     },
-    std::{collections::HashMap, time::Duration, u128},
+    std::{collections::HashMap, time::Duration},
 };
 
 /// Mock version of Pyth for testing cosmwasm contracts.

--- a/target_chains/solana/programs/pyth-push-oracle/src/lib.rs
+++ b/target_chains/solana/programs/pyth-push-oracle/src/lib.rs
@@ -1,3 +1,6 @@
+// We can't do much about the size of `anchor_lang::error::Error`.
+#![allow(clippy::result_large_err)]
+
 use {
     anchor_lang::prelude::*,
     pyth_solana_receiver_sdk::{

--- a/target_chains/solana/programs/pyth-solana-receiver/src/lib.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/src/lib.rs
@@ -1,3 +1,6 @@
+// We can't do much about the size of `anchor_lang::error::Error`.
+#![allow(clippy::result_large_err)]
+
 pub use pythnet_sdk::wire::v1::MerklePriceUpdate;
 use {
     crate::error::ReceiverError,
@@ -354,6 +357,7 @@ struct VaaComponents {
     emitter_chain: u16,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn post_price_update_from_vaa<'info>(
     config: &Account<'info, Config>,
     payer: &Signer<'info>,

--- a/target_chains/solana/programs/pyth-solana-receiver/src/sdk.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/src/sdk.rs
@@ -146,6 +146,7 @@ impl instruction::PostUpdate {
 }
 
 impl instruction::PostUpdateAtomic {
+    #[allow(clippy::too_many_arguments)]
     pub fn populate(
         payer: Pubkey,
         write_authority: Pubkey,

--- a/target_chains/solana/pyth_solana_receiver_sdk/src/cpi/accounts.rs
+++ b/target_chains/solana/pyth_solana_receiver_sdk/src/cpi/accounts.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::vec_init_then_push)]
+
 // This file was populated with the expanded macros of programs/pyth-solana-receiver/src/lib.rs
 
 pub struct PostUpdateAtomic<'info> {

--- a/target_chains/solana/pyth_solana_receiver_sdk/src/lib.rs
+++ b/target_chains/solana/pyth_solana_receiver_sdk/src/lib.rs
@@ -1,3 +1,6 @@
+// We can't do much about the size of `anchor_lang::error::Error`.
+#![allow(clippy::result_large_err)]
+
 use {
     anchor_lang::{declare_id, prelude::*},
     borsh::{BorshDeserialize, BorshSerialize},


### PR DESCRIPTION
Pre-commit config in CI previously used `clippy --fix`, which makes `-D warnings` have no effect. Now warnings should be properly denied. I fixed the simple warnings and added allow annonations for more complex cases.