### PR TITLE
feat(hermes): configurable cache size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,4 @@
 .git
 
 !apps/hermes/server/src/state/cache.rs
+!apps/hermes/server/src/config/cache.rs

--- a/apps/argus/Cargo.lock
+++ b/apps/argus/Cargo.lock
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "fortuna"
-version = "7.4.8"
+version = "7.4.10"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/hermes/server/Cargo.lock
+++ b/apps/hermes/server/Cargo.lock
@@ -1868,7 +1868,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/hermes/server/Cargo.toml
+++ b/apps/hermes/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "hermes"
-version     = "0.8.4"
+version     = "0.8.5"
 description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
 edition     = "2021"
 

--- a/apps/hermes/server/src/config.rs
+++ b/apps/hermes/server/src/config.rs
@@ -2,6 +2,7 @@ use clap::{crate_authors, crate_description, crate_name, crate_version, Args, Pa
 
 mod aggregate;
 mod benchmarks;
+mod cache;
 mod metrics;
 mod pythnet;
 mod rpc;
@@ -24,6 +25,10 @@ pub enum Options {
 
 #[derive(Args, Clone, Debug)]
 pub struct RunOptions {
+    /// Cache Options
+    #[command(flatten)]
+    pub cache: cache::Options,
+
     /// Aggregate Options
     #[command(flatten)]
     pub aggregate: aggregate::Options,

--- a/apps/hermes/server/src/config/cache.rs
+++ b/apps/hermes/server/src/config/cache.rs
@@ -10,9 +10,9 @@ pub struct Options {
     /// Higher values increase memory usage but allow access to more historical data
     /// without falling back to Benchmarks.
     ///
-    /// Default is 2000 slots, which gives ~13 minutes of cached updates.
+    /// Default is 1600 slots, which gives 640 seconds of cached updates.
     #[arg(long = "cache-size-slots")]
     #[arg(env = "CACHE_SIZE_SLOTS")]
-    #[arg(default_value = "2000")]
+    #[arg(default_value = "1600")]
     pub size_slots: u64,
 }

--- a/apps/hermes/server/src/config/cache.rs
+++ b/apps/hermes/server/src/config/cache.rs
@@ -1,0 +1,18 @@
+use clap::Args;
+
+#[derive(Args, Clone, Debug)]
+#[command(next_help_heading = "Cache Options")]
+#[group(id = "Cache")]
+pub struct Options {
+    /// The maximum number of slots to cache.
+    ///
+    /// This controls how many historical price updates are kept in memory.
+    /// Higher values increase memory usage but allow access to more historical data
+    /// without falling back to Benchmarks.
+    ///
+    /// Default is 2000 slots, which gives ~13 minutes of cached updates.
+    #[arg(long = "cache-size-slots")]
+    #[arg(env = "CACHE_SIZE_SLOTS")]
+    #[arg(default_value = "2000")]
+    pub size_slots: u64,
+}

--- a/apps/hermes/server/src/main.rs
+++ b/apps/hermes/server/src/main.rs
@@ -44,7 +44,7 @@ async fn init() -> Result<()> {
             // Initialize a cache store with a 1000 element circular buffer.
             let state = state::new(
                 update_tx.clone(),
-                1000,
+                opts.cache.size_slots,
                 opts.benchmarks.endpoint.clone(),
                 opts.aggregate.readiness_staleness_threshold.into(),
                 opts.aggregate.readiness_max_allowed_slot_lag,


### PR DESCRIPTION
## Summary
Make the cache size configurable, bump default to 1600 slots. 

## Rationale
This was motivated by the need to store more 1000 slots (400s) of data in Hermes to serve TWAPs from. The size is now configurable with a default of 1600 slots (640s), which is sufficient for our advertised max of 600s.

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
