### PR TITLE
chore: downgrade g++ to fix librocksdb-sys build in CI

### DIFF
--- a/.github/workflows/ci-message-buffer-idl.yml
+++ b/.github/workflows/ci-message-buffer-idl.yml
@@ -25,6 +25,8 @@ jobs:
           components: rustfmt, clippy
       - name: Install Solana
         run: |
+          wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
+          sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
           sh -c "$(curl -sSfL https://release.solana.com/v1.14.18/install)"
           echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       - name: Install Anchor

--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -30,6 +30,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install poetry
         run: pipx install poetry
+      - name: Install g++ 12
+        run: |
+          sudo apt-get install g++-12
+          echo "CXX=/usr/bin/g++-12" >> "${GITHUB_ENV}"
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}


### PR DESCRIPTION
The rocksdb version we use in message buffer has a bug that prevents it from building on g++ 13. This PR sets up g++ 12 to fix the build. It also adds a missing libssl1.1 library.