### PR TITLE
feat(xc-admin): add support for deserializing lazer instructions in xc-admin

### DIFF
--- a/governance/xc_admin/packages/xc_admin_common/src/__tests__/LazerMultisigInstruction.test.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/__tests__/LazerMultisigInstruction.test.ts
@@ -1,0 +1,171 @@
+import {
+  PublicKey,
+  TransactionInstruction,
+  SystemProgram,
+} from "@solana/web3.js";
+import { LazerMultisigInstruction } from "../multisig_transaction/LazerMultisigInstruction";
+import {
+  MultisigInstructionProgram,
+  UNRECOGNIZED_INSTRUCTION,
+} from "../multisig_transaction";
+
+describe("LazerMultisigInstruction", () => {
+  const mockProgramId = new PublicKey(
+    "pytd2yyk641x7ak7mkaasSJVXh6YYZnC7wTmtgAyxPt"
+  );
+  const systemProgram = SystemProgram.programId;
+
+  // Generate reusable keypairs for tests
+  const topAuthority = PublicKey.unique();
+  const storage = PublicKey.unique();
+  const payer = PublicKey.unique();
+
+  // Test recognized instruction
+  test("fromInstruction should decode update instruction", () => {
+    const instructionData = Buffer.from([
+      // Anchor discriminator for update (from IDL)
+      219,
+      200,
+      88,
+      176,
+      158,
+      63,
+      253,
+      127,
+      // trusted_signer (pubkey - 32 bytes)
+      ...Array(32).fill(1),
+      // expires_at (i64 - 8 bytes)
+      42,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+    ]);
+
+    const keys = [
+      {
+        pubkey: topAuthority,
+        isSigner: true,
+        isWritable: false,
+      },
+      {
+        pubkey: storage,
+        isSigner: false,
+        isWritable: true,
+      },
+    ];
+
+    const instruction = new TransactionInstruction({
+      programId: mockProgramId,
+      keys,
+      data: instructionData,
+    });
+
+    const lazerInstruction =
+      LazerMultisigInstruction.fromInstruction(instruction);
+
+    expect(lazerInstruction.name).toBe("update");
+    expect(lazerInstruction.args).toBeDefined();
+    expect(lazerInstruction.args.trustedSigner).toBeDefined();
+    expect(lazerInstruction.args.expiresAt).toBeDefined();
+    expect(lazerInstruction.accounts).toBeDefined();
+    expect(lazerInstruction.accounts.named.topAuthority).toBeDefined();
+    expect(lazerInstruction.accounts.named.storage).toBeDefined();
+  });
+
+  // Test unrecognized instruction
+  test("fromInstruction should handle unrecognized instruction", () => {
+    const unrecognizedData = Buffer.from([1, 2, 3, 4]);
+    const keys = [
+      {
+        pubkey: topAuthority,
+        isSigner: false,
+        isWritable: true,
+      },
+    ];
+
+    const instruction = new TransactionInstruction({
+      programId: mockProgramId,
+      keys,
+      data: unrecognizedData,
+    });
+
+    const lazerInstruction =
+      LazerMultisigInstruction.fromInstruction(instruction);
+
+    expect(lazerInstruction.name).toBe(UNRECOGNIZED_INSTRUCTION);
+    expect(lazerInstruction.args).toEqual({ data: unrecognizedData });
+    expect(lazerInstruction.accounts.remaining).toEqual(keys);
+  });
+
+  // Test initialize instruction
+  test("fromInstruction should decode initialize instruction", () => {
+    const instructionData = Buffer.from([
+      // Anchor discriminator for initialize (from IDL)
+      175,
+      175,
+      109,
+      31,
+      13,
+      152,
+      155,
+      237,
+      // top_authority (pubkey - 32 bytes)
+      ...Array(32).fill(2),
+      // treasury (pubkey - 32 bytes)
+      ...Array(32).fill(3),
+    ]);
+
+    const keys = [
+      {
+        pubkey: payer,
+        isSigner: true,
+        isWritable: true,
+      },
+      {
+        pubkey: storage,
+        isSigner: false,
+        isWritable: true,
+      },
+      {
+        pubkey: systemProgram,
+        isSigner: false,
+        isWritable: false,
+      },
+    ];
+
+    const instruction = new TransactionInstruction({
+      programId: mockProgramId,
+      keys,
+      data: instructionData,
+    });
+
+    const lazerInstruction =
+      LazerMultisigInstruction.fromInstruction(instruction);
+
+    expect(lazerInstruction.name).toBe("initialize");
+    expect(lazerInstruction.args).toBeDefined();
+    expect(lazerInstruction.args.topAuthority).toBeDefined();
+    expect(lazerInstruction.args.treasury).toBeDefined();
+    expect(lazerInstruction.accounts).toBeDefined();
+    expect(lazerInstruction.accounts.named.payer).toBeDefined();
+    expect(lazerInstruction.accounts.named.storage).toBeDefined();
+    expect(lazerInstruction.accounts.named.systemProgram).toBeDefined();
+  });
+
+  // Test program field
+  test("should have correct program type", () => {
+    const instruction = new TransactionInstruction({
+      programId: mockProgramId,
+      keys: [],
+      data: Buffer.from([]),
+    });
+
+    const lazerInstruction =
+      LazerMultisigInstruction.fromInstruction(instruction);
+    expect(lazerInstruction.program).toBe(MultisigInstructionProgram.Lazer);
+  });
+});

