### PR TITLE
Only build stuff that requires Vercel env to build on Vercel

### DIFF
--- a/.github/workflows/ci-turbo-build.yml
+++ b/.github/workflows/ci-turbo-build.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Cache for Turbo
         uses: rharkor/caching-for-turbo@v1.5
       - name: Build
-        run: pnpm build:ci
+        run: pnpm run turbo build

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -26,5 +26,5 @@ jobs:
         run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: pnpm build:ci
+        run: pnpm run turbo build
       - run: pnpm run publish

--- a/apps/api-reference/package.json
+++ b/apps/api-reference/package.json
@@ -7,7 +7,7 @@
     "node": "22"
   },
   "scripts": {
-    "build": "next build",
+    "build:vercelonly": "next build",
     "fix:format": "prettier --write .",
     "fix:lint": "eslint --fix . --max-warnings 0",
     "pull:env": "[ $CI ] || VERCEL_ORG_ID=team_BKQrg3JJFLxZyTqpuYtIY0rj VERCEL_PROJECT_ID=prj_gbljYVzp0m5EpCuOF6nZpM4WMFM6 vercel env pull",

--- a/apps/api-reference/turbo.json
+++ b/apps/api-reference/turbo.json
@@ -2,7 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
-    "build": {
+    "build:vercelonly": {
       "env": [
         "WALLETCONNECT_PROJECT_ID",
         "AMPLITUDE_API_KEY",

--- a/apps/api-reference/vercel.json
+++ b/apps/api-reference/vercel.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "../../vercel-ignore.sh"
+  "ignoreCommand": "../../vercel-ignore.sh",
+  "buildCommand": "turbo run build:vercelonly --filter @pythnetwork/api-reference"
 }

--- a/apps/insights/package.json
+++ b/apps/insights/package.json
@@ -7,7 +7,7 @@
     "node": "22"
   },
   "scripts": {
-    "build": "next build",
+    "build:vercelonly": "next build",
     "fix:format": "prettier --write .",
     "fix:lint:eslint": "eslint --fix .",
     "fix:lint:stylelint": "stylelint --fix 'src/**/*.scss'",

--- a/apps/insights/turbo.json
+++ b/apps/insights/turbo.json
@@ -2,7 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
-    "build": {
+    "build:vercelonly": {
       "env": [
         "VERCEL_ENV",
         "GOOGLE_ANALYTICS_ID",

--- a/apps/insights/vercel.json
+++ b/apps/insights/vercel.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "../../vercel-ignore.sh"
+  "ignoreCommand": "../../vercel-ignore.sh",
+  "buildCommand": "turbo run build:vercelonly --filter @pythnetwork/insights"
 }

--- a/apps/staking/package.json
+++ b/apps/staking/package.json
@@ -7,7 +7,7 @@
     "node": "22"
   },
   "scripts": {
-    "build": "next build",
+    "build:vercelonly": "next build",
     "fix:format": "prettier --write .",
     "fix:lint": "eslint --fix . --max-warnings 0",
     "pull:env": "[ $CI ] || VERCEL_ORG_ID=team_BKQrg3JJFLxZyTqpuYtIY0rj VERCEL_PROJECT_ID=prj_3TIYzlYYncZx7wRtfmzG2YUsNzKp vercel env pull",

--- a/apps/staking/turbo.json
+++ b/apps/staking/turbo.json
@@ -2,7 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
-    "build": {
+    "build:vercelonly": {
       "env": [
         "IP_ALLOWLIST",
         "GOVERNANCE_ONLY_REGIONS",

--- a/apps/staking/vercel.json
+++ b/apps/staking/vercel.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "../../vercel-ignore.sh"
+  "ignoreCommand": "../../vercel-ignore.sh",
+  "buildCommand": "turbo run build:vercelonly --filter @pythnetwork/staking"
 }

--- a/governance/xc_admin/packages/xc_admin_frontend/package.json
+++ b/governance/xc_admin/packages/xc_admin_frontend/package.json
@@ -6,7 +6,7 @@
     "node": "22"
   },
   "scripts": {
-    "build": "next build",
+    "build:vercelonly": "next build",
     "pull:env": "[ $CI ] || VERCEL_ORG_ID=team_BKQrg3JJFLxZyTqpuYtIY0rj VERCEL_PROJECT_ID=prj_TCjesnm3pxM7Ay8oxlTH4xLkkmP9 vercel env pull",
     "start:dev": "next dev --port 3004",
     "start:prod": "next start --port 3004",

--- a/governance/xc_admin/packages/xc_admin_frontend/turbo.json
+++ b/governance/xc_admin/packages/xc_admin_frontend/turbo.json
@@ -2,7 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
-    "build": {
+    "build:vercelonly": {
       "env": [
         "BUILD_STANDALONE",
         "NEXT_PUBLIC_MAINNET_RPC",

--- a/governance/xc_admin/packages/xc_admin_frontend/vercel.json
+++ b/governance/xc_admin/packages/xc_admin_frontend/vercel.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "../../../../vercel-ignore.sh"
+  "ignoreCommand": "../../../../vercel-ignore.sh",
+  "buildCommand": "turbo run build:vercelonly --filter @pythnetwork/xc-admin-frontend"
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "pnpm": "^9.15.3"
   },
   "scripts": {
-    "build:ci": "turbo build --filter=!./apps/api-reference --filter=!./apps/insights --filter=!./apps/staking",
     "fix:format": "prettier --write .",
     "install:modules": "[ $CI ] && true || pnpm install",
     "publish": "lerna publish from-package --no-private --no-git-tag-version --yes",

--- a/turbo.json
+++ b/turbo.json
@@ -70,6 +70,25 @@
       ],
       "outputs": ["lib/**", "dist/**", ".next/**", "!.next/cache/**"]
     },
+    "build:vercelonly": {
+      "dependsOn": [
+        "//#install:modules",
+        "pull:env",
+        "^build",
+        "build:cjs",
+        "build:esm"
+      ],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!README.md",
+        "!**/*.test.*",
+        "!jest.config.js",
+        "!eslint.config.js",
+        "!prettier.config.js",
+        "!vercel.json"
+      ],
+      "outputs": ["lib/**", "dist/**", ".next/**", "!.next/cache/**"]
+    },
     "build:cjs": {
       "dependsOn": ["//#install:modules"],
       "inputs": [


### PR DESCRIPTION
## Summary

Do not build packages that rely on the Vercel environment using `turbo build`, instead move them to build with `turbo build:vercelonly`

## Rationale

For many of our UI applications, in order to build the package, a number of environment variables must be present.

The values for these env vars are stored in Vercel, however not everyone who contributes to this repository will have access to Vercel.

This PR modifies the turbo config to not build those packages on `turbo build`. This is generally probably the right thing since we don't want those packages to build in Github Actions either, given the environment is not going to be present in GHA and so the builds would likely fail there too.

After this PR, to build any packages that rely on Vercel environments, you will run `turbo build:vercelonly`.  Running `turbo build` will build everything else and will exclude anything that depends on the Vercel env.

## How has this been tested?

CI will be the test
