### PR TITLE
feat(entropy): Add on-chain gas limits and mark out-of-gas failures on-chain

### DIFF
--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -661,6 +661,11 @@ abstract contract Entropy is IEntropy, EntropyState {
             providerAddr
         ];
 
+        // Providers charge a minimum of their configured feeInWei for every request. 
+        // Requests using more than the defaultGasLimit get a proportionally scaled fee.
+        // This approach may be somewhat simplistic, but it allows us to continue using the
+        // existing feeInWei parameter for the callback failure flow instead of defining new 
+        // configuration values.
         uint32 roundedGasLimit = uint32(roundGas(gasLimit)) * 10000;
         if (
             provider.defaultGasLimit > 0 &&

--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -253,17 +253,12 @@ abstract contract Entropy is IEntropy, EntropyState {
 
         req.blockNumber = SafeCast.toUint64(block.number);
         req.useBlockhash = useBlockhash;
-<<<<<<< HEAD
+
         req.callbackStatus = isRequestWithCallback
             ? EntropyStatusConstants.CALLBACK_NOT_STARTED
             : EntropyStatusConstants.CALLBACK_NOT_NECESSARY;
-=======
-        req.status = isRequestWithCallback
-            ? EntropyConstants.STATUS_CALLBACK_NOT_STARTED
-            : EntropyConstants.STATUS_NO_CALLBACK;
-        // TODO: rounding!            
+        // TODO: rounding!
         req.gasLimit10k = SafeCast.toUint16(callbackGasLimit / 10000);
->>>>>>> 185f7de53 (moving stuff around)
     }
 
     // As a user, request a random number from `provider`. Prior to calling this method, the user should
@@ -304,7 +299,12 @@ abstract contract Entropy is IEntropy, EntropyState {
         address provider,
         bytes32 userRandomNumber
     ) public payable override returns (uint64) {
-        return requestWithCallbackAndGasLimit(provider, userRandomNumber, _state.providers[provider].defaultGasLimit);
+        return
+            requestWithCallbackAndGasLimit(
+                provider,
+                userRandomNumber,
+                _state.providers[provider].defaultGasLimit
+            );
     }
 
     function requestWithCallbackAndGasLimit(

--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -317,7 +317,7 @@ abstract contract Entropy is IEntropy, EntropyState {
             requestWithCallbackAndGasLimit(
                 provider,
                 userRandomNumber,
-                _state.providers[provider].defaultGasLimit
+                0 // Passing 0 will assign the request the provider's default gas limit
             );
     }
 

--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -526,6 +526,8 @@ abstract contract Entropy is IEntropy, EntropyState {
 
         address callAddress = req.requester;
 
+        // If the request has an explicit gas limit, then run the new callback failure state flow.
+        //
         // Requests that haven't been invoked yet will be invoked safely (catching reverts), and
         // any reverts will be reported as an event. Any failing requests move to a failure state
         // at which point they can be recovered. The recovery flow invokes the callback directly
@@ -661,10 +663,10 @@ abstract contract Entropy is IEntropy, EntropyState {
             providerAddr
         ];
 
-        // Providers charge a minimum of their configured feeInWei for every request. 
+        // Providers charge a minimum of their configured feeInWei for every request.
         // Requests using more than the defaultGasLimit get a proportionally scaled fee.
         // This approach may be somewhat simplistic, but it allows us to continue using the
-        // existing feeInWei parameter for the callback failure flow instead of defining new 
+        // existing feeInWei parameter for the callback failure flow instead of defining new
         // configuration values.
         uint32 roundedGasLimit = uint32(roundGas(gasLimit)) * 10000;
         if (

--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -257,7 +257,13 @@ abstract contract Entropy is IEntropy, EntropyState {
         req.callbackStatus = isRequestWithCallback
             ? EntropyStatusConstants.CALLBACK_NOT_STARTED
             : EntropyStatusConstants.CALLBACK_NOT_NECESSARY;
-        req.gasLimit10k = roundGas(callbackGasLimit);
+        if (providerInfo.defaultGasLimit == 0) {
+            // Provider doesn't support the new callback failure state flow (toggled by setting the gas limit field).
+            // Set gasLimit10k to 0 to disable.
+            req.gasLimit10k = 0;
+        } else {
+            req.gasLimit10k = roundGas(callbackGasLimit);
+        }        
     }
 
     // As a user, request a random number from `provider`. Prior to calling this method, the user should

--- a/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
@@ -1451,6 +1451,8 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         uint32 newGasLimit = 100000;
 
         vm.prank(provider1);
+        vm.expectEmit(false, false, false, true, address(random));
+        emit ProviderDefaultGasLimitUpdated(provider1, 0, newGasLimit);
         random.setDefaultGasLimit(newGasLimit);
 
         EntropyStructs.ProviderInfo memory info = random.getProviderInfo(

--- a/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
@@ -1492,29 +1492,6 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         assertEq(req.gasLimit10k, 10);
     }
 
-    function testRequestWithCallbackAndCustomGasLimit() public {
-        uint32 defaultGasLimit = 100000;
-        uint32 customGasLimit = 200000;
-
-        vm.prank(provider1);
-        random.setDefaultGasLimit(defaultGasLimit);
-
-        bytes32 userRandomNumber = bytes32(uint(42));
-        uint fee = random.getFeeForGas(provider1, customGasLimit);
-
-        vm.deal(user1, fee);
-        vm.prank(user1);
-        uint64 sequenceNumber = random.requestWithCallbackAndGasLimit{
-            value: fee
-        }(provider1, userRandomNumber, customGasLimit);
-
-        EntropyStructs.Request memory req = random.getRequest(
-            provider1,
-            sequenceNumber
-        );
-        assertEq(req.gasLimit10k, 20);
-    }
-
     function testGasLimitsAndFeeRounding() public {
         vm.prank(provider1);
         random.setDefaultGasLimit(20000);
@@ -1768,7 +1745,8 @@ contract EntropyConsumer is IEntropyConsumer {
         bytes32 _randomness
     ) internal override {
         uint256 startGas = gasleft();
-
+        // These seemingly innocuous instructions are actually quite expensive
+        // (~60k gas) because they're writes to contract storage.
         sequence = _sequence;
         provider = _provider;
         randomness = _randomness;

--- a/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
@@ -1463,6 +1463,19 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         random.setDefaultGasLimit(0);
         info = random.getProviderInfo(provider1);
         assertEq(info.defaultGasLimit, 0);
+
+        // Can set to maximum value.
+        uint32 maxLimit = random.MAX_GAS_LIMIT();
+        vm.prank(provider1);
+        random.setDefaultGasLimit(maxLimit);
+        info = random.getProviderInfo(provider1);
+        assertEq(info.defaultGasLimit, random.MAX_GAS_LIMIT());
+
+        // Reverts if max value is exceeded
+        uint32 exceedsGasLimit = random.MAX_GAS_LIMIT() + 1;
+        vm.prank(provider1);
+        vm.expectRevert(EntropyErrors.MaxGasLimitExceeded.selector);
+        random.setDefaultGasLimit(exceedsGasLimit);
     }
 
     function testSetDefaultGasLimitRevertIfNotFromProvider() public {
@@ -1526,6 +1539,17 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             uint32(type(uint16).max) * 10000,
             type(uint16).max,
             uint128(type(uint16).max) / 2
+        );
+
+        // Test larger than max value reverts with expected error
+        uint32 exceedsGasLimit = uint32(type(uint16).max) * 10000 + 1;
+        vm.expectRevert(EntropyErrors.MaxGasLimitExceeded.selector);
+        random.getFeeForGas(provider1, exceedsGasLimit);
+        vm.expectRevert(EntropyErrors.MaxGasLimitExceeded.selector);
+        random.requestWithCallbackAndGasLimit{value: 10000000000000}(
+            provider1,
+            bytes32(uint(42)),
+            exceedsGasLimit
         );
 
         // A provider with a 0 gas limit is opted-out of the failure state flow, indicated by

--- a/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
@@ -805,7 +805,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
                 blockNumber: 1234,
                 requester: user1,
                 useBlockhash: false,
-                callbackStatus: EntropyStatusConstants.CALLBACK_NOT_STARTED
+                callbackStatus: EntropyStatusConstants.CALLBACK_NOT_STARTED,
                 gasLimit10k: 0
             })
         );
@@ -1178,8 +1178,8 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         );
         assertEq(reqAfterFailure.sequenceNumber, assignedSequenceNumber);
         assertEq(
-            reqAfterFailure.status,
-            EntropyConstants.STATUS_CALLBACK_FAILED
+            reqAfterFailure.callbackStatus,
+            EntropyStatusConstants.CALLBACK_FAILED
         );
 
         // A subsequent attempt passing insufficient gas should also revert
@@ -1195,8 +1195,8 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         reqAfterFailure = random.getRequest(provider1, assignedSequenceNumber);
         assertEq(reqAfterFailure.sequenceNumber, assignedSequenceNumber);
         assertEq(
-            reqAfterFailure.status,
-            EntropyConstants.STATUS_CALLBACK_FAILED
+            reqAfterFailure.callbackStatus,
+            EntropyStatusConstants.CALLBACK_FAILED
         );
 
         // Calling without a gas limit should succeed

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyErrors.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyErrors.sol
@@ -45,4 +45,6 @@ library EntropyErrors {
     error UpdateTooOld();
     // Not enough gas was provided to the function to execute the callback with the desired amount of gas.
     error InsufficientGas();
+    // An argument to the function call was invalid or out of the expected range.
+    error InvalidArgument();
 }

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyErrors.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyErrors.sol
@@ -43,4 +43,6 @@ library EntropyErrors {
     error LastRevealedTooOld();
     // A more recent commitment is already revealed on-chain
     error UpdateTooOld();
+    // Not enough gas was provided to the function to execute the callback with the desired amount of gas.
+    error InsufficientGas();
 }

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyErrors.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyErrors.sol
@@ -45,4 +45,6 @@ library EntropyErrors {
     error UpdateTooOld();
     // Not enough gas was provided to the function to execute the callback with the desired amount of gas.
     error InsufficientGas();
+    // A gas limit value was provided that was greater than the maximum possible limit of 655,350,000
+    error MaxGasLimitExceeded();
 }

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyErrors.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyErrors.sol
@@ -45,6 +45,4 @@ library EntropyErrors {
     error UpdateTooOld();
     // Not enough gas was provided to the function to execute the callback with the desired amount of gas.
     error InsufficientGas();
-    // An argument to the function call was invalid or out of the expected range.
-    error InvalidArgument();
 }

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyEvents.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyEvents.sol
@@ -39,16 +39,6 @@ interface EntropyEvents {
         bytes errorCode
     );
 
-    event CallbackOutOfGas(
-        address indexed provider,
-        address indexed requestor,
-        uint64 indexed sequenceNumber,
-        bytes32 userRandomNumber,
-        bytes32 providerRevelation,
-        bytes32 randomNumber,
-        bytes errorCode
-    );
-
     event ProviderFeeUpdated(address provider, uint128 oldFee, uint128 newFee);
 
     event ProviderDefaultGasLimitUpdated(

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyEvents.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyEvents.sol
@@ -39,8 +39,19 @@ interface EntropyEvents {
         bytes errorCode
     );
 
+    event CallbackOutOfGas(
+        address indexed provider,
+        address indexed requestor,
+        uint64 indexed sequenceNumber,
+        bytes32 userRandomNumber,
+        bytes32 providerRevelation,
+        bytes32 randomNumber,
+        bytes errorCode
+    );
+
     event ProviderFeeUpdated(address provider, uint128 oldFee, uint128 newFee);
 
+    // TODO: uint32
     event ProviderDefaultGasLimitUpdated(
         address indexed provider,
         uint64 oldDefaultGasLimit,

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyEvents.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyEvents.sol
@@ -41,6 +41,12 @@ interface EntropyEvents {
 
     event ProviderFeeUpdated(address provider, uint128 oldFee, uint128 newFee);
 
+    event ProviderDefaultGasLimitUpdated(
+        address indexed provider,
+        uint64 oldDefaultGasLimit,
+        uint64 newDefaultGasLimit
+    );
+
     event ProviderUriUpdated(address provider, bytes oldUri, bytes newUri);
 
     event ProviderFeeManagerUpdated(

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyEvents.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyEvents.sol
@@ -51,11 +51,10 @@ interface EntropyEvents {
 
     event ProviderFeeUpdated(address provider, uint128 oldFee, uint128 newFee);
 
-    // TODO: uint32
     event ProviderDefaultGasLimitUpdated(
         address indexed provider,
-        uint64 oldDefaultGasLimit,
-        uint64 newDefaultGasLimit
+        uint32 oldDefaultGasLimit,
+        uint32 newDefaultGasLimit
     );
 
     event ProviderUriUpdated(address provider, bytes oldUri, bytes newUri);

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
@@ -37,6 +37,8 @@ contract EntropyStructs {
         // Maximum number of hashes to record in a request. This should be set according to the maximum gas limit
         // the provider supports for callbacks.
         uint32 maxNumHashes;
+        // Default gas limit to use for callbacks.
+        uint32 defaultGasLimit;
     }
 
     struct Request {
@@ -62,5 +64,7 @@ contract EntropyStructs {
         // Status flag for requests with callbacks. See EntropyConstants for the possible values of this flag.
         uint8 callbackStatus;
         // 2 bytes of space left in this struct.
+        // The gasLimit in units of 10k gas. (i.e., 2 = 20k gas)
+        uint16 gasLimit10k;
     }
 }

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
@@ -63,8 +63,9 @@ contract EntropyStructs {
         bool useBlockhash;
         // Status flag for requests with callbacks. See EntropyConstants for the possible values of this flag.
         uint8 callbackStatus;
-        // 2 bytes of space left in this struct.
-        // The gasLimit in units of 10k gas. (i.e., 2 = 20k gas)
+        // The gasLimit in units of 10k gas. (i.e., 2 = 20k gas). We're using units of 10k in order to fit this
+        // field into the remaining 2 bytes of this storage slot. The dynamic range here is 10k - ~65M, which should
+        // cover all real-world use cases.
         uint16 gasLimit10k;
     }
 }

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyStructs.sol
@@ -64,7 +64,7 @@ contract EntropyStructs {
         // Status flag for requests with callbacks. See EntropyConstants for the possible values of this flag.
         uint8 callbackStatus;
         // The gasLimit in units of 10k gas. (i.e., 2 = 20k gas). We're using units of 10k in order to fit this
-        // field into the remaining 2 bytes of this storage slot. The dynamic range here is 10k - ~65M, which should
+        // field into the remaining 2 bytes of this storage slot. The dynamic range here is 10k - 655M, which should
         // cover all real-world use cases.
         uint16 gasLimit10k;
     }

--- a/target_chains/ethereum/entropy_sdk/solidity/IEntropy.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/IEntropy.sol
@@ -48,14 +48,30 @@ interface IEntropy is EntropyEvents {
     //
     // The address calling this function should be a contract that inherits from the IEntropyConsumer interface.
     // The `entropyCallback` method on that interface will receive a callback with the generated random number.
+    // `entropyCallback` will be run with the provider's default gas limit (see `getProviderInfo(provider).defaultGasLimit`).
+    // If your callback needs additional gas, please use `requestWithCallbackAndGasLimit`.
     //
-    // This method will revert unless the caller provides a sufficient fee (at least getFee(provider)) as msg.value.
+    // This method will revert unless the caller provides a sufficient fee (at least `getFee(provider)`) as msg.value.
     // Note that excess value is *not* refunded to the caller.
     function requestWithCallback(
         address provider,
         bytes32 userRandomNumber
     ) external payable returns (uint64 assignedSequenceNumber);
 
+    // Request a random number from `provider`, getting a callback with the result.
+    // The caller must specify a provider to fulfill the request -- `getDefaultProvider()` is a sane default --
+    // and a `userRandomNumber` to combine into the result. The method returns a sequence number which callers
+    // should save to correlate the request with the callback.
+    //
+    // The address calling this function should be a contract that inherits from the IEntropyConsumer interface.
+    // The `entropyCallback` method on that interface will receive a callback with the returned sequence number and
+    // the generated random number. `entropyCallback` will be run with the `gasLimit` provided to this function.
+    // The `gasLimit` will be rounded up to a multiple of 10k (e.g., 19000 -> 20000), and furthermore is lower bounded
+    // by the provider's configured default limit.
+    //
+    // This method will revert unless the caller provides a sufficient fee (at least `getFeeForGas(provider, gasLimit)`) as msg.value.
+    // Note that provider fees can change over time. Thus, callers of this method should explictly compute `getFeeForGas(provider, gasLimit)`
+    // prior to each invocation (as opposed to  hardcoding a value). Further note that excess value is *not* refunded to the caller.
     function requestWithCallbackAndGasLimit(
         address provider,
         bytes32 userRandomNumber,
@@ -104,8 +120,11 @@ interface IEntropy is EntropyEvents {
         uint64 sequenceNumber
     ) external view returns (EntropyStructs.Request memory req);
 
+    // Get the fee charged by provider for a request with the default gasLimit (`request` or `requestWithCallback`).
+    // If you are calling `requestWithCallbackAndGasLimit`, please use `getFeeForGas`.
     function getFee(address provider) external view returns (uint128 feeAmount);
 
+    // Get the fee charged by `provider` for a request with a specific `gasLimit` (`requestWithCallbackAndGasLimit`).
     function getFeeForGas(
         address provider,
         uint32 gasLimit

--- a/target_chains/ethereum/entropy_sdk/solidity/IEntropy.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/IEntropy.sol
@@ -56,6 +56,12 @@ interface IEntropy is EntropyEvents {
         bytes32 userRandomNumber
     ) external payable returns (uint64 assignedSequenceNumber);
 
+    function requestWithCallbackAndGasLimit(
+        address provider,
+        bytes32 userRandomNumber,
+        uint32 gasLimit
+    ) external payable returns (uint64 assignedSequenceNumber);
+
     // Fulfill a request for a random number. This method validates the provided userRandomness and provider's proof
     // against the corresponding commitments in the in-flight request. If both values are validated, this function returns
     // the corresponding random number.
@@ -100,6 +106,11 @@ interface IEntropy is EntropyEvents {
 
     function getFee(address provider) external view returns (uint128 feeAmount);
 
+    function getFeeForGas(
+        address provider,
+        uint32 gasLimit
+    ) external view returns (uint128 feeAmount);
+
     function getAccruedPythFees()
         external
         view
@@ -123,6 +134,9 @@ interface IEntropy is EntropyEvents {
     // Set the maximum number of hashes to record in a request. This should be set according to the maximum gas limit
     // the provider supports for callbacks.
     function setMaxNumHashes(uint32 maxNumHashes) external;
+
+    // Set the default gas limit for a request. If 0, no
+    function setDefaultGasLimit(uint32 gasLimit) external;
 
     // Advance the provider commitment and increase the sequence number.
     // This is used to reduce the `numHashes` required for future requests which leads to reduced gas usage.

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyErrors.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyErrors.json
@@ -26,6 +26,11 @@
   },
   {
     "inputs": [],
+    "name": "InvalidArgument",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "InvalidRevealCall",
     "type": "error"
   },

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyErrors.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyErrors.json
@@ -26,11 +26,6 @@
   },
   {
     "inputs": [],
-    "name": "InvalidArgument",
-    "type": "error"
-  },
-  {
-    "inputs": [],
     "name": "InvalidRevealCall",
     "type": "error"
   },

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyErrors.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyErrors.json
@@ -41,6 +41,11 @@
   },
   {
     "inputs": [],
+    "name": "MaxGasLimitExceeded",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "NoSuchProvider",
     "type": "error"
   },

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyErrors.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyErrors.json
@@ -21,6 +21,11 @@
   },
   {
     "inputs": [],
+    "name": "InsufficientGas",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "InvalidRevealCall",
     "type": "error"
   },

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyEvents.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyEvents.json
@@ -52,6 +52,31 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "oldDefaultGasLimit",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "newDefaultGasLimit",
+        "type": "uint64"
+      }
+    ],
+    "name": "ProviderDefaultGasLimitUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": false,
         "internalType": "address",
         "name": "provider",
@@ -212,6 +237,11 @@
             "internalType": "uint32",
             "name": "maxNumHashes",
             "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "defaultGasLimit",
+            "type": "uint32"
           }
         ],
         "indexed": false,
@@ -267,6 +297,11 @@
             "internalType": "uint8",
             "name": "callbackStatus",
             "type": "uint8"
+          },
+          {
+            "internalType": "uint16",
+            "name": "gasLimit10k",
+            "type": "uint16"
           }
         ],
         "indexed": false,
