### PR TITLE
chore(lazer): add locked to anchor install in CI

### DIFF
--- a/.github/workflows/ci-lazer-solana-contract.yml
+++ b/.github/workflows/ci-lazer-solana-contract.yml
@@ -43,6 +43,8 @@ jobs:
       - name: Create Solana key
         run: solana-keygen new --no-bip39-passphrase
       - name: Install Anchor
-        run: RUSTFLAGS= cargo install --git https://github.com/coral-xyz/anchor --tag v0.30.1 anchor-cli
+        run: |
+          rustup install 1.79.0
+          RUSTFLAGS= cargo +1.79.0 install --git https://github.com/coral-xyz/anchor --tag v0.30.1 --locked anchor-cli
       - name: Run anchor tests
         run: pnpm run test:anchor


### PR DESCRIPTION
## Summary

Add `--locked` to `cargo install` and build it on rustc 1.79 because it doesn't build on 1.80 or later.

## Rationale

Build was failing because a dependency required newer rustc.

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
