### PR TITLE
fix(pyth-solana-receiver): improve perf and security

### DIFF
--- a/target_chains/solana/Cargo.lock
+++ b/target_chains/solana/Cargo.lock
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-solana-receiver"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anchor-lang",
  "byteorder",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-solana-receiver-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anchor-lang",
  "hex",

--- a/target_chains/solana/programs/pyth-solana-receiver/Cargo.toml
+++ b/target_chains/solana/programs/pyth-solana-receiver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-solana-receiver"
-version = "0.2.0"
+version = "0.2.1"
 description = "Created with Anchor"
 edition = "2021"
 

--- a/target_chains/solana/programs/pyth-solana-receiver/src/lib.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/src/lib.rs
@@ -575,10 +575,6 @@ fn calculate_twap(start_msg: &TwapMessage, end_msg: &TwapMessage) -> Result<(i64
 
     // Calculate down_slots_ratio as an integer between 0 and 1_000_000
     // A value of 1_000_000 means all slots were missed and 0 means no slots were missed.
-    let total_slots = end_msg
-        .publish_slot
-        .checked_sub(start_msg.publish_slot)
-        .ok_or(ReceiverError::TwapCalculationOverflow)?;
     let total_down_slots = end_msg
         .num_down_slots
         .checked_sub(start_msg.num_down_slots)
@@ -586,7 +582,7 @@ fn calculate_twap(start_msg: &TwapMessage, end_msg: &TwapMessage) -> Result<(i64
     let down_slots_ratio = total_down_slots
         .checked_mul(1_000_000)
         .ok_or(ReceiverError::TwapCalculationOverflow)?
-        .checked_div(total_slots)
+        .checked_div(slot_diff)
         .ok_or(ReceiverError::TwapCalculationOverflow)?;
     // down_slots_ratio is a number in [0, 1_000_000], so we only need 32 unsigned bits
     let down_slots_ratio =

--- a/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
+++ b/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-solana-receiver-sdk"
-version = "0.4.0"
+version = "0.5.0"
 description = "SDK for the Pyth Solana Receiver program"
 authors = ["Pyth Data Association"]
 repository = "https://github.com/pyth-network/pyth-crosschain"

--- a/target_chains/solana/pyth_solana_receiver_sdk/src/error.rs
+++ b/target_chains/solana/pyth_solana_receiver_sdk/src/error.rs
@@ -5,6 +5,8 @@ use anchor_lang::error_code;
 pub enum GetPriceError {
     #[msg("This price feed update's age exceeds the requested maximum age")]
     PriceTooOld = 10000, // Big number to avoid conflicts with the SDK user's program error codes
+    #[msg("This TWAP update's window size is invalid")]
+    InvalidWindowSize,
     #[msg("The price feed update doesn't match the requested feed id")]
     MismatchedFeedId,
     #[msg("This price feed update has a lower verification level than the one requested")]

--- a/target_chains/solana/pyth_solana_receiver_sdk/src/price_update.rs
+++ b/target_chains/solana/pyth_solana_receiver_sdk/src/price_update.rs
@@ -91,7 +91,7 @@ impl TwapUpdate {
     /// - Whether the price update has been verified
     ///
     /// It is therefore unsafe to use this function without any extra checks,
-    /// as it allows for the possibility of using unverified, outdated, or unexpected price updates.
+    /// as it allows for the possibility of using unverified, outdated, or arbitrary window length twap updates.
     pub fn get_twap_unchecked(
         &self,
         feed_id: &FeedId,

--- a/target_chains/solana/pyth_solana_receiver_sdk/src/price_update.rs
+++ b/target_chains/solana/pyth_solana_receiver_sdk/src/price_update.rs
@@ -137,7 +137,7 @@ impl TwapUpdate {
         window_seconds: u64,
         feed_id: &FeedId,
     ) -> std::result::Result<TwapPrice, GetPriceError> {
-        // Ensure the update is isn't outdated
+        // Ensure the update isn't outdated
         let twap_price = self.get_twap_unchecked(feed_id)?;
         check!(
             twap_price


### PR DESCRIPTION
## Purpose
Performance and security improvements to the SVM TWAP feature.

## Implementation details
- Perf optimization: Reused `slot_diff` calculation in `calculate_twap` 
- Security optimization: Previously, the SDK's `get_twap_no_older_than` function only checked that the twap's `end_time` was more recent than `maximum_age`. However, the window size of the twap wasn't checked. This could result in a scenario where an attacker could frontrun a transaction that consumes a hardcoded TwapUpdate PDA. The attacker could overwrite the account with a verified twap of an unexpected window (very long/short). This could have the effect of manipulating, for example, the LTV ratio calculation of a lending protocol. 
  - The check has a +/- 1 second tolerance to account for Solana block time variations.

## Testing
Updated SDK test suite 