@@ -346,6 +381,11 @@
             "internalType": "uint8",
             "name": "callbackStatus",
             "type": "uint8"
+          },
+          {
+            "internalType": "uint16",
+            "name": "gasLimit10k",
+            "type": "uint16"
           }
         ],
         "indexed": false,
@@ -401,6 +441,11 @@
             "internalType": "uint8",
             "name": "callbackStatus",
             "type": "uint8"
+          },
+          {
+            "internalType": "uint16",
+            "name": "gasLimit10k",
+            "type": "uint16"
           }
         ],
         "indexed": false,
@@ -480,6 +525,11 @@
             "internalType": "uint8",
             "name": "callbackStatus",
             "type": "uint8"
+          },
+          {
+            "internalType": "uint16",
+            "name": "gasLimit10k",
+            "type": "uint16"
           }
         ],
         "indexed": false,

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyEvents.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyEvents.json
@@ -108,15 +108,15 @@
       },
       {
         "indexed": false,
-        "internalType": "uint64",
+        "internalType": "uint32",
         "name": "oldDefaultGasLimit",
-        "type": "uint64"
+        "type": "uint32"
       },
       {
         "indexed": false,
-        "internalType": "uint64",
+        "internalType": "uint32",
         "name": "newDefaultGasLimit",
-        "type": "uint64"
+        "type": "uint32"
       }
     ],
     "name": "ProviderDefaultGasLimitUpdated",

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyEvents.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyEvents.json
@@ -58,55 +58,6 @@
         "type": "address"
       },
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "requestor",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "uint64",
-        "name": "sequenceNumber",
-        "type": "uint64"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "userRandomNumber",
-        "type": "bytes32"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "providerRevelation",
-        "type": "bytes32"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "randomNumber",
-        "type": "bytes32"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes",
-        "name": "errorCode",
-        "type": "bytes"
-      }
-    ],
-    "name": "CallbackOutOfGas",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "provider",
-        "type": "address"
-      },
-      {
         "indexed": false,
         "internalType": "uint32",
         "name": "oldDefaultGasLimit",

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyEvents.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyEvents.json
@@ -58,6 +58,55 @@
         "type": "address"
       },
       {
+        "indexed": true,
+        "internalType": "address",
+        "name": "requestor",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "sequenceNumber",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "userRandomNumber",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "providerRevelation",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "randomNumber",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "errorCode",
+        "type": "bytes"
+      }
+    ],
+    "name": "CallbackOutOfGas",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
         "indexed": false,
         "internalType": "uint64",
         "name": "oldDefaultGasLimit",

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropy.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropy.json
@@ -108,15 +108,15 @@
       },
       {
         "indexed": false,
-        "internalType": "uint64",
+        "internalType": "uint32",
         "name": "oldDefaultGasLimit",
-        "type": "uint64"
+        "type": "uint32"
       },
       {
         "indexed": false,
-        "internalType": "uint64",
+        "internalType": "uint32",
         "name": "newDefaultGasLimit",
-        "type": "uint64"
+        "type": "uint32"
       }
     ],
     "name": "ProviderDefaultGasLimitUpdated",

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropy.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropy.json
@@ -58,55 +58,6 @@
         "type": "address"
       },
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "requestor",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "uint64",
-        "name": "sequenceNumber",
-        "type": "uint64"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "userRandomNumber",
-        "type": "bytes32"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "providerRevelation",
-        "type": "bytes32"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "randomNumber",
-        "type": "bytes32"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes",
-        "name": "errorCode",
-        "type": "bytes"
-      }
-    ],
-    "name": "CallbackOutOfGas",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "provider",
-        "type": "address"
-      },
-      {
         "indexed": false,
         "internalType": "uint32",
         "name": "oldDefaultGasLimit",

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropy.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropy.json
@@ -58,6 +58,55 @@
         "type": "address"
       },
       {
+        "indexed": true,
+        "internalType": "address",
+        "name": "requestor",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "sequenceNumber",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "userRandomNumber",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "providerRevelation",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "randomNumber",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "errorCode",
+        "type": "bytes"
+      }
+    ],
+    "name": "CallbackOutOfGas",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
         "indexed": false,
         "internalType": "uint64",
         "name": "oldDefaultGasLimit",

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropy.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropy.json
@@ -52,6 +52,31 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "oldDefaultGasLimit",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "newDefaultGasLimit",
+        "type": "uint64"
+      }
+    ],
+    "name": "ProviderDefaultGasLimitUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": false,
         "internalType": "address",
         "name": "provider",
