### PR TITLE
fix(pyth-lazer-protocol): deser Channel from String, not &str

### DIFF
--- a/lazer/Cargo.lock
+++ b/lazer/Cargo.lock
@@ -3771,7 +3771,7 @@ dependencies = [
  "futures-util",
  "hex",
  "libsecp256k1 0.7.1",
- "pyth-lazer-protocol 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pyth-lazer-protocol 0.4.1",
  "serde",
  "serde_json",
  "tokio",
@@ -3797,6 +3797,22 @@ dependencies = [
 [[package]]
 name = "pyth-lazer-protocol"
 version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9bbddb1201109b5b5f2d78ecb67ddee69148a4f4feed6935870013b3ac6bbb"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "byteorder",
+ "derive_more",
+ "itertools 0.13.0",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "pyth-lazer-protocol"
+version = "0.4.2"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -3809,22 +3825,6 @@ dependencies = [
  "hex",
  "itertools 0.13.0",
  "libsecp256k1 0.7.1",
- "rust_decimal",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "pyth-lazer-protocol"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c9bbddb1201109b5b5f2d78ecb67ddee69148a4f4feed6935870013b3ac6bbb"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "byteorder",
- "derive_more",
- "itertools 0.13.0",
  "rust_decimal",
  "serde",
  "serde_json",

--- a/lazer/sdk/rust/client/Cargo.toml
+++ b/lazer/sdk/rust/client/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0"
 tracing = "0.1"
 url = "2.4"
 
-[dev_dependencies]
+[dev-dependencies]
 bincode = "1.3.3"
 ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
 hex = "0.4.3"

--- a/lazer/sdk/rust/protocol/Cargo.toml
+++ b/lazer/sdk/rust/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-protocol"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Pyth Lazer SDK - protocol types."
 license = "Apache-2.0"

--- a/lazer/sdk/rust/protocol/src/router.rs
+++ b/lazer/sdk/rust/protocol/src/router.rs
@@ -228,8 +228,8 @@ impl<'de> Deserialize<'de> for Channel {
     where
         D: serde::Deserializer<'de>,
     {
-        let value = <&str>::deserialize(deserializer)?;
-        parse_channel(value).ok_or_else(|| D::Error::custom("unknown channel"))
+        let value = <String>::deserialize(deserializer)?;
+        parse_channel(&value).ok_or_else(|| D::Error::custom("unknown channel"))
     }
 }
 


### PR DESCRIPTION
The current deserializer for the Channel type fails to work with string values loaded from toml by [config](https://crates.io/crates/config) -- the config crate is trying to deserialize an owned `String` but the deserializer expects a borrowed `&str`, causing this error: 
```
invalid type: string "fixed_rate@50ms", expected a borrowed string for key lazer.subscriptions[0]channel" 
```

Fixed by making the deserializer accept both `String` and `&str` (Serde will coerce a `&str` into a `String`).
Also threw in a minor clippy fix (`dev_dependencies` -> `dev-dependencies`).