### PR TITLE
Lower pyth_near build artifact retention to 90d

### DIFF
--- a/.github/workflows/ci-near-contract.yml
+++ b/.github/workflows/ci-near-contract.yml
@@ -46,4 +46,4 @@ jobs:
         with:
           name: pyth_near.wasm
           path: target_chains/near/receiver/target/near/pyth_near.wasm
-          retention-days: 365
+          retention-days: 90


### PR DESCRIPTION
Fix warning in GHA: 90 days is [the max for public repos](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization)