### PR TITLE
fix: seed too long

### DIFF
--- a/governance/xc_admin/packages/xc_admin_common/src/deterministic_oracle_accounts.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/deterministic_oracle_accounts.ts
@@ -67,7 +67,7 @@ export async function findDetermisticAccountAddress(
   const seed: string = getSeed(type, symbol);
   const address: PublicKey = await PublicKey.createWithSeed(
     PRICE_FEED_OPS_KEY,
-    seed,
+    seed.slice(32),
     getPythProgramKeyForCluster(cluster)
   );
   return [address, seed];


### PR DESCRIPTION
On Pythnet, until now product and price accounts were created as seeded accounts with seed `product:{SYMBOL}` and `price:{SYMBOL}`. The problem is the seed can't exceed 32 characters. Some symbols in new price feeds are very long now like `Crypto.LIQUIDBERABTC/WBTC.RR` and fail at creation.

There are many solutions to this:
- slice the first 32 characters of the seed (bad because in the future there might be conflicts??? i.e. two symbols whose 24 first characters are the same but are not equal)
- hash the full seed and take the 32 first characters of the hash (this breaks the old way of doing things and will break all existing proposals since the seeded account needs to be computed at proposal).

