### PR TITLE
fix: remove redundant libusb install

### DIFF
--- a/.github/workflows/ci-turbo-build.yml
+++ b/.github/workflows/ci-turbo-build.yml
@@ -15,8 +15,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Install libusb
-        run: sudo apt install -y libusb-1.0-0-dev
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci-turbo-test.yml
+++ b/.github/workflows/ci-turbo-test.yml
@@ -15,8 +15,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Install libusb
-        run: sudo apt install -y libusb-1.0-0-dev
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -9,8 +9,6 @@ jobs:
     name: Publish Javascript Packages to NPM
     runs-on: ubuntu-latest
     steps:
-      - name: Install libusb
-        run: sudo apt install -y libusb-1.0-0-dev
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
I discovered that these tasks all install libusb twice, probably due to separate branches including similar fixes that were open at the same time.  This PR removes the redundant installation.