### PR TITLE
chore: move lazer contract tests out of pnpm test

### DIFF
--- a/.github/workflows/ci-lazer-solana-contract.yml
+++ b/.github/workflows/ci-lazer-solana-contract.yml
@@ -24,6 +24,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: "package.json"
+      # Libusb is a build requirement for the node-hid package and so pnpm
+      # install will fail if this isn't in the build environment and if a
+      # precompiled binary isn't found.
+      - name: Install libusb
+        run: sudo apt install -y libusb-1.0-0-dev libudev-dev
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: true
       - name: Install Solana Cli
         run: |
           sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
@@ -34,3 +43,5 @@ jobs:
         run: solana-keygen new --no-bip39-passphrase
       - name: Install Anchor
         run: RUSTFLAGS= cargo install --git https://github.com/coral-xyz/anchor --tag v0.30.1 anchor-cli
+      - name: Run anchor tests
+        run: pnpm run test:anchor

--- a/.github/workflows/ci-turbo-test.yml
+++ b/.github/workflows/ci-turbo-test.yml
@@ -21,20 +21,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: "package.json"
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: 1.81.0
-      - uses: Swatinem/rust-cache@v2
-      - name: Install Solana Cli
-        run: |
-          sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
-          echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
-      - name: Set Solana Cli version
-        run: agave-install init 1.18.26
-      - name: Create Solana key
-        run: solana-keygen new --no-bip39-passphrase
-      - name: Install Anchor
-        run: RUSTFLAGS= cargo install --git https://github.com/coral-xyz/anchor --tag v0.30.1 anchor-cli
       # Libusb is a build requirement for the node-hid package and so pnpm
       # install will fail if this isn't in the build environment and if a
       # precompiled binary isn't found.

--- a/lazer/contracts/solana/turbo.json
+++ b/lazer/contracts/solana/turbo.json
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "test": {
-      "dependsOn": ["test:format", "test:anchor"]
+      "dependsOn": ["test:format"]
     },
     "test:anchor": {}
   }


### PR DESCRIPTION
## Summary

Move anchor tests back to a separate workflow. 

## Rationale

Solana contract brings too many new dependencies (Rust, Solana SDK, anchor) to `pnpm test` so it complicates the setup process for pnpm users a lot.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

Adjusted CI tests.