### PR TITLE
fix(proposer server)

### DIFF
--- a/target_chains/solana/sdk/js/solana_utils/package.json
+++ b/target_chains/solana/sdk/js/solana_utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/solana-utils",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Utility functions for Solana",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/target_chains/solana/sdk/js/solana_utils/package.json
+++ b/target_chains/solana/sdk/js/solana_utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/solana-utils",
-  "version": "0.4.3",
+  "version": "0.4.2",
   "description": "Utility functions for Solana",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/target_chains/solana/sdk/js/solana_utils/src/transaction.ts
+++ b/target_chains/solana/sdk/js/solana_utils/src/transaction.ts
@@ -227,7 +227,7 @@ export class TransactionBuilder {
     args: PriorityFeeConfig
   ): Promise<{ tx: VersionedTransaction; signers: Signer[] }[]> {
     const blockhash = (
-      await this.connection.getLatestBlockhash({ commitment: "finalized" })
+      await this.connection.getLatestBlockhash({ commitment: "confirmed" })
     ).blockhash;
 
     const jitoBundleSize =

--- a/target_chains/solana/sdk/js/solana_utils/src/transaction.ts
+++ b/target_chains/solana/sdk/js/solana_utils/src/transaction.ts
@@ -512,7 +512,6 @@ export async function sendTransactions(
         // Set this manually so that the default is skipped
         maxRetries: 0,
         preflightCommitment: "confirmed",
-        minContextSlot: blockhashResult.context.slot,
       });
     }
     if (confirmedTx?.err) {


### PR DESCRIPTION
Turns out the solution to `Minimum context slot has not been reached` is probably removing the `minContextSlot: blockhashResult.context.slot` config