@@ -212,6 +237,11 @@
             "internalType": "uint32",
             "name": "maxNumHashes",
             "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "defaultGasLimit",
+            "type": "uint32"
           }
         ],
         "indexed": false,
@@ -267,6 +297,11 @@
             "internalType": "uint8",
             "name": "callbackStatus",
             "type": "uint8"
+          },
+          {
+            "internalType": "uint16",
+            "name": "gasLimit10k",
+            "type": "uint16"
           }
         ],
         "indexed": false,
@@ -346,6 +381,11 @@
             "internalType": "uint8",
             "name": "callbackStatus",
             "type": "uint8"
+          },
+          {
+            "internalType": "uint16",
+            "name": "gasLimit10k",
+            "type": "uint16"
           }
         ],
         "indexed": false,
@@ -401,6 +441,11 @@
             "internalType": "uint8",
             "name": "callbackStatus",
             "type": "uint8"
+          },
+          {
+            "internalType": "uint16",
+            "name": "gasLimit10k",
+            "type": "uint16"
           }
         ],
         "indexed": false,
@@ -480,6 +525,11 @@
             "internalType": "uint8",
             "name": "callbackStatus",
             "type": "uint8"
+          },
+          {
+            "internalType": "uint16",
+            "name": "gasLimit10k",
+            "type": "uint16"
           }
         ],
         "indexed": false,
