### PR TITLE
chore(contract_manager): add monad testnet deplmnt on beta channel

### DIFF
--- a/contract_manager/store/chains/EvmChains.yaml
+++ b/contract_manager/store/chains/EvmChains.yaml
@@ -851,7 +851,7 @@
   type: EvmChain
 - id: monad_testnet
   mainnet: false
-  rpcUrl: https://rpc.monad-testnet.category.xyz/rpc/nSyzM1wlIgaALWzbh3oIg5rW65AC6yjqrslOE8wb
+  rpcUrl: https://testnet-rpc.monad.xyz
   networkId: 10143
   type: EvmChain
 - id: berachain_mainnet

--- a/contract_manager/store/contracts/EvmPriceFeedContracts.yaml
+++ b/contract_manager/store/contracts/EvmPriceFeedContracts.yaml
@@ -490,3 +490,6 @@
 - chain: bittensor_mainnet
   address: "0x2880aB155794e7179c9eE2e38200202908C17B43"
   type: EvmPriceFeedContract
+- chain: monad_testnet # This is on beta channel
+  address: "0xad2B52D2af1a9bD5c561894Cdd84f7505e1CD0B5"
+  type: EvmPriceFeedContract

--- a/contract_manager/store/contracts/EvmWormholeContracts.yaml
+++ b/contract_manager/store/contracts/EvmWormholeContracts.yaml
@@ -484,3 +484,6 @@
 - chain: bittensor_mainnet
   address: "0xb27e5ca259702f209a29225d0eDdC131039C9933"
   type: EvmWormholeContract
+- chain: monad_testnet # this is on beta channel
+  address: "0xd74CdD8Eef0E97a5a7678F907991316f88E7965A"
+  type: EvmWormholeContract

--- a/contract_manager/store/contracts/NearPriceFeedContracts.yaml
+++ b/contract_manager/store/contracts/NearPriceFeedContracts.yaml
@@ -1,12 +1,12 @@
 - chain: near
   address: pyth-oracle.near
-  type: NearPriceFeedContract
   governanceDataSourceChain: 1
   governanceDataSourceAddress: 5635979a221c34931e32620b9293a463065555ea71fe97cd6237ade875b12e9e
   lastExecutedGovernanceSequence: 408
+  type: NearPriceFeedContract
 - chain: near_testnet
   address: pyth-oracle.testnet
-  type: NearPriceFeedContract
   governanceDataSourceChain: 1
   governanceDataSourceAddress: 63278d271099bfd491951b3e648f08b1c71631e4a53674ad43e8f9f98068c385
   lastExecutedGovernanceSequence: 100
+  type: NearPriceFeedContract

--- a/target_chains/ethereum/contracts/deploy.sh
+++ b/target_chains/ethereum/contracts/deploy.sh
@@ -11,24 +11,16 @@
 # $ ./deploy.sh ethereum bnb avalanche
 set -euo pipefail
 
-echo "=========== Building dependencies ==========="
-pushd ../../../
-pnpm turbo build --filter @pythnetwork/pyth-evm-contract
-popd
-
-echo "=========== Compiling ==========="
-
 if [[ -e contracts/pyth/PythUpgradable_merged.sol ]]; then
     echo "Flattened contract PythUpgradable_merged.sol exists. Removing before compiling."
     rm contracts/pyth/PythUpgradable_merged.sol
 fi
 
-echo "Building the contracts..."
-# Ensure that we deploy a fresh build with up-to-date dependencies.
-rm -rf build && pnpm exec truffle compile --all
+echo "=========== Building dependencies & compiling contract ==========="
+pnpm turbo build --filter @pythnetwork/pyth-evm-contract
 
 echo "Deploying the contracts..."
 
 pushd ../../../contract_manager/
 
-pnpm exec ts-node scripts/deploy_evm_pricefeed_contracts.ts --std-output-dir ../target_chains/ethereum/contracts/build/contracts --private-key $PK --chain "$@"
+pnpm exec ts-node scripts/deploy_evm_pricefeed_contracts.ts --std-output-dir ../target_chains/ethereum/contracts/build/contracts --private-key $PK --deployment-type "stable" --chain "$@"


### PR DESCRIPTION

## Summary

Add monad testnet deplmnt on beta channel so people can use a dummy testnet MON feed from Pythtest
This change also modifies deploy.sh to remove the double build

## How has this been tested?

- [x] Manually tested the contract
