### PR TITLE
chore(ci): update reviewers for /.github/ and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@ pnpm-workspace.yaml @pyth-network/web-team
 turbo.json @pyth-network/web-team
 .npmrc @pyth-network/web-team
 .nvmrc @pyth-network/web-team
-/.github/ @pyth-network/core-team @pyth-network/web-team
+/.github/ @pyth-network/core-team
 /.github/CODEOWNERS @pyth-network/core-team
 .github/workflows/publish-js.yml @pyth-network/web-team
 .github/workflows/ci-turbo-build.yml @pyth-network/web-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,8 @@ pnpm-workspace.yaml @pyth-network/web-team
 turbo.json @pyth-network/web-team
 .npmrc @pyth-network/web-team
 .nvmrc @pyth-network/web-team
+/.github/ @pyth-network/core-team @pyth-network/web-team
+/.github/CODEOWNERS @pyth-network/core-team
 .github/workflows/publish-js.yml @pyth-network/web-team
 .github/workflows/ci-turbo-build.yml @pyth-network/web-team
 .github/workflows/ci-turbo-test.yml @pyth-network/web-team


### PR DESCRIPTION
## Summary

CODEOWNERS for GH workflows, CODEOWNERS itself

## Rationale

Reduce the chances of PRs to use the [medium or large runners](https://github.com/pyth-network/pyth-crosschain/pull/2431) racking up our spend

## How has this been tested?

Only via the GH verification:
> This CODEOWNERS file is valid.

I don't believe we can fully test until it's merged.