### PR TITLE
chore(staking): use a separate rpc URL for api routes

### DIFF
--- a/apps/staking/src/app/api/v1/cmc/supply/route.ts
+++ b/apps/staking/src/app/api/v1/cmc/supply/route.ts
@@ -4,7 +4,7 @@ import { clusterApiUrl, Connection } from "@solana/web3.js";
 import type { NextRequest } from "next/server";
 import { z } from "zod";
 
-import { MAINNET_RPC } from "../../../../../config/server";
+import { MAINNET_API_RPC } from "../../../../../config/server";
 
 const querySchema = z.enum(["totalSupply", "circulatingSupply"]);
 
@@ -12,15 +12,9 @@ export async function GET(req: NextRequest) {
   const isMainnet = req.nextUrl.searchParams.get("devnet") !== "true";
   const stakingClient = new PythStakingClient({
     connection: new Connection(
-      isMainnet && MAINNET_RPC !== undefined
-        ? MAINNET_RPC
+      isMainnet && MAINNET_API_RPC !== undefined
+        ? MAINNET_API_RPC
         : clusterApiUrl(WalletAdapterNetwork.Devnet),
-      {
-        httpHeaders: {
-          Origin: req.nextUrl.origin,
-          "User-Agent": req.headers.get("User-Agent") ?? "",
-        },
-      },
     ),
   });
 

--- a/apps/staking/src/app/api/v1/locked_accounts/route.ts
+++ b/apps/staking/src/app/api/v1/locked_accounts/route.ts
@@ -4,7 +4,7 @@ import { clusterApiUrl, Connection, PublicKey } from "@solana/web3.js";
 import type { NextRequest } from "next/server";
 import { z } from "zod";
 
-import { MAINNET_RPC } from "../../../../config/server";
+import { MAINNET_API_RPC } from "../../../../config/server";
 import { tokensToString } from "../../../../tokens";
 
 const UnlockScheduleSchema = z.object({
@@ -38,15 +38,9 @@ export async function GET(req: NextRequest) {
   const isMainnet = req.nextUrl.searchParams.get("devnet") !== "true";
   const stakingClient = new PythStakingClient({
     connection: new Connection(
-      isMainnet && MAINNET_RPC !== undefined
-        ? MAINNET_RPC
+      isMainnet && MAINNET_API_RPC !== undefined
+        ? MAINNET_API_RPC
         : clusterApiUrl(WalletAdapterNetwork.Devnet),
-      {
-        httpHeaders: {
-          Origin: req.nextUrl.origin,
-          "User-Agent": req.headers.get("User-Agent") ?? "",
-        },
-      },
     ),
   });
 

--- a/apps/staking/src/config/server.ts
+++ b/apps/staking/src/config/server.ts
@@ -57,6 +57,8 @@ export const WALLETCONNECT_PROJECT_ID = demandInProduction(
   "WALLETCONNECT_PROJECT_ID",
 );
 export const MAINNET_RPC = process.env.MAINNET_RPC;
+export const MAINNET_API_RPC =
+  process.env.MAINNET_API_RPC ?? process.env.MAINNET_RPC;
 export const PYTHNET_RPC = getOr("PYTHNET_RPC", "https://pythnet.rpcpool.com");
 export const HERMES_URL = getOr("HERMES_URL", "https://hermes.pyth.network");
 export const BLOCKED_REGIONS = transformOr("BLOCKED_REGIONS", fromCsv, []);

--- a/apps/staking/turbo.json
+++ b/apps/staking/turbo.json
@@ -11,6 +11,7 @@
         "WALLETCONNECT_PROJECT_ID",
         "PROXYCHECK_API_KEY",
         "MAINNET_RPC",
+        "MAINNET_API_RPC",
         "BLOCKED_REGIONS",
         "AMPLITUDE_API_KEY",
         "GOOGLE_ANALYTICS_ID"


### PR DESCRIPTION
Turns out we do have to separate the RPC url for backend requests; it sounds like triton1 is explicitly blocking a subset of vercel IPs for requests that don't have a key even if they have the appropriate user-agent and origin headers...