### PR TITLE
fix(fortuna): Fix fortuna CI

### DIFF
--- a/.github/workflows/ci-fortuna.yml
+++ b/.github/workflows/ci-fortuna.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - .github/workflows/ci-fortuna.yml
       - apps/fortuna/**
+      - target_chains/ethereum/entropy_sdk/solidity/abis/**
   push:
     branches: [main]
 jobs:

--- a/apps/fortuna/src/command/inspect.rs
+++ b/apps/fortuna/src/command/inspect.rs
@@ -90,7 +90,7 @@ async fn inspect_chain(
 }
 
 async fn process_request(rpc_provider: Provider<Http>, request: Request) -> Result<()> {
-    if request.sequence_number != 0 && request.is_request_with_callback {
+    if request.sequence_number != 0 && request.callback_status != 0 {
         let block = rpc_provider
             .get_block(request.block_number)
             .await?

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyStatusConstants.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyStatusConstants.json
@@ -1,0 +1,54 @@
+[
+  {
+    "inputs": [],
+    "name": "CALLBACK_FAILED",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "CALLBACK_IN_PROGRESS",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "CALLBACK_NOT_NECESSARY",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "CALLBACK_NOT_STARTED",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/target_chains/ethereum/entropy_sdk/solidity/package.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "test:format": "prettier --check .",
     "fix:format": "prettier --write .",
-    "build": "generate-abis IEntropy IEntropyConsumer EntropyErrors EntropyEvents EntropyStructs PRNG",
+    "build": "generate-abis IEntropy IEntropyConsumer EntropyErrors EntropyEvents EntropyStructs EntropyStatusConstants PRNG",
     "test": "git diff --exit-code abis"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

I renamed a variable in the entropy contract, which broke Fortuna (which depends on the ABI). Update to use the new variable name.

In the process I exported the ABI for the entropy constants. Unfortunately, it's not easy to use this library in ethers.rs because the ABI looks like a contract and doesn't have the constant values in it. 

I also added the ABI directory to the fortuna CI to prevent similar issues going forward.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