@@ -656,6 +706,30 @@
         "internalType": "address",
         "name": "provider",
         "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "gasLimit",
+        "type": "uint32"
+      }
+    ],
+    "name": "getFeeForGas",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "feeAmount",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
       }
     ],
     "name": "getProviderInfo",
@@ -720,6 +794,11 @@
           {
             "internalType": "uint32",
             "name": "maxNumHashes",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "defaultGasLimit",
             "type": "uint32"
           }
         ],
@@ -787,6 +866,11 @@
             "internalType": "uint8",
             "name": "callbackStatus",
             "type": "uint8"
+          },
+          {
+            "internalType": "uint16",
+            "name": "gasLimit10k",
+            "type": "uint16"
           }
         ],
         "internalType": "struct EntropyStructs.Request",
@@ -891,6 +975,35 @@
         "type": "address"
       },
       {
+        "internalType": "bytes32",
+        "name": "userRandomNumber",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "gasLimit",
+        "type": "uint32"
+      }
+    ],
+    "name": "requestWithCallbackAndGasLimit",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "assignedSequenceNumber",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
         "internalType": "uint64",
         "name": "sequenceNumber",
         "type": "uint64"
@@ -941,6 +1054,19 @@
       }
     ],
     "name": "revealWithCallback",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "gasLimit",
+        "type": "uint32"
+      }
+    ],
+    "name": "setDefaultGasLimit",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"


### PR DESCRIPTION
## Summary

Follow up to the last PR around allowing providers to mark on-chain callbacks as failed. The previous PR covers cases where the contract manually reverts. This PR covers the case where the callback runs out of gas. 

This PR gives each callback a gas limit which is stored in the on-chain struct. Providers can set a default gas limit, or users can manually specify a different gas limit when making a request. We mark callbacks as failed if they revert with an out-of-gas error *and* the transaction had enough gas to forward -- there are some EVM nuances here that we need to be careful about. See inline comments for details.

## Rationale

Explicitly marking on-chain requests as failed will make the state transitions of entropy much clearer to end users.

## How has this been tested?

- [x] Current tests cover my changes
- [x] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
