### PR TITLE
fix: use finalized commitment for blocktime

### DIFF
--- a/governance/pyth_staking_sdk/src/utils/clock.ts
+++ b/governance/pyth_staking_sdk/src/utils/clock.ts
@@ -3,11 +3,12 @@ import { Connection } from "@solana/web3.js";
 import { EPOCH_DURATION } from "../constants";
 
 export const getCurrentSolanaTimestamp = async (connection: Connection) => {
-  const slot = await connection.getSlot();
+  const slot = await connection.getSlot("finalized");
   const blockTime = await connection.getBlockTime(slot);
   if (blockTime === null) {
     throw new Error("Block time is not available");
   }
+
   return BigInt(blockTime);
 };
 

--- a/governance/pyth_staking_sdk/src/utils/clock.ts
+++ b/governance/pyth_staking_sdk/src/utils/clock.ts
@@ -8,7 +8,6 @@ export const getCurrentSolanaTimestamp = async (connection: Connection) => {
   if (blockTime === null) {
     throw new Error("Block time is not available");
   }
-
   return BigInt(blockTime);
 };
 


### PR DESCRIPTION
By getting a finalized block, it is less likely than `getBlockTime` fails.