### PR TITLE
chore: (partially) resume pre-commit CI action

### DIFF
--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -1,6 +1,8 @@
 name: Pre-commit checks
 
 on:
+  pull_request:
+    branches: "**"
   push:
     branches: [main]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -110,7 +110,7 @@ repos:
       - id: cargo-clippy-pythnet-sdk
         name: Cargo clippy for pythnet SDK
         language: "rust"
-        entry: cargo +1.82.0 clippy --manifest-path ./pythnet/pythnet_sdk/Cargo.toml --tests -- --deny warnings
+        entry: cargo +1.82.0 clippy --manifest-path ./pythnet/pythnet_sdk/Cargo.toml -- --deny warnings
         pass_filenames: false
         files: pythnet/pythnet_sdk
       # Hooks for solana receiver contract


### PR DESCRIPTION
## Summary

Partially resume pre-commit CI. The problem is that a dependency of the pythnet_sdk has updated so that it now requires a newer rust version. Upgrading our rust version causes other problems however. The right fix to this is probably to add a Cargo.lock file (but I don't have one unfortunately). 

Luckily the failure happens in the test package, so as a temporary stopgap turn off the test part of the clippy check. 

