### PR TITLE
fix: fix storybook background color

### DIFF
--- a/packages/component-library/.storybook/preview.tsx
+++ b/packages/component-library/.storybook/preview.tsx
@@ -15,15 +15,15 @@ const preview = {
         cellSize: 4,
         cellAmount: 4,
       },
-      options: [
-        { name: "Primary", value: "var(--primary-background)" },
-        { name: "Secondary", value: "var(--secondary-background)" },
-      ],
+      options: {
+        primary: { name: "Primary", value: "var(--primary-background)" },
+        secondary: { name: "Secondary", value: "var(--secondary-background)" },
+      },
     },
     actions: { argTypesRegex: "^on[A-Z].*" },
   },
   initialGlobals: {
-    backgrounds: { value: "Primary" },
+    backgrounds: { value: "primary" },
   },
 } satisfies Preview;
 


### PR DESCRIPTION
## Summary

Fix the storybook background config.

## Rationale

The api for this changed in some storybook version between when I implement it originally and now, and I just noticed it isn't working since the storybook has been intermittently broken for a while.  This PR fixes it.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code
