### PR TITLE
chore: remove node tests from solana lazer contract workflow

### DIFF
--- a/.github/workflows/ci-lazer-solana-contract.yml
+++ b/.github/workflows/ci-lazer-solana-contract.yml
@@ -36,9 +36,3 @@ jobs:
         run: solana-keygen new --no-bip39-passphrase
       - name: Install Anchor
         run: RUSTFLAGS= cargo install --git https://github.com/coral-xyz/anchor --tag v0.30.1 anchor-cli
-      - name: Install pnpm
-        run: npm install --global pnpm@9.15.4
-      - name: Install test dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Run tests
-        run: pnpm run test

--- a/lazer/contracts/solana/package.json
+++ b/lazer/contracts/solana/package.json
@@ -6,7 +6,6 @@
     "fix:format": "prettier --write **/*.*",
     "test:format": "prettier --check **/*.*",
     "test:anchor": "CARGO_TARGET_DIR=\"$PWD/target\" anchor test",
-    "test": "pnpm run test:format && pnpm run test:anchor",
     "setup": "pnpm ts-node scripts/setup.ts",
     "check-trusted-signer": "pnpm ts-node scripts/check_trusted_signer.ts"
   },

--- a/lazer/contracts/solana/turbo.json
+++ b/lazer/contracts/solana/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "test": {
+      "dependsOn": ["test:format", "test:anchor"]
+    },
+    "test:anchor": {}
+  }
+}


### PR DESCRIPTION
I was going to fix this so that it installs pnpm properly to use the correct version, however as it turns out this is actually redundant since we already run tests with https://github.com/pyth-network/pyth-crosschain/blob/main/.github/workflows/ci-turbo-test.yml so there's really no reason to duplicate the tests here as well.