### PR TITLE
feat(pyth-lazer-protocol): add pub error type

### DIFF
--- a/lazer/Cargo.lock
+++ b/lazer/Cargo.lock
@@ -3698,7 +3698,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-protocol"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-primitives",
  "anyhow",

--- a/lazer/sdk/rust/protocol/Cargo.toml
+++ b/lazer/sdk/rust/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-protocol"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Pyth Lazer SDK - protocol types."
 license = "Apache-2.0"

--- a/lazer/sdk/rust/protocol/src/publisher.rs
+++ b/lazer/sdk/rust/protocol/src/publisher.rs
@@ -4,6 +4,7 @@
 
 use {
     super::router::{Price, PriceFeedId, TimestampUs},
+    derive_more::derive::From,
     serde::{Deserialize, Serialize},
 };
 
@@ -30,6 +31,21 @@ pub struct PriceFeedData {
     /// `None` if no value is currently available.
     #[serde(with = "crate::serde_price_as_i64")]
     pub best_ask_price: Option<Price>,
+}
+
+/// A response sent from the server to the publisher client.
+/// Currently only serde errors are reported back to the client.
+#[derive(Debug, Clone, Serialize, Deserialize, From)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
+pub enum PublisherResponse {
+    UpdateDeserializationError(UpdateDeserializationErrorResponse),
+}
+/// Sent to the publisher if the binary data could not be parsed
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateDeserializationErrorResponse {
+    pub error: String,
 }
 
 #[test]

--- a/lazer/sdk/rust/protocol/src/subscription.rs
+++ b/lazer/sdk/rust/protocol/src/subscription.rs
@@ -67,7 +67,8 @@ pub struct SubscriptionErrorResponse {
     pub error: String,
 }
 
-/// Sent from the server if an error occured while serving data for an existing subscription.
+/// Sent from the server if an internal error occured while serving data for an existing subscription,
+/// or a client request sent a bad request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ErrorResponse {


### PR DESCRIPTION
Add a type for Lazer publisher errors. This will let us gracefully return an error if they send us a malformed binary update rather than just drop the websocket.