### PR TITLE
feat(lazer/js-sdk): add promises for open and disconnected

### DIFF
--- a/lazer/sdk/js/examples/index.ts
+++ b/lazer/sdk/js/examples/index.ts
@@ -6,65 +6,82 @@ import { PythLazerClient } from "../src/index.js";
 // Ignore debug messages
 console.debug = () => {};
 
-const client = new PythLazerClient(
-  ["wss://pyth-lazer.dourolabs.app/v1/stream"],
-  "access_token",
-  3, // Optionally specify number of parallel redundant connections to reduce the chance of dropped messages. The connections will round-robin across the provided URLs. Default is 3.
-  console // Optionally log socket operations (to the console in this case.)
-);
+async function main() {
+  try {
+    const client = await PythLazerClient.create(
+      ["wss://pyth-lazer.dourolabs.app/v1/stream"],
+      "access_token",
+      3, // Optionally specify number of parallel redundant connections to reduce the chance of dropped messages. The connections will round-robin across the provided URLs. Default is 3.
+      console // Optionally log socket operations (to the console in this case.)
+    );
 
-client.addMessageListener((message) => {
-  console.info("got message:", message);
-  switch (message.type) {
-    case "json": {
-      if (message.value.type == "streamUpdated") {
-        console.info(
-          "stream updated for subscription",
-          message.value.subscriptionId,
-          ":",
-          message.value.parsed?.priceFeeds
-        );
+    client.addMessageListener((message) => {
+      console.info("got message:", message);
+      switch (message.type) {
+        case "json": {
+          if (message.value.type == "streamUpdated") {
+            console.info(
+              "stream updated for subscription",
+              message.value.subscriptionId,
+              ":",
+              message.value.parsed?.priceFeeds
+            );
+          }
+          break;
+        }
+        case "binary": {
+          if ("solana" in message.value) {
+            console.info(
+              "solana message:",
+              message.value.solana?.toString("hex")
+            );
+          }
+          if ("evm" in message.value) {
+            console.info("evm message:", message.value.evm?.toString("hex"));
+          }
+          break;
+        }
       }
-      break;
-    }
-    case "binary": {
-      if ("solana" in message.value) {
-        console.info("solana message:", message.value.solana?.toString("hex"));
-      }
-      if ("evm" in message.value) {
-        console.info("evm message:", message.value.evm?.toString("hex"));
-      }
-      break;
-    }
+    });
+
+    // Create and remove one or more subscriptions on the fly
+    await client.subscribe({
+      type: "subscribe",
+      subscriptionId: 1,
+      priceFeedIds: [1, 2],
+      properties: ["price"],
+      chains: ["solana"],
+      deliveryFormat: "binary",
+      channel: "fixed_rate@200ms",
+      parsed: false,
+      jsonBinaryEncoding: "base64",
+    });
+    await client.subscribe({
+      type: "subscribe",
+      subscriptionId: 2,
+      priceFeedIds: [1, 2, 3, 4, 5],
+      properties: ["price"],
+      chains: ["evm"],
+      deliveryFormat: "json",
+      channel: "fixed_rate@200ms",
+      parsed: true,
+      jsonBinaryEncoding: "hex",
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10_000));
+
+    await client.unsubscribe(1);
+    await client.unsubscribe(2);
+
+    await new Promise((resolve) => setTimeout(resolve, 10_000));
+    client.shutdown();
+  } catch (error) {
+    console.error("Error initializing client:", error);
+    process.exit(1);
   }
-});
+}
 
-// Create and remove one or more subscriptions on the fly
-await client.subscribe({
-  type: "subscribe",
-  subscriptionId: 1,
-  priceFeedIds: [1, 2],
-  properties: ["price"],
-  chains: ["solana"],
-  deliveryFormat: "binary",
-  channel: "fixed_rate@200ms",
-  parsed: false,
-  jsonBinaryEncoding: "base64",
+main().catch((error) => {
+  console.error("Unhandled error:", error);
+  process.exit(1);
 });
-await client.subscribe({
-  type: "subscribe",
-  subscriptionId: 2,
-  priceFeedIds: [1, 2, 3, 4, 5],
-  properties: ["price"],
-  chains: ["evm"],
-  deliveryFormat: "json",
-  channel: "fixed_rate@200ms",
-  parsed: true,
-  jsonBinaryEncoding: "hex",
-});
-
-await new Promise((resolve) => setTimeout(resolve, 10_000));
-
-await client.unsubscribe(1);
-await client.unsubscribe(2);
-client.shutdown();

--- a/lazer/sdk/js/examples/index.ts
+++ b/lazer/sdk/js/examples/index.ts
@@ -7,78 +7,81 @@ import { PythLazerClient } from "../src/index.js";
 console.debug = () => {};
 
 async function main() {
-  try {
-    const client = await PythLazerClient.create(
-      ["wss://pyth-lazer.dourolabs.app/v1/stream"],
-      "access_token",
-      3, // Optionally specify number of parallel redundant connections to reduce the chance of dropped messages. The connections will round-robin across the provided URLs. Default is 3.
-      console // Optionally log socket operations (to the console in this case.)
-    );
+  const client = await PythLazerClient.create(
+    ["wss://pyth-lazer.dourolabs.app/v1/stream"],
+    "access_token",
+    3, // Optionally specify number of parallel redundant connections to reduce the chance of dropped messages. The connections will round-robin across the provided URLs. Default is 3.
+    console // Optionally log socket operations (to the console in this case.)
+  );
 
-    client.addMessageListener((message) => {
-      console.info("got message:", message);
-      switch (message.type) {
-        case "json": {
-          if (message.value.type == "streamUpdated") {
-            console.info(
-              "stream updated for subscription",
-              message.value.subscriptionId,
-              ":",
-              message.value.parsed?.priceFeeds
-            );
-          }
-          break;
+  // Monitor for all connections being down
+  client.onAllConnectionsDown().then(() => {
+    // Handle complete connection failure.
+    // The connections will keep attempting to reconnect with expo backoff.
+    // To shutdown the client completely, call shutdown().
+    console.error("All connections are down!");
+  });
+
+  client.addMessageListener((message) => {
+    console.info("got message:", message);
+    switch (message.type) {
+      case "json": {
+        if (message.value.type == "streamUpdated") {
+          console.info(
+            "stream updated for subscription",
+            message.value.subscriptionId,
+            ":",
+            message.value.parsed?.priceFeeds
+          );
         }
-        case "binary": {
-          if ("solana" in message.value) {
-            console.info(
-              "solana message:",
-              message.value.solana?.toString("hex")
-            );
-          }
-          if ("evm" in message.value) {
-            console.info("evm message:", message.value.evm?.toString("hex"));
-          }
-          break;
-        }
+        break;
       }
-    });
+      case "binary": {
+        if ("solana" in message.value) {
+          console.info(
+            "solana message:",
+            message.value.solana?.toString("hex")
+          );
+        }
+        if ("evm" in message.value) {
+          console.info("evm message:", message.value.evm?.toString("hex"));
+        }
+        break;
+      }
+    }
+  });
 
-    // Create and remove one or more subscriptions on the fly
-    await client.subscribe({
-      type: "subscribe",
-      subscriptionId: 1,
-      priceFeedIds: [1, 2],
-      properties: ["price"],
-      chains: ["solana"],
-      deliveryFormat: "binary",
-      channel: "fixed_rate@200ms",
-      parsed: false,
-      jsonBinaryEncoding: "base64",
-    });
-    await client.subscribe({
-      type: "subscribe",
-      subscriptionId: 2,
-      priceFeedIds: [1, 2, 3, 4, 5],
-      properties: ["price"],
-      chains: ["evm"],
-      deliveryFormat: "json",
-      channel: "fixed_rate@200ms",
-      parsed: true,
-      jsonBinaryEncoding: "hex",
-    });
+  // Create and remove one or more subscriptions on the fly
+  await client.subscribe({
+    type: "subscribe",
+    subscriptionId: 1,
+    priceFeedIds: [1, 2],
+    properties: ["price"],
+    chains: ["solana"],
+    deliveryFormat: "binary",
+    channel: "fixed_rate@200ms",
+    parsed: false,
+    jsonBinaryEncoding: "base64",
+  });
+  await client.subscribe({
+    type: "subscribe",
+    subscriptionId: 2,
+    priceFeedIds: [1, 2, 3, 4, 5],
+    properties: ["price"],
+    chains: ["evm"],
+    deliveryFormat: "json",
+    channel: "fixed_rate@200ms",
+    parsed: true,
+    jsonBinaryEncoding: "hex",
+  });
 
-    await new Promise((resolve) => setTimeout(resolve, 10_000));
+  await new Promise((resolve) => setTimeout(resolve, 10_000));
 
-    await client.unsubscribe(1);
-    await client.unsubscribe(2);
+  await client.unsubscribe(1);
+  await client.unsubscribe(2);
 
-    await new Promise((resolve) => setTimeout(resolve, 10_000));
-    client.shutdown();
-  } catch (error) {
-    console.error("Error initializing client:", error);
-    process.exit(1);
-  }
+  await new Promise((resolve) => setTimeout(resolve, 10_000));
+  client.shutdown();
 }
 
 main().catch((error) => {

--- a/lazer/sdk/js/src/client.ts
+++ b/lazer/sdk/js/src/client.ts
@@ -111,6 +111,13 @@ export class PythLazerClient {
     await this.wsp.sendRequest(request);
   }
 
+  /**
+   * Returns a promise that resolves when all WebSocket connections are down or attempting to reconnect
+   */
+  onAllConnectionsDown(): Promise<void> {
+    return this.wsp.onAllConnectionsDown();
+  }
+
   shutdown(): void {
     this.wsp.shutdown();
   }

--- a/lazer/sdk/js/src/client.ts
+++ b/lazer/sdk/js/src/client.ts
@@ -30,7 +30,7 @@ const UINT32_NUM_BYTES = 4;
 const UINT64_NUM_BYTES = 8;
 
 export class PythLazerClient {
-  wsp: WebSocketPool;
+  private constructor(private readonly wsp: WebSocketPool) {}
 
   /**
    * Creates a new PythLazerClient instance.
@@ -39,13 +39,14 @@ export class PythLazerClient {
    * @param numConnections - The number of parallel WebSocket connections to establish (default: 3). A higher number gives a more reliable stream.
    * @param logger - Optional logger to get socket level logs. Compatible with most loggers such as the built-in console and `bunyan`.
    */
-  constructor(
+  static async create(
     urls: string[],
     token: string,
     numConnections = 3,
     logger: Logger = dummyLogger
-  ) {
-    this.wsp = new WebSocketPool(urls, token, numConnections, logger);
+  ): Promise<PythLazerClient> {
+    const wsp = await WebSocketPool.create(urls, token, numConnections, logger);
+    return new PythLazerClient(wsp);
   }
 
   addMessageListener(handler: (event: JsonOrBinaryResponse) => void) {

--- a/lazer/sdk/js/src/socket/web-socket-pool.ts
+++ b/lazer/sdk/js/src/socket/web-socket-pool.ts
@@ -5,7 +5,6 @@ import { dummyLogger, type Logger } from "ts-log";
 import { ResilientWebSocket } from "./resilient-web-socket.js";
 import type { Request, Response } from "../protocol.js";
 
-// Number of redundant parallel WebSocket connections
 const DEFAULT_NUM_CONNECTIONS = 3;
 
 export class WebSocketPool {
@@ -13,6 +12,13 @@ export class WebSocketPool {
   private cache: TTLCache<string, boolean>;
   private subscriptions: Map<number, Request>; // id -> subscription Request
   private messageListeners: ((event: WebSocket.Data) => void)[];
+
+  private constructor(private readonly logger: Logger = dummyLogger) {
+    this.rwsPool = [];
+    this.cache = new TTLCache({ ttl: 1000 * 10 }); // TTL of 10 seconds
+    this.subscriptions = new Map();
+    this.messageListeners = [];
+  }
 
   /**
    * Creates a new WebSocketPool instance that uses multiple redundant WebSocket connections for reliability.
@@ -22,22 +28,21 @@ export class WebSocketPool {
    * @param numConnections - Number of parallel WebSocket connections to maintain (default: 3)
    * @param logger - Optional logger to get socket level logs. Compatible with most loggers such as the built-in console and `bunyan`.
    */
-  constructor(
+  static async create(
     urls: string[],
     token: string,
     numConnections: number = DEFAULT_NUM_CONNECTIONS,
-    private readonly logger: Logger = dummyLogger
-  ) {
+    logger: Logger = dummyLogger
+  ): Promise<WebSocketPool> {
     if (urls.length === 0) {
       throw new Error("No URLs provided");
     }
-    // This cache is used to deduplicate messages received across different websocket clients in the pool.
-    // A TTL cache is used to prevent unbounded memory usage. A very short TTL of 10 seconds is chosen since
-    // deduplication only needs to happen between messages received very close together in time.
-    this.cache = new TTLCache({ ttl: 1000 * 10 }); // TTL of 10 seconds
-    this.rwsPool = [];
-    this.subscriptions = new Map();
-    this.messageListeners = [];
+
+    const pool = new WebSocketPool(logger);
+
+    // Create all websocket instances
+    const connectionPromises: Promise<void>[] = [];
+
     for (let i = 0; i < numConnections; i++) {
       const url = urls[i % urls.length];
       if (!url) {
@@ -52,36 +57,44 @@ export class WebSocketPool {
 
       // If a websocket client unexpectedly disconnects, ResilientWebSocket will reestablish
       // the connection and call the onReconnect callback.
-      // When we reconnect, replay all subscription messages to resume the data stream.
       rws.onReconnect = () => {
         if (rws.wsUserClosed) {
           return;
         }
-        for (const [, request] of this.subscriptions) {
+        for (const [, request] of pool.subscriptions) {
           try {
             void rws.send(JSON.stringify(request));
           } catch (error) {
-            this.logger.error(
+            pool.logger.error(
               "Failed to resend subscription on reconnect:",
               error
             );
           }
         }
       };
+
       // Handle all client messages ourselves. Dedupe before sending to registered message handlers.
-      rws.onMessage = this.dedupeHandler;
-      this.rwsPool.push(rws);
+      rws.onMessage = pool.dedupeHandler;
+      pool.rwsPool.push(rws);
+
+      // Start the websocket and collect the promise
+      connectionPromises.push(rws.startWebSocket());
     }
 
-    // Let it rip
-    // TODO: wait for sockets to receive `open` msg before subscribing?
-    for (const rws of this.rwsPool) {
-      rws.startWebSocket();
+    // Wait for all connections to be established
+    try {
+      await Promise.all(connectionPromises);
+    } catch (error) {
+      // If any connection fails, clean up and throw
+      pool.shutdown();
+      throw error;
     }
 
-    this.logger.info(
-      `Using ${numConnections.toString()} redundant WebSocket connections`
+    pool.logger.info(
+      `Successfully established ${numConnections.toString()} redundant WebSocket connections`
     );
+
+    return pool;
   }
 
   /**
@@ -105,23 +118,18 @@ export class WebSocketPool {
    * multiple connections before forwarding to registered handlers
    */
   dedupeHandler = (data: WebSocket.Data): void => {
-    // For string data, use the whole string as the cache key. This avoids expensive JSON parsing during deduping.
-    // For binary data, use the hex string representation as the cache key
     const cacheKey =
       typeof data === "string"
         ? data
         : Buffer.from(data as Buffer).toString("hex");
 
-    // If we've seen this exact message recently, drop it
     if (this.cache.has(cacheKey)) {
       this.logger.debug("Dropping duplicate message");
       return;
     }
 
-    // Haven't seen this message, cache it and forward to handlers
     this.cache.set(cacheKey, true);
 
-    // Check for errors in JSON responses
     if (typeof data === "string") {
       this.handleErrorMessages(data);
     }
@@ -131,28 +139,18 @@ export class WebSocketPool {
     }
   };
 
-  /**
-   * Sends a message to all websockets in the pool
-   * @param request - The request to send
-   */
   async sendRequest(request: Request): Promise<void> {
-    // Send to all websockets in the pool
     const sendPromises = this.rwsPool.map(async (rws) => {
       try {
         await rws.send(JSON.stringify(request));
       } catch (error) {
         this.logger.error("Failed to send request:", error);
-        throw error; // Re-throw the error
+        throw error;
       }
     });
     await Promise.all(sendPromises);
   }
 
-  /**
-   * Adds a subscription by sending a subscribe request to all websockets in the pool
-   * and storing it for replay on reconnection
-   * @param request - The subscription request to send
-   */
   async addSubscription(request: Request): Promise<void> {
     if (request.type !== "subscribe") {
       throw new Error("Request must be a subscribe request");
@@ -161,11 +159,6 @@ export class WebSocketPool {
     await this.sendRequest(request);
   }
 
-  /**
-   * Removes a subscription by sending an unsubscribe request to all websockets in the pool
-   * and removing it from stored subscriptions
-   * @param subscriptionId - The ID of the subscription to remove
-   */
   async removeSubscription(subscriptionId: number): Promise<void> {
     this.subscriptions.delete(subscriptionId);
     const request: Request = {
@@ -175,17 +168,10 @@ export class WebSocketPool {
     await this.sendRequest(request);
   }
 
-  /**
-   * Adds a message handler function to receive websocket messages
-   * @param handler - Function that will be called with each received message
-   */
   addMessageListener(handler: (data: WebSocket.Data) => void): void {
     this.messageListeners.push(handler);
   }
 
-  /**
-   * Elegantly closes all websocket connections in the pool
-   */
   shutdown(): void {
     for (const rws of this.rwsPool) {
       rws.closeWebSocket();


### PR DESCRIPTION
- The client's `create()` method will only resolve upon receiving a valid "open" message from the server.
- Add the ability to handle a total disconnection (if all underlying sockets have disconnected and are waiting to retry)
  - This can happen if we lose internet connection or if all Lazer endpoints are down.