### PR TITLE
feat(insights): add permissioned feeds column to the publisher list

### DIFF
--- a/apps/insights/src/components/Explanations/index.tsx
+++ b/apps/insights/src/components/Explanations/index.tsx
@@ -4,6 +4,24 @@ import { useMemo } from "react";
 import { Explain } from "../Explain";
 import { FormattedDate } from "../FormattedDate";
 
+export const ExplainPermissioned = ({
+  scoreTime,
+}: {
+  scoreTime?: Date | undefined;
+}) => {
+  return (
+    <Explain size="xs" title="Permissioned Feeds">
+      <p>
+        This is the number of <b>Price Feeds</b> that a <b>Publisher</b> has
+        permissions to publish to. The publisher is not necessarily push data
+        for all the feeds they have access to, and some feeds may not be live
+        yet.
+      </p>
+      {scoreTime && <EvaluationTime scoreTime={scoreTime} />}
+    </Explain>
+  );
+};
+
 export const ExplainAverage = ({
   scoreTime,
 }: {

--- a/apps/insights/src/components/Publishers/index.tsx
+++ b/apps/insights/src/components/Publishers/index.tsx
@@ -147,6 +147,7 @@ export const Publishers = async () => {
 const toTableRow = ({
   key,
   rank,
+  permissionedFeeds,
   inactiveFeeds,
   activeFeeds,
   averageScore,
@@ -155,8 +156,9 @@ const toTableRow = ({
   return {
     id: key,
     ranking: rank,
-    activeFeeds: activeFeeds,
-    inactiveFeeds: inactiveFeeds,
+    permissionedFeeds,
+    activeFeeds,
+    inactiveFeeds,
     averageScore,
     ...(knownPublisher && {
       name: knownPublisher.name,

--- a/apps/insights/src/components/Publishers/publishers-card.tsx
+++ b/apps/insights/src/components/Publishers/publishers-card.tsx
@@ -24,7 +24,11 @@ import styles from "./publishers-card.module.scss";
 import { useQueryParamFilterPagination } from "../../hooks/use-query-param-filter-pagination";
 import { CLUSTER_NAMES } from "../../services/pyth";
 import { EntityList } from "../EntityList";
-import { ExplainActive, ExplainInactive } from "../Explanations";
+import {
+  ExplainPermissioned,
+  ExplainActive,
+  ExplainInactive,
+} from "../Explanations";
 import { NoResults } from "../NoResults";
 import { PublisherTag } from "../PublisherTag";
 import { Ranking } from "../Ranking";
@@ -43,6 +47,7 @@ type Props = {
 type Publisher = {
   id: string;
   ranking: number;
+  permissionedFeeds: number;
   activeFeeds: number;
   inactiveFeeds: number;
   averageScore: number;
@@ -99,6 +104,7 @@ const ResolvedPublishersCard = ({
     (a, b, { column, direction }) => {
       switch (column) {
         case "ranking":
+        case "permissionedFeeds":
         case "activeFeeds":
         case "inactiveFeeds":
         case "averageScore": {
@@ -131,6 +137,7 @@ const ResolvedPublishersCard = ({
           id,
           ranking,
           averageScore,
+          permissionedFeeds,
           activeFeeds,
           inactiveFeeds,
           ...publisher
@@ -149,6 +156,7 @@ const ResolvedPublishersCard = ({
                 })}
               />
             ),
+            permissionedFeeds,
             activeFeeds: (
               <Link
                 href={`/publishers/${cluster}/${id}/price-feeds?status=Active`}
@@ -224,7 +232,12 @@ type PublishersCardContentsProps = Pick<Props, "className" | "explainAverage"> &
         cluster: (typeof CLUSTER_NAMES)[number];
         onChangeCluster: (value: (typeof CLUSTER_NAMES)[number]) => void;
         rows: (RowConfig<
-          "ranking" | "name" | "activeFeeds" | "inactiveFeeds" | "averageScore"
+          | "ranking"
+          | "name"
+          | "permissionedFeeds"
+          | "activeFeeds"
+          | "inactiveFeeds"
+          | "averageScore"
         > & { textValue: string })[];
       }
   );
@@ -299,6 +312,7 @@ const PublishersCardContents = ({
       headerLoadingSkeleton={<PublisherTag isLoading />}
       fields={[
         { id: "averageScore", name: "Average Score" },
+        { id: "permissionedFeeds", name: "Permissioned Feeds" },
         { id: "activeFeeds", name: "Active Feeds" },
         { id: "inactiveFeeds", name: "Inactive Feeds" },
       ]}
@@ -340,10 +354,22 @@ const PublishersCardContents = ({
           allowsSorting: true,
         },
         {
+          id: "permissionedFeeds",
+          name: (
+            <>
+              FEEDS
+              <ExplainPermissioned />
+            </>
+          ),
+          alignment: "center",
+          width: 30,
+          allowsSorting: true,
+        },
+        {
           id: "activeFeeds",
           name: (
             <>
-              ACTIVE FEEDS
+              ACTIVE
               <ExplainActive />
             </>
           ),
@@ -355,7 +381,7 @@ const PublishersCardContents = ({
           id: "inactiveFeeds",
           name: (
             <>
-              INACTIVE FEEDS
+              INACTIVE
               <ExplainInactive />
             </>
           ),

--- a/apps/insights/src/services/clickhouse.ts
+++ b/apps/insights/src/services/clickhouse.ts
@@ -15,6 +15,9 @@ export const getPublishers = async (cluster: Cluster) =>
       z.strictObject({
         key: z.string(),
         rank: z.number(),
+        permissionedFeeds: z
+          .string()
+          .transform((value) => Number.parseInt(value, 10)),
         activeFeeds: z
           .string()
           .transform((value) => Number.parseInt(value, 10)),
@@ -50,6 +53,7 @@ export const getPublishers = async (cluster: Cluster) =>
             timestamp,
             publisher AS key,
             rank,
+            LENGTH(symbols) AS permissionedFeeds,
             activeFeeds,
             inactiveFeeds,
             score_data.averageScore,


### PR DESCRIPTION
## Summary

Adds a "Permissioned Feeds" column to the publisher list in Insights Hub.

## Rationale

The ranking is hard to understand without this column, so adding this column helps making the ranking information obvious.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code
