### PR TITLE
chore: Pause pre-commit on branches

### DIFF
--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -1,7 +1,6 @@
 name: Pre-commit checks
 
 on:
-  pull_request:
   push:
     branches: [main]
 

--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -2,7 +2,6 @@ name: Pre-commit checks
 
 on:
   pull_request:
-    branches: "**"
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary

The pre-commit cache expired and on re-download, it's causing some solana-net build error. Presumably solana semver is broken somewhere but I'm not sure. CI is also taking 30 mins right now which is going to block everyone.

I'm disabling pre-commit on prs temporarily while I debug to unblock people. I will reenable and fix any problems after.
 
