### PR TITLE
chore(target_chains/near): update last executed governance sequence

### DIFF
--- a/contract_manager/store/contracts/NearPriceFeedContracts.yaml
+++ b/contract_manager/store/contracts/NearPriceFeedContracts.yaml
@@ -3,7 +3,7 @@
   type: NearPriceFeedContract
   governanceDataSourceChain: 1
   governanceDataSourceAddress: 5635979a221c34931e32620b9293a463065555ea71fe97cd6237ade875b12e9e
-  lastExecutedGovernanceSequence: 0
+  lastExecutedGovernanceSequence: 408
 - chain: near_testnet
   address: pyth-oracle.testnet
   type: NearPriceFeedContract


### PR DESCRIPTION
I've applied the VAA with seq no 408 on near mainnet.