### PR TITLE
chore: Update cache saving policy for github actions

### DIFF
--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -37,6 +37,9 @@ jobs:
             pythnet/message_buffer
             pythnet/pythnet_sdk
             pythnet/stake_caps_parameters
+        # We only save the cache from runs on `main` because the cache is ~5GB, and the total Github Cache limit is 10GB.
+        # Branches have their own caches, so saving this cache on PRs can result in evicting the main cache.
+        save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install protoc
         uses: arduino/setup-protoc@v3
         with:


### PR DESCRIPTION
At the moment, pre-commit randomly takes the full 25 mins because it can't find the cache entry for the Rust build. I think what's happening is that we are evicting the `main` branch cache sometimes due to the Github cache size limit. (see inline comment for more details)