### PR TITLE
fix(contract_manager): ton rpc url

### DIFF
--- a/contract_manager/store/chains/TonChains.yaml
+++ b/contract_manager/store/chains/TonChains.yaml
@@ -3,7 +3,7 @@
   mainnet: false
   # using # is a hack so we can later separate the key from the URL and pass
   # it as a header
-  rpcUrl: https://testnet.toncenter.com/api/v2/#$ENV_TON_TESTNET_API_KEY
+  rpcUrl: https://testnet.toncenter.com/api/v2/jsonRPC#$ENV_TON_TESTNET_API_KEY
   type: TonChain
 - id: ton_mainnet
   wormholeChainName: ton_mainnet


### PR DESCRIPTION
i think this was broken during the refactor here https://github.com/pyth-network/pyth-crosschain/pull/2160/files#diff-b0c3a1ff52c917a976a1a4b2b91011340840e9253d92a5b4b3dda2df366d8d21R4-R6