### PR TITLE
fix(insights): fix feed component drawer stretching on large screens

### DIFF
--- a/apps/insights/src/components/PriceComponentDrawer/index.module.scss
+++ b/apps/insights/src/components/PriceComponentDrawer/index.module.scss
@@ -1,6 +1,11 @@
 @use "@pythnetwork/component-library/theme";
 
 .priceComponentDrawer {
+  .priceComponentDrawerBody {
+    grid-template-rows: max-content max-content;
+    grid-template-columns: 100%;
+  }
+
   .badges {
     @include theme.breakpoint("lg") {
       display: none;

--- a/apps/insights/src/components/PriceComponentDrawer/index.tsx
+++ b/apps/insights/src/components/PriceComponentDrawer/index.tsx
@@ -149,6 +149,7 @@ export const PriceComponentDrawer = ({
       }
       isOpen={isFeedDrawerOpen}
       className={styles.priceComponentDrawer ?? ""}
+      bodyClassName={styles.priceComponentDrawerBody ?? ""}
     >
       {cluster === Cluster.PythtestConformance && (
         <InfoBox


### PR DESCRIPTION
## Summary

Fixes an issue where the items in the price component drawer would stretch to fill the height, resulting in jumping after loading and stretching on tall screens.

## Rationale

Fixes a display bug.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code