### PR TITLE
fix(lazer): address evm contract audit

### DIFF
--- a/lazer/contracts/evm/src/PythLazer.sol
+++ b/lazer/contracts/evm/src/PythLazer.sol
@@ -3,10 +3,15 @@ pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 contract PythLazer is OwnableUpgradeable, UUPSUpgradeable {
     TrustedSignerInfo[100] internal trustedSigners;
     uint256 public verification_fee;
+
+    constructor() {
+        _disableInitializers();
+    }
 
     struct TrustedSignerInfo {
         address pubkey;
@@ -17,10 +22,6 @@ contract PythLazer is OwnableUpgradeable, UUPSUpgradeable {
         __Ownable_init(_topAuthority);
         __UUPSUpgradeable_init();
 
-        verification_fee = 1 wei;
-    }
-
-    function migrate() public onlyOwner {
         verification_fee = 1 wei;
     }
 
@@ -91,7 +92,7 @@ contract PythLazer is OwnableUpgradeable, UUPSUpgradeable {
         }
         payload = update[71:71 + payload_len];
         bytes32 hash = keccak256(payload);
-        signer = ecrecover(
+        (signer, , ) = ECDSA.tryRecover(
             hash,
             uint8(update[68]) + 27,
             bytes32(update[4:36]),

--- a/lazer/contracts/evm/src/PythLazerLib.sol
+++ b/lazer/contracts/evm/src/PythLazerLib.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {console} from "forge-std/console.sol";
 import {PythLazer} from "./PythLazer.sol";
 
 library PythLazerLib {


### PR DESCRIPTION
### 3.1. Signature malleability

Fixed by using OpenZeppelin's ECDSA library instead of the raw ecrecover function.

### 3.2. Improper initialization within the UUPS pattern

Fixed by adding `_disableInitializers()` to the constructor. Updated tests to set up a proxy.

### 3.3. Performing duplicate checks within the same range of update length

It's not possible to remove the `if update.length < 71` check because that would add a possibility of out-of-bounds access at the next line (`update[69:71]`).

### 3.4. Inclusion of unnecessary migrate function

Removed `migrate()`.

### 3.5. Remove unused code lines

Removed unused import.
