### PR TITLE
fix(staking-sdk): more staking-sdk improvements

### DIFF
--- a/governance/pyth_staking_sdk/eslint.config.js
+++ b/governance/pyth_staking_sdk/eslint.config.js
@@ -1,12 +1,1 @@
-import { base } from "@cprussin/eslint-config";
-
-export default [
-  ...base,
-  {
-    rules: {
-      "n/no-unpublished-import": "off",
-      "unicorn/no-null": "off",
-      "unicorn/prefer-node-protocol": "off",
-    },
-  },
-];
+export { base as default } from "@cprussin/eslint-config";

--- a/governance/pyth_staking_sdk/package.json
+++ b/governance/pyth_staking_sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/staking-sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pyth staking SDK",
   "type": "module",
   "exports": {

--- a/governance/pyth_staking_sdk/src/utils/pool.ts
+++ b/governance/pyth_staking_sdk/src/utils/pool.ts
@@ -17,7 +17,7 @@ export const extractPublisherData = (
       stakeAccount:
         poolData.publisherStakeAccounts[index] === undefined ||
         poolData.publisherStakeAccounts[index].equals(PublicKey.default)
-          ? null
+          ? null // eslint-disable-line unicorn/no-null
           : poolData.publisherStakeAccounts[index],
       totalDelegation:
         (poolData.delState[index]?.totalDelegation ?? 0n) +


### PR DESCRIPTION
## Summary

Some more fixes / improvements to staking-sdk:

- Don't disable eslint rules unnecessarily
- Ensure we handle `Uint8Array`s in the response body too
- Throw an explicit error if we reach the end of the stream without finding a result