### PR TITLE
fix(pulse): Miscellaneous contract fixes

### DIFF
--- a/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
@@ -53,7 +53,7 @@ interface IPulse is PulseEvents {
      */
     function requestPriceUpdatesWithCallback(
         address provider,
-        uint256 publishTime,
+        uint64 publishTime,
         bytes32[] calldata priceIds,
         uint256 callbackGasLimit
     ) external payable returns (uint64 sequenceNumber);

--- a/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
@@ -113,9 +113,18 @@ interface IPulse is PulseEvents {
 
     function withdrawAsFeeManager(address provider, uint128 amount) external;
 
-    function registerProvider(uint128 feeInWei) external;
+    function registerProvider(
+        uint128 baseFeeInWei,
+        uint128 feePerFeedInWei,
+        uint128 feePerGasInWei
+    ) external;
 
-    function setProviderFee(address provider, uint128 newFeeInWei) external;
+    function setProviderFee(
+        address provider,
+        uint128 newBaseFeeInWei,
+        uint128 newFeePerFeedInWei,
+        uint128 newFeePerGasInWei
+    ) external;
 
     function getProviderInfo(
         address provider

--- a/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/IPulse.sol
@@ -40,10 +40,10 @@ interface IPulse is PulseEvents {
      * @notice Requests price updates with a callback
      * @dev The msg.value must be equal to getFee(callbackGasLimit)
      * @param provider The provider to fulfill the request
-     * @param callbackGasLimit The amount of gas allocated for the callback execution
      * @param publishTime The minimum publish time for price updates, it should be less than or equal to block.timestamp + 60
      * @param priceIds The price feed IDs to update. Maximum 10 price feeds per request.
      *        Requests requiring more feeds should be split into multiple calls.
+     * @param callbackGasLimit The amount of gas allocated for the callback execution
      * @return sequenceNumber The sequence number assigned to this request
      * @dev Security note: The 60-second future limit on publishTime prevents a DoS vector where
      *      attackers could submit many low-fee requests for far-future updates when gas prices
@@ -84,8 +84,7 @@ interface IPulse is PulseEvents {
 
     /**
      * @notice Calculates the total fee required for a price update request
-     * FIXME: is this comment right?
-     * @dev Total fee = base Pyth protocol fee + gas costs for callback
+     * @dev Total fee = base Pyth protocol fee + base provider fee + provider fee per feed + gas costs for callback
      * @param provider The provider to fulfill the request
      * @param callbackGasLimit The amount of gas allocated for callback execution
      * @param priceIds The price feed IDs to update.
@@ -97,7 +96,10 @@ interface IPulse is PulseEvents {
         bytes32[] calldata priceIds
     ) external view returns (uint128 feeAmount);
 
-    function getAccruedFees() external view returns (uint128 accruedFeesInWei);
+    function getAccruedPythFees()
+        external
+        view
+        returns (uint128 accruedFeesInWei);
 
     function getRequest(
         uint64 sequenceNumber

--- a/target_chains/ethereum/contracts/contracts/pulse/Pulse.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/Pulse.sol
@@ -198,13 +198,16 @@ abstract contract Pulse is IPulse, PulseState {
         int64[] memory prices = new int64[](priceFeeds.length);
         uint64[] memory conf = new uint64[](priceFeeds.length);
         int32[] memory expos = new int32[](priceFeeds.length);
-        uint64[] memory publishTimes = new uint256[](priceFeeds.length);
+        uint64[] memory publishTimes = new uint64[](priceFeeds.length);
 
         for (uint i = 0; i < priceFeeds.length; i++) {
             prices[i] = priceFeeds[i].price.price;
             conf[i] = priceFeeds[i].price.conf;
             expos[i] = priceFeeds[i].price.expo;
-            publishTimes[i] = priceFeeds[i].price.publishTime;
+            // Safe cast because this is a unix timestamp in seconds.
+            publishTimes[i] = SafeCast.toUint64(
+                priceFeeds[i].price.publishTime
+            );
         }
 
         emit PriceUpdateExecuted(

--- a/target_chains/ethereum/contracts/contracts/pulse/Pulse.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/Pulse.sol
@@ -251,7 +251,7 @@ abstract contract Pulse is IPulse, PulseState {
         pythFeeInWei = _state.pythFeeInWei;
     }
 
-    function getAccruedFees()
+    function getAccruedPythFees()
         public
         view
         override

--- a/target_chains/ethereum/contracts/contracts/pulse/Pulse.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/Pulse.sol
@@ -53,17 +53,19 @@ abstract contract Pulse is IPulse, PulseState {
         }
     }
 
+    // TODO: there can be a separate wrapper function that defaults the provider (or uses the cheapest or something).
     function requestPriceUpdatesWithCallback(
+        address provider,
         uint256 publishTime,
         bytes32[] calldata priceIds,
         uint256 callbackGasLimit
     ) external payable override returns (uint64 requestSequenceNumber) {
-        address provider = _state.defaultProvider;
         require(
             _state.providers[provider].isRegistered,
             "Provider not registered"
         );
 
+        // FIXME: this comment is wrong.
         // NOTE: The 60-second future limit on publishTime prevents a DoS vector where
         //      attackers could submit many low-fee requests for far-future updates when gas prices
         //      are low, forcing executors to fulfill them later when gas prices might be much higher.
@@ -75,7 +77,7 @@ abstract contract Pulse is IPulse, PulseState {
         }
         requestSequenceNumber = _state.currentSequenceNumber++;
 
-        uint128 requiredFee = getFee(callbackGasLimit);
+        uint128 requiredFee = getFee(provider, callbackGasLimit, priceIds);
         if (msg.value < requiredFee) revert InsufficientFee();
 
         Request storage req = allocRequest(requestSequenceNumber);
@@ -85,21 +87,21 @@ abstract contract Pulse is IPulse, PulseState {
         req.requester = msg.sender;
         req.numPriceIds = uint8(priceIds.length);
         req.provider = provider;
+        req.fee = SafeCast.toUint128(msg.value - _state.pythFeeInWei);
 
         // Copy price IDs to storage
         for (uint8 i = 0; i < priceIds.length; i++) {
             req.priceIds[i] = priceIds[i];
         }
 
-        _state.providers[provider].accruedFeesInWei += SafeCast.toUint128(
-            msg.value - _state.pythFeeInWei
-        );
         _state.accruedFeesInWei += _state.pythFeeInWei;
 
         emit PriceUpdateRequested(req, priceIds);
     }
 
+    // TODO: I don't think this should be payable. Any cost paid to Pyth should come from the contract and be taken out of the provider's accrued fees.
     function executeCallback(
+        address providerToCredit,
         uint64 sequenceNumber,
         bytes[] calldata updateData,
         bytes32[] calldata priceIds
@@ -111,7 +113,7 @@ abstract contract Pulse is IPulse, PulseState {
             block.timestamp < req.publishTime + _state.exclusivityPeriodSeconds
         ) {
             require(
-                msg.sender == req.provider,
+                providerToCredit == req.provider,
                 "Only assigned provider during exclusivity period"
             );
         }
@@ -128,15 +130,24 @@ abstract contract Pulse is IPulse, PulseState {
         }
 
         // Parse price feeds first to measure gas usage
-        PythStructs.PriceFeed[] memory priceFeeds = IPyth(_state.pyth)
-            .parsePriceFeedUpdates(
-                updateData,
-                priceIds,
-                SafeCast.toUint64(req.publishTime),
-                SafeCast.toUint64(req.publishTime)
-            );
+        // TODO: should this use parsePriceFeedUpdatesUnique? also, do we need to add 1 to maxPublishTime?
+        IPyth pyth = IPyth(_state.pyth);
+        uint256 pythFee = pyth.getUpdateFee(updateData);
+        PythStructs.PriceFeed[] memory priceFeeds = pyth.parsePriceFeedUpdates{
+            value: pythFee
+        }(
+            updateData,
+            priceIds,
+            SafeCast.toUint64(req.publishTime),
+            SafeCast.toUint64(req.publishTime)
+        );
 
         clearRequest(sequenceNumber);
+        // TODO: if this effect occurs here, we need to guarantee that executeCallback can never revert.
+        // If executeCallback can revert, then funds can be permanently locked in the contract.
+        _state.providers[providerToCredit].accruedFeesInWei += req.fee;
+        _state.providers[providerToCredit].accruedFeesInWei += SafeCast
+            .toUint128(msg.value - pythFee);
 
         try
             IPulseConsumer(req.requester).pulseCallback{
@@ -165,6 +176,7 @@ abstract contract Pulse is IPulse, PulseState {
             );
         }
 
+        // TODO: I'm pretty sure this is going to use a lot of gas because it's doing a storage lookup for each sequence number.
         // After successful callback, update firstUnfulfilledSeq if needed
         while (
             _state.firstUnfulfilledSeq < _state.currentSequenceNumber &&
@@ -203,12 +215,16 @@ abstract contract Pulse is IPulse, PulseState {
     }
 
     function getFee(
-        uint256 callbackGasLimit
+        address provider,
+        uint256 callbackGasLimit,
+        bytes32[] calldata priceIds
     ) public view override returns (uint128 feeAmount) {
         uint128 baseFee = _state.pythFeeInWei; // Fixed fee to Pyth
-        uint128 providerFeeInWei = _state
-            .providers[_state.defaultProvider]
-            .feeInWei; // Provider's per-gas rate
+        // FIXME: this also needs to consider the Pyth fee charged for the update.
+        // Unfortunately, the getUpdateFee function takes the entire update data as an argument, not just the priceIds.
+        // uint128 pythFee = IPyth(_state.pyth).getUpdateFee(updateData);
+
+        uint128 providerFeeInWei = _state.providers[provider].feePerGasInWei; // Provider's per-gas rate
         uint256 gasFee = callbackGasLimit * providerFeeInWei; // Total provider fee based on gas
         feeAmount = baseFee + SafeCast.toUint128(gasFee); // Total fee user needs to pay
     }
@@ -244,6 +260,7 @@ abstract contract Pulse is IPulse, PulseState {
         shortHash = uint8(hash[0] & NUM_REQUESTS_MASK);
     }
 
+    // TODO: move out governance functions into a separate PulseGovernance contract
     function withdrawFees(uint128 amount) external override {
         require(msg.sender == _state.admin, "Only admin can withdraw fees");
         require(_state.accruedFeesInWei >= amount, "Insufficient balance");
@@ -336,22 +353,31 @@ abstract contract Pulse is IPulse, PulseState {
         emit FeesWithdrawn(msg.sender, amount);
     }
 
-    function registerProvider(uint128 feeInWei) external override {
+    function registerProvider(uint128 feePerGasInWei) external override {
         ProviderInfo storage provider = _state.providers[msg.sender];
         require(!provider.isRegistered, "Provider already registered");
-        provider.feeInWei = feeInWei;
+        provider.feePerGasInWei = feePerGasInWei;
         provider.isRegistered = true;
-        emit ProviderRegistered(msg.sender, feeInWei);
+        emit ProviderRegistered(msg.sender, feePerGasInWei);
     }
 
-    function setProviderFee(uint128 newFeeInWei) external override {
+    function setProviderFee(
+        address provider,
+        uint128 newFeePerGasInWei
+    ) external override {
         require(
-            _state.providers[msg.sender].isRegistered,
+            _state.providers[provider].isRegistered,
             "Provider not registered"
         );
-        uint128 oldFee = _state.providers[msg.sender].feeInWei;
-        _state.providers[msg.sender].feeInWei = newFeeInWei;
-        emit ProviderFeeUpdated(msg.sender, oldFee, newFeeInWei);
+        require(
+            msg.sender == provider ||
+                msg.sender == _state.providers[provider].feeManager,
+            "Only provider or fee manager can invoke this method"
+        );
+
+        uint128 oldFee = _state.providers[provider].feePerGasInWei;
+        _state.providers[provider].feePerGasInWei = newFeePerGasInWei;
+        emit ProviderFeeUpdated(provider, oldFee, newFeePerGasInWei);
     }
 
     function getProviderInfo(

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseErrors.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseErrors.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 
 error NoSuchProvider();
 error NoSuchRequest();
+// TODO: add expected / provided values
 error InsufficientFee();
 error Unauthorized();
 error InvalidCallbackGas();

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseEvents.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseEvents.sol
@@ -13,7 +13,7 @@ interface PulseEvents {
         int64[] prices,
         uint64[] conf,
         int32[] expos,
-        uint256[] publishTimes
+        uint64[] publishTimes
     );
 
     event FeesWithdrawn(address indexed recipient, uint128 amount);

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseEvents.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseEvents.sol
@@ -35,8 +35,12 @@ interface PulseEvents {
     event ProviderRegistered(address indexed provider, uint128 feeInWei);
     event ProviderFeeUpdated(
         address indexed provider,
-        uint128 oldFee,
-        uint128 newFee
+        uint128 oldBaseFee,
+        uint128 oldFeePerFeed,
+        uint128 oldFeePerGas,
+        uint128 newBaseFee,
+        uint128 newFeePerFeed,
+        uint128 newFeePerGas
     );
     event DefaultProviderUpdated(address oldProvider, address newProvider);
 

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
@@ -17,10 +17,11 @@ contract PulseState {
         uint256 callbackGasLimit;
         address requester;
         address provider;
+        uint128 fee;
     }
 
     struct ProviderInfo {
-        uint128 feeInWei;
+        uint128 feePerGasInWei;
         uint128 accruedFeesInWei;
         address feeManager;
         bool isRegistered;

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
@@ -12,6 +12,7 @@ contract PulseState {
     struct Request {
         uint64 sequenceNumber;
         uint256 publishTime;
+        // TODO: this is going to absolutely explode gas costs. Need to do something smarter here.
         bytes32[MAX_PRICE_IDS] priceIds;
         uint8 numPriceIds; // Actual number of price IDs used
         uint256 callbackGasLimit;

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
@@ -24,6 +24,8 @@ contract PulseState {
     }
 
     struct ProviderInfo {
+        uint128 baseFeeInWei;
+        uint128 feePerFeedInWei;
         uint128 feePerGasInWei;
         uint128 accruedFeesInWei;
         address feeManager;

--- a/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/PulseState.sol
@@ -11,8 +11,10 @@ contract PulseState {
 
     struct Request {
         uint64 sequenceNumber;
-        uint256 publishTime;
+        uint64 publishTime;
         // TODO: this is going to absolutely explode gas costs. Need to do something smarter here.
+        // possible solution is to hash the price ids and store the hash instead.
+        // The ids themselves can be retrieved from the event.
         bytes32[MAX_PRICE_IDS] priceIds;
         uint8 numPriceIds; // Actual number of price IDs used
         uint256 callbackGasLimit;

--- a/target_chains/ethereum/contracts/forge-test/Pulse.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pulse.t.sol
@@ -643,7 +643,7 @@ contract PulseTest is Test, PulseEvents, IPulseConsumer {
 
         // Get admin's balance before withdrawal
         uint256 adminBalanceBefore = admin.balance;
-        uint128 accruedFees = pulse.getAccruedFees();
+        uint128 accruedFees = pulse.getAccruedPythFees();
 
         // Withdraw fees as admin
         vm.prank(admin);
@@ -656,7 +656,7 @@ contract PulseTest is Test, PulseEvents, IPulseConsumer {
             "Admin balance should increase by withdrawn amount"
         );
         assertEq(
-            pulse.getAccruedFees(),
+            pulse.getAccruedPythFees(),
             0,
             "Contract should have no fees after withdrawal"
         );


### PR DESCRIPTION
## Summary

I was looking through the Pulse contract and noticed some issues:
* There's a security issue with the IPulseConsumer interface as anyone can mock data and pass it as the legitimate response to the request
* publishTimes are unix timestamps so should be uint64
* The provider fee / backup mechanism doesn't work properly because it doesn't account for pyth fees, and it also doesn't give any incentive to backup providers. 

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

