### PR TITLE
chore(ci): Disable runs-on

### DIFF
--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -11,7 +11,6 @@ env:
   POETRY_VERSION: "1.4.2"
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest-x64-m
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
## Summary

CI pre-commit is stalled. Disable the runs_on clause to see if the larger runner is the problem.

