### PR TITLE
fix(fortuna): Configurable backlog processing

### DIFF
--- a/apps/fortuna/Cargo.lock
+++ b/apps/fortuna/Cargo.lock
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "fortuna"
-version = "7.4.6"
+version = "7.4.7"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/fortuna/Cargo.toml
+++ b/apps/fortuna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortuna"
-version = "7.4.6"
+version = "7.4.7"
 edition = "2021"
 
 [lib]

--- a/apps/fortuna/src/config.rs
+++ b/apps/fortuna/src/config.rs
@@ -128,6 +128,10 @@ pub struct EthereumConfig {
     #[serde(default)]
     pub confirmed_block_status: BlockStatus,
 
+    /// The number of blocks to look back for events that might be missed when starting the keeper
+    #[serde(default = "default_backlog_range")]
+    pub backlog_range: u64,
+
     /// Use the legacy transaction format (for networks without EIP 1559)
     #[serde(default)]
     pub legacy_tx: bool,
@@ -192,6 +196,10 @@ fn default_block_delays() -> Vec<u64> {
 
 fn default_priority_fee_multiplier_pct() -> u64 {
     100
+}
+
+fn default_backlog_range() -> u64 {
+    1000
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]

--- a/apps/fortuna/src/keeper.rs
+++ b/apps/fortuna/src/keeper.rs
@@ -33,8 +33,6 @@ pub(crate) mod keeper_metrics;
 pub(crate) mod process_event;
 pub(crate) mod track;
 
-/// How many blocks to look back for events that might be missed when starting the keeper
-const BACKLOG_RANGE: u64 = 1000;
 /// Track metrics in this interval
 const TRACK_INTERVAL: Duration = Duration::from_secs(10);
 /// Check whether we need to conduct a withdrawal at this interval.
@@ -80,12 +78,12 @@ pub async fn run_keeper_threads(
 
     let fulfilled_requests_cache = Arc::new(RwLock::new(HashSet::<u64>::new()));
 
-    // Spawn a thread to handle the events from last BACKLOG_RANGE blocks.
+    // Spawn a thread to handle the events from last backlog_range blocks.
     let gas_limit: U256 = chain_eth_config.gas_limit.into();
     spawn(
         process_backlog(
             BlockRange {
-                from: latest_safe_block.saturating_sub(BACKLOG_RANGE),
+                from: latest_safe_block.saturating_sub(chain_eth_config.backlog_range),
                 to: latest_safe_block,
             },
             contract.clone(),


### PR DESCRIPTION
## Summary

Make the backlog range configurable

## Rationale

Abstract had an outage a little while ago, and the blocks are fast, so we need a longer range to process the backlog.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code
