### PR TITLE
feat(staking): improve tester app feedback

### DIFF
--- a/apps/staking/src/middleware.ts
+++ b/apps/staking/src/middleware.ts
@@ -27,10 +27,6 @@ const proxyCheckClient = PROXYCHECK_API_KEY
   : undefined;
 
 export const middleware = async (request: NextRequest) => {
-  // eslint-disable-next-line no-console
-  console.log("IP Allowlist:", IP_ALLOWLIST);
-  // eslint-disable-next-line no-console
-  console.log("Are they allowed?", isIpAllowlisted("163.116.252.75"));
   const ip = ipAddress(request);
   if (isIpAllowlisted(ip)) {
     return isBlockedSegment(request)


### PR DESCRIPTION
## Summary

Adds better feedback when testing wallets

## Rationale

Currently the feedback only feels nice if your wallet pops up, but e.g. if you use walletconnect you don't get a popup so the app looks like it isn't doing anything after you click "test"

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code