### PR TITLE
fix(ci): fix CI js builds

### DIFF
--- a/.github/workflows/ci-turbo-build.yml
+++ b/.github/workflows/ci-turbo-build.yml
@@ -1,0 +1,35 @@
+name: Turbo build
+on:
+  pull_request:
+    paths:
+      - "**.tsx?"
+      - "**.jsx?"
+      - "**.json"
+      - "**.sol"
+      - "**/package.json"
+      - "**/package-lock.json"
+      - "**/tsconfig.json"
+  push:
+    branches: [main]
+    paths:
+      - "**.tsx?"
+      - "**.jsx?"
+      - "**.json"
+      - "**.sol"
+      - "**/package.json"
+      - "**/package-lock.json"
+      - "**/tsconfig.json"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: "package.json"
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: true
+      - name: Build
+        run: pnpm build:ci

--- a/.github/workflows/ci-turbo-test.yml
+++ b/.github/workflows/ci-turbo-test.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           run_install: true
       - name: Test
-        run: pnpm turbo test --ui stream
+        run: pnpm test:ci

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -21,5 +21,5 @@ jobs:
         run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: pnpm turbo build
-      - run: pnpm exec lerna publish from-package --no-private --no-git-tag-version --yes
+      - run: pnpm build:ci
+      - run: pnpm publish

--- a/package.json
+++ b/package.json
@@ -7,11 +7,14 @@
     "pnpm": "^9.12.3"
   },
   "scripts": {
+    "build:ci": "turbo build --filter=!./apps/api-reference --filter=!./apps/insights --filter=!./apps/staking",
     "example:hermes-client": "pnpm i && turbo example --filter @pythnetwork/hermes-client --ui stream",
     "fix": "pnpm i && turbo fix",
+    "publish": "lerna publish from-package --no-private --no-git-tag-version --yes",
     "start:dev": "pnpm i && turbo start:dev",
     "start:prod": "pnpm i && turbo start:prod",
-    "test": "pnpm i && turbo test"
+    "test": "pnpm i && turbo test",
+    "test:ci": "turbo test"
   },
   "devDependencies": {
     "lerna": "^8.1.8",

--- a/target_chains/ton/contracts/package.json
+++ b/target_chains/ton/contracts/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "blueprint run",
-    "build": "echo Pyth | blueprint build",
+    "build:blueprint": "echo Pyth | blueprint build",
     "test:unit": "jest --verbose"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR does a few related things:

- Excludes nextjs packages from building on github as part of CI or before publishing js packages -- this is because these packages are intended to be built on Vercel and require system access & env vars to build that we don't have any good reason to expose to Github Actions

- Adds a new github workflow to run the turbo build in github actions on any PRs that modify any ts/js files

- Renames the "build" script for the pyth-ton package so it doesn't trigger on CI builds -- this script is an interactive build that doesn't seem to produce any results in a CI environment and so it shouldn't be included in the build on CI