### PR TITLE
fix: set --no-git-checks on pnpm publish

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -27,4 +27,4 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: pnpm run turbo build
-      - run: pnpm publish -r
+      - run: pnpm publish -r --no-git-checks


### PR DESCRIPTION
## Summary

Add `--no-git-checks` to the pnpm publish command.

## Rationale

Without this, pnpm fails to publish off a tag as it believes we're not on a publish branch.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