--- a/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/LazerMultisigInstruction.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/LazerMultisigInstruction.ts
@@ -6,7 +6,7 @@ import {
 import { AnchorAccounts, resolveAccountNames } from "./anchor";
 import { PublicKey, TransactionInstruction } from "@solana/web3.js";
 import { Idl, BorshInstructionCoder } from "@coral-xyz/anchor";
-import * as pythLazerSolanaContractIdl from "../../../../../../lazer/contracts/solana/target/idl/pyth_lazer_solana_contract.json";
+import lazerIdl from "./idl/lazer.json";
 
 export const LAZER_PROGRAM_ID = new PublicKey(
   "pytd2yyk641x7ak7mkaasSJVXh6YYZnC7wTmtgAyxPt"
@@ -33,9 +33,9 @@ export class LazerMultisigInstruction implements MultisigInstruction {
   ): LazerMultisigInstruction {
     // TODO: This is a hack to transform the IDL to be compatible with the anchor version we are using, we can't upgrade anchor to 0.30.1 because then the existing idls will break
     const idl = {
-      version: pythLazerSolanaContractIdl.metadata.version,
-      name: pythLazerSolanaContractIdl.metadata.name,
-      instructions: pythLazerSolanaContractIdl.instructions.map((ix) => ({
+      version: lazerIdl.metadata.version,
+      name: lazerIdl.metadata.name,
+      instructions: lazerIdl.instructions.map((ix) => ({
         ...ix,
         accounts: ix.accounts.map((acc) => ({
           name: acc.name,

--- a/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/LazerMultisigInstruction.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/LazerMultisigInstruction.ts
@@ -32,18 +32,7 @@ export class LazerMultisigInstruction implements MultisigInstruction {
     instruction: TransactionInstruction
   ): LazerMultisigInstruction {
     // TODO: This is a hack to transform the IDL to be compatible with the anchor version we are using, we can't upgrade anchor to 0.30.1 because then the existing idls will break
-    const idl = {
-      version: lazerIdl.metadata.version,
-      name: lazerIdl.metadata.name,
-      instructions: lazerIdl.instructions.map((ix) => ({
-        ...ix,
-        accounts: ix.accounts.map((acc) => ({
-          name: acc.name,
-          isMut: acc.writable ?? false,
-          isSigner: acc.signer ?? false,
-        })),
-      })),
-    } as Idl;
+    const idl = lazerIdl as Idl;
 
     const coder = new BorshInstructionCoder(idl);
 

--- a/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/LazerMultisigInstruction.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/LazerMultisigInstruction.ts
@@ -1,0 +1,66 @@
+import {
+  MultisigInstruction,
+  MultisigInstructionProgram,
+  UNRECOGNIZED_INSTRUCTION,
+} from "./index";
+import { AnchorAccounts, resolveAccountNames } from "./anchor";
+import { PublicKey, TransactionInstruction } from "@solana/web3.js";
+import { Idl, BorshInstructionCoder } from "@coral-xyz/anchor";
+import * as pythLazerSolanaContractIdl from "../../../../../../lazer/contracts/solana/target/idl/pyth_lazer_solana_contract.json";
+
+export const LAZER_PROGRAM_ID = new PublicKey(
+  "pytd2yyk641x7ak7mkaasSJVXh6YYZnC7wTmtgAyxPt"
+);
+
+export class LazerMultisigInstruction implements MultisigInstruction {
+  readonly program = MultisigInstructionProgram.Lazer;
+  readonly name: string;
+  readonly args: { [key: string]: any };
+  readonly accounts: AnchorAccounts;
+
+  constructor(
+    name: string,
+    args: { [key: string]: any },
+    accounts: AnchorAccounts
+  ) {
+    this.name = name;
+    this.args = args;
+    this.accounts = accounts;
+  }
+
+  static fromInstruction(
+    instruction: TransactionInstruction
+  ): LazerMultisigInstruction {
+    // TODO: This is a hack to transform the IDL to be compatible with the anchor version we are using, we can't upgrade anchor to 0.30.1 because then the existing idls will break
+    const idl = {
+      version: pythLazerSolanaContractIdl.metadata.version,
+      name: pythLazerSolanaContractIdl.metadata.name,
+      instructions: pythLazerSolanaContractIdl.instructions.map((ix) => ({
+        ...ix,
+        accounts: ix.accounts.map((acc) => ({
+          name: acc.name,
+          isMut: acc.writable ?? false,
+          isSigner: acc.signer ?? false,
+        })),
+      })),
+    } as Idl;
+
+    const coder = new BorshInstructionCoder(idl);
+
+    const deserializedData = coder.decode(instruction.data);
+
+    if (deserializedData) {
+      return new LazerMultisigInstruction(
+        deserializedData.name,
+        deserializedData.data,
+        resolveAccountNames(idl, deserializedData.name, instruction)
+      );
+    } else {
+      return new LazerMultisigInstruction(
+        UNRECOGNIZED_INSTRUCTION,
+        { data: instruction.data },
+        { named: {}, remaining: instruction.keys }
+      );
+    }
+  }
+}

--- a/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/idl/lazer.json
+++ b/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/idl/lazer.json
@@ -1,117 +1,90 @@
 {
-  "address": "",
-  "metadata": {
-    "name": "pyth_lazer_solana_contract",
-    "version": "0.2.0",
-    "spec": "0.1.0",
-    "description": "Pyth Lazer Solana contract and SDK.",
-    "repository": "https://github.com/pyth-network/pyth-crosschain"
-  },
+  "version": "0.2.0",
+  "name": "pyth_lazer_solana_contract",
   "instructions": [
     {
       "name": "initialize",
-      "discriminator": [175, 175, 109, 31, 13, 152, 155, 237],
       "accounts": [
         {
           "name": "payer",
-          "writable": true,
-          "signer": true
+          "isMut": true,
+          "isSigner": true
         },
         {
           "name": "storage",
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [115, 116, 111, 114, 97, 103, 101]
-              }
-            ]
-          }
+          "isMut": true,
+          "isSigner": false
         },
         {
-          "name": "system_program",
-          "address": "11111111111111111111111111111111"
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         }
       ],
       "args": [
         {
-          "name": "top_authority",
-          "type": "pubkey"
+          "name": "topAuthority",
+          "type": "publicKey"
         },
         {
           "name": "treasury",
-          "type": "pubkey"
+          "type": "publicKey"
         }
       ]
     },
     {
-      "name": "migrate_from_0_1_0",
-      "discriminator": [25, 185, 91, 207, 130, 36, 0, 255],
+      "name": "migrateFrom010",
       "accounts": [
         {
-          "name": "top_authority",
-          "signer": true
+          "name": "topAuthority",
+          "isMut": false,
+          "isSigner": true
         },
         {
           "name": "storage",
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [115, 116, 111, 114, 97, 103, 101]
-              }
-            ]
-          }
+          "isMut": true,
+          "isSigner": false
         },
         {
-          "name": "system_program",
-          "address": "11111111111111111111111111111111"
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         }
       ],
       "args": [
         {
           "name": "treasury",
-          "type": "pubkey"
+          "type": "publicKey"
         }
       ]
     },
     {
       "name": "update",
-      "discriminator": [219, 200, 88, 176, 158, 63, 253, 127],
       "accounts": [
         {
-          "name": "top_authority",
-          "signer": true,
-          "relations": ["storage"]
+          "name": "topAuthority",
+          "isMut": false,
+          "isSigner": true
         },
         {
           "name": "storage",
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [115, 116, 111, 114, 97, 103, 101]
-              }
-            ]
-          }
+          "isMut": true,
+          "isSigner": false
         }
       ],
       "args": [
         {
-          "name": "trusted_signer",
-          "type": "pubkey"
+          "name": "trustedSigner",
+          "type": "publicKey"
         },
         {
-          "name": "expires_at",
+          "name": "expiresAt",
           "type": "i64"
         }
       ]
     },
     {
-      "name": "verify_message",
+      "name": "verifyMessage",
       "docs": [
         "Verifies a ed25519 signature on Solana by checking that the transaction contains",
         "a correct call to the built-in `ed25519_program`.",
@@ -123,34 +96,31 @@
         "- `message_offset` is the offset of the signed message within the",
         "input data for the current instruction."
       ],
-      "discriminator": [180, 193, 120, 55, 189, 135, 203, 83],
       "accounts": [
         {
           "name": "payer",
-          "writable": true,
-          "signer": true
+          "isMut": true,
+          "isSigner": true
         },
         {
           "name": "storage",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [115, 116, 111, 114, 97, 103, 101]
-              }
-            ]
-          }
+          "isMut": false,
+          "isSigner": false
         },
         {
           "name": "treasury",
-          "relations": ["storage"]
+          "isMut": false,
+          "isSigner": false
         },
         {
-          "name": "system_program",
-          "address": "11111111111111111111111111111111"
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
         },
         {
-          "name": "instructions_sysvar",
+          "name": "instructionsSysvar",
+          "isMut": false,
+          "isSigner": false,
           "docs": [
             "(e.g. in `sysvar::instructions::load_instruction_at_checked`).",
             "This account is not usable with anchor's `Program` account type because it's not executable."
@@ -159,75 +129,86 @@
       ],
       "args": [
         {
-          "name": "message_data",
+          "name": "messageData",
           "type": "bytes"
         },
         {
-          "name": "ed25519_instruction_index",
+          "name": "ed25519InstructionIndex",
           "type": "u16"
         },
         {
-          "name": "signature_index",
+          "name": "signatureIndex",
           "type": "u8"
         },
         {
-          "name": "message_offset",
+          "name": "messageOffset",
           "type": "u16"
         }
       ],
       "returns": {
-        "defined": {
-          "name": "VerifiedMessage"
-        }
+        "defined": "VerifiedMessage"
       }
     }
   ],
   "accounts": [
     {
       "name": "Storage",
-      "discriminator": [209, 117, 255, 185, 196, 175, 68, 9]
-    }
-  ],
-  "types": [
-    {
-      "name": "Storage",
       "type": {
         "kind": "struct",
         "fields": [
           {
-            "name": "top_authority",
-            "type": "pubkey"
+            "name": "topAuthority",
+            "type": "publicKey"
           },
           {
             "name": "treasury",
-            "type": "pubkey"
+            "type": "publicKey"
           },
           {
-            "name": "single_update_fee_in_lamports",
+            "name": "singleUpdateFeeInLamports",
             "type": "u64"
           },
           {
-            "name": "num_trusted_signers",
+            "name": "numTrustedSigners",
             "type": "u8"
           },
           {
-            "name": "trusted_signers",
+            "name": "trustedSigners",
             "type": {
               "array": [
                 {
-                  "defined": {
-                    "name": "TrustedSignerInfo"
-                  }
+                  "defined": "TrustedSignerInfo"
                 },
                 5
               ]
             }
           },
           {
-            "name": "_extra_space",
+            "name": "extraSpace",
             "type": {
               "array": ["u8", 100]
             }
+          }
+        ]
+      }
+    }
+  ],
+  "types": [
+    {
+      "name": "VerifiedMessage",
+      "docs": ["A message with a verified ed25519 signature."],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "publicKey",
+            "docs": ["Public key that signed the message."],
+            "type": "publicKey"
+          },
+          {
+            "name": "payload",
+            "docs": ["Signed message payload."],
+            "type": "bytes"
           }
         ]
       }
@@ -239,30 +220,85 @@
         "fields": [
           {
             "name": "pubkey",
-            "type": "pubkey"
+            "type": "publicKey"
           },
           {
-            "name": "expires_at",
+            "name": "expiresAt",
             "type": "i64"
           }
         ]
       }
     },
     {
-      "name": "VerifiedMessage",
-      "docs": ["A message with a verified ed25519 signature."],
+      "name": "SignatureVerificationError",
       "type": {
-        "kind": "struct",
-        "fields": [
+        "kind": "enum",
+        "variants": [
           {
-            "name": "public_key",
-            "docs": ["Public key that signed the message."],
-            "type": "pubkey"
+            "name": "Ed25519InstructionMustPrecedeCurrentInstruction"
           },
           {
-            "name": "payload",
-            "docs": ["Signed message payload."],
-            "type": "bytes"
+            "name": "LoadInstructionAtFailed",
+            "fields": [
+              {
+                "defined": "ProgramError"
+              }
+            ]
+          },
+          {
+            "name": "LoadCurrentIndexFailed",
+            "fields": [
+              {
+                "defined": "ProgramError"
+              }
+            ]
+          },
+          {
+            "name": "ClockGetFailed",
+            "fields": [
+              {
+                "defined": "ProgramError"
+              }
+            ]
+          },
+          {
+            "name": "InvalidEd25519InstructionProgramId"
+          },
+          {
+            "name": "InvalidEd25519InstructionDataLength"
+          },
+          {
+            "name": "InvalidSignatureIndex"
+          },
+          {
+            "name": "InvalidSignatureOffset"
+          },
+          {
+            "name": "InvalidPublicKeyOffset"
+          },
+          {
+            "name": "InvalidMessageOffset"
+          },
+          {
+            "name": "InvalidMessageDataSize"
+          },
+          {
+            "name": "InvalidInstructionIndex"
+          },
+          {
+            "name": "MessageOffsetOverflow"
+          },
+          {
+            "name": "FormatMagicMismatch"
+          },
+          {
+            "name": "InvalidStorageAccountId"
+          },
+          {
+            "name": "InvalidStorageData"
+          },
+          {
+            "name": "NotTrustedSigner"
           }
         ]
       }

--- a/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/idl/lazer.json
+++ b/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/idl/lazer.json
@@ -1,0 +1,271 @@
+{
+  "address": "",
+  "metadata": {
+    "name": "pyth_lazer_solana_contract",
+    "version": "0.2.0",
+    "spec": "0.1.0",
+    "description": "Pyth Lazer Solana contract and SDK.",
+    "repository": "https://github.com/pyth-network/pyth-crosschain"
+  },
+  "instructions": [
+    {
+      "name": "initialize",
+      "discriminator": [175, 175, 109, 31, 13, 152, 155, 237],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "storage",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [115, 116, 111, 114, 97, 103, 101]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "top_authority",
+          "type": "pubkey"
+        },
+        {
+          "name": "treasury",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "migrate_from_0_1_0",
+      "discriminator": [25, 185, 91, 207, 130, 36, 0, 255],
+      "accounts": [
+        {
+          "name": "top_authority",
+          "signer": true
+        },
+        {
+          "name": "storage",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [115, 116, 111, 114, 97, 103, 101]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "treasury",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "update",
+      "discriminator": [219, 200, 88, 176, 158, 63, 253, 127],
+      "accounts": [
+        {
+          "name": "top_authority",
+          "signer": true,
+          "relations": ["storage"]
+        },
+        {
+          "name": "storage",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [115, 116, 111, 114, 97, 103, 101]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "trusted_signer",
+          "type": "pubkey"
+        },
+        {
+          "name": "expires_at",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "verify_message",
+      "docs": [
+        "Verifies a ed25519 signature on Solana by checking that the transaction contains",
+        "a correct call to the built-in `ed25519_program`.",
+        "",
+        "- `message_data` is the signed message that is being verified.",
+        "- `ed25519_instruction_index` is the index of the `ed25519_program` instruction",
+        "within the transaction. This instruction must precede the current instruction.",
+        "- `signature_index` is the index of the signature within the inputs to the `ed25519_program`.",
+        "- `message_offset` is the offset of the signed message within the",
+        "input data for the current instruction."
+      ],
+      "discriminator": [180, 193, 120, 55, 189, 135, 203, 83],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "storage",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [115, 116, 111, 114, 97, 103, 101]
+              }
+            ]
+          }
+        },
+        {
+          "name": "treasury",
+          "relations": ["storage"]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "instructions_sysvar",
+          "docs": [
+            "(e.g. in `sysvar::instructions::load_instruction_at_checked`).",
+            "This account is not usable with anchor's `Program` account type because it's not executable."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "message_data",
+          "type": "bytes"
+        },
+        {
+          "name": "ed25519_instruction_index",
+          "type": "u16"
+        },
+        {
+          "name": "signature_index",
+          "type": "u8"
+        },
+        {
+          "name": "message_offset",
+          "type": "u16"
+        }
+      ],
+      "returns": {
+        "defined": {
+          "name": "VerifiedMessage"
+        }
+      }
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Storage",
+      "discriminator": [209, 117, 255, 185, 196, 175, 68, 9]
+    }
+  ],
+  "types": [
+    {
+      "name": "Storage",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "top_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "treasury",
+            "type": "pubkey"
+          },
+          {
+            "name": "single_update_fee_in_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "num_trusted_signers",
+            "type": "u8"
+          },
+          {
+            "name": "trusted_signers",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "TrustedSignerInfo"
+                  }
+                },
+                5
+              ]
+            }
+          },
+          {
+            "name": "_extra_space",
+            "type": {
+              "array": ["u8", 100]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TrustedSignerInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "expires_at",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VerifiedMessage",
+      "docs": ["A message with a verified ed25519 signature."],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "public_key",
+            "docs": ["Public key that signed the message."],
+            "type": "pubkey"
+          },
+          {
+            "name": "payload",
+            "docs": ["Signed message payload."],
+            "type": "bytes"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/index.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/index.ts
@@ -27,6 +27,10 @@ import {
   PRICE_STORE_PROGRAM_ID,
   PriceStoreMultisigInstruction,
 } from "../price_store";
+import {
+  LazerMultisigInstruction,
+  LAZER_PROGRAM_ID,
+} from "./LazerMultisigInstruction";
 
 export const UNRECOGNIZED_INSTRUCTION = "unrecognizedInstruction";
 export enum MultisigInstructionProgram {
@@ -41,6 +45,7 @@ export enum MultisigInstructionProgram {
   SolanaReceiver,
   UnrecognizedProgram,
   PythPriceStore,
+  Lazer,
 }
 
 export function getProgramName(program: MultisigInstructionProgram) {
@@ -67,6 +72,8 @@ export function getProgramName(program: MultisigInstructionProgram) {
       return "Pyth Price Store";
     case MultisigInstructionProgram.UnrecognizedProgram:
       return "Unknown";
+    case MultisigInstructionProgram.Lazer:
+      return "Lazer";
   }
 }
 
@@ -161,6 +168,8 @@ export class MultisigParser {
       return SolanaStakingMultisigInstruction.fromTransactionInstruction(
         instruction
       );
+    } else if (instruction.programId.equals(LAZER_PROGRAM_ID)) {
+      return LazerMultisigInstruction.fromInstruction(instruction);
     } else {
       return UnrecognizedProgram.fromTransactionInstruction(instruction);
     }


### PR DESCRIPTION
I had to regenerate the lazer idl with anchor `0.29.0` and comment out `idl-build = ["anchor-lang/idl-build"]` for it to work otherwise all the existing idls on xc-admin will break if i used the idl from anchor `0.30.1` since the idl format changed