### PR TITLE
chore(ci): use Org-defined larger runner

### DIFF
--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -11,7 +11,7 @@ env:
   POETRY_VERSION: "1.4.2"
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-x64-m
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
## Summary

Increate runner size for CI pre-commit

### Currently defined runners

| Runner name | OS | Arch | vCPU | RAM (GiB) | SSD (GB) |
| --- | --- | --- | --- | --- | --- |
| ubuntu-22.04-x64-m | Ubuntu 22.04 | x64_64 | 4 | 16 | 150 |
| ubuntu-24.04-x64-m | Ubuntu 24.04 | x64_64 | 4 | 16 | 150 |
| ubuntu-latest-x64-m | _Currently_ Ubuntu 24.04 | x64_64 | 4 | 16 | 150 |
| ubuntu-22.04-x64-l | Ubuntu 22.04 | x64_64 | 8 | 32 | 300 |
| ubuntu-24.04-x64-l | Ubuntu 22.04 | x64_64 | 8 | 32 | 300 |
| ubuntu-latest-x64-l | _Currently_ Ubuntu 22.04 | x64_64 | 8 | 32 | 300 |

💡 Initially, these runners are only available on this repo.

See also: [GitHub Actions Runner Images](https://github.com/actions/runner-images)

## Rationale

This GHA workflow currently takes 27.5 minutes and ran out of disk space, [example](https://github.com/pyth-network/pyth-crosschain/actions/runs/13568732621)

## How has this been tested?

If the pre-commit workflow fails, we'll know 🙂