### PR TITLE
Revert "feat: add rust-cache to all Rust workflows"

### DIFF
--- a/.github/workflows/ci-fuel-contract.yml
+++ b/.github/workflows/ci-fuel-contract.yml
@@ -21,9 +21,6 @@ jobs:
         working-directory: target_chains/fuel/contracts/
     steps:
       - uses: actions/checkout@v2
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "target_chains/fuel/contracts -> target"
       - name: Install Fuel toolchain
         run: |
           curl https://install.fuel.network | sh

--- a/.github/workflows/ci-hermes-server.yml
+++ b/.github/workflows/ci-hermes-server.yml
@@ -11,9 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "apps/hermes/server -> target"
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/ci-lazer-rust.yml
+++ b/.github/workflows/ci-lazer-rust.yml
@@ -23,9 +23,6 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.81.0
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "lazer -> target"
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: install extra tools

--- a/.github/workflows/ci-near-contract.yml
+++ b/.github/workflows/ci-near-contract.yml
@@ -36,9 +36,6 @@ jobs:
         working-directory: target_chains/near/receiver
     steps:
       - uses: actions/checkout@v2
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "target_chains/near/receiver -> target"
       - run: sudo apt-get install -y libudev-dev
       - run: cargo +stable install --locked cargo-near@0.13.3
       - run: cargo near build reproducible-wasm

--- a/.github/workflows/ci-remote-executor.yml
+++ b/.github/workflows/ci-remote-executor.yml
@@ -18,9 +18,6 @@ jobs:
           toolchain: 1.73.0
           components: rustfmt, clippy
           override: true
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "governance/remote_executor -> target"
       - name: Install Solana
         run: |
           sh -c "$(curl -sSfL https://release.solana.com/v1.18.23/install)"

--- a/.github/workflows/ci-starknet-tools.yml
+++ b/.github/workflows/ci-starknet-tools.yml
@@ -18,9 +18,6 @@ jobs:
           components: rustfmt, clippy
           override: true
       - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "target_chains/starknet/tools/test_vaas -> target"
       - name: Install Scarb
         uses: software-mansion/setup-scarb@v1
         with:

--- a/.github/workflows/ci-stylus-nostd.yml
+++ b/.github/workflows/ci-stylus-nostd.yml
@@ -37,9 +37,6 @@ jobs:
         with:
           toolchain: stable
           rustflags: ""
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "target_chains/ethereum/sdk/stylus -> target"
       - name: Add rust targets ${{ matrix.target }}
         run: rustup target add ${{ matrix.target }}
       - name: Cargo check

--- a/.github/workflows/ci-sui-contract.yml
+++ b/.github/workflows/ci-sui-contract.yml
@@ -19,9 +19,6 @@ jobs:
         working-directory: target_chains/sui/contracts/
     steps:
       - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "target_chains/sui/contracts -> target"
 
       - name: Update rust
         run: rustup update stable


### PR DESCRIPTION
Reverts pyth-network/pyth-crosschain#2355 -- this broke the near workflow for some reason? Not sure what the problem is but I'm going to roll it back in the meanwhile 