### PR TITLE
feat(fortuna): Add a couple more config values

### DIFF
--- a/apps/fortuna/Cargo.lock
+++ b/apps/fortuna/Cargo.lock
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "fortuna"
-version = "7.1.0"
+version = "7.3.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/fortuna/Cargo.lock
+++ b/apps/fortuna/Cargo.lock
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "fortuna"
-version = "7.3.0"
+version = "7.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/fortuna/Cargo.toml
+++ b/apps/fortuna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortuna"
-version = "7.3.0"
+version = "7.2.0"
 edition = "2021"
 
 [dependencies]

--- a/apps/fortuna/Cargo.toml
+++ b/apps/fortuna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortuna"
-version = "7.1.0"
+version = "7.3.0"
 edition = "2021"
 
 [dependencies]

--- a/apps/fortuna/src/config.rs
+++ b/apps/fortuna/src/config.rs
@@ -199,17 +199,9 @@ pub struct EscalationPolicyConfig {
     #[serde(default = "default_gas_multiplier_cap_pct")]
     pub gas_multiplier_cap_pct: u64,
 
-    /// The initial fee multiplier to apply to the fee estimate.
-    /// Note: consider carefully whether you want to adjust this value or priority_fee_multiplier_pct in the chain configuration.
-    /// The difference between these is that priority_fee_multiplier_pct additionally influences the fees charged by the keeper.
-    /// Setting this value to >100 means that the keeper may lose money on callbacks -- only do this if you know what you are doing.
-    #[serde(default = "default_initial_fee_multiplier_pct")]
-    pub initial_fee_multiplier_pct: u64,
-
     /// The fee multiplier to apply to the fee during backoff retries.
-    /// The fee estimate for the chain (which itself may be padded based on our chain configuration) is multiplied by the fee multiplier.
-    /// The initial multiplier is initial_fee_multiplier_pct, which is multiplied by fee_multiplier_pct on each successive retry.
-    /// The maximum multiplier capped at `fee_multiplier_cap_pct`.
+    /// The initial fee is 100% of the estimate (which itself may be padded based on our chain configuration)
+    /// The fee on each successive retry is multiplied by this value, with the maximum multiplier capped at `fee_multiplier_cap_pct`.
     #[serde(default = "default_fee_multiplier_pct")]
     pub fee_multiplier_pct: u64,
     #[serde(default = "default_fee_multiplier_cap_pct")]
@@ -232,10 +224,6 @@ fn default_gas_multiplier_cap_pct() -> u64 {
     600
 }
 
-fn default_initial_fee_multiplier_pct() -> u64 {
-    100
-}
-
 fn default_fee_multiplier_pct() -> u64 {
     110
 }
@@ -251,7 +239,6 @@ impl Default for EscalationPolicyConfig {
             initial_gas_multiplier_pct: default_initial_gas_multiplier_pct(),
             gas_multiplier_pct: default_gas_multiplier_pct(),
             gas_multiplier_cap_pct: default_gas_multiplier_cap_pct(),
-            initial_fee_multiplier_pct: default_initial_fee_multiplier_pct(),
             fee_multiplier_pct: default_fee_multiplier_pct(),
             fee_multiplier_cap_pct: default_fee_multiplier_cap_pct(),
         }
@@ -271,7 +258,7 @@ impl EscalationPolicyConfig {
     pub fn get_fee_multiplier_pct(&self, num_retries: u64) -> u64 {
         self.apply_escalation_policy(
             num_retries,
-            self.initial_fee_multiplier_pct,
+            100,
             self.fee_multiplier_pct,
             self.fee_multiplier_cap_pct,
         )

--- a/apps/fortuna/src/config.rs
+++ b/apps/fortuna/src/config.rs
@@ -199,7 +199,10 @@ pub struct EscalationPolicyConfig {
     #[serde(default = "default_gas_multiplier_cap_pct")]
     pub gas_multiplier_cap_pct: u64,
 
-    /// The initial fee multiplier to apply to the fee estimate
+    /// The initial fee multiplier to apply to the fee estimate.
+    /// Note: consider carefully whether you want to adjust this value or priority_fee_multiplier_pct in the chain configuration.
+    /// The difference between these is that priority_fee_multiplier_pct additionally influences the fees charged by the keeper.
+    /// Setting this value to >100 means that the keeper may lose money on callbacks -- only do this if you know what you are doing.
     #[serde(default = "default_initial_fee_multiplier_pct")]
     pub initial_fee_multiplier_pct: u64,
 

--- a/apps/fortuna/src/config.rs
+++ b/apps/fortuna/src/config.rs
@@ -145,18 +145,21 @@ pub struct EthereumConfig {
     /// The minimum percentage profit to earn as a function of the callback cost.
     /// For example, 20 means a profit of 20% over the cost of a callback that uses the full gas limit.
     /// The fee will be raised if the profit is less than this number.
-    pub min_profit_pct: u64,
+    /// The minimum value for this is -100. If set to < 0, it means the keeper may lose money on callbacks that use the full gas limit.
+    pub min_profit_pct: i64,
 
     /// The target percentage profit to earn as a function of the callback cost.
     /// For example, 20 means a profit of 20% over the cost of a callback that uses the full gas limit.
     /// The fee will be set to this target whenever it falls outside the min/max bounds.
-    pub target_profit_pct: u64,
+    /// The minimum value for this is -100. If set to < 0, it means the keeper may lose money on callbacks that use the full gas limit.
+    pub target_profit_pct: i64,
 
     /// The maximum percentage profit to earn as a function of the callback cost.
     /// For example, 100 means a profit of 100% over the cost of a callback that uses the full gas limit.
     /// The fee will be lowered if it is more profitable than specified here.
     /// Must be larger than min_profit_pct.
-    pub max_profit_pct: u64,
+    /// The minimum value for this is -100. If set to < 0, it means the keeper may lose money on callbacks that use the full gas limit.
+    pub max_profit_pct: i64,
 
     /// Minimum wallet balance for the keeper. If the balance falls below this level, the keeper will
     /// withdraw fees from the contract to top up. This functionality requires the keeper to be the fee

--- a/apps/fortuna/src/keeper.rs
+++ b/apps/fortuna/src/keeper.rs
@@ -435,7 +435,7 @@ pub async fn process_event_with_backoff(
                 &event,
                 &chain_state,
                 &contract,
-                gas_limit,
+                gas_limit.saturating_mul(escalation_policy.gas_limit_tolerance_pct.into()) / 100,
                 gas_multiplier_pct,
                 fee_multiplier_pct,
                 metrics.clone(),

--- a/apps/fortuna/src/keeper.rs
+++ b/apps/fortuna/src/keeper.rs
@@ -338,9 +338,10 @@ pub async fn run_keeper_threads(
             // In the unlikely event that the keeper fees aren't sufficient, the solution to this is to configure the target
             // fee percentage to be higher on that specific chain.
             chain_eth_config.gas_limit,
-            chain_eth_config.min_profit_pct,
-            chain_eth_config.target_profit_pct,
-            chain_eth_config.max_profit_pct,
+            // NOTE: unwrap() here so we panic early if someone configures these values below -100.
+            u64::try_from(100 + chain_eth_config.min_profit_pct).unwrap(),
+            u64::try_from(100 + chain_eth_config.target_profit_pct).unwrap(),
+            u64::try_from(100 + chain_eth_config.max_profit_pct).unwrap(),
             chain_eth_config.fee,
         )
         .in_current_span(),
@@ -1253,15 +1254,15 @@ pub async fn adjust_fee_if_necessary(
         .await
         .map_err(|e| anyhow!("Could not estimate transaction cost. error {:?}", e))?;
     let target_fee_min = std::cmp::max(
-        (max_callback_cost * (100 + u128::from(min_profit_pct))) / 100,
+        (max_callback_cost * u128::from(min_profit_pct)) / 100,
         min_fee_wei,
     );
     let target_fee = std::cmp::max(
-        (max_callback_cost * (100 + u128::from(target_profit_pct))) / 100,
+        (max_callback_cost * u128::from(target_profit_pct)) / 100,
         min_fee_wei,
     );
     let target_fee_max = std::cmp::max(
-        (max_callback_cost * (100 + u128::from(max_profit_pct))) / 100,
+        (max_callback_cost * u128::from(max_profit_pct)) / 100,
         min_fee_wei,
     );
 

--- a/apps/fortuna/src/keeper.rs
+++ b/apps/fortuna/src/keeper.rs
@@ -339,9 +339,12 @@ pub async fn run_keeper_threads(
             // fee percentage to be higher on that specific chain.
             chain_eth_config.gas_limit,
             // NOTE: unwrap() here so we panic early if someone configures these values below -100.
-            u64::try_from(100 + chain_eth_config.min_profit_pct).unwrap(),
-            u64::try_from(100 + chain_eth_config.target_profit_pct).unwrap(),
-            u64::try_from(100 + chain_eth_config.max_profit_pct).unwrap(),
+            u64::try_from(100 + chain_eth_config.min_profit_pct)
+                .expect("min_profit_pct must be >= -100"),
+            u64::try_from(100 + chain_eth_config.target_profit_pct)
+                .expect("target_profit_pct must be >= -100"),
+            u64::try_from(100 + chain_eth_config.max_profit_pct)
+                .expect("max_profit_pct must be >= -100"),
             chain_eth_config.fee,
         )
         .in_current_span(),


### PR DESCRIPTION
Two simple changes here
* add a padding multiplier for the gas limit so that the keeper is willing to submit txs that slightly exceed the limit. I noticed a few failing txs in mainnet that are at ~510k gas, which could happen due to differences in the number of hashes. This defaults to 10% and that number should probably be fine without configuration.
* support negative target profit percentages. It turns out that for abstract-testnet, you get a gas refund at the end of the tx which is like 50% of the tx cost. However, you need to set the priority fee *without counting this refund*. Given that, we're systematically overestimating the needed fee.