### PR TITLE
feat: add a staking endpoint to return a stake summary per account

### DIFF
--- a/apps/staking/src/app/api/v1/amount_staked_per_account/route.ts
+++ b/apps/staking/src/app/api/v1/amount_staked_per_account/route.ts
@@ -1,0 +1,53 @@
+import type { PositionState } from "@pythnetwork/staking-sdk";
+import {
+  PythStakingClient,
+  summarizeAccountPositions,
+  getCurrentEpoch,
+} from "@pythnetwork/staking-sdk";
+import { WalletAdapterNetwork } from "@solana/wallet-adapter-base";
+import { clusterApiUrl, Connection } from "@solana/web3.js";
+
+import {
+  AMOUNT_STAKED_PER_ACCOUNT_SECRET,
+  MAINNET_API_RPC,
+} from "../../../../config/server";
+
+export const maxDuration = 800;
+
+export const GET = async (req: Request) => {
+  if (
+    AMOUNT_STAKED_PER_ACCOUNT_SECRET === undefined ||
+    req.headers.get("authorization") ===
+      `Bearer ${AMOUNT_STAKED_PER_ACCOUNT_SECRET}`
+  ) {
+    const [accounts, epoch] = await Promise.all([
+      client.getAllStakeAccountPositionsAllOwners(),
+      getCurrentEpoch(client.connection),
+    ]);
+    return Response.json(
+      accounts.map((account) => {
+        const summary = summarizeAccountPositions(account, epoch);
+        return [
+          account.data.owner,
+          {
+            voting: stringifySummaryValues(summary.voting),
+            integrityPool: stringifySummaryValues(summary.integrityPool),
+          },
+        ];
+      }),
+    );
+  } else {
+    return new Response("Unauthorized", { status: 400 });
+  }
+};
+
+const stringifySummaryValues = (values: Record<PositionState, bigint>) =>
+  Object.fromEntries(
+    Object.entries(values).map(([state, value]) => [state, value.toString()]),
+  );
+
+const client = new PythStakingClient({
+  connection: new Connection(
+    MAINNET_API_RPC ?? clusterApiUrl(WalletAdapterNetwork.Mainnet),
+  ),
+});

--- a/apps/staking/src/config/server.ts
+++ b/apps/staking/src/config/server.ts
@@ -80,6 +80,10 @@ export const SIMULATION_PAYER_ADDRESS = getOr(
   "SIMULATION_PAYER_ADDRESS",
   "E5KR7yfb9UyVB6ZhmhQki1rM1eBcxHvyGKFZakAC5uc",
 );
+export const AMOUNT_STAKED_PER_ACCOUNT_SECRET = demandInProduction(
+  "AMOUNT_STAKED_PER_ACCOUNT_SECRET",
+);
+
 class MissingEnvironmentError extends Error {
   constructor(name: string) {
     super(`Missing environment variable: ${name}!`);

--- a/apps/staking/turbo.json
+++ b/apps/staking/turbo.json
@@ -12,7 +12,8 @@
         "MAINNET_API_RPC",
         "BLOCKED_REGIONS",
         "AMPLITUDE_API_KEY",
-        "GOOGLE_ANALYTICS_ID"
+        "GOOGLE_ANALYTICS_ID",
+        "AMOUNT_STAKED_PER_ACCOUNT_SECRET"
       ]
     },
     "start:dev": {

--- a/governance/pyth_staking_sdk/package.json
+++ b/governance/pyth_staking_sdk/package.json
@@ -8,6 +8,9 @@
   "files": [
     "dist/**/*"
   ],
+  "engines": {
+    "node": "22"
+  },
   "publishConfig": {
     "access": "public"
   },
@@ -39,6 +42,8 @@
     "@pythnetwork/solana-utils": "workspace:*",
     "@solana/spl-governance": "^0.3.28",
     "@solana/spl-token": "^0.3.7",
-    "@solana/web3.js": "catalog:"
+    "@solana/web3.js": "catalog:",
+    "@streamparser/json": "^0.0.22",
+    "zod": "catalog:"
   }
 }

--- a/governance/pyth_staking_sdk/src/utils/position.ts
+++ b/governance/pyth_staking_sdk/src/utils/position.ts
@@ -111,3 +111,33 @@ export const getVotingTokenAmount = (
   );
   return totalVotingTokenAmount;
 };
+
+export const summarizeAccountPositions = (
+  positions: StakeAccountPositions,
+  epoch: bigint,
+) => {
+  const summary = {
+    voting: {
+      [PositionState.LOCKED]: 0n,
+      [PositionState.LOCKING]: 0n,
+      [PositionState.PREUNLOCKING]: 0n,
+      [PositionState.UNLOCKED]: 0n,
+      [PositionState.UNLOCKING]: 0n,
+    },
+    integrityPool: {
+      [PositionState.LOCKED]: 0n,
+      [PositionState.LOCKING]: 0n,
+      [PositionState.PREUNLOCKING]: 0n,
+      [PositionState.UNLOCKED]: 0n,
+      [PositionState.UNLOCKING]: 0n,
+    },
+  };
+  for (const position of positions.data.positions) {
+    const category = position.targetWithParameters.voting
+      ? "voting"
+      : "integrityPool";
+    const state = getPositionState(position, epoch);
+    summary[category][state] += position.amount;
+  }
+  return summary;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1193,6 +1193,12 @@ importers:
       '@solana/web3.js':
         specifier: 'catalog:'
         version: 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@streamparser/json':
+        specifier: ^0.0.22
+        version: 0.0.22
+      zod:
+        specifier: 'catalog:'
+        version: 3.24.2
     devDependencies:
       '@cprussin/eslint-config':
         specifier: 'catalog:'
@@ -9405,6 +9411,9 @@ packages:
     resolution: {integrity: sha512-6VjZg8HJ2Op7+KV7ihJpYrDnFtd9D1jrQnUS8LckcpuBXrIEbaut5+34ObY8ssQnSqkk2GwIZBBBQYQBCVvkOw==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@streamparser/json@0.0.22':
+    resolution: {integrity: sha512-b6gTSBjJ8G8SuO3Gbbj+zXbVx8NSs1EbpbMKpzGLWMdkR+98McH9bEjSz3+0mPJf68c5nxa3CrJHp5EQNXM6zQ==}
 
   '@suchipi/femver@1.0.0':
     resolution: {integrity: sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg==}
@@ -33482,6 +33491,8 @@ snapshots:
   '@storybook/theming@8.6.12(storybook@8.6.12(bufferutil@4.0.9)(prettier@3.5.3)(utf-8-validate@6.0.3))':
     dependencies:
       storybook: 8.6.12(bufferutil@4.0.9)(prettier@3.5.3)(utf-8-validate@6.0.3)
+
+  '@streamparser/json@0.0.22': {}
 
   '@suchipi/femver@1.0.0': {}
 


### PR DESCRIPTION
## Summary

Adds an endpoint to the staking app to return a stake summary per account.

## Rationale

This is required to calculate Fogo flames

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code
