### PR TITLE
fix: ignore vesting dates in the future

### DIFF
--- a/apps/staking/src/app/api/v1/locked_accounts/route.ts
+++ b/apps/staking/src/app/api/v1/locked_accounts/route.ts
@@ -72,10 +72,12 @@ export async function GET(req: NextRequest) {
         actualAmount: tokensToString(custodyAccount.amount),
         lock: {
           type: lock.type,
-          schedule: lock.schedule.map((unlock) => ({
-            date: unlock.date,
-            amount: tokensToString(unlock.amount),
-          })),
+          schedule: lock.schedule
+            .filter((unlock) => unlock.date > new Date())
+            .map((unlock) => ({
+              date: unlock.date,
+              amount: tokensToString(unlock.amount),
+            })),
         },
       };
     }),


### PR DESCRIPTION
Some locked account owners have complained about the past vesting dates appearing here
