### PR TITLE
fix(fortuna): Fix gas padding bug caused by refactor

### DIFF
--- a/apps/fortuna/Cargo.lock
+++ b/apps/fortuna/Cargo.lock
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "fortuna"
-version = "7.4.7"
+version = "7.4.8"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/fortuna/Cargo.toml
+++ b/apps/fortuna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortuna"
-version = "7.4.7"
+version = "7.4.8"
 edition = "2021"
 
 [lib]

--- a/apps/fortuna/src/eth_utils/utils.rs
+++ b/apps/fortuna/src/eth_utils/utils.rs
@@ -166,6 +166,8 @@ pub async fn submit_tx_with_backoff<T: Middleware + NonceManaged + 'static>(
 
     let num_retries = Arc::new(AtomicU64::new(0));
 
+    let padded_gas_limit = U256::from(escalation_policy.gas_limit_tolerance_pct) * gas_limit / 100;
+
     let success = backoff::future::retry_notify(
         backoff,
         || async {
@@ -176,7 +178,7 @@ pub async fn submit_tx_with_backoff<T: Middleware + NonceManaged + 'static>(
             submit_tx(
                 middleware.clone(),
                 &call,
-                gas_limit,
+                padded_gas_limit,
                 gas_multiplier_pct,
                 fee_multiplier_pct,
             )


### PR DESCRIPTION
## Summary

Add in the calculation of the padded gas limit. I dropped this padding value during the refactor. This is probably responsible for the current set of gas estimation issues.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
