### PR TITLE
docs(hermes-client): Correct function name from getStreamingPriceUpdates to getPriceUpdatesStream in README.md

### DIFF
--- a/apps/hermes/client/js/README.md
+++ b/apps/hermes/client/js/README.md
@@ -44,7 +44,7 @@ console.log(priceUpdates);
 
 ```typescript
 // Streaming price updates
-const eventSource = await connection.getStreamingPriceUpdates(priceIds);
+const eventSource = await connection.getPriceUpdatesStream(priceIds);
 
 eventSource.onmessage = (event) => {
   console.log("Received price update:", event.data);


### PR DESCRIPTION
This pull request corrects the function name from getStreamingPriceUpdates to getPriceUpdatesStream in the README.md file.  The previous name was incorrect and did not match the actual function implementation.
