### PR TITLE
chore(target_chains/cosmwasm): add xion mainnet

### DIFF
--- a/contract_manager/store/chains/CosmWasmChains.yaml
+++ b/contract_manager/store/chains/CosmWasmChains.yaml
@@ -82,3 +82,11 @@
   prefix: xion
   feeDenom: uxion
   type: CosmWasmChain
+- endpoint: https://rpc.xion-mainnet-1.burnt.com:443
+  id: xion
+  wormholeChainName: xion
+  mainnet: true
+  gasPrice: "0.025"
+  prefix: xion
+  feeDenom: uxion
+  type: CosmWasmChain

--- a/contract_manager/store/contracts/CosmWasmPriceFeedContracts.yaml
+++ b/contract_manager/store/contracts/CosmWasmPriceFeedContracts.yaml
@@ -46,3 +46,6 @@
 - chain: xion_testnet_2
   address: xion1wptw89weav8tnpgxg4fyhcahgk8yy99lka3w308536ktadkvjwxqe463hl
   type: CosmWasmPriceFeedContract
+- chain: xion
+  address: xion18nsqwhfwnqzs4vkxdr02x40awm0gz9pl0wn4ecsl8qqra2vxqppq57qx5a
+  type: CosmWasmPriceFeedContract

--- a/contract_manager/store/contracts/CosmWasmWormholeContracts.yaml
+++ b/contract_manager/store/contracts/CosmWasmWormholeContracts.yaml
@@ -46,3 +46,6 @@
 - chain: xion_testnet_2
   address: xion1qlrdccrcw4rew9ervlazeyt9qmcx84r87vrq74sfd48f4q8y3qrqf59syp
   type: CosmWasmWormholeContract
+- chain: xion
+  address: xion1zfdqgkd9lcqwc4ywkeg2pr2v2p5xxa7n2s9layq2623pvhp4xv0sr4659c
+  type: CosmWasmWormholeContract

--- a/contract_manager/store/contracts/NearPriceFeedContracts.yaml
+++ b/contract_manager/store/contracts/NearPriceFeedContracts.yaml
@@ -1,12 +1,12 @@
 - chain: near
   address: pyth-oracle.near
-  type: NearPriceFeedContract
   governanceDataSourceChain: 1
   governanceDataSourceAddress: 5635979a221c34931e32620b9293a463065555ea71fe97cd6237ade875b12e9e
   lastExecutedGovernanceSequence: 408
+  type: NearPriceFeedContract
 - chain: near_testnet
   address: pyth-oracle.testnet
-  type: NearPriceFeedContract
   governanceDataSourceChain: 1
   governanceDataSourceAddress: 63278d271099bfd491951b3e648f08b1c71631e4a53674ad43e8f9f98068c385
   lastExecutedGovernanceSequence: 100
+  type: NearPriceFeedContract

--- a/governance/xc_admin/packages/xc_admin_common/src/chains.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/chains.ts
@@ -108,6 +108,7 @@ export const RECEIVER_CHAINS = {
   story: 60078,
   hyperevm: 60079,
   bittensor_mainnet: 60080,
+  xion: 60081,
 
   // Testnets as a separate chain ids (to use stable data sources and governance for them)
   injective_testnet: 60013,


### PR DESCRIPTION
## Summary

This PR adds the specs of Pyth deployment on Xion Mainnet.