### PR TITLE
fix: use key with sol for simulations

### DIFF
--- a/apps/staking/src/api.ts
+++ b/apps/staking/src/api.ts
@@ -106,7 +106,7 @@ export const loadData = async (
   pythnetClient: PythnetClient,
   hermesClient: HermesClient,
   stakeAccount?: PublicKey | undefined,
-  simulationPayer?: PublicKey | undefined,
+  simulationPayer?: PublicKey,
 ): Promise<Data> =>
   stakeAccount === undefined
     ? loadDataNoStakeAccount(client, pythnetClient, hermesClient)

--- a/apps/staking/src/api.ts
+++ b/apps/staking/src/api.ts
@@ -106,6 +106,7 @@ export const loadData = async (
   pythnetClient: PythnetClient,
   hermesClient: HermesClient,
   stakeAccount?: PublicKey | undefined,
+  simulationPayer?: PublicKey | undefined,
 ): Promise<Data> =>
   stakeAccount === undefined
     ? loadDataNoStakeAccount(client, pythnetClient, hermesClient)
@@ -114,6 +115,7 @@ export const loadData = async (
         pythnetClient,
         hermesClient,
         stakeAccount,
+        simulationPayer,
       );
 
 const loadDataNoStakeAccount = async (
@@ -149,6 +151,7 @@ const loadDataForStakeAccount = async (
   pythnetClient: PythnetClient,
   hermesClient: HermesClient,
   stakeAccount: PublicKey,
+  simulationPayer?: PublicKey,
 ): Promise<Data> => {
   const [
     { publishers, ...baseInfo },
@@ -160,7 +163,7 @@ const loadDataForStakeAccount = async (
     loadBaseInfo(client, pythnetClient, hermesClient),
     client.getStakeAccountCustody(stakeAccount),
     client.getUnlockSchedule(stakeAccount),
-    client.getClaimableRewards(stakeAccount),
+    client.getClaimableRewards(stakeAccount, simulationPayer),
     client.getStakeAccountPositions(stakeAccount),
   ]);
 

--- a/apps/staking/src/components/Root/index.tsx
+++ b/apps/staking/src/components/Root/index.tsx
@@ -83,7 +83,11 @@ const HtmlWithProviders = ({ lang, ...props }: HTMLProps<HTMLHtmlElement>) => (
             walletConnectProjectId={WALLETCONNECT_PROJECT_ID}
             mainnetRpc={MAINNET_RPC}
           >
-            <ApiProvider hermesUrl={HERMES_URL} pythnetRpcUrl={PYTHNET_RPC} simulationPayer={SIMULATION_PAYER}>
+            <ApiProvider
+              hermesUrl={HERMES_URL}
+              pythnetRpcUrl={PYTHNET_RPC}
+              simulationPayer={SIMULATION_PAYER}
+            >
               <ToastProvider>
                 <html lang={lang} {...props} />
               </ToastProvider>

--- a/apps/staking/src/components/Root/index.tsx
+++ b/apps/staking/src/components/Root/index.tsx
@@ -28,7 +28,6 @@ import { MaxWidth } from "../MaxWidth";
 import { ReportAccessibility } from "../ReportAccessibility";
 import { RouterProvider } from "../RouterProvider";
 import { WalletProvider } from "../WalletProvider";
-import { PublicKey } from "@solana/web3.js";
 
 const redHatText = Red_Hat_Text({
   subsets: ["latin"],

--- a/apps/staking/src/components/Root/index.tsx
+++ b/apps/staking/src/components/Root/index.tsx
@@ -14,6 +14,7 @@ import {
   MAINNET_RPC,
   HERMES_URL,
   PYTHNET_RPC,
+  SIMULATION_PAYER,
 } from "../../config/server";
 import { ApiProvider } from "../../hooks/use-api";
 import { LoggerProvider } from "../../hooks/use-logger";
@@ -27,6 +28,7 @@ import { MaxWidth } from "../MaxWidth";
 import { ReportAccessibility } from "../ReportAccessibility";
 import { RouterProvider } from "../RouterProvider";
 import { WalletProvider } from "../WalletProvider";
+import { PublicKey } from "@solana/web3.js";
 
 const redHatText = Red_Hat_Text({
   subsets: ["latin"],
@@ -82,7 +84,7 @@ const HtmlWithProviders = ({ lang, ...props }: HTMLProps<HTMLHtmlElement>) => (
             walletConnectProjectId={WALLETCONNECT_PROJECT_ID}
             mainnetRpc={MAINNET_RPC}
           >
-            <ApiProvider hermesUrl={HERMES_URL} pythnetRpcUrl={PYTHNET_RPC}>
+            <ApiProvider hermesUrl={HERMES_URL} pythnetRpcUrl={PYTHNET_RPC} simulationPayer={SIMULATION_PAYER}>
               <ToastProvider>
                 <html lang={lang} {...props} />
               </ToastProvider>

--- a/apps/staking/src/components/Root/index.tsx
+++ b/apps/staking/src/components/Root/index.tsx
@@ -14,7 +14,7 @@ import {
   MAINNET_RPC,
   HERMES_URL,
   PYTHNET_RPC,
-  SIMULATION_PAYER,
+  SIMULATION_PAYER_ADDRESS,
 } from "../../config/server";
 import { ApiProvider } from "../../hooks/use-api";
 import { LoggerProvider } from "../../hooks/use-logger";
@@ -86,7 +86,7 @@ const HtmlWithProviders = ({ lang, ...props }: HTMLProps<HTMLHtmlElement>) => (
             <ApiProvider
               hermesUrl={HERMES_URL}
               pythnetRpcUrl={PYTHNET_RPC}
-              simulationPayer={SIMULATION_PAYER}
+              simulationPayerAddress={SIMULATION_PAYER_ADDRESS}
             >
               <ToastProvider>
                 <html lang={lang} {...props} />

--- a/apps/staking/src/config/server.ts
+++ b/apps/staking/src/config/server.ts
@@ -76,7 +76,7 @@ export const GOVERNANCE_ONLY_REGIONS = transformOr(
 export const PROXYCHECK_API_KEY = demandInProduction("PROXYCHECK_API_KEY");
 // This needs to be a public key that has SOL in it all the time, it will be used as a payer in the transaction simulation to compute the claimable rewards
 // such simulation fails when the payer has no funds.
-export const SIMULATION_PAYER = process.env.SIMULATION_PAYER;
+export const SIMULATION_PAYER = getOr("SIMULATION_PAYER", "E5KR7yfb9UyVB6ZhmhQki1rM1eBcxHvyGKFZakAC5uc");
 class MissingEnvironmentError extends Error {
   constructor(name: string) {
     super(`Missing environment variable: ${name}!`);

--- a/apps/staking/src/config/server.ts
+++ b/apps/staking/src/config/server.ts
@@ -74,8 +74,8 @@ export const GOVERNANCE_ONLY_REGIONS = transformOr(
   [],
 );
 export const PROXYCHECK_API_KEY = demandInProduction("PROXYCHECK_API_KEY");
-// This needs to be a public key that has SOL in it all the time, it will be used in the simulation to compute the claimable rewards
-// such simulation fails when the payer has no funds
+// This needs to be a public key that has SOL in it all the time, it will be used as a payer in the transaction simulation to compute the claimable rewards
+// such simulation fails when the payer has no funds.
 export const SIMULATION_PAYER = process.env.SIMULATION_PAYER
 class MissingEnvironmentError extends Error {
   constructor(name: string) {

--- a/apps/staking/src/config/server.ts
+++ b/apps/staking/src/config/server.ts
@@ -74,7 +74,9 @@ export const GOVERNANCE_ONLY_REGIONS = transformOr(
   [],
 );
 export const PROXYCHECK_API_KEY = demandInProduction("PROXYCHECK_API_KEY");
-
+// This needs to be a public key that has SOL in it all the time, it will be used in the simulation to compute the claimable rewards
+// such simulation fails when the payer has no funds
+export const SIMULATION_PAYER = process.env.SIMULATION_PAYER
 class MissingEnvironmentError extends Error {
   constructor(name: string) {
     super(`Missing environment variable: ${name}!`);

--- a/apps/staking/src/config/server.ts
+++ b/apps/staking/src/config/server.ts
@@ -76,7 +76,7 @@ export const GOVERNANCE_ONLY_REGIONS = transformOr(
 export const PROXYCHECK_API_KEY = demandInProduction("PROXYCHECK_API_KEY");
 // This needs to be a public key that has SOL in it all the time, it will be used as a payer in the transaction simulation to compute the claimable rewards
 // such simulation fails when the payer has no funds.
-export const SIMULATION_PAYER = getOr("SIMULATION_PAYER", "E5KR7yfb9UyVB6ZhmhQki1rM1eBcxHvyGKFZakAC5uc");
+export const SIMULATION_PAYER_ADDRESS = getOr("SIMULATION_PAYER_ADDRESS", "E5KR7yfb9UyVB6ZhmhQki1rM1eBcxHvyGKFZakAC5uc");
 class MissingEnvironmentError extends Error {
   constructor(name: string) {
     super(`Missing environment variable: ${name}!`);

--- a/apps/staking/src/config/server.ts
+++ b/apps/staking/src/config/server.ts
@@ -76,7 +76,7 @@ export const GOVERNANCE_ONLY_REGIONS = transformOr(
 export const PROXYCHECK_API_KEY = demandInProduction("PROXYCHECK_API_KEY");
 // This needs to be a public key that has SOL in it all the time, it will be used as a payer in the transaction simulation to compute the claimable rewards
 // such simulation fails when the payer has no funds.
-export const SIMULATION_PAYER = process.env.SIMULATION_PAYER
+export const SIMULATION_PAYER = process.env.SIMULATION_PAYER;
 class MissingEnvironmentError extends Error {
   constructor(name: string) {
     super(`Missing environment variable: ${name}!`);

--- a/apps/staking/src/config/server.ts
+++ b/apps/staking/src/config/server.ts
@@ -76,7 +76,10 @@ export const GOVERNANCE_ONLY_REGIONS = transformOr(
 export const PROXYCHECK_API_KEY = demandInProduction("PROXYCHECK_API_KEY");
 // This needs to be a public key that has SOL in it all the time, it will be used as a payer in the transaction simulation to compute the claimable rewards
 // such simulation fails when the payer has no funds.
-export const SIMULATION_PAYER_ADDRESS = getOr("SIMULATION_PAYER_ADDRESS", "E5KR7yfb9UyVB6ZhmhQki1rM1eBcxHvyGKFZakAC5uc");
+export const SIMULATION_PAYER_ADDRESS = getOr(
+  "SIMULATION_PAYER_ADDRESS",
+  "E5KR7yfb9UyVB6ZhmhQki1rM1eBcxHvyGKFZakAC5uc",
+);
 class MissingEnvironmentError extends Error {
   constructor(name: string) {
     super(`Missing environment variable: ${name}!`);

--- a/apps/staking/src/hooks/use-api.tsx
+++ b/apps/staking/src/hooks/use-api.tsx
@@ -96,7 +96,13 @@ const State = {
       dashboardDataCacheKey,
 
       loadData: () =>
-        api.loadData(client, pythnetClient, hermesClient, account, simulationPayer ? new PublicKey(simulationPayer) : undefined),
+        api.loadData(
+          client,
+          pythnetClient,
+          hermesClient,
+          account,
+          simulationPayer ? new PublicKey(simulationPayer) : undefined,
+        ),
 
       claim: bindApi(api.claim),
       deposit: bindApi(api.deposit),
@@ -146,7 +152,11 @@ export const ApiProvider = ({
   return <ApiContext.Provider value={state} {...props} />;
 };
 
-const useApiContext = (hermesUrl: string, pythnetRpcUrl: string, simulationPayer: string | undefined) => {
+const useApiContext = (
+  hermesUrl: string,
+  pythnetRpcUrl: string,
+  simulationPayer: string | undefined,
+) => {
   const wallet = useWallet();
   const { connection } = useConnection();
   const { isMainnet } = useNetwork();

--- a/apps/staking/src/hooks/use-api.tsx
+++ b/apps/staking/src/hooks/use-api.tsx
@@ -65,7 +65,7 @@ const State = {
     pythnetClient: PythnetClient,
     hermesClient: HermesClient,
     account: PublicKey,
-    simulationPayer: string | undefined,
+    simulationPayer: PublicKey,
     allAccounts: [PublicKey, ...PublicKey[]],
     selectAccount: (account: PublicKey) => void,
     mutate: ReturnType<typeof useSWRConfig>["mutate"],
@@ -101,7 +101,7 @@ const State = {
           pythnetClient,
           hermesClient,
           account,
-          simulationPayer ? new PublicKey(simulationPayer) : undefined,
+          simulationPayer,
         ),
 
       claim: bindApi(api.claim),
@@ -138,16 +138,16 @@ type ApiProviderProps = Omit<
 > & {
   pythnetRpcUrl: string;
   hermesUrl: string;
-  simulationPayer: string | undefined;
+  simulationPayerAddress: string;
 };
 
 export const ApiProvider = ({
   hermesUrl,
   pythnetRpcUrl,
-  simulationPayer,
+  simulationPayerAddress,
   ...props
 }: ApiProviderProps) => {
-  const state = useApiContext(hermesUrl, pythnetRpcUrl, simulationPayer);
+  const state = useApiContext(hermesUrl, pythnetRpcUrl, simulationPayerAddress);
 
   return <ApiContext.Provider value={state} {...props} />;
 };
@@ -155,7 +155,7 @@ export const ApiProvider = ({
 const useApiContext = (
   hermesUrl: string,
   pythnetRpcUrl: string,
-  simulationPayer: string | undefined,
+  simulationPayerAddress: string,
 ) => {
   const wallet = useWallet();
   const { connection } = useConnection();
@@ -165,6 +165,10 @@ const useApiContext = (
   const pythnetClient = useMemo(
     () => new PythnetClient(new Connection(pythnetRpcUrl)),
     [pythnetRpcUrl],
+  );
+  const simulationPayer = useMemo(
+    () => new PublicKey(simulationPayerAddress),
+    [simulationPayerAddress],
   );
   const pythStakingClient = useMemo(
     () =>

--- a/governance/pyth_staking_sdk/src/pyth-staking-client.ts
+++ b/governance/pyth_staking_sdk/src/pyth-staking-client.ts
@@ -688,7 +688,7 @@ export class PythStakingClient {
 
   async getAdvanceDelegationRecordInstructions(
     stakeAccountPositions: PublicKey,
-    payer?: PublicKey
+    payer?: PublicKey,
   ) {
     const poolData = await this.getPoolDataAccount();
     const stakeAccountPositionsData = await this.getStakeAccountPositions(
@@ -796,10 +796,13 @@ export class PythStakingClient {
     );
   }
 
-  public async getClaimableRewards(stakeAccountPositions: PublicKey, simulationPayer?: PublicKey) {
+  public async getClaimableRewards(
+    stakeAccountPositions: PublicKey,
+    simulationPayer?: PublicKey,
+  ) {
     const instructions = await this.getAdvanceDelegationRecordInstructions(
       stakeAccountPositions,
-      simulationPayer
+      simulationPayer,
     );
 
     let totalRewards = 0n;


### PR DESCRIPTION
Users that don't have SOL in their wallet can't see their claimable rewards.
I want to fix this by running the simulations with a fixed key that always has SOL, this is possible because claiming rewards for a user is actually permissionsless.