### PR TITLE
fix(fortuna): fix too high fees

### DIFF
--- a/apps/fortuna/Cargo.lock
+++ b/apps/fortuna/Cargo.lock
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "fortuna"
-version = "7.4.9"
+version = "7.4.10"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/fortuna/Cargo.toml
+++ b/apps/fortuna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortuna"
-version = "7.4.9"
+version = "7.4.10"
 edition = "2021"
 
 [lib]

--- a/apps/fortuna/src/keeper/fee.rs
+++ b/apps/fortuna/src/keeper/fee.rs
@@ -107,7 +107,7 @@ pub async fn adjust_fee_wrapper(
         .in_current_span()
         .await
         {
-            tracing::error!("Withdrawing fees. error: {:?}", e);
+            tracing::error!("Fee adjustment failed: {:?}", e);
         }
         time::sleep(poll_interval).await;
     }
@@ -212,6 +212,9 @@ pub async fn adjust_fee_if_necessary(
     if is_chain_active
         && ((provider_fee > target_fee_max && can_reduce_fees) || provider_fee < target_fee_min)
     {
+        if min_fee_wei * 100 < target_fee {
+            return Err(anyhow!("Cowardly refusing to set target fee more than 100x min_fee_wei. Target: {:?} Min: {:?}", target_fee, min_fee_wei));
+        }
         tracing::info!(
             "Adjusting fees. Current: {:?} Target: {:?}",
             provider_fee,


### PR DESCRIPTION
## Summary

Reject setting the fees too high

## Rationale

We estimate priority fees similar to how ethers.rs library does it. This is the general algo:
1- Get the priority fees of the last 10 blocks
2- Sort them
3- Get the median OR if there is any sudden increase, take the median from that index forward  (https://github.com/gakonst/ethers-rs/blob/master/ethers-core/src/utils/mod.rs#L590)

Now the way priority fees are calculated for a block is just the average of priority fees for the transactions in that block. So if a block (https://berascan.com/block/2933426) only includes a single tx with very high priority fee, that would be overall priority fee for that block. So what happened for fortuna is we took that priority fee (because of that sudden increase heuristic) and set our fees according to that and that led to a super high fee.
This is what happens once in a while in berachain. When there is not a lot of activity on-chain, it's pretty easy to skew the priority fees.
I think adjusting the algo is a bit futile, I just set some hard caps. Also, in case we exceed that hardcap, we don't even attempt to set it but just try to wait a minute and recalculate again.