### PR TITLE
fix: fix vercel's use of corepack during the ignoreCommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ __pycache__
 .next
 .turbo/
 .cursorrules
+.corepack

--- a/apps/api-reference/vercel.json
+++ b/apps/api-reference/vercel.json
@@ -1,7 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "pnpm dlx turbo-ignore --fallback=HEAD^",
-  "env": {
-    "ENABLE_EXPERIMENTAL_COREPACK": "1"
-  }
+  "ignoreCommand": "../../vercel-ignore.sh"
 }

--- a/apps/entropy-debugger/vercel.json
+++ b/apps/entropy-debugger/vercel.json
@@ -1,7 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "pnpm dlx turbo-ignore --fallback=HEAD^",
-  "env": {
-    "ENABLE_EXPERIMENTAL_COREPACK": "1"
-  }
+  "ignoreCommand": "../../vercel-ignore.sh"
 }

--- a/apps/insights/vercel.json
+++ b/apps/insights/vercel.json
@@ -1,7 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "pnpm dlx turbo-ignore --fallback=HEAD^",
-  "env": {
-    "ENABLE_EXPERIMENTAL_COREPACK": "1"
-  }
+  "ignoreCommand": "../../vercel-ignore.sh"
 }

--- a/apps/staking/vercel.json
+++ b/apps/staking/vercel.json
@@ -1,7 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "pnpm dlx turbo-ignore --fallback=HEAD^",
-  "env": {
-    "ENABLE_EXPERIMENTAL_COREPACK": "1"
-  }
+  "ignoreCommand": "../../vercel-ignore.sh"
 }

--- a/governance/xc_admin/packages/xc_admin_frontend/vercel.json
+++ b/governance/xc_admin/packages/xc_admin_frontend/vercel.json
@@ -1,7 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "pnpm dlx turbo-ignore --fallback=HEAD^",
-  "env": {
-    "ENABLE_EXPERIMENTAL_COREPACK": "1"
-  }
+  "ignoreCommand": "../../../../vercel-ignore.sh"
 }

--- a/packages/component-library/vercel.json
+++ b/packages/component-library/vercel.json
@@ -1,10 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "turbo --filter @pythnetwork/component-library build:storybook",
-  "ignoreCommand": "pnpm dlx turbo-ignore --fallback=HEAD^",
+  "ignoreCommand": "../../vercel-ignore.sh",
   "framework": null,
-  "outputDirectory": "storybook-static",
-  "env": {
-    "ENABLE_EXPERIMENTAL_COREPACK": "1"
-  }
+  "outputDirectory": "storybook-static"
 }

--- a/vercel-ignore.sh
+++ b/vercel-ignore.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Vercel currently does not properly enable corepack when running the
+# ignoreCommand.  This was recommended as a stopgap by Vercel support until they
+# fix that issue.
+COREPACK_ROOT="$PWD/.corepack"
+COREPACK_SHIM="$COREPACK_ROOT/shim"
+export COREPACK_HOME="$COREPACK_ROOT/home"
+export PATH="$COREPACK_SHIM:$PATH"
+mkdir -p "$COREPACK_HOME"
+mkdir -p "$COREPACK_SHIM"
+corepack enable --install-directory "$COREPACK_SHIM"
+
+exec pnpm dlx turbo-ignore --fallback=HEAD^


### PR DESCRIPTION
## Summary

It seems like vercel does not correctly use corepack during the `ignoreCommand`, which was the cause of the flakiness with ignoring builds for so long.

We thought we had fixed it in #2468 , but it turns out this doesn't actually work -- it seems like Vercel does not properly apply env vars from the `vercel.json` config file -- so in effect that just disabled corepack entirely.  It wasn't a huge issue as Vercel was choosing a close enough version of pnpm by default, but it would be better to actually use corepack and ensure Vercel is using the exact same version of pnpm that we are locked to in the monorepo.

This PR, along with readding the `ENABLE_EXPERIMENTAL_COREPACK` env var via the Vercel dashboard, should both re-enable corepack on builds AND fix the `ignoreCommand` to properly use corepack.

## Rationale

Using corepack correctly ensures that Vercel builds are using the same version of pnpm that we're locked to in the monorepo, which prevents subtle issues caused by differing tooling versions.

## How has this been tested?

I can't test this until it builds on Vercel, so I'll look at the logs to see if it worked!
