### PR TITLE
fix(price-service-sdk): make price-service-sdk portable

### DIFF
--- a/price_service/sdk/js/package.json
+++ b/price_service/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-service-sdk",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Pyth price service SDK",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",


### PR DESCRIPTION
The price-service-sdk package previously used `Buffers` in it's interface in many places.  However, `Buffer` is a node-specific interface which does not exist in browsers.

Many browsers ship [a polyfill](https://github.com/feross/buffer), however I've discovered that the polyfill is not actually fully compatible with the Node module.  In particular, while the Node module [supports aliases such as `readUint8` for `readUInt8`](https://nodejs.org/api/buffer.html#bufreaduint8offset) (note the difference in capitalization), [the polyfill does not](https://github.com/feross/buffer/blob/master/index.d.ts).

As a result, attempting to utilize `price-service-sdk` in the browser was either going to cause errors because the Buffer polyfill isn't present, or it would cause errors because of the use of aliased function names.

There were three options to fix this issue:

1. Switch everything to using unaliased function names.  This would work portably, but only assuming that the Buffer polyfill is present.

2. Switch everything to using [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array), which is a more generic [typed array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) and largely supersedes the need to use the `Buffer` class at all (and which is a superclass of `Buffer`).  This would work, however it would be a breaking change.

3. Switch everything to using a generic interface which accepts anything which extends `Uint8Array` (including `Buffer`), and use `Uint8Array` methods exclusively inside `price-service-sdk`.  This requires a few gross typescript hacks to type check correctly and avoid anything being a breaking change, but it makes the code the most portable without requiring any polyfills or requiring a major version bump.

This commit implements option 3.