### PR TITLE
fix: add libusb to github action runners that do pnpm install

### DIFF
--- a/.github/workflows/ci-ethereum-contract.yml
+++ b/.github/workflows/ci-ethereum-contract.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           node-version-file: "package.json"
 
+      # Libusb is a build requirement for the node-hid package and so pnpm
+      # install will fail if this isn't in the build environment and if a
+      # precompiled binary isn't found.
+      - name: Install libusb
+        run: sudo apt install -y libusb-1.0-0-dev libudev-dev
+
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:

--- a/.github/workflows/ci-message-buffer-idl.yml
+++ b/.github/workflows/ci-message-buffer-idl.yml
@@ -37,6 +37,11 @@ jobs:
         run: anchor build
       - name: Copy anchor target files
         run: cp ./target/idl/message_buffer.json idl/ && cp ./target/types/message_buffer.ts idl/
+      # Libusb is a build requirement for the node-hid package and so pnpm
+      # install will fail if this isn't in the build environment and if a
+      # precompiled binary isn't found.
+      - name: Install libusb
+        run: sudo apt install -y libusb-1.0-0-dev libudev-dev
       - uses: pnpm/action-setup@v4
         name: Install pnpm
       - name: Install prettier globally

--- a/.github/workflows/ci-turbo-build.yml
+++ b/.github/workflows/ci-turbo-build.yml
@@ -20,6 +20,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: "package.json"
+      # Libusb is a build requirement for the node-hid package and so pnpm
+      # install will fail if this isn't in the build environment and if a
+      # precompiled binary isn't found.
+      - name: Install libusb
+        run: sudo apt install -y libusb-1.0-0-dev libudev-dev
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:

--- a/.github/workflows/ci-turbo-test.yml
+++ b/.github/workflows/ci-turbo-test.yml
@@ -33,6 +33,11 @@ jobs:
         run: solana-keygen new --no-bip39-passphrase
       - name: Install Anchor
         run: RUSTFLAGS= cargo install --git https://github.com/coral-xyz/anchor --tag v0.30.1 anchor-cli
+      # Libusb is a build requirement for the node-hid package and so pnpm
+      # install will fail if this isn't in the build environment and if a
+      # precompiled binary isn't found.
+      - name: Install libusb
+        run: sudo apt install -y libusb-1.0-0-dev libudev-dev
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -13,6 +13,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: "package.json"
+      # Libusb is a build requirement for the node-hid package and so pnpm
+      # install will fail if this isn't in the build environment and if a
+      # precompiled binary isn't found.
+      - name: Install libusb
+        run: sudo apt install -y libusb-1.0-0-dev libudev-dev
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:


### PR DESCRIPTION
## Summary

Add libusb to github action runners (where `pnpm install` is needed)

## Rationale

One of our node dependencies, `node-hid`, is a native extension which depends on `libusb`.  In the past this dependency has distributed precompiled binaries so it wasn't necessary to have `libusb` because usually the compile wouldn't be required as part of the install.    However, it seems something has changed and those precompiled binaries are no longer being found reliably, and so we need to make sure we have `libusb` available wherever we do a `pnpm install` in case a build is needed.

## How has this been tested?

N/A, if CI succeeds then it works.