### PR TITLE
fix: update corepack on js dockerfile

### DIFF
--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -3,6 +3,7 @@ WORKDIR /usr/src/pyth
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN apt-get update && apt-get install -y git python3 make gcc g++ curl && corepack enable
+RUN npm install -g corepack@0.31.0
 COPY ./ .
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 


### PR DESCRIPTION
The existing corepack version in the base node image that we have has some problems (on its keys) for installation. See https://github.com/nodejs/corepack/issues/612 for more details.