### PR TITLE
fix: fix installing libusb in github actions

### DIFF
--- a/.github/workflows/ci-ethereum-contract.yml
+++ b/.github/workflows/ci-ethereum-contract.yml
@@ -27,7 +27,7 @@ jobs:
       # install will fail if this isn't in the build environment and if a
       # precompiled binary isn't found.
       - name: Install libusb
-        run: sudo apt install -y libusb-1.0-0-dev libudev-dev
+        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev libudev-dev
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm

--- a/.github/workflows/ci-lazer-solana-contract.yml
+++ b/.github/workflows/ci-lazer-solana-contract.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - lazer/**
+      - .github/workflows/ci-lazer-solana-contract.yml
 
 jobs:
   lazer-solana-contract-test:
@@ -28,7 +29,7 @@ jobs:
       # install will fail if this isn't in the build environment and if a
       # precompiled binary isn't found.
       - name: Install libusb
-        run: sudo apt install -y libusb-1.0-0-dev libudev-dev
+        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev libudev-dev
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:

--- a/.github/workflows/ci-message-buffer.yml
+++ b/.github/workflows/ci-message-buffer.yml
@@ -45,7 +45,7 @@ jobs:
       # install will fail if this isn't in the build environment and if a
       # precompiled binary isn't found.
       - name: Install libusb
-        run: sudo apt install -y libusb-1.0-0-dev libudev-dev
+        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev libudev-dev
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:

--- a/.github/workflows/ci-turbo-build.yml
+++ b/.github/workflows/ci-turbo-build.yml
@@ -9,6 +9,7 @@ on:
       - "**/package.json"
       - "**/package-lock.json"
       - "**/tsconfig.json"
+      - .github/workflows/ci-turbo-build.yml
   push:
     branches: [main]
 jobs:
@@ -24,7 +25,7 @@ jobs:
       # install will fail if this isn't in the build environment and if a
       # precompiled binary isn't found.
       - name: Install libusb
-        run: sudo apt install -y libusb-1.0-0-dev libudev-dev
+        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev libudev-dev
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:

--- a/.github/workflows/ci-turbo-test.yml
+++ b/.github/workflows/ci-turbo-test.yml
@@ -9,6 +9,7 @@ on:
       - "**/package.json"
       - "**/package-lock.json"
       - "**/tsconfig.json"
+      - .github/workflows/ci-turbo-test.yml
   push:
     branches: [main]
 jobs:
@@ -23,7 +24,7 @@ jobs:
       # install will fail if this isn't in the build environment and if a
       # precompiled binary isn't found.
       - name: Install libusb
-        run: sudo apt install -y libusb-1.0-0-dev libudev-dev
+        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev libudev-dev
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -17,7 +17,7 @@ jobs:
       # install will fail if this isn't in the build environment and if a
       # precompiled binary isn't found.
       - name: Install libusb
-        run: sudo apt install -y libusb-1.0-0-dev libudev-dev
+        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev libudev-dev
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:


### PR DESCRIPTION
## Summary

Installing node packages requires libusb & libudev due to some native extensions that get compiled during install.  However this started failing today, presumably due to package upgrades in the upstream repository.

This PR fixes the libusb & libudev install to do an `apt-get update` before installing the packages.

## Rationale

CI is currently failing on tasks that require these libs.

## How has this been tested?

We'll see when the Github Actions trigger