### PR TITLE
chore(staking-sdk): rev staking-sdk version

### DIFF
--- a/governance/pyth_staking_sdk/package.json
+++ b/governance/pyth_staking_sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/staking-sdk",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Pyth staking SDK",
   "main": "src/index.ts",
   "types": "src/index.d.ts",

--- a/governance/pyth_staking_sdk/src/pyth-staking-client.ts
+++ b/governance/pyth_staking_sdk/src/pyth-staking-client.ts
@@ -1047,9 +1047,6 @@ export class PythStakingClient {
   public async getAllStakeAccountPositionsAllOwners(): Promise<
     StakeAccountPositions[]
   > {
-    // eslint-disable-next-line no-console
-    console.log("Calling RPC");
-
     const res = await fetch(this.connection.rpcEndpoint, {
       method: "POST",
       headers: {
@@ -1078,9 +1075,6 @@ export class PythStakingClient {
       }),
     });
 
-    // eslint-disable-next-line no-console
-    console.log("Received response");
-
     if (res.ok) {
       const { body } = res;
       if (body) {
@@ -1101,16 +1095,16 @@ export class PythStakingClient {
             }
           };
 
-          // eslint-disable-next-line no-console
-          console.log("Running JSON parser");
-
           parse().catch((error: unknown) => {
-            reject(error instanceof Error ? error : new Error("Unknown Error"));
+            reject(
+              error instanceof Error
+                ? error
+                : new Error(
+                    typeof error === "string" ? error : "Unknown Error",
+                  ),
+            );
           });
         });
-
-        // eslint-disable-next-line no-console
-        console.log("Parsed JSON");
 
         return accountSchema
           .parse(accounts)


### PR DESCRIPTION
## Summary

This PR bumps the staking-sdk version in preparation for release.  I also remove some debug logging I'd added in #2561  and improve error handling a bit.

## Rationale

I need to release the updated version of the staking sdk for use in fogo points and I need to clean up the logging before I can do that.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code
