### PR TITLE
chore(pyth-solana-receiver-sdk): enable solana-program >= 2 (and thus anchor-lang 0.31.0)

### DIFF
--- a/target_chains/solana/Cargo.lock
+++ b/target_chains/solana/Cargo.lock
@@ -3120,9 +3120,10 @@ dependencies = [
 
 [[package]]
 name = "pyth-solana-receiver-sdk"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anchor-lang",
+ "bytemuck_derive",
  "hex",
  "pythnet-sdk",
  "solana-program",

--- a/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
+++ b/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-solana-receiver-sdk"
-version = "0.5.0"
+version = "0.6.0"
 description = "SDK for the Pyth Solana Receiver program"
 authors = ["Pyth Data Association"]
 repository = "https://github.com/pyth-network/pyth-crosschain"
@@ -15,7 +15,8 @@ name = "pyth_solana_receiver_sdk"
 [dependencies]
 anchor-lang = ">=0.28.0"
 hex = ">=0.4.3"
+bytemuck_derive = "<=1.8.1" # After this version, MSRV 1.84 is required.
 pythnet-sdk = { path = "../../../pythnet/pythnet_sdk", version = "2.1.0", features = [
     "solana-program",
 ] }
-solana-program = ">=1.16.0, <2.0.0"
+solana-program = ">=1.16.0"


### PR DESCRIPTION
## Summary
Remove the solana-program<2 bound in our `pyth-solana-receiver-sdk` dependencies to enable using the SDK with anchor 0.31.0.

## Rationale
- `anchor-lang` v0.31.0 requires `solana-program=^2`. Thus, this change enables using anchor 0.31.0 with our SDK. This change has been requested by a few consumers. 
- `bytemuck_derive` has been restricted to <=1.8.1 since after this version, minimum rust version 1.84 is required, which breaks compatibility with the other packages in the workspace.
- We did not bump the minimum anchor version to 0.31.0 since solana-program ^2 requires a higher rust version, which would also break compatibility with other packages in the workspace.
- Once this lands, I'll publish [this repo](https://github.com/guibescos/anchor-pyth/tree/v0.30.1) to our GH org which shows a example of using the SDK with anchor 0.31.0 (and other versions).

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
