### PR TITLE
fix(insights): fix ois info box not spanning columns

### DIFF
--- a/apps/insights/src/components/Publisher/layout.module.scss
+++ b/apps/insights/src/components/Publisher/layout.module.scss
@@ -93,6 +93,10 @@
         display: grid;
       }
     }
+
+    .oisInfoBox {
+      grid-column: span 2 / span 2;
+    }
   }
 
   .oisDrawerFooter {

--- a/apps/insights/src/components/Publisher/layout.tsx
+++ b/apps/insights/src/components/Publisher/layout.tsx
@@ -365,6 +365,7 @@ export const PublishersLayout = async ({ children, params }: Props) => {
                   />
                   <OisApyHistory apyHistory={oisStats.apyHistory ?? []} />
                   <InfoBox
+                    className={styles.oisInfoBox}
                     icon={<ShieldChevron />}
                     header="Oracle Integrity Staking (OIS)"
                   >


### PR DESCRIPTION
## Summary

Fix OIS infobox not properly spanning columns

## Rationale

Before:
![screenshot-2025-02-26-204119](https://github.com/user-attachments/assets/6794b94e-ba4f-450a-8987-eb4dc17bd6cf)

After:
![screenshot-2025-02-26-204125](https://github.com/user-attachments/assets/33a56d0e-2e87-427f-9781-588518bb59d8)


## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code