### PR TITLE
feat(price_pusher/solana): use an Address Lookup Table to reduce number of txs

### DIFF
--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/apps/price_pusher/src/solana/command.ts
+++ b/apps/price_pusher/src/solana/command.ts
@@ -86,6 +86,12 @@ export default {
       type: "string",
       optional: true,
     } as Options,
+    "treasury-id": {
+      description:
+        "The treasuryId to use. Useful when the corresponding treasury account is indexed in the ALT passed to --address-lookup-table-account. This is a tx size optimization and is optional; if not set, a random treasury account will be used.",
+      type: "number",
+      optional: true,
+    } as Options,
     ...options.priceConfigFile,
     ...options.priceServiceEndpoint,
     ...options.pythContractAddress,
@@ -113,6 +119,7 @@ export default {
       jitoBundleSize,
       updatesPerJitoBundle,
       addressLookupTableAccount,
+      treasuryId,
       logLevel,
       controllerLogLevel,
     } = argv;
@@ -156,15 +163,15 @@ export default {
       connection,
       wallet,
       pushOracleProgramId: new PublicKey(pythContractAddress),
+      treasuryId: treasuryId,
     });
 
     // Fetch the account lookup table if provided
-    const lookupTableAccount =
-      (
-        await connection.getAddressLookupTable(
-          new PublicKey(addressLookupTableAccount)
-        )
-      ).value ?? undefined;
+    const lookupTableAccount = addressLookupTableAccount
+      ? await connection
+          .getAddressLookupTable(new PublicKey(addressLookupTableAccount))
+          .then((result) => result.value ?? undefined)
+      : undefined;
 
     let solanaPricePusher;
     if (jitoTipLamports) {

--- a/target_chains/solana/sdk/js/pyth_solana_receiver/examples/update_price_feed.ts
+++ b/target_chains/solana/sdk/js/pyth_solana_receiver/examples/update_price_feed.ts
@@ -13,11 +13,6 @@ const ETH_PRICE_FEED_ID =
   "0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace";
 const PRICE_FEED_IDS = [SOL_PRICE_FEED_ID, ETH_PRICE_FEED_ID];
 
-// Optionally use an account lookup table to reduce tx sizes
-const addressLookupTableAccount = new PublicKey(
-  "5DNCErWQFBdvCxWQXaC1mrEFsvL3ftrzZ2gVZWNybaSX"
-);
-
 let keypairFile = "";
 if (process.env["SOLANA_KEYPAIR"]) {
   keypairFile = process.env["SOLANA_KEYPAIR"];
@@ -32,11 +27,23 @@ async function main() {
     `Sending transactions from account: ${keypair.publicKey.toBase58()}`
   );
   const wallet = new Wallet(keypair);
-  const pythSolanaReceiver = new PythSolanaReceiver({ connection, wallet });
+
+  // Optionally use an account lookup table to reduce tx sizes.
+  const addressLookupTableAccount = new PublicKey(
+    "5DNCErWQFBdvCxWQXaC1mrEFsvL3ftrzZ2gVZWNybaSX"
+  );
+  // Use a stable treasury ID of 0, since its address is indexed in the address lookup table.
+  // This is a tx size optimization and is optional. If not provided, a random treasury account will be used.
+  const treasuryId = 1;
+  const pythSolanaReceiver = new PythSolanaReceiver({
+    connection,
+    wallet,
+    treasuryId,
+  });
 
   // Get the price update from hermes
   const priceUpdateData = await getPriceUpdateData(PRICE_FEED_IDS);
-  // console.log(`Posting price update: ${priceUpdateData}`);
+  console.log(`Posting price update: ${priceUpdateData}`);
 
   // The shard indicates which set of price feed accounts you wish to update.
   const shardId = 1;

--- a/target_chains/solana/sdk/js/pyth_solana_receiver/package.json
+++ b/target_chains/solana/sdk/js/pyth_solana_receiver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-solana-receiver",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Pyth solana receiver SDK",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/target_chains/solana/sdk/js/pyth_solana_receiver/src/PythSolanaReceiver.ts
+++ b/target_chains/solana/sdk/js/pyth_solana_receiver/src/PythSolanaReceiver.ts
@@ -67,6 +67,12 @@ export type PythTransactionBuilderConfig = {
 };
 
 /**
+ * A stable treasury ID. This ID's corresponding treasury address
+ * can be cached in an account lookup table in order to reduce the overall txn size.
+ */
+export const DEFAULT_TREASURY_ID = 0;
+
+/**
  * A builder class to build transactions that:
  * - Post price updates (fully or partially verified) or update price feed accounts
  * - Consume price updates in a consumer program
@@ -470,9 +476,10 @@ export class PythSolanaReceiver {
    * Get a new transaction builder to build transactions that interact with the Pyth Solana Receiver program and consume price updates
    */
   newTransactionBuilder(
-    config: PythTransactionBuilderConfig
+    config: PythTransactionBuilderConfig,
+    address_lookup_account?: AddressLookupTableAccount
   ): PythTransactionBuilder {
-    return new PythTransactionBuilder(this, config);
+    return new PythTransactionBuilder(this, config, address_lookup_account);
   }
 
   /**
@@ -497,7 +504,7 @@ export class PythSolanaReceiver {
     const priceFeedIdToPriceUpdateAccount: Record<string, PublicKey> = {};
     const closeInstructions: InstructionWithEphemeralSigners[] = [];
 
-    const treasuryId = getRandomTreasuryId();
+    const treasuryId = DEFAULT_TREASURY_ID;
 
     for (const priceUpdateData of priceUpdateDataArray) {
       const accumulatorUpdateData = parseAccumulatorUpdateData(
@@ -730,7 +737,7 @@ export class PythSolanaReceiver {
     const priceFeedIdToPriceUpdateAccount: Record<string, PublicKey> = {};
     const closeInstructions: InstructionWithEphemeralSigners[] = [];
 
-    const treasuryId = getRandomTreasuryId();
+    const treasuryId = DEFAULT_TREASURY_ID;
 
     for (const priceUpdateData of priceUpdateDataArray) {
       const accumulatorUpdateData = parseAccumulatorUpdateData(

--- a/target_chains/solana/sdk/js/pyth_solana_receiver/src/vaa.ts
+++ b/target_chains/solana/sdk/js/pyth_solana_receiver/src/vaa.ts
@@ -46,7 +46,7 @@ export const VAA_START = 46;
  * `initEncodedVaa` and `writeEncodedVaa` in a single Solana transaction, while using an address lookup table.
  * This way, the packing of the instructions to post an encoded vaa is more efficient.
  */
-export const VAA_SPLIT_INDEX = 700;
+export const VAA_SPLIT_INDEX = 721;
 
 /**
  * Trim the number of signatures of a VAA.

--- a/target_chains/solana/sdk/js/pyth_solana_receiver/src/vaa.ts
+++ b/target_chains/solana/sdk/js/pyth_solana_receiver/src/vaa.ts
@@ -42,10 +42,11 @@ export const VAA_START = 46;
  *
  * The first one writes the first `VAA_SPLIT_INDEX` bytes and the second one writes the rest.
  *
- * This number was chosen as the biggest number such that one can still call `createInstruction`, `initEncodedVaa` and `writeEncodedVaa` in a single Solana transaction.
+ * This number was chosen as the biggest number such that one can still call `createInstruction`,
+ * `initEncodedVaa` and `writeEncodedVaa` in a single Solana transaction, while using an address lookup table.
  * This way, the packing of the instructions to post an encoded vaa is more efficient.
  */
-export const VAA_SPLIT_INDEX = 755;
+export const VAA_SPLIT_INDEX = 700;
 
 /**
  * Trim the number of signatures of a VAA.


### PR DESCRIPTION
## Purpose
Recently our merkle proof size grew due to newly added feeds. This caused two `postUpdate` ixs to no longer fit inside a single tx. This resulted in us needing to use more transactions to land our updates, which means increased operational costs of running the price pusher.

This PR uses [Address Lookup Tables](https://solana.com/developers/guides/advanced/lookup-tables) to save space in order to fit 2 postUpdate ixs in a single tx again.

## ALT details
The following accounts are static and are indexed in the ALT: 
1. Pyth Solana Receiver
   [rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ](https://explorer.solana.com/address/rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ)
2. Treasury (id 0):
   [GakrHE9QQeeJKoZ6oww9qzJZrzXY7C1jZdVfpYHc6KSz](https://solscan.io/account/GakrHE9QQeeJKoZ6oww9qzJZrzXY7C1jZdVfpYHc6KSz)
3. Config:
   [DaWUKXCyXsnzcvLUyeJRWou8KTn7XtadgTsdhJ6RHS7b](https://solscan.io/account/DaWUKXCyXsnzcvLUyeJRWou8KTn7XtadgTsdhJ6RHS7b)
4. Wormhole Solana Receiver: [
   HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ](https://explorer.solana.com/address/HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ)
5. Wormhole Guardian Set PDA: [5gxPdahvSzcKySxXxPuRXZZ9s6h8hZ88XDVKavWpaQGn](https://explorer.solana.com/address/5gxPdahvSzcKySxXxPuRXZZ9s6h8hZ88XDVKavWpaQGn)
6. Compute budget program: ComputeBudget111111111111111111111111111111

The following ALTs have been created, owned by our SVM deployer key:
- Mainnet: [GFaAdJik9jgaDc7dyLRkev335JEqDJvPRPVhhSNMhqrH](https://explorer.solana.com/address/GFaAdJik9jgaDc7dyLRkev335JEqDJvPRPVhhSNMhqrH)
- Devnet: [5DNCErWQFBdvCxWQXaC1mrEFsvL3ftrzZ2gVZWNybaSX](https://explorer.solana.com/address/5DNCErWQFBdvCxWQXaC1mrEFsvL3ftrzZ2gVZWNybaSX?cluster=devnet)

## Pusher/SDK details
- Added `--address-lookup-table-account` argument to the pusher to enable using an ALT. This should enable us to set a `--updates-per-jito-bundle` value of 6 (back from 4).
  - Surfaced the `addressLookupTable` ctor arg in `pythSolanaReceiver.newTransactionBuilder` so that any client can use an ALT.
- Added `--treasury-id` argument to the pusher and the receiver SDK to be able to use a stable treasury account. The treasury account with id 0 is indexed in the ALTs above.
- Updated `VAA_SPLIT_INDEX` to 700 from 750 to make space for the ALT. Without this change, the first part of the VAA doesn't fit in the first tx.

## Testing 
- Manually tested and verified that 2 updates fit in a single tx again: https://solscan.io/tx/44sLArJmAT42zq8ge7ZCxs1MWU7abHoQYbPfZKQzTNkm8nmo2LDh5jPGFtfNx14bTRgCuRA8nY46DZLEK5DNYSHu?cluster=devnet
  - Full tx and outputs here: https://app.warp.dev/block/Oods0m6C0qmzIJ0Lx9cIE0
- Manually tested that pusher works with `--updates-per-jito-bundle 6` with the ALT. First tx of the bundle: https://solscan.io/tx/4QEj9GkNUJ2HMwoqKA9KZDkB1r3SR6KWCuViNEmnCyPAyXZAiKA9P7m4CRVba3UBTs9w7oPPcjxZYhxiwcvKdtQ8