### PR TITLE
chore: update ConfluxScan link

### DIFF
--- a/apps/entropy-debugger/src/store/entropy-deployments.ts
+++ b/apps/entropy-debugger/src/store/entropy-deployments.ts
@@ -113,7 +113,7 @@ export const EntropyDeployments = {
     network: "testnet",
     delay: "",
     address: "0xdF21D137Aadc95588205586636710ca2890538d5",
-    explorer: "https://evmtestnet.confluxscan.io/address/$ADDRESS",
+    explorer: "https://evmtestnet.confluxscan.org/address/$ADDRESS",
     gasLimit: "500K",
     nativeCurrency: "CFX",
   },


### PR DESCRIPTION
Official Conflux blockchain explorer ConfluxScan is now live with new domain links. This PR updates the ConfluxScan link.

Check the official announcement here: https://forum.conflux.fun/t/confluxscan-domain-update-announcement-march-28-2025/21920