### PR TITLE
chore(apps/hermes): bump pyth-sdk-solana to v0.10.3

### DIFF
--- a/apps/hermes/server/Cargo.lock
+++ b/apps/hermes/server/Cargo.lock
@@ -1868,7 +1868,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/hermes/server/Cargo.lock
+++ b/apps/hermes/server/Cargo.lock
@@ -3214,9 +3214,9 @@ dependencies = [
 
 [[package]]
 name = "pyth-sdk-solana"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9301b3c3db3766fd1dd0c5769a706d886265b3f56772ac279365bdd807d3076"
+checksum = "65841f3d9d5a025ca32999463f720ba16da2dfe9ffe5b668b2e26dd4239dfa9e"
 dependencies = [
  "borsh 0.10.3",
  "borsh-derive 0.10.3",

--- a/apps/hermes/server/Cargo.toml
+++ b/apps/hermes/server/Cargo.toml
@@ -30,7 +30,7 @@ nonzero_ext        = { version = "0.3.0" }
 prometheus-client  = { version = "0.21.2" }
 prost              = { version = "0.12.1" }
 pyth-sdk           = { version = "0.8.0" }
-pyth-sdk-solana    = { version = "0.10.2" }
+pyth-sdk-solana    = "0.10.3"
 pythnet-sdk        = { path = "../../../pythnet/pythnet_sdk/", version = "2.0.0", features = ["strum"] }
 rand               = { version = "0.8.5" }
 reqwest            = { version = "0.11.14", features = ["blocking", "json"] }

--- a/apps/hermes/server/Cargo.toml
+++ b/apps/hermes/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "hermes"
-version     = "0.8.1"
+version     = "0.8.2"
 description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
 edition     = "2021"
 

--- a/apps/hermes/server/Cargo.toml
+++ b/apps/hermes/server/Cargo.toml
@@ -30,7 +30,7 @@ nonzero_ext        = { version = "0.3.0" }
 prometheus-client  = { version = "0.21.2" }
 prost              = { version = "0.12.1" }
 pyth-sdk           = { version = "0.8.0" }
-pyth-sdk-solana    = "0.10.3"
+pyth-sdk-solana    = { version = "0.10.3" }
 pythnet-sdk        = { path = "../../../pythnet/pythnet_sdk/", version = "2.0.0", features = ["strum"] }
 rand               = { version = "0.8.5" }
 reqwest            = { version = "0.11.14", features = ["blocking", "json"] }


### PR DESCRIPTION
this fixes the `v2/price_feeds` endpoint not returning the full list of supported assets as the old version of `pyth-sdk-solana` was hardcoded at 640 price feeds max