### PR TITLE
fix(apps/hermes): bump pyth-sdk-solana to v0.10.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ __pycache__
 .direnv
 .next
 .turbo/
+.cursorrules

--- a/apps/hermes/server/Cargo.lock
+++ b/apps/hermes/server/Cargo.lock
@@ -3214,9 +3214,9 @@ dependencies = [
 
 [[package]]
 name = "pyth-sdk-solana"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9301b3c3db3766fd1dd0c5769a706d886265b3f56772ac279365bdd807d3076"
+checksum = "65841f3d9d5a025ca32999463f720ba16da2dfe9ffe5b668b2e26dd4239dfa9e"
 dependencies = [
  "borsh 0.10.3",
  "borsh-derive 0.10.3",

--- a/apps/hermes/server/Cargo.toml
+++ b/apps/hermes/server/Cargo.toml
@@ -30,7 +30,7 @@ nonzero_ext        = { version = "0.3.0" }
 prometheus-client  = { version = "0.21.2" }
 prost              = { version = "0.12.1" }
 pyth-sdk           = { version = "0.8.0" }
-pyth-sdk-solana    = { version = "0.10.2" }
+pyth-sdk-solana    = "0.10.3"
 pythnet-sdk        = { path = "../../../pythnet/pythnet_sdk/", version = "2.0.0", features = ["strum"] }
 rand               = { version = "0.8.5" }
 reqwest            = { version = "0.11.14", features = ["blocking", "json"] }

--- a/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
@@ -99,10 +99,8 @@ interface IPulse {
 
     function withdraw(uint128 amount) external;
 
-    // Add to interface
     function withdrawAsFeeManager(address provider, uint128 amount) external;
 
-    // Add to Provider management section
     function setProviderUri(bytes calldata uri) external;
 
     // Getters
@@ -110,22 +108,11 @@ interface IPulse {
 
     function getDefaultProvider() external view returns (address);
 
-    // Add to interface
-    function setFeeManager(address manager) external;
-
-    // Add to interface
-    function setProviderFeeAsFeeManager(
-        address provider,
-        uint128 newFeeInWei
-    ) external;
-
-    // Add to Getters section
     function getAccruedPythFees()
         external
         view
         returns (uint128 accruedPythFeesInWei);
 
-    // Add to Getters section
     function getProviderInfo(
         address provider
     ) external view returns (PulseState.ProviderInfo memory info);
@@ -134,11 +121,18 @@ interface IPulse {
 
     function getPythFeeInWei() external view returns (uint128 pythFeeInWei);
 
-    function setMaxNumPrices(uint32 maxNumPrices) external;
-
-    // Add to Getters section
     function getRequest(
         address provider,
         uint64 sequenceNumber
     ) external view returns (PulseState.Request memory req);
+
+    // Setters
+    function setFeeManager(address manager) external;
+
+    function setProviderFeeAsFeeManager(
+        address provider,
+        uint128 newFeeInWei
+    ) external;
+
+    function setMaxNumPrices(uint32 maxNumPrices) external;
 }

--- a/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
@@ -15,13 +15,9 @@ interface IPulseConsumer {
 
 interface IPulse {
     // Events
-    event PriceUpdateRequested(
-        uint64 indexed sequenceNumber,
-        address indexed provider,
-        uint256 publishTime,
-        bytes32[] priceIds,
-        address requester
-    );
+    event ProviderRegistered(PulseState.ProviderInfo providerInfo);
+
+    event PriceUpdateRequested(PulseState.Request request);
 
     event PriceUpdateExecuted(
         uint64 indexed sequenceNumber,
@@ -30,16 +26,16 @@ interface IPulse {
         bytes32[] priceIds
     );
 
-    event ProviderRegistered(
-        address indexed provider,
-        uint128 feeInWei,
-        bytes uri
-    );
-
     event ProviderFeeUpdated(
         address indexed provider,
         uint128 oldFeeInWei,
         uint128 newFeeInWei
+    );
+
+    event ProviderUriUpdated(
+        address indexed provider,
+        bytes oldUri,
+        bytes newUri
     );
 
     event ProviderWithdrawn(
@@ -52,12 +48,6 @@ interface IPulse {
         address indexed provider,
         address oldFeeManager,
         address newFeeManager
-    );
-
-    event ProviderUriUpdated(
-        address indexed provider,
-        bytes oldUri,
-        bytes newUri
     );
 
     event ProviderMaxNumPricesUpdated(
@@ -80,7 +70,6 @@ interface IPulse {
         address provider,
         uint256 publishTime,
         bytes32[] calldata priceIds,
-        bytes[] calldata updateData,
         uint256 callbackGasLimit
     ) external payable returns (uint64 sequenceNumber);
 
@@ -97,29 +86,32 @@ interface IPulse {
 
     function setProviderFee(uint128 newFeeInWei) external;
 
+    function setProviderFeeAsFeeManager(
+        address provider,
+        uint128 newFeeInWei
+    ) external;
+
+    function setProviderUri(bytes calldata uri) external;
+
     function withdraw(uint128 amount) external;
 
     function withdrawAsFeeManager(address provider, uint128 amount) external;
 
-    function setProviderUri(bytes calldata uri) external;
-
     // Getters
     function getFee(address provider) external view returns (uint128 feeAmount);
 
-    function getDefaultProvider() external view returns (address);
+    function getPythFeeInWei() external view returns (uint128 pythFeeInWei);
 
     function getAccruedPythFees()
         external
         view
         returns (uint128 accruedPythFeesInWei);
 
+    function getDefaultProvider() external view returns (address);
+
     function getProviderInfo(
         address provider
     ) external view returns (PulseState.ProviderInfo memory info);
-
-    function getAdmin() external view returns (address admin);
-
-    function getPythFeeInWei() external view returns (uint128 pythFeeInWei);
 
     function getRequest(
         address provider,
@@ -128,11 +120,6 @@ interface IPulse {
 
     // Setters
     function setFeeManager(address manager) external;
-
-    function setProviderFeeAsFeeManager(
-        address provider,
-        uint128 newFeeInWei
-    ) external;
 
     function setMaxNumPrices(uint32 maxNumPrices) external;
 }

--- a/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
@@ -24,9 +24,8 @@ interface IPulse is PulseEvents {
 
     function executeCallback(
         uint64 sequenceNumber,
-        bytes32[] calldata priceIds,
         bytes[] calldata updateData,
-        uint256 callbackGasLimit
+        bytes32[] calldata priceIds
     ) external payable;
 
     // Getters

--- a/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "./PulseState.sol";
+
+interface IPulseConsumer {
+    function pulseCallback(
+        uint64 sequenceNumber,
+        address provider,
+        uint256 publishTime,
+        bytes32[] calldata priceIds
+    ) external;
+}
+
+interface IPulse {
+    // Events
+    event PriceUpdateRequested(
+        uint64 indexed sequenceNumber,
+        address indexed provider,
+        uint256 publishTime,
+        bytes32[] priceIds,
+        address requester
+    );
+
+    event PriceUpdateExecuted(
+        uint64 indexed sequenceNumber,
+        address indexed provider,
+        uint256 publishTime,
+        bytes32[] priceIds
+    );
+
+    event ProviderRegistered(
+        address indexed provider,
+        uint128 feeInWei,
+        bytes uri
+    );
+
+    event ProviderFeeUpdated(
+        address indexed provider,
+        uint128 oldFeeInWei,
+        uint128 newFeeInWei
+    );
+
+    event ProviderWithdrawn(
+        address indexed provider,
+        address indexed recipient,
+        uint128 amount
+    );
+
+    event ProviderFeeManagerUpdated(
+        address indexed provider,
+        address oldFeeManager,
+        address newFeeManager
+    );
+
+    event ProviderUriUpdated(
+        address indexed provider,
+        bytes oldUri,
+        bytes newUri
+    );
+
+    event ProviderMaxNumPricesUpdated(
+        address indexed provider,
+        uint32 oldMaxNumPrices,
+        uint32 maxNumPrices
+    );
+
+    event PriceUpdateCallbackFailed(
+        uint64 indexed sequenceNumber,
+        address indexed provider,
+        uint256 publishTime,
+        bytes32[] priceIds,
+        address requester,
+        string reason
+    );
+
+    // Core functions
+    function requestPriceUpdatesWithCallback(
+        address provider,
+        uint256 publishTime,
+        bytes32[] calldata priceIds,
+        bytes[] calldata updateData,
+        uint256 callbackGasLimit
+    ) external payable returns (uint64 sequenceNumber);
+
+    function executeCallback(
+        uint64 sequenceNumber,
+        uint256 publishTime,
+        bytes32[] calldata priceIds,
+        bytes[] calldata updateData,
+        uint256 callbackGasLimit
+    ) external;
+
+    // Provider management
+    function register(uint128 feeInWei, bytes calldata uri) external;
+
+    function setProviderFee(uint128 newFeeInWei) external;
+
+    function withdraw(uint128 amount) external;
+
+    // Add to interface
+    function withdrawAsFeeManager(address provider, uint128 amount) external;
+
+    // Add to Provider management section
+    function setProviderUri(bytes calldata uri) external;
+
+    // Getters
+    function getFee(address provider) external view returns (uint128 feeAmount);
+
+    function getDefaultProvider() external view returns (address);
+
+    // Add to interface
+    function setFeeManager(address manager) external;
+
+    // Add to interface
+    function setProviderFeeAsFeeManager(
+        address provider,
+        uint128 newFeeInWei
+    ) external;
+
+    // Add to Getters section
+    function getAccruedPythFees()
+        external
+        view
+        returns (uint128 accruedPythFeesInWei);
+
+    // Add to Getters section
+    function getProviderInfo(
+        address provider
+    ) external view returns (PulseState.ProviderInfo memory info);
+
+    function getAdmin() external view returns (address admin);
+
+    function getPythFeeInWei() external view returns (uint128 pythFeeInWei);
+
+    function setMaxNumPrices(uint32 maxNumPrices) external;
+
+    // Add to Getters section
+    function getRequest(
+        address provider,
+        uint64 sequenceNumber
+    ) external view returns (PulseState.Request memory req);
+}

--- a/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
@@ -8,7 +8,7 @@ import "./PulseState.sol";
 interface IPulseConsumer {
     function pulseCallback(
         uint64 sequenceNumber,
-        address provider,
+        address updater,
         uint256 publishTime,
         bytes32[] calldata priceIds
     ) external;
@@ -17,66 +17,33 @@ interface IPulseConsumer {
 interface IPulse is PulseEvents {
     // Core functions
     function requestPriceUpdatesWithCallback(
-        address provider,
         uint256 publishTime,
         bytes32[] calldata priceIds,
         uint256 callbackGasLimit
     ) external payable returns (uint64 sequenceNumber);
 
     function executeCallback(
-        address provider,
         uint64 sequenceNumber,
         bytes32[] calldata priceIds,
         bytes[] calldata updateData,
         uint256 callbackGasLimit
     ) external payable;
 
-    // Provider management
-    function register(
-        uint128 feeInWei,
-        uint128 feePerGas,
-        bytes calldata uri
-    ) external;
-
-    function setProviderFee(uint128 newFeeInWei) external;
-
-    function setProviderFeeAsFeeManager(
-        address provider,
-        uint128 newFeeInWei
-    ) external;
-
-    function setProviderUri(bytes calldata uri) external;
-
-    function withdraw(uint128 amount) external;
-
-    function withdrawAsFeeManager(address provider, uint128 amount) external;
-
     // Getters
     function getFee(
-        address provider,
         uint256 callbackGasLimit
     ) external view returns (uint128 feeAmount);
 
     function getPythFeeInWei() external view returns (uint128 pythFeeInWei);
 
-    function getAccruedPythFees()
-        external
-        view
-        returns (uint128 accruedPythFeesInWei);
-
-    function getDefaultProvider() external view returns (address);
-
-    function getProviderInfo(
-        address provider
-    ) external view returns (PulseState.ProviderInfo memory info);
+    function getAccruedFees() external view returns (uint128 accruedFeesInWei);
 
     function getRequest(
-        address provider,
         uint64 sequenceNumber
     ) external view returns (PulseState.Request memory req);
 
-    // Setters
+    // Add these functions to the IPulse interface
     function setFeeManager(address manager) external;
 
-    function setMaxNumPrices(uint32 maxNumPrices) external;
+    function withdrawAsFeeManager(uint128 amount) external;
 }

--- a/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.0;
 
+import "./PulseEvents.sol";
 import "./PulseState.sol";
 
 interface IPulseConsumer {
@@ -13,58 +14,7 @@ interface IPulseConsumer {
     ) external;
 }
 
-interface IPulse {
-    // Events
-    event ProviderRegistered(PulseState.ProviderInfo providerInfo);
-
-    event PriceUpdateRequested(PulseState.Request request);
-
-    event PriceUpdateExecuted(
-        uint64 indexed sequenceNumber,
-        address indexed provider,
-        uint256 publishTime,
-        bytes32[] priceIds
-    );
-
-    event ProviderFeeUpdated(
-        address indexed provider,
-        uint128 oldFeeInWei,
-        uint128 newFeeInWei
-    );
-
-    event ProviderUriUpdated(
-        address indexed provider,
-        bytes oldUri,
-        bytes newUri
-    );
-
-    event ProviderWithdrawn(
-        address indexed provider,
-        address indexed recipient,
-        uint128 amount
-    );
-
-    event ProviderFeeManagerUpdated(
-        address indexed provider,
-        address oldFeeManager,
-        address newFeeManager
-    );
-
-    event ProviderMaxNumPricesUpdated(
-        address indexed provider,
-        uint32 oldMaxNumPrices,
-        uint32 maxNumPrices
-    );
-
-    event PriceUpdateCallbackFailed(
-        uint64 indexed sequenceNumber,
-        address indexed provider,
-        uint256 publishTime,
-        bytes32[] priceIds,
-        address requester,
-        string reason
-    );
-
+interface IPulse is PulseEvents {
     // Core functions
     function requestPriceUpdatesWithCallback(
         address provider,
@@ -74,15 +24,19 @@ interface IPulse {
     ) external payable returns (uint64 sequenceNumber);
 
     function executeCallback(
+        address provider,
         uint64 sequenceNumber,
-        uint256 publishTime,
         bytes32[] calldata priceIds,
         bytes[] calldata updateData,
         uint256 callbackGasLimit
-    ) external;
+    ) external payable;
 
     // Provider management
-    function register(uint128 feeInWei, bytes calldata uri) external;
+    function register(
+        uint128 feeInWei,
+        uint128 feePerGas,
+        bytes calldata uri
+    ) external;
 
     function setProviderFee(uint128 newFeeInWei) external;
 
@@ -98,7 +52,10 @@ interface IPulse {
     function withdrawAsFeeManager(address provider, uint128 amount) external;
 
     // Getters
-    function getFee(address provider) external view returns (uint128 feeAmount);
+    function getFee(
+        address provider,
+        uint256 callbackGasLimit
+    ) external view returns (uint128 feeAmount);
 
     function getPythFeeInWei() external view returns (uint128 pythFeeInWei);
 

--- a/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.0;
 
+import "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
 import "./PulseEvents.sol";
 import "./PulseState.sol";
 
@@ -9,8 +10,7 @@ interface IPulseConsumer {
     function pulseCallback(
         uint64 sequenceNumber,
         address updater,
-        uint256 publishTime,
-        bytes32[] calldata priceIds
+        PythStructs.PriceFeed[] memory priceFeeds
     ) external;
 }
 

--- a/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
@@ -16,12 +16,30 @@ interface IPulseConsumer {
 
 interface IPulse is PulseEvents {
     // Core functions
+    /**
+     * @notice Requests price updates with a callback
+     * @dev The msg.value must cover both the Pyth fee and gas costs
+     * Note: The actual gas required for execution will be 1.5x the callbackGasLimit
+     * to account for cross-contract call overhead + some gas for some other operations in the function before the callback
+     * @param publishTime The minimum publish time for price updates
+     * @param priceIds The price feed IDs to update
+     * @param callbackGasLimit Gas limit for the callback execution
+     * @return sequenceNumber The sequence number assigned to this request
+     */
     function requestPriceUpdatesWithCallback(
         uint256 publishTime,
         bytes32[] calldata priceIds,
         uint256 callbackGasLimit
     ) external payable returns (uint64 sequenceNumber);
 
+    /**
+     * @notice Executes the callback for a price update request
+     * @dev Requires 1.5x the callback gas limit to account for cross-contract call overhead
+     * For example, if callbackGasLimit is 1M, the transaction needs at least 1.5M gas + some gas for some other operations in the function before the callback
+     * @param sequenceNumber The sequence number of the request
+     * @param updateData The raw price update data from Pyth
+     * @param priceIds The price feed IDs to update, must match the request
+     */
     function executeCallback(
         uint64 sequenceNumber,
         bytes[] calldata updateData,

--- a/target_chains/ethereum/contracts/contracts/pulse/Pulse.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/Pulse.sol
@@ -1,0 +1,411 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import "./IPulse.sol";
+import "./PulseState.sol";
+import "./PulseErrors.sol";
+
+contract Pulse is IPulse, ReentrancyGuard, PulseState {
+    using SafeCast for uint256;
+
+    function _initialize(
+        address admin,
+        uint128 pythFeeInWei,
+        address defaultProvider,
+        bool prefillRequestStorage
+    ) internal {
+        require(admin != address(0), "admin is zero address");
+        require(
+            defaultProvider != address(0),
+            "defaultProvider is zero address"
+        );
+
+        _state.admin = admin;
+        _state.pythFeeInWei = pythFeeInWei;
+        _state.accruedPythFeesInWei = 0;
+        _state.defaultProvider = defaultProvider;
+
+        if (prefillRequestStorage) {
+            // Prefill storage slots to make future requests use less gas
+            for (uint8 i = 0; i < NUM_REQUESTS; i++) {
+                Request storage req = _state.requests[i];
+                req.provider = address(1);
+                req.sequenceNumber = 0; // Keep it inactive
+                req.publishTime = 1;
+                // No need to prefill dynamic arrays (priceIds, updateData)
+                req.callbackGasLimit = 1;
+                req.requester = address(1);
+            }
+        }
+    }
+
+    function requestPriceUpdatesWithCallback(
+        address provider,
+        uint256 publishTime,
+        bytes32[] calldata priceIds,
+        bytes[] calldata updateData,
+        uint256 callbackGasLimit
+    )
+        external
+        payable
+        override
+        nonReentrant
+        returns (uint64 requestSequenceNumber)
+    {
+        ProviderInfo storage providerInfo = _state.providers[provider];
+        if (providerInfo.sequenceNumber == 0) revert NoSuchProvider();
+
+        if (
+            providerInfo.maxNumPrices > 0 &&
+            priceIds.length > providerInfo.maxNumPrices
+        ) {
+            revert("Exceeds max number of prices");
+        }
+
+        // Assign sequence number and increment
+        requestSequenceNumber = providerInfo.sequenceNumber++;
+
+        // Verify fee payment
+        uint128 requiredFee = getFee(provider);
+        if (msg.value < requiredFee) revert InsufficientFee();
+
+        // Store request for callback execution
+        Request storage req = allocRequest(provider, requestSequenceNumber);
+        req.provider = provider;
+        req.sequenceNumber = requestSequenceNumber;
+        req.publishTime = publishTime;
+        req.priceIds = priceIds;
+        req.updateData = updateData;
+        req.callbackGasLimit = callbackGasLimit;
+        req.requester = msg.sender;
+
+        // Update fee balances
+        providerInfo.accruedFeesInWei += providerInfo.feeInWei;
+        _state.accruedPythFeesInWei += (msg.value.toUint128() -
+            providerInfo.feeInWei);
+
+        emit PriceUpdateRequested(
+            requestSequenceNumber,
+            provider,
+            publishTime,
+            priceIds,
+            msg.sender
+        );
+    }
+
+    function executeCallback(
+        uint64 sequenceNumber,
+        uint256 publishTime,
+        bytes32[] calldata priceIds,
+        bytes[] calldata updateData,
+        uint256 callbackGasLimit
+    ) external override nonReentrant {
+        Request storage req = findActiveRequest(msg.sender, sequenceNumber);
+
+        // Verify request parameters match
+        require(req.publishTime == publishTime, "Invalid publish time");
+        require(
+            keccak256(abi.encode(req.priceIds)) ==
+                keccak256(abi.encode(priceIds)),
+            "Invalid price IDs"
+        );
+        require(
+            keccak256(abi.encode(req.updateData)) ==
+                keccak256(abi.encode(updateData)),
+            "Invalid update data"
+        );
+        require(
+            req.callbackGasLimit == callbackGasLimit,
+            "Invalid callback gas limit"
+        );
+
+        // Execute callback but don't revert if it fails
+        try
+            IPulseConsumer(req.requester).pulseCallback(
+                sequenceNumber,
+                msg.sender,
+                publishTime,
+                priceIds
+            )
+        {
+            // Callback succeeded
+            emit PriceUpdateExecuted(
+                sequenceNumber,
+                msg.sender,
+                publishTime,
+                priceIds
+            );
+        } catch Error(string memory reason) {
+            // Explicit revert/require
+            emit PriceUpdateCallbackFailed(
+                sequenceNumber,
+                msg.sender,
+                publishTime,
+                priceIds,
+                req.requester,
+                reason
+            );
+        } catch {
+            // Out of gas or other low-level errors
+            emit PriceUpdateCallbackFailed(
+                sequenceNumber,
+                msg.sender,
+                publishTime,
+                priceIds,
+                req.requester,
+                "low-level error (possibly out of gas)"
+            );
+        }
+
+        // Clear request regardless of callback success
+        clearRequest(msg.sender, sequenceNumber);
+    }
+
+    function register(uint128 feeInWei, bytes calldata uri) public override {
+        ProviderInfo storage provider = _state.providers[msg.sender];
+
+        provider.feeInWei = feeInWei;
+        provider.uri = uri;
+
+        if (provider.sequenceNumber == 0) {
+            provider.sequenceNumber = 1;
+        }
+
+        emit ProviderRegistered(msg.sender, feeInWei, uri);
+    }
+
+    function setProviderFee(uint128 newFeeInWei) external override {
+        ProviderInfo storage provider = _state.providers[msg.sender];
+        if (provider.sequenceNumber == 0) revert NoSuchProvider();
+
+        uint128 oldFeeInWei = provider.feeInWei;
+        provider.feeInWei = newFeeInWei;
+
+        emit ProviderFeeUpdated(msg.sender, oldFeeInWei, newFeeInWei);
+    }
+
+    function getFee(
+        address provider
+    ) public view override returns (uint128 feeAmount) {
+        feeAmount = _state.providers[provider].feeInWei + _state.pythFeeInWei;
+    }
+
+    function getDefaultProvider()
+        external
+        view
+        override
+        returns (address defaultProvider)
+    {
+        defaultProvider = _state.defaultProvider;
+    }
+
+    // Internal helper functions
+    function findActiveRequest(
+        address provider,
+        uint64 sequenceNumber
+    ) internal view returns (Request storage activeRequest) {
+        activeRequest = findRequest(provider, sequenceNumber);
+        if (
+            !isActive(activeRequest) ||
+            activeRequest.provider != provider ||
+            activeRequest.sequenceNumber != sequenceNumber
+        ) {
+            revert NoSuchRequest();
+        }
+    }
+
+    function findRequest(
+        address provider,
+        uint64 sequenceNumber
+    ) internal view returns (Request storage foundRequest) {
+        (bytes32 key, uint8 shortKey) = requestKey(provider, sequenceNumber);
+        foundRequest = _state.requests[shortKey];
+
+        if (
+            foundRequest.provider == provider &&
+            foundRequest.sequenceNumber == sequenceNumber
+        ) {
+            return foundRequest;
+        } else {
+            foundRequest = _state.requestsOverflow[key];
+        }
+    }
+
+    function clearRequest(address provider, uint64 sequenceNumber) internal {
+        (bytes32 key, uint8 shortKey) = requestKey(provider, sequenceNumber);
+        Request storage req = _state.requests[shortKey];
+
+        if (req.provider == provider && req.sequenceNumber == sequenceNumber) {
+            req.sequenceNumber = 0;
+        } else {
+            delete _state.requestsOverflow[key];
+        }
+    }
+
+    function allocRequest(
+        address provider,
+        uint64 sequenceNumber
+    ) internal returns (Request storage newRequest) {
+        (, uint8 shortKey) = requestKey(provider, sequenceNumber);
+        newRequest = _state.requests[shortKey];
+
+        if (isActive(newRequest)) {
+            (bytes32 reqKey, ) = requestKey(
+                newRequest.provider,
+                newRequest.sequenceNumber
+            );
+            _state.requestsOverflow[reqKey] = newRequest;
+        }
+    }
+
+    function requestKey(
+        address provider,
+        uint64 sequenceNumber
+    ) internal pure returns (bytes32 hashKey, uint8 shortHashKey) {
+        hashKey = keccak256(abi.encodePacked(provider, sequenceNumber));
+        shortHashKey = uint8(hashKey[0] & NUM_REQUESTS_MASK);
+    }
+
+    function isActive(
+        Request storage req
+    ) internal view returns (bool isRequestActive) {
+        isRequestActive = req.sequenceNumber != 0;
+    }
+
+    function withdraw(uint128 amount) public override {
+        ProviderInfo storage providerInfo = _state.providers[msg.sender];
+
+        // Use checks-effects-interactions pattern to prevent reentrancy attacks
+        require(
+            providerInfo.accruedFeesInWei >= amount,
+            "Insufficient balance"
+        );
+        providerInfo.accruedFeesInWei -= amount;
+
+        // Interaction with an external contract or token transfer
+        (bool sent, ) = msg.sender.call{value: amount}("");
+        require(sent, "withdrawal to msg.sender failed");
+
+        emit ProviderWithdrawn(msg.sender, msg.sender, amount);
+    }
+
+    function withdrawAsFeeManager(
+        address provider,
+        uint128 amount
+    ) external override {
+        ProviderInfo storage providerInfo = _state.providers[provider];
+
+        if (providerInfo.sequenceNumber == 0) {
+            revert NoSuchProvider();
+        }
+
+        if (providerInfo.feeManager != msg.sender) {
+            revert Unauthorized();
+        }
+
+        // Use checks-effects-interactions pattern to prevent reentrancy attacks
+        require(
+            providerInfo.accruedFeesInWei >= amount,
+            "Insufficient balance"
+        );
+        providerInfo.accruedFeesInWei -= amount;
+
+        // Interaction with an external contract or token transfer
+        (bool sent, ) = msg.sender.call{value: amount}("");
+        require(sent, "withdrawal to msg.sender failed");
+
+        emit ProviderWithdrawn(provider, msg.sender, amount);
+    }
+
+    function setFeeManager(address manager) external override {
+        ProviderInfo storage provider = _state.providers[msg.sender];
+        if (provider.sequenceNumber == 0) revert NoSuchProvider();
+
+        address oldFeeManager = provider.feeManager;
+        provider.feeManager = manager;
+
+        emit ProviderFeeManagerUpdated(msg.sender, oldFeeManager, manager);
+    }
+
+    function setProviderFeeAsFeeManager(
+        address provider,
+        uint128 newFeeInWei
+    ) external override {
+        ProviderInfo storage providerInfo = _state.providers[provider];
+
+        if (providerInfo.sequenceNumber == 0) {
+            revert NoSuchProvider();
+        }
+
+        if (providerInfo.feeManager != msg.sender) {
+            revert Unauthorized();
+        }
+
+        uint128 oldFeeInWei = providerInfo.feeInWei;
+        providerInfo.feeInWei = newFeeInWei;
+
+        emit ProviderFeeUpdated(provider, oldFeeInWei, newFeeInWei);
+    }
+
+    function getAccruedPythFees()
+        public
+        view
+        override
+        returns (uint128 accruedPythFeesInWei)
+    {
+        accruedPythFeesInWei = _state.accruedPythFeesInWei;
+    }
+
+    function getProviderInfo(
+        address provider
+    ) public view override returns (ProviderInfo memory info) {
+        info = _state.providers[provider];
+    }
+
+    function getAdmin() external view override returns (address adminAddress) {
+        adminAddress = _state.admin;
+    }
+
+    function getPythFeeInWei()
+        external
+        view
+        override
+        returns (uint128 pythFee)
+    {
+        pythFee = _state.pythFeeInWei;
+    }
+
+    function setProviderUri(bytes calldata uri) external override {
+        ProviderInfo storage provider = _state.providers[msg.sender];
+        if (provider.sequenceNumber == 0) revert NoSuchProvider();
+
+        bytes memory oldUri = provider.uri;
+        provider.uri = uri;
+
+        emit ProviderUriUpdated(msg.sender, oldUri, uri);
+    }
+
+    function setMaxNumPrices(uint32 maxNumPrices) external override {
+        ProviderInfo storage provider = _state.providers[msg.sender];
+        if (provider.sequenceNumber == 0) revert NoSuchProvider();
+
+        uint32 oldMaxNumPrices = provider.maxNumPrices;
+        provider.maxNumPrices = maxNumPrices;
+
+        emit ProviderMaxNumPricesUpdated(
+            msg.sender,
+            oldMaxNumPrices,
+            maxNumPrices
+        );
+    }
+
+    function getRequest(
+        address provider,
+        uint64 sequenceNumber
+    ) public view override returns (Request memory req) {
+        req = findRequest(provider, sequenceNumber);
+    }
+}

--- a/target_chains/ethereum/contracts/contracts/pulse/Pulse.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/Pulse.sol
@@ -12,150 +12,58 @@ abstract contract Pulse is IPulse, PulseState {
     function _initialize(
         address admin,
         uint128 pythFeeInWei,
-        address defaultProvider,
         address pythAddress,
         bool prefillRequestStorage
     ) internal {
         require(admin != address(0), "admin is zero address");
-        require(
-            defaultProvider != address(0),
-            "defaultProvider is zero address"
-        );
         require(pythAddress != address(0), "pyth is zero address");
 
         _state.admin = admin;
-        _state.accruedPythFeesInWei = 0;
+        _state.accruedFeesInWei = 0;
         _state.pythFeeInWei = pythFeeInWei;
-        _state.defaultProvider = defaultProvider;
         _state.pyth = pythAddress;
+        _state.currentSequenceNumber = 1;
 
         if (prefillRequestStorage) {
-            // Write some data to every storage slot in the requests array such that new requests
-            // use a more consistent amount of gas.
-            // Note that these requests are not live because their sequenceNumber is 0.
             for (uint8 i = 0; i < NUM_REQUESTS; i++) {
                 Request storage req = _state.requests[i];
-                req.sequenceNumber = 0; // Keep it inactive
+                req.sequenceNumber = 0;
                 req.publishTime = 1;
-                // No need to prefill dynamic arrays (priceIds, updateData)
                 req.callbackGasLimit = 1;
                 req.requester = address(1);
             }
         }
     }
 
-    function register(
-        uint128 feeInWei,
-        uint128 feePerGas,
-        bytes calldata uri
-    ) public override {
-        ProviderInfo storage providerInfo = _state.providers[msg.sender];
-
-        providerInfo.feeInWei = feeInWei;
-        providerInfo.feePerGas = feePerGas;
-        providerInfo.uri = uri;
-        providerInfo.sequenceNumber += 1;
-
-        emit ProviderRegistered(providerInfo);
-    }
-
-    function withdraw(uint128 amount) public override {
-        ProviderInfo storage providerInfo = _state.providers[msg.sender];
-
-        // Use checks-effects-interactions pattern to prevent reentrancy attacks.
-        require(
-            providerInfo.accruedFeesInWei >= amount,
-            "Insufficient balance"
-        );
-        providerInfo.accruedFeesInWei -= amount;
-
-        // Interaction with an external contract or token transfer
-        (bool sent, ) = msg.sender.call{value: amount}("");
-        require(sent, "withdrawal to msg.sender failed");
-
-        emit ProviderWithdrawn(msg.sender, msg.sender, amount);
-    }
-
-    function withdrawAsFeeManager(
-        address provider,
-        uint128 amount
-    ) external override {
-        ProviderInfo storage providerInfo = _state.providers[provider];
-
-        if (providerInfo.sequenceNumber == 0) {
-            revert NoSuchProvider();
-        }
-
-        if (providerInfo.feeManager != msg.sender) {
-            revert Unauthorized();
-        }
-
-        // Use checks-effects-interactions pattern to prevent reentrancy attacks.
-        require(
-            providerInfo.accruedFeesInWei >= amount,
-            "Insufficient balance"
-        );
-        providerInfo.accruedFeesInWei -= amount;
-
-        // Interaction with an external contract or token transfer
-        (bool sent, ) = msg.sender.call{value: amount}("");
-        require(sent, "withdrawal to msg.sender failed");
-
-        emit ProviderWithdrawn(provider, msg.sender, amount);
-    }
-
     function requestPriceUpdatesWithCallback(
-        address provider,
         uint256 publishTime,
         bytes32[] calldata priceIds,
         uint256 callbackGasLimit
     ) external payable override returns (uint64 requestSequenceNumber) {
-        ProviderInfo storage providerInfo = _state.providers[provider];
-        if (providerInfo.sequenceNumber == 0) revert NoSuchProvider();
+        requestSequenceNumber = _state.currentSequenceNumber++;
 
-        if (
-            providerInfo.maxNumPrices > 0 &&
-            priceIds.length > providerInfo.maxNumPrices
-        ) {
-            revert ExceedsMaxPrices(
-                uint32(priceIds.length),
-                providerInfo.maxNumPrices
-            );
-        }
-
-        // Assign sequence number and increment
-        requestSequenceNumber = providerInfo.sequenceNumber++;
-
-        // Verify fee payment
-        uint128 requiredFee = getFee(provider, callbackGasLimit);
+        uint128 requiredFee = getFee(callbackGasLimit);
         if (msg.value < requiredFee) revert InsufficientFee();
 
-        // Store request for callback execution
-        Request storage req = allocRequest(provider, requestSequenceNumber);
-        req.provider = provider;
+        Request storage req = allocRequest(requestSequenceNumber);
         req.sequenceNumber = requestSequenceNumber;
         req.publishTime = publishTime;
         req.priceIds = priceIds;
         req.callbackGasLimit = callbackGasLimit;
         req.requester = msg.sender;
 
-        // Update fee balances
-        providerInfo.accruedFeesInWei += providerInfo.feeInWei;
-        _state.accruedPythFeesInWei +=
-            SafeCast.toUint128(msg.value) -
-            providerInfo.feeInWei;
+        _state.accruedFeesInWei += SafeCast.toUint128(msg.value);
 
         emit PriceUpdateRequested(req);
     }
 
     function executeCallback(
-        address provider,
         uint64 sequenceNumber,
         bytes32[] calldata priceIds,
         bytes[] calldata updateData,
         uint256 callbackGasLimit
     ) external payable override {
-        Request storage req = findActiveRequest(provider, sequenceNumber);
+        Request storage req = findActiveRequest(sequenceNumber);
 
         if (
             keccak256(abi.encode(req.priceIds)) !=
@@ -190,13 +98,7 @@ abstract contract Pulse is IPulse, PulseState {
             )
         {
             // Callback succeeded
-            emitPriceUpdate(
-                sequenceNumber,
-                msg.sender,
-                publishTime,
-                priceIds,
-                priceFeeds
-            );
+            emitPriceUpdate(sequenceNumber, publishTime, priceIds, priceFeeds);
         } catch Error(string memory reason) {
             // Explicit revert/require
             emit PriceUpdateCallbackFailed(
@@ -219,13 +121,11 @@ abstract contract Pulse is IPulse, PulseState {
             );
         }
 
-        // Clear request regardless of callback success
-        clearRequest(msg.sender, sequenceNumber);
+        clearRequest(sequenceNumber);
     }
 
     function emitPriceUpdate(
         uint64 sequenceNumber,
-        address provider,
         uint256 publishTime,
         bytes32[] memory priceIds,
         PythStructs.PriceFeed[] memory priceFeeds
@@ -244,7 +144,7 @@ abstract contract Pulse is IPulse, PulseState {
 
         emit PriceUpdateExecuted(
             sequenceNumber,
-            provider,
+            msg.sender,
             publishTime,
             priceIds,
             prices,
@@ -254,37 +154,12 @@ abstract contract Pulse is IPulse, PulseState {
         );
     }
 
-    function getProviderInfo(
-        address provider
-    ) public view override returns (ProviderInfo memory info) {
-        info = _state.providers[provider];
-    }
-
-    function getDefaultProvider()
-        public
-        view
-        override
-        returns (address provider)
-    {
-        provider = _state.defaultProvider;
-    }
-
-    function getRequest(
-        address provider,
-        uint64 sequenceNumber
-    ) public view override returns (Request memory req) {
-        req = findRequest(provider, sequenceNumber);
-    }
-
     function getFee(
-        address provider,
         uint256 callbackGasLimit
     ) public view override returns (uint128 feeAmount) {
-        ProviderInfo storage providerInfo = _state.providers[provider];
-        feeAmount =
-            providerInfo.feeInWei +
-            (providerInfo.feePerGas * uint128(callbackGasLimit)) +
-            _state.pythFeeInWei;
+        uint128 baseFee = _state.pythFeeInWei;
+        uint256 gasFee = callbackGasLimit * tx.gasprice;
+        feeAmount = baseFee + SafeCast.toUint128(gasFee);
     }
 
     function getPythFeeInWei()
@@ -296,167 +171,105 @@ abstract contract Pulse is IPulse, PulseState {
         pythFeeInWei = _state.pythFeeInWei;
     }
 
-    function getAccruedPythFees()
+    function getAccruedFees()
         public
         view
         override
-        returns (uint128 accruedPythFeesInWei)
+        returns (uint128 accruedFeesInWei)
     {
-        accruedPythFeesInWei = _state.accruedPythFeesInWei;
+        accruedFeesInWei = _state.accruedFeesInWei;
     }
 
-    // Set provider fee. It will revert if provider is not registered.
-    function setProviderFee(uint128 newFeeInWei) external override {
-        ProviderInfo storage provider = _state.providers[msg.sender];
-
-        if (provider.sequenceNumber == 0) {
-            revert NoSuchProvider();
-        }
-        uint128 oldFeeInWei = provider.feeInWei;
-        provider.feeInWei = newFeeInWei;
-        emit ProviderFeeUpdated(msg.sender, oldFeeInWei, newFeeInWei);
-    }
-
-    function setProviderFeeAsFeeManager(
-        address provider,
-        uint128 newFeeInWei
-    ) external override {
-        ProviderInfo storage providerInfo = _state.providers[provider];
-
-        if (providerInfo.sequenceNumber == 0) {
-            revert NoSuchProvider();
-        }
-
-        if (providerInfo.feeManager != msg.sender) {
-            revert Unauthorized();
-        }
-
-        uint128 oldFeeInWei = providerInfo.feeInWei;
-        providerInfo.feeInWei = newFeeInWei;
-
-        emit ProviderFeeUpdated(provider, oldFeeInWei, newFeeInWei);
-    }
-
-    // Set provider uri. It will revert if provider is not registered.
-    function setProviderUri(bytes calldata newUri) external override {
-        ProviderInfo storage provider = _state.providers[msg.sender];
-        if (provider.sequenceNumber == 0) {
-            revert NoSuchProvider();
-        }
-        bytes memory oldUri = provider.uri;
-        provider.uri = newUri;
-        emit ProviderUriUpdated(msg.sender, oldUri, newUri);
-    }
-
-    function setFeeManager(address manager) external override {
-        ProviderInfo storage provider = _state.providers[msg.sender];
-        if (provider.sequenceNumber == 0) {
-            revert NoSuchProvider();
-        }
-
-        address oldFeeManager = provider.feeManager;
-        provider.feeManager = manager;
-        emit ProviderFeeManagerUpdated(msg.sender, oldFeeManager, manager);
+    function getRequest(
+        uint64 sequenceNumber
+    ) public view override returns (Request memory req) {
+        req = findRequest(sequenceNumber);
     }
 
     function requestKey(
-        address provider,
         uint64 sequenceNumber
     ) internal pure returns (bytes32 hash, uint8 shortHash) {
-        hash = keccak256(abi.encodePacked(provider, sequenceNumber));
+        hash = keccak256(abi.encodePacked(sequenceNumber));
         shortHash = uint8(hash[0] & NUM_REQUESTS_MASK);
     }
 
-    // Find an in-flight active request for given the provider and the sequence number.
-    // This method returns a reference to the request, and will revert if the request is
-    // not active.
-    function findActiveRequest(
-        address provider,
-        uint64 sequenceNumber
-    ) internal view returns (Request storage req) {
-        req = findRequest(provider, sequenceNumber);
+    function withdrawFees(uint128 amount) external {
+        require(msg.sender == _state.admin, "Only admin can withdraw fees");
+        require(_state.accruedFeesInWei >= amount, "Insufficient balance");
 
-        // Check there is an active request for the given provider and sequence number.
-        if (
-            !isActive(req) ||
-            req.provider != provider ||
-            req.sequenceNumber != sequenceNumber
-        ) revert NoSuchRequest();
+        _state.accruedFeesInWei -= amount;
+
+        (bool sent, ) = msg.sender.call{value: amount}("");
+        require(sent, "Failed to send fees");
+
+        emit FeesWithdrawn(msg.sender, amount);
     }
 
-    // Find an in-flight request.
-    // Note that this method can return requests that are not currently active. The caller is responsible for checking
-    // that the returned request is active (if they care).
-    function findRequest(
-        address provider,
+    function findActiveRequest(
         uint64 sequenceNumber
     ) internal view returns (Request storage req) {
-        (bytes32 key, uint8 shortKey) = requestKey(provider, sequenceNumber);
+        req = findRequest(sequenceNumber);
+
+        if (!isActive(req) || req.sequenceNumber != sequenceNumber)
+            revert NoSuchRequest();
+    }
+
+    function findRequest(
+        uint64 sequenceNumber
+    ) internal view returns (Request storage req) {
+        (bytes32 key, uint8 shortKey) = requestKey(sequenceNumber);
 
         req = _state.requests[shortKey];
-        if (req.provider == provider && req.sequenceNumber == sequenceNumber) {
+        if (req.sequenceNumber == sequenceNumber) {
             return req;
         } else {
             req = _state.requestsOverflow[key];
         }
     }
 
-    // Clear the storage for an in-flight request, deleting it from the hash table.
-    function clearRequest(address provider, uint64 sequenceNumber) internal {
-        (bytes32 key, uint8 shortKey) = requestKey(provider, sequenceNumber);
+    function clearRequest(uint64 sequenceNumber) internal {
+        (bytes32 key, uint8 shortKey) = requestKey(sequenceNumber);
 
         Request storage req = _state.requests[shortKey];
-        if (req.provider == provider && req.sequenceNumber == sequenceNumber) {
+        if (req.sequenceNumber == sequenceNumber) {
             req.sequenceNumber = 0;
         } else {
             delete _state.requestsOverflow[key];
         }
     }
 
-    // Allocate storage space for a new in-flight request. This method returns a pointer to a storage slot
-    // that the caller should overwrite with the new request. Note that the memory at this storage slot may
-    // -- and will -- be filled with arbitrary values, so the caller *must* overwrite every field of the returned
-    // struct.
     function allocRequest(
-        address provider,
         uint64 sequenceNumber
     ) internal returns (Request storage req) {
-        (, uint8 shortKey) = requestKey(provider, sequenceNumber);
+        (, uint8 shortKey) = requestKey(sequenceNumber);
 
         req = _state.requests[shortKey];
         if (isActive(req)) {
-            // There's already a prior active request in the storage slot we want to use.
-            // Overflow the prior request to the requestsOverflow mapping.
-            // It is important that this code overflows the *prior* request to the mapping, and not the new request.
-            // There is a chance that some requests never get revealed and remain active forever. We do not want such
-            // requests to fill up all of the space in the array and cause all new requests to incur the higher gas cost
-            // of the mapping.
-            //
-            // This operation is expensive, but should be rare. If overflow happens frequently, increase
-            // the size of the requests array to support more concurrent active requests.
-            (bytes32 reqKey, ) = requestKey(req.provider, req.sequenceNumber);
+            (bytes32 reqKey, ) = requestKey(req.sequenceNumber);
             _state.requestsOverflow[reqKey] = req;
         }
     }
 
-    // Returns true if a request is active, i.e., its corresponding price update has not yet been executed.
     function isActive(Request storage req) internal view returns (bool) {
-        // Note that a provider's initial registration occupies sequence number 0, so there is no way to construct
-        // a price update request with sequence number 0.
         return req.sequenceNumber != 0;
     }
 
-    function setMaxNumPrices(uint32 maxNumPrices) external override {
-        ProviderInfo storage provider = _state.providers[msg.sender];
-        if (provider.sequenceNumber == 0) revert NoSuchProvider();
+    function setFeeManager(address manager) external override {
+        require(msg.sender == _state.admin, "Only admin can set fee manager");
+        address oldFeeManager = _state.feeManager;
+        _state.feeManager = manager;
+        emit FeeManagerUpdated(_state.admin, oldFeeManager, manager);
+    }
 
-        uint32 oldMaxNumPrices = provider.maxNumPrices;
-        provider.maxNumPrices = maxNumPrices;
+    function withdrawAsFeeManager(uint128 amount) external override {
+        require(msg.sender == _state.feeManager, "Only fee manager");
+        require(_state.accruedFeesInWei >= amount, "Insufficient balance");
 
-        emit ProviderMaxNumPricesUpdated(
-            msg.sender,
-            oldMaxNumPrices,
-            maxNumPrices
-        );
+        _state.accruedFeesInWei -= amount;
+
+        (bool sent, ) = msg.sender.call{value: amount}("");
+        require(sent, "Failed to send fees");
+
+        emit FeesWithdrawn(msg.sender, amount);
     }
 }

--- a/target_chains/ethereum/contracts/contracts/pulse/Pulse.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/Pulse.sol
@@ -40,6 +40,7 @@ abstract contract Pulse is IPulse, PulseState {
         bytes32[] calldata priceIds,
         uint256 callbackGasLimit
     ) external payable override returns (uint64 requestSequenceNumber) {
+        require(publishTime <= block.timestamp + 60, "Too far in future");
         requestSequenceNumber = _state.currentSequenceNumber++;
 
         uint128 requiredFee = getFee(callbackGasLimit);

--- a/target_chains/ethereum/contracts/contracts/pulse/Pulse.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/Pulse.sol
@@ -55,7 +55,7 @@ abstract contract Pulse is IPulse, PulseState {
 
         _state.accruedFeesInWei += SafeCast.toUint128(msg.value);
 
-        emit PriceUpdateRequested(req);
+        emit PriceUpdateRequested(req, priceIds);
     }
 
     function executeCallback(

--- a/target_chains/ethereum/contracts/contracts/pulse/Pulse.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/Pulse.sol
@@ -81,8 +81,8 @@ abstract contract Pulse is IPulse, PulseState {
                 SafeCast.toUint64(req.publishTime)
             );
 
-        // Check if enough gas remains for the callback
-        if (gasleft() < req.callbackGasLimit) {
+        // Check if enough gas remains for the callback plus 50% overhead for cross-contract call (uses integer arithmetic to avoid floating point)
+        if (gasleft() < (req.callbackGasLimit * 3) / 2) {
             revert InsufficientGas();
         }
 

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseErrors.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseErrors.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+error NoSuchProvider();
+error NoSuchRequest();
+error InsufficientFee();
+error Unauthorized();
+error InvalidCallbackGas();
+error CallbackFailed();

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseErrors.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseErrors.sol
@@ -8,6 +8,7 @@ error InsufficientFee();
 error Unauthorized();
 error InvalidCallbackGas();
 error CallbackFailed();
-error InvalidPriceIds(bytes32[] requested, bytes32[] stored);
+error InvalidPriceIds(bytes32 providedPriceIdsHash, bytes32 storedPriceIdsHash);
 error InvalidCallbackGasLimit(uint256 requested, uint256 stored);
 error ExceedsMaxPrices(uint32 requested, uint32 maxAllowed);
+error InsufficientGas();

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseErrors.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseErrors.sol
@@ -8,3 +8,6 @@ error InsufficientFee();
 error Unauthorized();
 error InvalidCallbackGas();
 error CallbackFailed();
+error InvalidPriceIds(bytes32[] requested, bytes32[] stored);
+error InvalidCallbackGasLimit(uint256 requested, uint256 stored);
+error ExceedsMaxPrices(uint32 requested, uint32 maxAllowed);

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseErrors.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseErrors.sol
@@ -12,3 +12,4 @@ error InvalidPriceIds(bytes32 providedPriceIdsHash, bytes32 storedPriceIdsHash);
 error InvalidCallbackGasLimit(uint256 requested, uint256 stored);
 error ExceedsMaxPrices(uint32 requested, uint32 maxAllowed);
 error InsufficientGas();
+error TooManyPriceIds(uint256 provided, uint256 maximum);

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseEvents.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseEvents.sol
@@ -13,7 +13,11 @@ interface PulseEvents {
         uint64 indexed sequenceNumber,
         address indexed provider,
         uint256 publishTime,
-        bytes32[] priceIds
+        bytes32[] priceIds,
+        int64[] prices,
+        uint64[] conf,
+        int32[] expos,
+        uint256[] publishTimes
     );
 
     event ProviderFeeUpdated(

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseEvents.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseEvents.sol
@@ -9,7 +9,6 @@ interface PulseEvents {
     event PriceUpdateExecuted(
         uint64 indexed sequenceNumber,
         address indexed updater,
-        uint256 publishTime,
         bytes32[] priceIds,
         int64[] prices,
         uint64[] conf,
@@ -22,7 +21,6 @@ interface PulseEvents {
     event PriceUpdateCallbackFailed(
         uint64 indexed sequenceNumber,
         address indexed updater,
-        uint256 publishTime,
         bytes32[] priceIds,
         address requester,
         string reason

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseEvents.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseEvents.sol
@@ -4,14 +4,11 @@ pragma solidity ^0.8.0;
 import "./PulseState.sol";
 
 interface PulseEvents {
-    // Events
-    event ProviderRegistered(PulseState.ProviderInfo providerInfo);
-
     event PriceUpdateRequested(PulseState.Request request);
 
     event PriceUpdateExecuted(
         uint64 indexed sequenceNumber,
-        address indexed provider,
+        address indexed updater,
         uint256 publishTime,
         bytes32[] priceIds,
         int64[] prices,
@@ -20,42 +17,20 @@ interface PulseEvents {
         uint256[] publishTimes
     );
 
-    event ProviderFeeUpdated(
-        address indexed provider,
-        uint128 oldFeeInWei,
-        uint128 newFeeInWei
-    );
-
-    event ProviderUriUpdated(
-        address indexed provider,
-        bytes oldUri,
-        bytes newUri
-    );
-
-    event ProviderWithdrawn(
-        address indexed provider,
-        address indexed recipient,
-        uint128 amount
-    );
-
-    event ProviderFeeManagerUpdated(
-        address indexed provider,
-        address oldFeeManager,
-        address newFeeManager
-    );
-
-    event ProviderMaxNumPricesUpdated(
-        address indexed provider,
-        uint32 oldMaxNumPrices,
-        uint32 maxNumPrices
-    );
+    event FeesWithdrawn(address indexed recipient, uint128 amount);
 
     event PriceUpdateCallbackFailed(
         uint64 indexed sequenceNumber,
-        address indexed provider,
+        address indexed updater,
         uint256 publishTime,
         bytes32[] priceIds,
         address requester,
         string reason
+    );
+
+    event FeeManagerUpdated(
+        address indexed admin,
+        address oldFeeManager,
+        address newFeeManager
     );
 }

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseEvents.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseEvents.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "./PulseState.sol";
+
+interface PulseEvents {
+    // Events
+    event ProviderRegistered(PulseState.ProviderInfo providerInfo);
+
+    event PriceUpdateRequested(PulseState.Request request);
+
+    event PriceUpdateExecuted(
+        uint64 indexed sequenceNumber,
+        address indexed provider,
+        uint256 publishTime,
+        bytes32[] priceIds
+    );
+
+    event ProviderFeeUpdated(
+        address indexed provider,
+        uint128 oldFeeInWei,
+        uint128 newFeeInWei
+    );
+
+    event ProviderUriUpdated(
+        address indexed provider,
+        bytes oldUri,
+        bytes newUri
+    );
+
+    event ProviderWithdrawn(
+        address indexed provider,
+        address indexed recipient,
+        uint128 amount
+    );
+
+    event ProviderFeeManagerUpdated(
+        address indexed provider,
+        address oldFeeManager,
+        address newFeeManager
+    );
+
+    event ProviderMaxNumPricesUpdated(
+        address indexed provider,
+        uint32 oldMaxNumPrices,
+        uint32 maxNumPrices
+    );
+
+    event PriceUpdateCallbackFailed(
+        uint64 indexed sequenceNumber,
+        address indexed provider,
+        uint256 publishTime,
+        bytes32[] priceIds,
+        address requester,
+        string reason
+    );
+}

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseEvents.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseEvents.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import "./PulseState.sol";
 
 interface PulseEvents {
-    event PriceUpdateRequested(PulseState.Request request);
+    event PriceUpdateRequested(PulseState.Request request, bytes32[] priceIds);
 
     event PriceUpdateExecuted(
         uint64 indexed sequenceNumber,

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
@@ -7,7 +7,6 @@ contract PulseState {
     bytes1 public constant NUM_REQUESTS_MASK = 0x1f;
 
     struct Request {
-        address provider;
         uint64 sequenceNumber;
         uint256 publishTime;
         bytes32[] priceIds;
@@ -15,25 +14,15 @@ contract PulseState {
         address requester;
     }
 
-    struct ProviderInfo {
-        uint64 sequenceNumber;
-        uint128 feeInWei;
-        uint128 accruedFeesInWei;
-        bytes uri;
-        address feeManager;
-        uint32 maxNumPrices;
-        uint128 feePerGas;
-    }
-
     struct State {
         address admin;
         uint128 pythFeeInWei;
-        uint128 accruedPythFeesInWei;
-        address defaultProvider;
+        uint128 accruedFeesInWei;
         address pyth;
+        uint64 currentSequenceNumber;
+        address feeManager;
         Request[32] requests;
         mapping(bytes32 => Request) requestsOverflow;
-        mapping(address => ProviderInfo) providers;
     }
 
     State internal _state;

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
@@ -11,7 +11,6 @@ contract PulseState {
         uint64 sequenceNumber;
         uint256 publishTime;
         bytes32[] priceIds;
-        bytes[] updateData;
         uint256 callbackGasLimit;
         address requester;
     }
@@ -23,6 +22,7 @@ contract PulseState {
         bytes uri;
         address feeManager;
         uint32 maxNumPrices;
+        uint128 feePerGas;
     }
 
     struct State {
@@ -30,6 +30,7 @@ contract PulseState {
         uint128 pythFeeInWei;
         uint128 accruedPythFeesInWei;
         address defaultProvider;
+        address pyth;
         Request[32] requests;
         mapping(bytes32 => Request) requestsOverflow;
         mapping(address => ProviderInfo) providers;

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+contract PulseState {
+    uint8 public constant NUM_REQUESTS = 32;
+    bytes1 public constant NUM_REQUESTS_MASK = 0x1f;
+
+    struct Request {
+        address provider;
+        uint64 sequenceNumber;
+        uint256 publishTime;
+        bytes32[] priceIds;
+        bytes[] updateData;
+        uint256 callbackGasLimit;
+        address requester;
+    }
+
+    struct ProviderInfo {
+        uint64 sequenceNumber;
+        uint128 feeInWei;
+        uint128 accruedFeesInWei;
+        bytes uri;
+        address feeManager;
+        uint32 maxNumPrices;
+    }
+
+    struct State {
+        address admin;
+        uint128 pythFeeInWei;
+        uint128 accruedPythFeesInWei;
+        address defaultProvider;
+        Request[32] requests;
+        mapping(bytes32 => Request) requestsOverflow;
+        mapping(address => ProviderInfo) providers;
+    }
+
+    State internal _state;
+}

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
@@ -9,7 +9,7 @@ contract PulseState {
     struct Request {
         uint64 sequenceNumber;
         uint256 publishTime;
-        bytes32[] priceIds;
+        bytes32 priceIdsHash;
         uint256 callbackGasLimit;
         address requester;
     }

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
@@ -5,6 +5,8 @@ pragma solidity ^0.8.0;
 contract PulseState {
     uint8 public constant NUM_REQUESTS = 32;
     bytes1 public constant NUM_REQUESTS_MASK = 0x1f;
+    // Maximum number of price feeds per request. This limit keeps gas costs predictable and reasonable. 10 is a reasonable number for most use cases.
+    // Requests with more than 10 price feeds should be split into multiple requests
     uint8 public constant MAX_PRICE_IDS = 10;
 
     struct Request {
@@ -23,7 +25,7 @@ contract PulseState {
         address pyth;
         uint64 currentSequenceNumber;
         address feeManager;
-        Request[32] requests;
+        Request[NUM_REQUESTS] requests;
         mapping(bytes32 => Request) requestsOverflow;
     }
 

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
@@ -5,11 +5,13 @@ pragma solidity ^0.8.0;
 contract PulseState {
     uint8 public constant NUM_REQUESTS = 32;
     bytes1 public constant NUM_REQUESTS_MASK = 0x1f;
+    uint8 public constant MAX_PRICE_IDS = 10;
 
     struct Request {
         uint64 sequenceNumber;
         uint256 publishTime;
-        bytes32 priceIdsHash;
+        bytes32[MAX_PRICE_IDS] priceIds;
+        uint8 numPriceIds; // Actual number of price IDs used
         uint256 callbackGasLimit;
         address requester;
     }

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseUpgradeable.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseUpgradeable.sol
@@ -23,6 +23,7 @@ contract PulseUpgradeable is
         address admin,
         uint128 pythFeeInWei,
         address defaultProvider,
+        address pythAddress,
         bool prefillRequestStorage
     ) public initializer {
         require(owner != address(0), "owner is zero address");
@@ -34,6 +35,7 @@ contract PulseUpgradeable is
             admin,
             pythFeeInWei,
             defaultProvider,
+            pythAddress,
             prefillRequestStorage
         );
 

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseUpgradeable.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseUpgradeable.sol
@@ -22,11 +22,11 @@ contract PulseUpgradeable is
         address owner,
         address admin,
         uint128 pythFeeInWei,
-        address defaultProvider,
         address pythAddress,
         bool prefillRequestStorage
     ) public initializer {
         require(owner != address(0), "owner is zero address");
+        require(admin != address(0), "admin is zero address");
 
         __Ownable_init();
         __UUPSUpgradeable_init();
@@ -34,7 +34,6 @@ contract PulseUpgradeable is
         Pulse._initialize(
             admin,
             pythFeeInWei,
-            defaultProvider,
             pythAddress,
             prefillRequestStorage
         );

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseUpgradeable.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseUpgradeable.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import "./Pulse.sol";
+
+contract PulseUpgradeable is
+    Initializable,
+    Ownable2StepUpgradeable,
+    UUPSUpgradeable,
+    Pulse
+{
+    event ContractUpgraded(
+        address oldImplementation,
+        address newImplementation
+    );
+
+    function initialize(
+        address owner,
+        address admin,
+        uint128 pythFeeInWei,
+        address defaultProvider,
+        bool prefillRequestStorage
+    ) public initializer {
+        require(owner != address(0), "owner is zero address");
+
+        __Ownable_init();
+        __UUPSUpgradeable_init();
+
+        Pulse._initialize(
+            admin,
+            pythFeeInWei,
+            defaultProvider,
+            prefillRequestStorage
+        );
+
+        _transferOwnership(owner);
+    }
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() initializer {}
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
+
+    function upgradeTo(address newImplementation) external override onlyProxy {
+        address oldImplementation = _getImplementation();
+        _authorizeUpgrade(newImplementation);
+        _upgradeToAndCallUUPS(newImplementation, new bytes(0), false);
+
+        emit ContractUpgraded(oldImplementation, _getImplementation());
+    }
+
+    function upgradeToAndCall(
+        address newImplementation,
+        bytes memory data
+    ) external payable override onlyProxy {
+        address oldImplementation = _getImplementation();
+        _authorizeUpgrade(newImplementation);
+        _upgradeToAndCallUUPS(newImplementation, data, true);
+
+        emit ContractUpgraded(oldImplementation, _getImplementation());
+    }
+
+    function version() public pure returns (string memory) {
+        return "1.0.0";
+    }
+}

--- a/target_chains/ethereum/contracts/forge-test/Pulse.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pulse.t.sol
@@ -482,4 +482,26 @@ contract PulseTest is Test, PulseEvents {
             managerBalanceBefore + info.accruedFeesInWei
         );
     }
+
+    function testMaxNumPrices() public {
+        // Set max number of prices
+        vm.prank(provider);
+        pulse.setMaxNumPrices(1);
+
+        // Try to request more prices than allowed
+        bytes32[] memory priceIds = new bytes32[](2);
+        priceIds[0] = BTC_PRICE_FEED_ID;
+        priceIds[1] = ETH_PRICE_FEED_ID;
+
+        vm.deal(address(consumer), 1 gwei);
+        vm.prank(address(consumer));
+
+        vm.expectRevert("Exceeds max number of prices");
+        pulse.requestPriceUpdatesWithCallback{value: calculateTotalFee()}(
+            provider,
+            block.timestamp,
+            priceIds,
+            CALLBACK_GAS_LIMIT
+        );
+    }
 }

--- a/target_chains/ethereum/contracts/forge-test/Pulse.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pulse.t.sol
@@ -504,4 +504,14 @@ contract PulseTest is Test, PulseEvents {
             CALLBACK_GAS_LIMIT
         );
     }
+
+    function testSetProviderUri() public {
+        bytes memory newUri = "https://updated-provider.com";
+
+        vm.prank(provider);
+        pulse.setProviderUri(newUri);
+
+        PulseState.ProviderInfo memory info = pulse.getProviderInfo(provider);
+        assertEq(info.uri, newUri);
+    }
 }

--- a/target_chains/ethereum/contracts/forge-test/Pulse.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pulse.t.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "../contracts/pulse/PulseUpgradeable.sol";
 import "../contracts/pulse/IPulse.sol";
 import "../contracts/pulse/PulseState.sol";
+import "../contracts/pulse/PulseEvents.sol";
 
 contract MockPulseConsumer is IPulseConsumer {
     uint64 public lastSequenceNumber;
@@ -27,401 +28,164 @@ contract MockPulseConsumer is IPulseConsumer {
     }
 }
 
-contract PulseTest is Test {
+contract PulseTest is Test, PulseEvents {
     ERC1967Proxy public proxy;
     PulseUpgradeable public pulse;
     MockPulseConsumer public consumer;
     address public owner;
     address public admin;
     address public provider;
-    uint128 constant PYTH_FEE = 0.001 ether;
-    uint128 constant PROVIDER_FEE = 0.002 ether;
+    address public pyth;
+    uint128 constant PYTH_FEE = 1 wei;
+    uint128 constant PROVIDER_FEE = 1 wei;
+    uint128 constant PROVIDER_FEE_PER_GAS = 1 wei;
+    uint128 constant CALLBACK_GAS_LIMIT = 1_000_000;
+    bytes32 constant BTC_PRICE_FEED_ID =
+        0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43;
+    bytes32 constant ETH_PRICE_FEED_ID =
+        0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace;
 
     function setUp() public {
         owner = address(1);
         admin = address(2);
         provider = address(3);
+        pyth = address(4);
 
         PulseUpgradeable _pulse = new PulseUpgradeable();
         proxy = new ERC1967Proxy(address(_pulse), "");
         // wrap in ABI to support easier calls
         pulse = PulseUpgradeable(address(proxy));
 
-        pulse.initialize(owner, admin, PYTH_FEE, provider, false);
+        pulse.initialize(owner, admin, PYTH_FEE, provider, pyth, false);
         consumer = new MockPulseConsumer();
 
         // Register provider
         vm.prank(provider);
-        pulse.register(PROVIDER_FEE, "https://provider.com");
+        pulse.register(
+            PROVIDER_FEE,
+            PROVIDER_FEE_PER_GAS,
+            "https://provider.com"
+        );
     }
 
     function testRequestPriceUpdate() public {
         bytes32[] memory priceIds = new bytes32[](2);
-        priceIds[0] = bytes32("BTC/USD");
-        priceIds[1] = bytes32("ETH/USD");
-
-        bytes[] memory updateData = new bytes[](2);
-        updateData[0] = bytes("data1");
-        updateData[1] = bytes("data2");
+        priceIds[0] = BTC_PRICE_FEED_ID;
+        priceIds[1] = ETH_PRICE_FEED_ID;
 
         uint256 publishTime = block.timestamp;
-        uint256 callbackGasLimit = 500000;
 
         // Fund the consumer contract
-        vm.deal(address(consumer), 1 ether);
+        vm.deal(address(consumer), 1 gwei);
 
         vm.prank(address(consumer));
-        uint64 sequenceNumber = pulse.requestPriceUpdatesWithCallback{
-            value: PYTH_FEE + PROVIDER_FEE
-        }(provider, publishTime, priceIds, callbackGasLimit);
 
-        assertEq(sequenceNumber, 1);
+        // Create the event data we expect to see
+        PulseState.Request memory expectedRequest = PulseState.Request({
+            provider: provider,
+            sequenceNumber: 1,
+            publishTime: publishTime,
+            priceIds: priceIds,
+            callbackGasLimit: CALLBACK_GAS_LIMIT,
+            requester: address(consumer)
+        });
+
+        // Emit event with expected parameters
+        vm.expectEmit();
+        emit PriceUpdateRequested(expectedRequest);
+
+        // Calculate total fee including gas component
+        uint128 totalFee = PYTH_FEE +
+            PROVIDER_FEE +
+            (PROVIDER_FEE_PER_GAS * uint128(CALLBACK_GAS_LIMIT));
+
+        // Make the actual call that should emit the event
+        pulse.requestPriceUpdatesWithCallback{value: totalFee}(
+            provider,
+            publishTime,
+            priceIds,
+            CALLBACK_GAS_LIMIT
+        );
+
+        // Additional assertions to verify event data was stored correctly
+        PulseState.Request memory lastRequest = pulse.getRequest(provider, 1);
+        assertEq(lastRequest.provider, expectedRequest.provider);
+        assertEq(lastRequest.sequenceNumber, expectedRequest.sequenceNumber);
+        assertEq(lastRequest.publishTime, expectedRequest.publishTime);
+        assertEq(
+            lastRequest.callbackGasLimit,
+            expectedRequest.callbackGasLimit
+        );
+        assertEq(lastRequest.requester, expectedRequest.requester);
     }
 
     function testExecuteCallback() public {
         bytes32[] memory priceIds = new bytes32[](2);
-        priceIds[0] = bytes32("BTC/USD");
-        priceIds[1] = bytes32("ETH/USD");
+        priceIds[0] = BTC_PRICE_FEED_ID;
+        priceIds[1] = ETH_PRICE_FEED_ID;
 
         uint256 publishTime = block.timestamp;
-        uint256 callbackGasLimit = 500000;
 
         // Fund the consumer contract
-        vm.deal(address(consumer), 1 ether);
+        vm.deal(address(consumer), 1 gwei);
 
         // Step 1: Make the request as consumer
         vm.prank(address(consumer));
+
+        // Calculate total fee including gas component
+        uint128 totalFee = PYTH_FEE +
+            PROVIDER_FEE +
+            (PROVIDER_FEE_PER_GAS * uint128(CALLBACK_GAS_LIMIT));
+
         uint64 sequenceNumber = pulse.requestPriceUpdatesWithCallback{
-            value: PYTH_FEE + PROVIDER_FEE
-        }(provider, publishTime, priceIds, callbackGasLimit);
+            value: totalFee
+        }(provider, publishTime, priceIds, CALLBACK_GAS_LIMIT);
 
-        // Step 2: Execute callback as provider with empty updateData array
-        // Important: must be empty array, not array with empty elements
-        bytes[] memory updateData = new bytes[](0);
+        // Step 2: Create mock price feeds that match the expected publish time
+        PythStructs.PriceFeed[] memory priceFeeds = new PythStructs.PriceFeed[](
+            2
+        );
 
+        // Create mock price feed for BTC
+        priceFeeds[0].price.publishTime = publishTime;
+        priceFeeds[0].id = BTC_PRICE_FEED_ID;
+
+        // Create mock price feed for ETH
+        priceFeeds[1].price.publishTime = publishTime;
+        priceFeeds[1].id = ETH_PRICE_FEED_ID;
+
+        // Mock Pyth's parsePriceFeedUpdates to return our price feeds
+        vm.mockCall(
+            address(pyth),
+            abi.encodeWithSelector(IPyth.parsePriceFeedUpdates.selector),
+            abi.encode(priceFeeds)
+        );
+
+        // Mock Pyth's updatePriceFeeds
+        vm.mockCall(
+            address(pyth),
+            abi.encodeWithSelector(IPyth.updatePriceFeeds.selector),
+            abi.encode()
+        );
+
+        // Create mock update data
+        bytes[] memory updateData = new bytes[](2);
+        updateData[0] = abi.encode(priceFeeds[0]);
+        updateData[1] = abi.encode(priceFeeds[1]);
+
+        // Execute callback as provider
         vm.prank(provider);
         pulse.executeCallback(
+            provider,
             sequenceNumber,
-            publishTime,
             priceIds,
             updateData,
-            callbackGasLimit
+            CALLBACK_GAS_LIMIT
         );
 
         // Verify callback was executed
         assertEq(consumer.lastSequenceNumber(), sequenceNumber);
         assertEq(consumer.lastProvider(), provider);
         assertEq(consumer.lastPublishTime(), publishTime);
-    }
-
-    function testProviderRegistration() public {
-        address newProvider = address(4);
-        vm.prank(newProvider);
-        pulse.register(PROVIDER_FEE, "https://newprovider.com");
-
-        uint128 fee = pulse.getFee(newProvider);
-        assertEq(fee, PYTH_FEE + PROVIDER_FEE);
-    }
-
-    function testUpdateProviderFee() public {
-        uint128 newFee = 0.003 ether;
-        vm.prank(provider);
-        pulse.setProviderFee(newFee);
-
-        uint128 fee = pulse.getFee(provider);
-        assertEq(fee, PYTH_FEE + newFee);
-    }
-
-    function testFailInsufficientFee() public {
-        bytes32[] memory priceIds = new bytes32[](1);
-
-        vm.prank(address(consumer));
-        pulse.requestPriceUpdatesWithCallback{value: PYTH_FEE}( // Not paying provider fee
-            provider,
-            block.timestamp,
-            priceIds,
-            500000
-        );
-    }
-
-    function testFailUnregisteredProvider() public {
-        bytes32[] memory priceIds = new bytes32[](1);
-
-        vm.prank(address(consumer));
-        pulse.requestPriceUpdatesWithCallback{value: PYTH_FEE + PROVIDER_FEE}(
-            address(99), // Unregistered provider
-            block.timestamp,
-            priceIds,
-            500000
-        );
-    }
-
-    function testGasCostsWithPrefill() public {
-        // Deploy implementation and proxy with prefill
-        pulse = new PulseUpgradeable();
-        bytes memory initData = abi.encodeWithSelector(
-            PulseUpgradeable.initialize.selector,
-            owner,
-            admin,
-            PYTH_FEE,
-            provider,
-            true
-        );
-        proxy = new ERC1967Proxy(address(pulse), initData);
-        PulseUpgradeable pulseWithPrefill = PulseUpgradeable(address(proxy));
-
-        // Register provider
-        vm.prank(provider);
-        pulseWithPrefill.register(PROVIDER_FEE, "https://provider.com");
-
-        // Measure gas for first request
-        uint256 gasBefore = gasleft();
-        makeRequest(address(pulseWithPrefill));
-        uint256 gasUsed = gasBefore - gasleft();
-
-        // Should be lower due to prefill
-        assertLt(gasUsed, 130000);
-    }
-
-    function testGasCostsWithoutPrefill() public {
-        // Deploy implementation and proxy without prefill
-        pulse = new PulseUpgradeable();
-        bytes memory initData = abi.encodeWithSelector(
-            PulseUpgradeable.initialize.selector,
-            owner,
-            admin,
-            PYTH_FEE,
-            provider,
-            false
-        );
-        proxy = new ERC1967Proxy(address(pulse), initData);
-        PulseUpgradeable pulseWithoutPrefill = PulseUpgradeable(address(proxy));
-
-        // Register provider
-        vm.prank(provider);
-        pulseWithoutPrefill.register(PROVIDER_FEE, "https://provider.com");
-
-        // Measure gas for first request
-        uint256 gasBefore = gasleft();
-        makeRequest(address(pulseWithoutPrefill));
-        uint256 gasUsed = gasBefore - gasleft();
-
-        // Should be higher without prefill
-        assertGt(gasUsed, 130000);
-    }
-
-    function makeRequest(address pulseAddress) internal {
-        // Helper to make a standard request
-        bytes32[] memory priceIds = new bytes32[](1);
-        IPulse(pulseAddress).requestPriceUpdatesWithCallback{
-            value: PYTH_FEE + PROVIDER_FEE
-        }(provider, block.timestamp, priceIds, 500000);
-    }
-
-    function testWithdraw() public {
-        // Setup - make a request to accrue some fees
-        bytes32[] memory priceIds = new bytes32[](1);
-
-        vm.deal(address(consumer), 1 ether);
-        vm.prank(address(consumer));
-        pulse.requestPriceUpdatesWithCallback{value: PYTH_FEE + PROVIDER_FEE}(
-            provider,
-            block.timestamp,
-            priceIds,
-            500000
-        );
-
-        // Check provider balance before withdrawal
-        uint256 providerBalanceBefore = address(provider).balance;
-
-        // Provider withdraws fees
-        vm.prank(provider);
-        pulse.withdraw(PROVIDER_FEE);
-
-        // Verify balance increased
-        assertEq(
-            address(provider).balance,
-            providerBalanceBefore + PROVIDER_FEE
-        );
-    }
-
-    function testFailWithdrawTooMuch() public {
-        vm.prank(provider);
-        pulse.withdraw(1 ether); // Try to withdraw more than accrued
-    }
-
-    function testFailWithdrawUnregistered() public {
-        vm.prank(address(99)); // Unregistered provider
-        pulse.withdraw(1 ether);
-    }
-
-    function testWithdrawAsFeeManager() public {
-        // Setup fee manager
-        vm.prank(provider);
-        pulse.setFeeManager(address(99));
-
-        // Setup fees
-        bytes32[] memory priceIds = new bytes32[](1);
-
-        vm.deal(address(consumer), 1 ether);
-        vm.prank(address(consumer));
-        pulse.requestPriceUpdatesWithCallback{value: PYTH_FEE + PROVIDER_FEE}(
-            provider,
-            block.timestamp,
-            priceIds,
-            500000
-        );
-
-        // Check fee manager balance before withdrawal
-        uint256 managerBalanceBefore = address(99).balance;
-
-        // Fee manager withdraws
-        vm.prank(address(99));
-        pulse.withdrawAsFeeManager(provider, PROVIDER_FEE);
-
-        // Verify balance increased
-        assertEq(address(99).balance, managerBalanceBefore + PROVIDER_FEE);
-    }
-
-    function testFailWithdrawAsFeeManagerUnauthorized() public {
-        vm.prank(address(88)); // Not the fee manager
-        pulse.withdrawAsFeeManager(provider, PROVIDER_FEE);
-    }
-
-    function testSetProviderFeeAsFeeManager() public {
-        // Setup fee manager
-        vm.prank(provider);
-        pulse.setFeeManager(address(99));
-
-        uint128 newFee = 0.005 ether;
-
-        // Fee manager updates fee
-        vm.prank(address(99));
-        pulse.setProviderFeeAsFeeManager(provider, newFee);
-
-        // Verify fee was updated
-        uint128 fee = pulse.getFee(provider);
-        assertEq(fee, PYTH_FEE + newFee);
-    }
-
-    function testFailSetProviderFeeAsFeeManagerUnauthorized() public {
-        vm.prank(address(88)); // Not the fee manager
-        pulse.setProviderFeeAsFeeManager(provider, 0.005 ether);
-    }
-
-    function testGetAccruedPythFees() public {
-        // Setup - make a request to accrue some fees
-        bytes32[] memory priceIds = new bytes32[](1);
-
-        // Fund the consumer contract
-        vm.deal(address(consumer), 1 ether);
-
-        vm.prank(address(consumer));
-        pulse.requestPriceUpdatesWithCallback{value: PYTH_FEE + PROVIDER_FEE}(
-            provider,
-            block.timestamp,
-            priceIds,
-            500000
-        );
-
-        // Verify accrued fees
-        assertEq(pulse.getAccruedPythFees(), PYTH_FEE);
-    }
-
-    function testGetProviderInfo() public {
-        // Get provider info
-        PulseState.ProviderInfo memory info = pulse.getProviderInfo(provider);
-
-        // Verify initial values
-        assertEq(info.sequenceNumber, 1); // Set during registration
-        assertEq(info.feeInWei, PROVIDER_FEE);
-        assertEq(info.accruedFeesInWei, 0);
-        assertEq(string(info.uri), "https://provider.com");
-        assertEq(info.feeManager, address(0));
-        assertEq(info.maxNumPrices, 0);
-    }
-
-    function testGetPythFeeInWei() public {
-        assertEq(pulse.getPythFeeInWei(), PYTH_FEE);
-    }
-
-    function testSetProviderUri() public {
-        bytes memory newUri = bytes("https://new-provider-endpoint.com");
-
-        vm.prank(provider);
-        pulse.setProviderUri(newUri);
-
-        // Get provider info and verify URI was updated
-        PulseState.ProviderInfo memory providerInfo = pulse.getProviderInfo(
-            provider
-        );
-        assertEq(string(providerInfo.uri), string(newUri));
-    }
-
-    function testFailSetProviderUriUnregistered() public {
-        vm.prank(address(99)); // Unregistered provider
-        pulse.setProviderUri(bytes("https://new-uri.com"));
-    }
-
-    function testSetMaxNumPrices() public {
-        uint32 maxPrices = 5;
-
-        vm.prank(provider);
-        pulse.setMaxNumPrices(maxPrices);
-
-        // Get provider info and verify maxNumPrices was updated
-        PulseState.ProviderInfo memory providerInfo = pulse.getProviderInfo(
-            provider
-        );
-        assertEq(uint256(maxPrices), uint256(providerInfo.maxNumPrices));
-    }
-
-    function testFailExceedMaxNumPrices() public {
-        // Set max prices to 2
-        vm.prank(provider);
-        pulse.setMaxNumPrices(2);
-
-        // Try to request 3 prices
-        bytes32[] memory priceIds = new bytes32[](3);
-
-        vm.prank(address(consumer));
-        pulse.requestPriceUpdatesWithCallback{value: PYTH_FEE + PROVIDER_FEE}(
-            provider,
-            block.timestamp,
-            priceIds,
-            500000
-        );
-    }
-
-    function testGetRequest() public {
-        // Setup - make a request
-        bytes32[] memory priceIds = new bytes32[](2);
-        priceIds[0] = bytes32("BTC/USD");
-        priceIds[1] = bytes32("ETH/USD");
-
-        uint256 publishTime = block.timestamp;
-        uint256 callbackGasLimit = 500000;
-
-        // Fund the consumer contract
-        vm.deal(address(consumer), 1 ether);
-
-        vm.prank(address(consumer));
-        uint64 sequenceNumber = pulse.requestPriceUpdatesWithCallback{
-            value: PYTH_FEE + PROVIDER_FEE
-        }(provider, publishTime, priceIds, callbackGasLimit);
-
-        // Get request and verify
-        PulseState.Request memory req = pulse.getRequest(
-            provider,
-            sequenceNumber
-        );
-
-        assertEq(req.provider, provider);
-        assertEq(req.sequenceNumber, sequenceNumber);
-        assertEq(req.publishTime, publishTime);
-        assertEq(req.priceIds[0], priceIds[0]);
-        assertEq(req.priceIds[1], priceIds[1]);
-        assertEq(req.callbackGasLimit, callbackGasLimit);
-        assertEq(req.requester, address(consumer));
     }
 }

--- a/target_chains/ethereum/contracts/forge-test/Pulse.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pulse.t.sol
@@ -328,7 +328,7 @@ contract PulseTest is Test {
         assertEq(pulse.getAccruedPythFees(), PYTH_FEE);
     }
 
-    function testGetProviderInfo() public view {
+    function testGetProviderInfo() public {
         // Get provider info
         PulseState.ProviderInfo memory info = pulse.getProviderInfo(provider);
 
@@ -341,7 +341,7 @@ contract PulseTest is Test {
         assertEq(info.maxNumPrices, 0);
     }
 
-    function testGetPythFeeInWei() public view {
+    function testGetPythFeeInWei() public {
         assertEq(pulse.getPythFeeInWei(), PYTH_FEE);
     }
 

--- a/target_chains/ethereum/contracts/forge-test/Pulse.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pulse.t.sol
@@ -1,0 +1,401 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "../contracts/pulse/PulseUpgradeable.sol";
+import "../contracts/pulse/IPulse.sol";
+import "../contracts/pulse/PulseState.sol";
+
+contract MockPulseConsumer is IPulseConsumer {
+    uint64 public lastSequenceNumber;
+    address public lastProvider;
+    uint256 public lastPublishTime;
+    bytes32[] public lastPriceIds;
+
+    function pulseCallback(
+        uint64 sequenceNumber,
+        address provider,
+        uint256 publishTime,
+        bytes32[] calldata priceIds
+    ) external override {
+        lastSequenceNumber = sequenceNumber;
+        lastProvider = provider;
+        lastPublishTime = publishTime;
+        lastPriceIds = priceIds;
+    }
+}
+
+contract PulseTest is Test {
+    PulseUpgradeable public pulse;
+    MockPulseConsumer public consumer;
+    address public owner;
+    address public admin;
+    address public provider;
+    uint128 constant PYTH_FEE = 0.001 ether;
+    uint128 constant PROVIDER_FEE = 0.002 ether;
+
+    function setUp() public {
+        owner = address(1);
+        admin = address(2);
+        provider = address(3);
+
+        // Deploy contracts
+        pulse = new PulseUpgradeable();
+        pulse.initialize(owner, admin, PYTH_FEE, provider);
+        consumer = new MockPulseConsumer();
+
+        // Register provider
+        vm.prank(provider);
+        pulse.register(PROVIDER_FEE, "https://provider.com");
+    }
+
+    function testRequestPriceUpdate() public {
+        bytes32[] memory priceIds = new bytes32[](2);
+        priceIds[0] = bytes32("BTC/USD");
+        priceIds[1] = bytes32("ETH/USD");
+
+        bytes[] memory updateData = new bytes[](2);
+        updateData[0] = bytes("data1");
+        updateData[1] = bytes("data2");
+
+        uint256 publishTime = block.timestamp;
+        uint256 callbackGasLimit = 500000;
+
+        vm.prank(address(consumer));
+        uint64 sequenceNumber = pulse.requestPriceUpdatesWithCallback{
+            value: PYTH_FEE + PROVIDER_FEE
+        }(provider, publishTime, priceIds, updateData, callbackGasLimit);
+
+        assertEq(sequenceNumber, 1);
+    }
+
+    function testExecuteCallback() public {
+        bytes32[] memory priceIds = new bytes32[](2);
+        priceIds[0] = bytes32("BTC/USD");
+        priceIds[1] = bytes32("ETH/USD");
+
+        bytes[] memory updateData = new bytes[](2);
+        updateData[0] = bytes("data1");
+        updateData[1] = bytes("data2");
+
+        uint256 publishTime = block.timestamp;
+        uint256 callbackGasLimit = 500000;
+
+        vm.prank(address(consumer));
+        uint64 sequenceNumber = pulse.requestPriceUpdatesWithCallback{
+            value: PYTH_FEE + PROVIDER_FEE
+        }(provider, publishTime, priceIds, updateData, callbackGasLimit);
+
+        vm.prank(provider);
+        pulse.executeCallback(
+            sequenceNumber,
+            publishTime,
+            priceIds,
+            updateData,
+            callbackGasLimit
+        );
+
+        assertEq(consumer.lastSequenceNumber(), sequenceNumber);
+        assertEq(consumer.lastProvider(), provider);
+        assertEq(consumer.lastPublishTime(), publishTime);
+        assertEq(consumer.lastPriceIds()[0], priceIds[0]);
+        assertEq(consumer.lastPriceIds()[1], priceIds[1]);
+    }
+
+    function testProviderRegistration() public {
+        address newProvider = address(4);
+        vm.prank(newProvider);
+        pulse.register(PROVIDER_FEE, "https://newprovider.com");
+
+        uint128 fee = pulse.getFee(newProvider);
+        assertEq(fee, PYTH_FEE + PROVIDER_FEE);
+    }
+
+    function testUpdateProviderFee() public {
+        uint128 newFee = 0.003 ether;
+        vm.prank(provider);
+        pulse.setProviderFee(newFee);
+
+        uint128 fee = pulse.getFee(provider);
+        assertEq(fee, PYTH_FEE + newFee);
+    }
+
+    function testFailInsufficientFee() public {
+        bytes32[] memory priceIds = new bytes32[](1);
+        bytes[] memory updateData = new bytes[](1);
+
+        vm.prank(address(consumer));
+        pulse.requestPriceUpdatesWithCallback{value: PYTH_FEE}( // Not paying provider fee
+            provider,
+            block.timestamp,
+            priceIds,
+            updateData,
+            500000
+        );
+    }
+
+    function testFailUnregisteredProvider() public {
+        bytes32[] memory priceIds = new bytes32[](1);
+        bytes[] memory updateData = new bytes[](1);
+
+        vm.prank(address(consumer));
+        pulse.requestPriceUpdatesWithCallback{value: PYTH_FEE + PROVIDER_FEE}(
+            address(99), // Unregistered provider
+            block.timestamp,
+            priceIds,
+            updateData,
+            500000
+        );
+    }
+
+    function testGasCostsWithPrefill() public {
+        // Deploy with prefill
+        PulseUpgradeable pulseWithPrefill = new PulseUpgradeable();
+        pulseWithPrefill.initialize(owner, admin, PYTH_FEE, provider, true);
+
+        // Measure gas for first request
+        uint256 gasBefore = gasleft();
+        makeRequest(address(pulseWithPrefill));
+        uint256 gasUsed = gasBefore - gasleft();
+
+        // Should be lower due to prefill
+        assertLt(gasUsed, 30000);
+    }
+
+    function testGasCostsWithoutPrefill() public {
+        // Deploy without prefill
+        PulseUpgradeable pulseWithoutPrefill = new PulseUpgradeable();
+        pulseWithoutPrefill.initialize(owner, admin, PYTH_FEE, provider, false);
+
+        // Measure gas for first request
+        uint256 gasBefore = gasleft();
+        makeRequest(address(pulseWithoutPrefill));
+        uint256 gasUsed = gasBefore - gasleft();
+
+        // Should be higher without prefill
+        assertGt(gasUsed, 35000);
+    }
+
+    function makeRequest(address pulseAddress) internal {
+        // Helper to make a standard request
+        bytes32[] memory priceIds = new bytes32[](1);
+        bytes[] memory updateData = new bytes[](1);
+        IPulse(pulseAddress).requestPriceUpdatesWithCallback{
+            value: PYTH_FEE + PROVIDER_FEE
+        }(provider, block.timestamp, priceIds, updateData, 500000);
+    }
+
+    function testWithdraw() public {
+        // Setup - make a request to accrue some fees
+        bytes32[] memory priceIds = new bytes32[](1);
+        bytes[] memory updateData = new bytes[](1);
+
+        vm.prank(address(consumer));
+        pulse.requestPriceUpdatesWithCallback{value: PYTH_FEE + PROVIDER_FEE}(
+            provider,
+            block.timestamp,
+            priceIds,
+            updateData,
+            500000
+        );
+
+        // Check provider balance before withdrawal
+        uint256 providerBalanceBefore = address(provider).balance;
+
+        // Provider withdraws fees
+        vm.prank(provider);
+        pulse.withdraw(PROVIDER_FEE);
+
+        // Verify balance increased
+        assertEq(
+            address(provider).balance,
+            providerBalanceBefore + PROVIDER_FEE
+        );
+    }
+
+    function testFailWithdrawTooMuch() public {
+        vm.prank(provider);
+        pulse.withdraw(1 ether); // Try to withdraw more than accrued
+    }
+
+    function testFailWithdrawUnregistered() public {
+        vm.prank(address(99)); // Unregistered provider
+        pulse.withdraw(1 ether);
+    }
+
+    function testWithdrawAsFeeManager() public {
+        // Setup fee manager
+        vm.prank(provider);
+        pulse.setFeeManager(address(99));
+
+        // Setup fees
+        bytes32[] memory priceIds = new bytes32[](1);
+        bytes[] memory updateData = new bytes[](1);
+
+        vm.prank(address(consumer));
+        pulse.requestPriceUpdatesWithCallback{value: PYTH_FEE + PROVIDER_FEE}(
+            provider,
+            block.timestamp,
+            priceIds,
+            updateData,
+            500000
+        );
+
+        // Check fee manager balance before withdrawal
+        uint256 managerBalanceBefore = address(99).balance;
+
+        // Fee manager withdraws
+        vm.prank(address(99));
+        pulse.withdrawAsFeeManager(provider, PROVIDER_FEE);
+
+        // Verify balance increased
+        assertEq(address(99).balance, managerBalanceBefore + PROVIDER_FEE);
+    }
+
+    function testFailWithdrawAsFeeManagerUnauthorized() public {
+        vm.prank(address(88)); // Not the fee manager
+        pulse.withdrawAsFeeManager(provider, PROVIDER_FEE);
+    }
+
+    function testSetProviderFeeAsFeeManager() public {
+        // Setup fee manager
+        vm.prank(provider);
+        pulse.setFeeManager(address(99));
+
+        uint128 newFee = 0.005 ether;
+
+        // Fee manager updates fee
+        vm.prank(address(99));
+        pulse.setProviderFeeAsFeeManager(provider, newFee);
+
+        // Verify fee was updated
+        uint128 fee = pulse.getFee(provider);
+        assertEq(fee, PYTH_FEE + newFee);
+    }
+
+    function testFailSetProviderFeeAsFeeManagerUnauthorized() public {
+        vm.prank(address(88)); // Not the fee manager
+        pulse.setProviderFeeAsFeeManager(provider, 0.005 ether);
+    }
+
+    function testGetAccruedPythFees() public {
+        // Setup - make a request to accrue some fees
+        bytes32[] memory priceIds = new bytes32[](1);
+        bytes[] memory updateData = new bytes[](1);
+
+        vm.prank(address(consumer));
+        pulse.requestPriceUpdatesWithCallback{value: PYTH_FEE + PROVIDER_FEE}(
+            provider,
+            block.timestamp,
+            priceIds,
+            updateData,
+            500000
+        );
+
+        // Verify accrued fees
+        assertEq(pulse.getAccruedPythFees(), PYTH_FEE);
+    }
+
+    function testGetProviderInfo() public {
+        // Get provider info
+        PulseState.ProviderInfo memory info = pulse.getProviderInfo(provider);
+
+        // Verify initial values
+        assertEq(info.sequenceNumber, 1); // Set during registration
+        assertEq(info.feeInWei, PROVIDER_FEE);
+        assertEq(info.accruedFeesInWei, 0);
+        assertEq(string(info.uri), "https://provider.com");
+        assertEq(info.feeManager, address(0));
+        assertEq(info.maxNumPrices, 0);
+    }
+
+    function testGetAdmin() public {
+        assertEq(pulse.getAdmin(), admin);
+    }
+
+    function testGetPythFeeInWei() public {
+        assertEq(pulse.getPythFeeInWei(), PYTH_FEE);
+    }
+
+    function testSetProviderUri() public {
+        bytes memory newUri = bytes("https://new-provider-endpoint.com");
+
+        vm.prank(provider);
+        pulse.setProviderUri(newUri);
+
+        // Get provider info and verify URI was updated
+        (, , , bytes memory uri, ) = pulse.getProviderInfo(provider);
+        assertEq(string(uri), string(newUri));
+    }
+
+    function testFailSetProviderUriUnregistered() public {
+        vm.prank(address(99)); // Unregistered provider
+        pulse.setProviderUri(bytes("https://new-uri.com"));
+    }
+
+    function testSetMaxNumPrices() public {
+        uint32 maxPrices = 5;
+
+        vm.prank(provider);
+        pulse.setMaxNumPrices(maxPrices);
+
+        // Get provider info and verify maxNumPrices was updated
+        (, , , , address feeManager) = pulse.getProviderInfo(provider);
+        assertEq(uint256(maxPrices), uint256(maxPrices));
+    }
+
+    function testFailExceedMaxNumPrices() public {
+        // Set max prices to 2
+        vm.prank(provider);
+        pulse.setMaxNumPrices(2);
+
+        // Try to request 3 prices
+        bytes32[] memory priceIds = new bytes32[](3);
+        bytes[] memory updateData = new bytes[](3);
+
+        vm.prank(address(consumer));
+        pulse.requestPriceUpdatesWithCallback{value: PYTH_FEE + PROVIDER_FEE}(
+            provider,
+            block.timestamp,
+            priceIds,
+            updateData,
+            500000
+        );
+    }
+
+    function testGetRequest() public {
+        // Setup - make a request
+        bytes32[] memory priceIds = new bytes32[](2);
+        priceIds[0] = bytes32("BTC/USD");
+        priceIds[1] = bytes32("ETH/USD");
+
+        bytes[] memory updateData = new bytes[](2);
+        updateData[0] = bytes("data1");
+        updateData[1] = bytes("data2");
+
+        uint256 publishTime = block.timestamp;
+        uint256 callbackGasLimit = 500000;
+
+        vm.prank(address(consumer));
+        uint64 sequenceNumber = pulse.requestPriceUpdatesWithCallback{
+            value: PYTH_FEE + PROVIDER_FEE
+        }(provider, publishTime, priceIds, updateData, callbackGasLimit);
+
+        // Get request and verify
+        PulseState.Request memory req = pulse.getRequest(
+            provider,
+            sequenceNumber
+        );
+
+        assertEq(req.provider, provider);
+        assertEq(req.sequenceNumber, sequenceNumber);
+        assertEq(req.publishTime, publishTime);
+        assertEq(req.priceIds[0], priceIds[0]);
+        assertEq(req.priceIds[1], priceIds[1]);
+        assertEq(string(req.updateData[0]), string(updateData[0]));
+        assertEq(string(req.updateData[1]), string(updateData[1]));
+        assertEq(req.callbackGasLimit, callbackGasLimit);
+        assertEq(req.requester, address(consumer));
+    }
+}

--- a/target_chains/ethereum/contracts/forge-test/Pulse.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pulse.t.sol
@@ -401,7 +401,7 @@ contract PulseTest is Test, PulseEvents {
     function testExecuteCallbackWithFutureTimestamp() public {
         // Setup request with future timestamp
         bytes32[] memory priceIds = createPriceIds();
-        uint256 futureTime = block.timestamp + 1 days;
+        uint256 futureTime = block.timestamp + 10; // 10 seconds in future
         vm.deal(address(consumer), 1 gwei);
 
         uint128 totalFee = calculateTotalFee();
@@ -432,6 +432,22 @@ contract PulseTest is Test, PulseEvents {
                 priceFeeds[i].price.publishTime
             );
         }
+    }
+
+    function testRevertOnTooFarFutureTimestamp() public {
+        bytes32[] memory priceIds = createPriceIds();
+        uint256 farFutureTime = block.timestamp + 61; // Just over 1 minute
+        vm.deal(address(consumer), 1 gwei);
+
+        uint128 totalFee = calculateTotalFee();
+        vm.prank(address(consumer));
+
+        vm.expectRevert("Too far in future");
+        pulse.requestPriceUpdatesWithCallback{value: totalFee}(
+            farFutureTime,
+            priceIds,
+            CALLBACK_GAS_LIMIT
+        );
     }
 
     function testDoubleExecuteCallback() public {

--- a/target_chains/ethereum/contracts/forge-test/Pulse.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pulse.t.sol
@@ -202,7 +202,7 @@ contract PulseTest is Test, PulseEvents {
         });
 
         vm.expectEmit();
-        emit PriceUpdateRequested(expectedRequest);
+        emit PriceUpdateRequested(expectedRequest, priceIds);
 
         vm.prank(address(consumer));
         pulse.requestPriceUpdatesWithCallback{value: totalFee}(


### PR DESCRIPTION
- **add initial contracts**
- **refactor**
- **fix**
- **fix test**
- **fix test**
- **fix**
- **fix**
- **add more tests**
- **add test for getFee**
- **add testWithdraw**
- **add testSetAndWithdrawAssFeeManager**
- **add testMaxNumPrices**
- **add testSetProviderUri**
- **add more test**
- **add testExecuteCallbackWithFutureTimestamp**
- **update tests**
- **remove provider**
- **address comments**
- **address comments**
- **prevent requests 60 mins in the future that could exploit gas price difference**
- **fix test**
- **add priceIds to PriceUpdateRequested event**
- **add 50% overhead to gas for cross-contract calls**
- **feat: add test for executing callback with gas overhead**
- **feat: add docs for requestPriceUpdatesWithCallback and executeCallback functions to IPulse interface**
- **fix: use fixed-length array for priceIds in req**
- **add test**
- **address comments**
- **bump pyth-sdk-solana to v0.10.3**
