### PR TITLE
chore: fix some more CI stuff

### DIFF
--- a/.github/workflows/ci-ethereum-contract.yml
+++ b/.github/workflows/ci-ethereum-contract.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1.1.1
         with:
-          version: nightly
+          version: 0.2.0
 
       - name: Install Forge dependencies
         run: pnpm run install-forge-deps

--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -48,9 +48,3 @@ jobs:
           path: ~/.cache/pypoetry
           key: poetry-cache-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ env.POETRY_VERSION }}
       - uses: pre-commit/action@v3.0.0
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          # Run only on files changed in the PR
-          extra_args: --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}
-      - uses: pre-commit/action@v3.0.0
-        if: ${{ github.event_name != 'pull_request' }}

--- a/apps/hermes/server/Cargo.lock
+++ b/apps/hermes/server/Cargo.lock
@@ -1895,7 +1895,7 @@ dependencies = [
  "prometheus-client",
  "prost",
  "prost-build",
- "pyth-sdk",
+ "pyth-sdk 0.8.0",
  "pyth-sdk-solana",
  "pythnet-sdk",
  "rand 0.8.5",
@@ -3200,6 +3200,19 @@ dependencies = [
 
 [[package]]
 name = "pyth-sdk"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5c805ba3dfb5b7ed6a8ffa62ec38391f485a79c7cf6b3b11d3bd44fb0325824"
+dependencies = [
+ "borsh 0.9.3",
+ "borsh-derive 0.9.3",
+ "hex",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "pyth-sdk"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7aeef4d5f0a9c98ff5af2ddd84a8b89919c512188305b497a9eb9afa97a949"
@@ -3223,7 +3236,7 @@ dependencies = [
  "bytemuck",
  "num-derive 0.3.3",
  "num-traits",
- "pyth-sdk",
+ "pyth-sdk 0.8.0",
  "serde",
  "solana-program",
  "thiserror",
@@ -3239,6 +3252,7 @@ dependencies = [
  "byteorder",
  "fast-math",
  "hex",
+ "pyth-sdk 0.5.0",
  "rustc_version",
  "serde",
  "sha3 0.10.8",

--- a/target_chains/solana/Cargo.lock
+++ b/target_chains/solana/Cargo.lock
@@ -1027,7 +1027,7 @@ dependencies = [
  "lazy_static",
  "libsecp256k1 0.7.1",
  "program-simulator",
- "pyth-sdk",
+ "pyth-sdk 0.8.0",
  "pyth-sdk-solana",
  "pyth-solana-receiver",
  "pyth-solana-receiver-sdk",
@@ -3034,6 +3034,19 @@ dependencies = [
 
 [[package]]
 name = "pyth-sdk"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5c805ba3dfb5b7ed6a8ffa62ec38391f485a79c7cf6b3b11d3bd44fb0325824"
+dependencies = [
+ "borsh 0.9.3",
+ "borsh-derive 0.9.3",
+ "hex",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "pyth-sdk"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7aeef4d5f0a9c98ff5af2ddd84a8b89919c512188305b497a9eb9afa97a949"
@@ -3057,7 +3070,7 @@ dependencies = [
  "bytemuck",
  "num-derive 0.3.3",
  "num-traits",
- "pyth-sdk",
+ "pyth-sdk 0.8.0",
  "serde",
  "solana-program",
  "thiserror",
@@ -3127,6 +3140,7 @@ dependencies = [
  "fast-math",
  "hex",
  "libsecp256k1 0.7.1",
+ "pyth-sdk 0.5.0",
  "rand 0.8.5",
  "rustc_version",
  "serde",


### PR DESCRIPTION
CI on `main` is failing for two different reasons. (1) the Forge version wasn't pinned for the ethereum contract, and (2) the Cargo.lock file wasn't updated properly after a recent merge. The root cause of the 2nd item is that pre-commit is being run on a subset of files on PRs, which causes it to succeed on PRs then fail on main. I removed this option in the pre-commit check. This means pre-commit will run on all files, which will take longer, though it shouldn't be too long since I already added caching for all the Rust build stuff.