### PR TITLE
Fix vercel ignore command

### DIFF
--- a/apps/api-reference/vercel.json
+++ b/apps/api-reference/vercel.json
@@ -1,3 +1,7 @@
 {
-  "ignoreCommand": "pnpm dlx turbo-ignore --fallback=HEAD^"
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "pnpm dlx turbo-ignore --fallback=HEAD^",
+  "env": {
+    "ENABLE_EXPERIMENTAL_COREPACK": "1"
+  }
 }

--- a/apps/entropy-debugger/vercel.json
+++ b/apps/entropy-debugger/vercel.json
@@ -1,3 +1,7 @@
 {
-  "ignoreCommand": "pnpm dlx turbo-ignore --fallback=HEAD^"
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "pnpm dlx turbo-ignore --fallback=HEAD^",
+  "env": {
+    "ENABLE_EXPERIMENTAL_COREPACK": "1"
+  }
 }

--- a/apps/insights/vercel.json
+++ b/apps/insights/vercel.json
@@ -1,3 +1,7 @@
 {
-  "ignoreCommand": "pnpm dlx turbo-ignore --fallback=HEAD^"
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "pnpm dlx turbo-ignore --fallback=HEAD^",
+  "env": {
+    "ENABLE_EXPERIMENTAL_COREPACK": "1"
+  }
 }

--- a/apps/staking/vercel.json
+++ b/apps/staking/vercel.json
@@ -1,3 +1,7 @@
 {
-  "ignoreCommand": "pnpm dlx turbo-ignore --fallback=HEAD^"
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "pnpm dlx turbo-ignore --fallback=HEAD^",
+  "env": {
+    "ENABLE_EXPERIMENTAL_COREPACK": "1"
+  }
 }

--- a/governance/xc_admin/packages/xc_admin_frontend/vercel.json
+++ b/governance/xc_admin/packages/xc_admin_frontend/vercel.json
@@ -1,3 +1,7 @@
 {
-  "ignoreCommand": "pnpm dlx turbo-ignore --fallback=HEAD^"
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "pnpm dlx turbo-ignore --fallback=HEAD^",
+  "env": {
+    "ENABLE_EXPERIMENTAL_COREPACK": "1"
+  }
 }

--- a/packages/component-library/vercel.json
+++ b/packages/component-library/vercel.json
@@ -1,6 +1,10 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "turbo --filter @pythnetwork/component-library build:storybook",
   "ignoreCommand": "pnpm dlx turbo-ignore --fallback=HEAD^",
   "framework": null,
-  "outputDirectory": "storybook-static"
+  "outputDirectory": "storybook-static",
+  "env": {
+    "ENABLE_EXPERIMENTAL_COREPACK": "1"
+  }
 }


### PR DESCRIPTION
## Summary

Vercel's ignore command hasn't been reliably working, resulting in a ton of Vercel noise on PRs that aren't touching apps and a ton of unneeded builds.

I have been going back and forth with Vercel for a while and recently received this message:

> Hi Connor,
>
> Thanks for your patience. 
>
> I received an update from the Engineering team indicating that this appears to be a bug where ENABLE_EXPERIMENTAL_COREPACK is not properly detected during the ignore build step. We apologise for any inconvenience this may have caused. To resolve the issue, could you please remove the environment variable ENABLE_EXPERIMENTAL_COREPACK from the project settings and create a vercel.json file with the following code?
> {
>   "$schema": "https://openapi.vercel.sh/vercel.json",
>   "env": {
>     "ENABLE_EXPERIMENTAL_COREPACK": "1"
>   },
> }
> Please let me know if the information provided was useful. Feel free to let me know if you have any other queries or questions, I am happy to help.

This PR implements the required change.