### PR TITLE
fix(lazer/aptos-contract): add coin conversion map to tests

### DIFF
--- a/lazer/contracts/aptos/Move.toml
+++ b/lazer/contracts/aptos/Move.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 license = "UNLICENSED"
 
 [dependencies]
-AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "1d54fe08792ea702f840965808520f057d1321bb" }
 
 [addresses]
 pyth_lazer = "_"

--- a/lazer/contracts/aptos/tests/pyth_lazer_tests.move
+++ b/lazer/contracts/aptos/tests/pyth_lazer_tests.move
@@ -35,6 +35,8 @@ module pyth_lazer::pyth_lazer_tests {
                 8,
                 false
             );
+        coin::create_coin_conversion_map(framework);
+        coin::create_pairing<AptosCoin>(framework);
         coin::destroy_burn_cap(burn_cap);
         coin::destroy_freeze_cap(freeze_cap);
         mint_cap


### PR DESCRIPTION
## Summary
Fix Aptos contract CI by explicitly creating a coin conversion map in the test setup.

## Rationale
A recent update to the `AptosFramework` dependency made it required to explicitly define a coin conversion map when initializing a coin. We init an APT coin in tests to verify fee withdrawals. Since our dep was pointed to `mainnet`, this caused CI to randomly start failing. This fix adheres to the requirement and also pins the version to the latest revision to avoid other surprises from deps.


## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

