### PR TITLE
fix(hermes-client): fix hermes-client prepublish script

### DIFF
--- a/apps/hermes/client/js/package.json
+++ b/apps/hermes/client/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/hermes-client",
-  "version": "1.2.0",
+  "version": "1.1.0",
   "description": "Pyth Hermes Client",
   "author": {
     "name": "Pyth Data Association"
@@ -26,7 +26,7 @@
     "example": "node lib/examples/HermesClient.js",
     "format": "prettier --write \"src/**/*.ts\"",
     "test:lint": "eslint src/",
-    "prepublishOnly": "pnpm run build && pnpm run test:lint",
+    "prepublishOnly": "pnpm run build:typescript && pnpm run test:lint",
     "preversion": "pnpm run test:lint",
     "version": "pnpm run format && git add -A src"
   },

--- a/apps/hermes/client/js/package.json
+++ b/apps/hermes/client/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/hermes-client",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Pyth Hermes Client",
   "author": {
     "name": "Pyth Data Association"


### PR DESCRIPTION
this commit https://github.com/pyth-network/pyth-crosschain/commit/e08052c2c42b0c8562fc16147a1448800c4aacb3#diff-d410d1d6da096f2ed035def56a8c9e5ac39c31870cbec8512d0c8c100ae8767aR23 broke the ci for publishing new js packages