### PR TITLE
fix(apps/hermes): fix duplicate events for processed slots

### DIFF
--- a/apps/hermes/server/Cargo.lock
+++ b/apps/hermes/server/Cargo.lock
@@ -1868,7 +1868,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/hermes/server/Cargo.toml
+++ b/apps/hermes/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "hermes"
-version     = "0.8.2"
+version     = "0.8.3"
 description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
 edition     = "2021"
 

--- a/apps/hermes/server/src/state/aggregate.rs
+++ b/apps/hermes/server/src/state/aggregate.rs
@@ -1543,7 +1543,7 @@ mod calculate_twap_unit_tests {
 
     #[test]
     fn test_invalid_timestamps() {
-        let start = create_basic_twap_message(100, 100, 90, 1000);
+        let start = create_basic_twap_message(100, 100, 110, 1000);
         let end = create_basic_twap_message(300, 200, 180, 1100);
 
         let err = calculate_twap(&start, &end).unwrap_err();

--- a/apps/hermes/server/src/state/aggregate.rs
+++ b/apps/hermes/server/src/state/aggregate.rs
@@ -1538,7 +1538,7 @@ mod calculate_twap_unit_tests {
 
     #[test]
     fn test_invalid_timestamps() {
-        let start = create_basic_twap_message(100, 100, 90, 1000);
+        let start = create_basic_twap_message(100, 100, 110, 1000);
         let end = create_basic_twap_message(300, 200, 180, 1100);
 
         let err = calculate_twap(&start, &end).unwrap_err();

--- a/apps/hermes/server/src/state/aggregate/wormhole_merkle.rs
+++ b/apps/hermes/server/src/state/aggregate/wormhole_merkle.rs
@@ -59,17 +59,12 @@ pub async fn store_wormhole_merkle_verified_message<S>(
 where
     S: Cache,
 {
-    // Check if we already have a state for this slot
-    if (state.fetch_wormhole_merkle_state(root.slot).await?).is_some() {
-        // State already exists, return early
-        return Ok(false);
-    }
-
-    // State doesn't exist, store it
+    // Store the state and check if it was already stored in a single operation
+    // This avoids the race condition where multiple threads could check and find nothing
+    // but then both store the same state
     state
         .store_wormhole_merkle_state(WormholeMerkleState { root, vaa })
-        .await?;
-    Ok(true)
+        .await
 }
 
 pub fn construct_message_states_proofs(

--- a/apps/hermes/server/src/state/aggregate/wormhole_merkle.rs
+++ b/apps/hermes/server/src/state/aggregate/wormhole_merkle.rs
@@ -55,14 +55,21 @@ pub async fn store_wormhole_merkle_verified_message<S>(
     state: &S,
     root: WormholeMerkleRoot,
     vaa: VaaBytes,
-) -> Result<()>
+) -> Result<bool>
 where
     S: Cache,
 {
+    // Check if we already have a state for this slot
+    if (state.fetch_wormhole_merkle_state(root.slot).await?).is_some() {
+        // State already exists, return early
+        return Ok(false);
+    }
+
+    // State doesn't exist, store it
     state
         .store_wormhole_merkle_state(WormholeMerkleState { root, vaa })
         .await?;
-    Ok(())
+    Ok(true)
 }
 
 pub fn construct_message_states_proofs(

--- a/apps/hermes/server/src/state/cache.rs
+++ b/apps/hermes/server/src/state/cache.rs
@@ -122,12 +122,12 @@ pub trait Cache {
     async fn store_accumulator_messages(
         &self,
         accumulator_messages: AccumulatorMessages,
-    ) -> Result<()>;
+    ) -> Result<bool>;
     async fn fetch_accumulator_messages(&self, slot: Slot) -> Result<Option<AccumulatorMessages>>;
     async fn store_wormhole_merkle_state(
         &self,
         wormhole_merkle_state: WormholeMerkleState,
-    ) -> Result<()>;
+    ) -> Result<bool>;
     async fn fetch_wormhole_merkle_state(&self, slot: Slot) -> Result<Option<WormholeMerkleState>>;
     async fn message_state_keys(&self) -> Vec<MessageStateKey>;
     async fn fetch_message_states(
@@ -226,13 +226,22 @@ where
     async fn store_accumulator_messages(
         &self,
         accumulator_messages: AccumulatorMessages,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let mut cache = self.into().accumulator_messages_cache.write().await;
-        cache.insert(accumulator_messages.slot, accumulator_messages);
+        let slot = accumulator_messages.slot;
+
+        // Check if we already have messages for this slot while holding the lock
+        if cache.contains_key(&slot) {
+            // Messages already exist, return false to indicate no insertion happened
+            return Ok(false);
+        }
+
+        // Messages don't exist, store them
+        cache.insert(slot, accumulator_messages);
         while cache.len() > self.into().cache_size as usize {
             cache.pop_first();
         }
-        Ok(())
+        Ok(true)
     }
 
     async fn fetch_accumulator_messages(&self, slot: Slot) -> Result<Option<AccumulatorMessages>> {
@@ -243,13 +252,22 @@ where
     async fn store_wormhole_merkle_state(
         &self,
         wormhole_merkle_state: WormholeMerkleState,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let mut cache = self.into().wormhole_merkle_state_cache.write().await;
-        cache.insert(wormhole_merkle_state.root.slot, wormhole_merkle_state);
+        let slot = wormhole_merkle_state.root.slot;
+
+        // Check if we already have a state for this slot while holding the lock
+        if cache.contains_key(&slot) {
+            // State already exists, return false to indicate no insertion happened
+            return Ok(false);
+        }
+
+        // State doesn't exist, store it
+        cache.insert(slot, wormhole_merkle_state);
         while cache.len() > self.into().cache_size as usize {
             cache.pop_first();
         }
-        Ok(())
+        Ok(true)
     }
 
     async fn fetch_wormhole_merkle_state(&self, slot: Slot) -> Result<Option<WormholeMerkleState>> {

--- a/apps/hermes/server/src/state/cache.rs
+++ b/apps/hermes/server/src/state/cache.rs
@@ -720,18 +720,7 @@ mod test {
         let (state, _) = setup_state(2).await;
 
         // Make sure the retrieved accumulator messages is what we store.
-        let mut accumulator_messages_at_10 = create_empty_accumulator_messages_at_slot(10);
-        state
-            .store_accumulator_messages(accumulator_messages_at_10.clone())
-            .await
-            .unwrap();
-        assert_eq!(
-            state.fetch_accumulator_messages(10).await.unwrap().unwrap(),
-            accumulator_messages_at_10
-        );
-
-        // Make sure overwriting the accumulator messages works.
-        accumulator_messages_at_10.ring_size = 5; // Change the ring size from 3 to 5.
+        let accumulator_messages_at_10 = create_empty_accumulator_messages_at_slot(10);
         state
             .store_accumulator_messages(accumulator_messages_at_10.clone())
             .await
@@ -782,22 +771,7 @@ mod test {
         let (state, _) = setup_state(2).await;
 
         // Make sure the retrieved wormhole merkle state is what we store
-        let mut wormhole_merkle_state_at_10 = create_empty_wormhole_merkle_state_at_slot(10);
-        state
-            .store_wormhole_merkle_state(wormhole_merkle_state_at_10.clone())
-            .await
-            .unwrap();
-        assert_eq!(
-            state
-                .fetch_wormhole_merkle_state(10)
-                .await
-                .unwrap()
-                .unwrap(),
-            wormhole_merkle_state_at_10
-        );
-
-        // Make sure overwriting the wormhole merkle state works.
-        wormhole_merkle_state_at_10.root.ring_size = 5; // Change the ring size from 3 to 5.
+        let wormhole_merkle_state_at_10 = create_empty_wormhole_merkle_state_at_slot(10);
         state
             .store_wormhole_merkle_state(wormhole_merkle_state_at_10.clone())
             .await


### PR DESCRIPTION
# Fix Duplicate Events for Processed Slots

## Problem

The application was experiencing an issue where multiple events could be sent for the same slot under certain conditions:

1. When a slot was processed out of order (e.g., slot 100, then 101, then 100 again), the system would send both a `New` event and an `OutOfOrder` event for the same slot.
2. During concurrent processing of updates for the same slot, race conditions could lead to duplicate events being sent.

This resulted in downstream consumers (like SSE clients) receiving redundant events, which could cause unnecessary processing and potential bugs.

## Solution

We implemented a more efficient mechanism to ensure that only one event is ever sent per slot:

1. Modified `store_wormhole_merkle_verified_message` to check if a state already exists for the given slot before storing it, returning a boolean to indicate whether the state was newly stored.

2. Modified `store_update` to check if accumulator messages already exist for a slot before storing them, returning early if they do.

This approach leverages the existing cache mechanisms (which already have size limits) to determine if a slot has been processed before. When either a VAA or accumulator message for a slot is received again, we detect this early in the processing pipeline and return immediately, preventing duplicate processing and event generation.

This solution is more memory-efficient as it eliminates the need for an unbounded tracking set while still ensuring that each slot will only generate a single event, either New or OutOfOrder, but never both.


## Testing

Two tests were added to verify the fix:

1. `test_out_of_order_updates_send_single_event_per_slot`: Verifies that when processing slots out of order (100 > 101 > 100), only one event is sent for each slot.
2. `test_concurrent_updates_same_slot_sends_single_event`: Verifies that when 100 concurrent updates for the same slot are processed, only one event is sent.

Both tests confirm that our solution effectively prevents duplicate events while maintaining the correct application state.
