### PR TITLE
chore(governance/xc_admin): add a few features to frontend

### DIFF
--- a/governance/xc_admin/packages/xc_admin_frontend/components/tabs/General.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/tabs/General.tsx
@@ -155,8 +155,7 @@ const General = ({ proposerServerUrl }: { proposerServerUrl: string }) => {
               }
             }),
           }
-          // these fields are immutable and should not be updated
-          delete symbolToData[product.metadata.symbol].metadata.symbol
+          // this field is immutable and should not be updated
           delete symbolToData[product.metadata.symbol].metadata.price_account
         })
       setExistingSymbols(new Set(Object.keys(symbolToData)))
@@ -211,8 +210,8 @@ const General = ({ proposerServerUrl }: { proposerServerUrl: string }) => {
               changes[symbol] = { new: {} }
               changes[symbol].new = { ...fileDataParsed[symbol] }
               changes[symbol].new.metadata = {
-                ...changes[symbol].new.metadata,
                 symbol,
+                ...changes[symbol].new.metadata,
               }
               // these fields are generated deterministically and should not be updated
               delete changes[symbol].new.address
@@ -441,6 +440,25 @@ const General = ({ proposerServerUrl }: { proposerServerUrl: string }) => {
               instructions.push(
                 await pythProgramClient.methods
                   .setMinPub(newChanges.priceAccounts[0].minPub, [0, 0, 0])
+                  .accounts({
+                    priceAccount: priceAccountKey,
+                    fundingAccount,
+                  })
+                  .instruction()
+              )
+            }
+
+            // If maxLatency is set and is not 0, create update maxLatency instruction
+            if (
+              newChanges.priceAccounts[0].maxLatency !== undefined &&
+              newChanges.priceAccounts[0].maxLatency !== 0
+            ) {
+              instructions.push(
+                await pythProgramClient.methods
+                  .setMaxLatency(
+                    newChanges.priceAccounts[0].maxLatency,
+                    [0, 0, 0]
+                  )
                   .accounts({
                     priceAccount: priceAccountKey,
                     fundingAccount,


### PR DESCRIPTION
## Summary
- support renaming a symbol
- set maxLatency upon feed creation

## Rationale

These two are features/requests from price feeds ops council.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

I checked it manually through the UI and logs to ensure the new instruction for updating metadata gets created.


