### PR TITLE
refactor(pyth-lazer-protocol): rename PublisherResponse -> ServerResponse

### DIFF
--- a/lazer/Cargo.lock
+++ b/lazer/Cargo.lock
@@ -3698,7 +3698,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-protocol"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "alloy-primitives",
  "anyhow",

--- a/lazer/sdk/rust/protocol/Cargo.toml
+++ b/lazer/sdk/rust/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-protocol"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "Pyth Lazer SDK - protocol types."
 license = "Apache-2.0"

--- a/lazer/sdk/rust/protocol/src/publisher.rs
+++ b/lazer/sdk/rust/protocol/src/publisher.rs
@@ -38,7 +38,7 @@ pub struct PriceFeedData {
 #[derive(Debug, Clone, Serialize, Deserialize, From)]
 #[serde(tag = "type")]
 #[serde(rename_all = "camelCase")]
-pub enum PublisherResponse {
+pub enum ServerResponse {
     UpdateDeserializationError(UpdateDeserializationErrorResponse),
 }
 /// Sent to the publisher if the binary data could not be parsed


### PR DESCRIPTION
rename `PublisherResponse` -> `ServerResponse` to better communicate that this is a message generated by the server.