### PR TITLE
feat(pulse-scheduler): address initial comments, update sub management, enforce mininum balance

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -902,13 +902,13 @@ importers:
         version: 0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-react':
         specifier: 'catalog:'
-        version: 0.15.36(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@5.0.0)(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+        version: 0.15.36(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       '@solana/wallet-adapter-react-ui':
         specifier: 'catalog:'
-        version: 0.9.36(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(react-dom@19.1.0(react@19.1.0))(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+        version: 0.9.36(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)(react-dom@19.1.0(react@19.1.0))(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       '@solana/wallet-adapter-wallets':
         specifier: 'catalog:'
-        version: 0.19.33(@babel/runtime@7.27.0)(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(tslib@2.8.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)
+        version: 0.19.33(@babel/runtime@7.27.0)(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(tslib@2.8.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)
       '@solana/web3.js':
         specifier: 'catalog:'
         version: 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
@@ -1482,13 +1482,13 @@ importers:
         version: 0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-react':
         specifier: 'catalog:'
-        version: 0.15.36(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@5.0.0)(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+        version: 0.15.36(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       '@solana/wallet-adapter-react-ui':
         specifier: 'catalog:'
-        version: 0.9.36(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(react-dom@19.1.0(react@19.1.0))(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+        version: 0.9.36(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)(react-dom@19.1.0(react@19.1.0))(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       '@solana/wallet-adapter-wallets':
         specifier: 'catalog:'
-        version: 0.19.33(@babel/runtime@7.27.0)(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(tslib@2.8.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)
+        version: 0.19.33(@babel/runtime@7.27.0)(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(tslib@2.8.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)
       '@solana/web3.js':
         specifier: ^1.73.0
         version: 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
@@ -28063,10 +28063,11 @@ snapshots:
       crypto-js: 4.2.0
       uuidv4: 6.2.13
 
-  '@particle-network/solana-wallet@1.3.2(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))':
+  '@particle-network/solana-wallet@1.3.2(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)':
     dependencies:
       '@particle-network/auth': 1.3.1
       '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      bs58: 6.0.0
 
   '@paulmillr/qr@0.2.1': {}
 
@@ -31351,9 +31352,9 @@ snapshots:
       '@solana/wallet-adapter-base': 0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
 
-  '@solana/wallet-adapter-base-ui@0.1.3(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)':
+  '@solana/wallet-adapter-base-ui@0.1.3(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)':
     dependencies:
-      '@solana/wallet-adapter-react': 0.15.36(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@5.0.0)(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+      '@solana/wallet-adapter-react': 0.15.36(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
       react: 19.1.0
     transitivePeerDependencies:
@@ -31469,9 +31470,9 @@ snapshots:
       '@solana/wallet-adapter-base': 0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
 
-  '@solana/wallet-adapter-particle@0.1.13(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))':
+  '@solana/wallet-adapter-particle@0.1.13(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)':
     dependencies:
-      '@particle-network/solana-wallet': 1.3.2(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
+      '@particle-network/solana-wallet': 1.3.2(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)
       '@solana/wallet-adapter-base': 0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -31482,11 +31483,11 @@ snapshots:
       '@solana/wallet-adapter-base': 0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
 
-  '@solana/wallet-adapter-react-ui@0.9.36(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(react-dom@19.1.0(react@19.1.0))(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)':
+  '@solana/wallet-adapter-react-ui@0.9.36(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)(react-dom@19.1.0(react@19.1.0))(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)':
     dependencies:
       '@solana/wallet-adapter-base': 0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
-      '@solana/wallet-adapter-base-ui': 0.1.3(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
-      '@solana/wallet-adapter-react': 0.15.36(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@5.0.0)(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+      '@solana/wallet-adapter-base-ui': 0.1.3(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+      '@solana/wallet-adapter-react': 0.15.36(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
@@ -31499,6 +31500,17 @@ snapshots:
       '@solana-mobile/wallet-adapter-mobile': 2.1.5(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       '@solana/wallet-adapter-base': 0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/wallet-standard-wallet-adapter-react': 1.1.4(@solana/wallet-adapter-base@0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@5.0.0)(react@19.1.0)
+      '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      react: 19.1.0
+    transitivePeerDependencies:
+      - bs58
+      - react-native
+
+  '@solana/wallet-adapter-react@0.15.36(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)':
+    dependencies:
+      '@solana-mobile/wallet-adapter-mobile': 2.1.5(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+      '@solana/wallet-adapter-base': 0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
+      '@solana/wallet-standard-wallet-adapter-react': 1.1.4(@solana/wallet-adapter-base@0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@19.1.0)
       '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
       react: 19.1.0
     transitivePeerDependencies:
@@ -31634,7 +31646,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@solana/wallet-adapter-wallets@0.19.33(@babel/runtime@7.27.0)(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(tslib@2.8.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)':
+  '@solana/wallet-adapter-wallets@0.19.33(@babel/runtime@7.27.0)(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react-native@0.78.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@19.1.0)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(tslib@2.8.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)':
     dependencies:
       '@solana/wallet-adapter-alpha': 0.1.11(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-avana': 0.1.14(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
@@ -31655,7 +31667,7 @@ snapshots:
       '@solana/wallet-adapter-nightly': 0.1.17(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-nufi': 0.1.18(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-onto': 0.1.8(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
-      '@solana/wallet-adapter-particle': 0.1.13(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
+      '@solana/wallet-adapter-particle': 0.1.13(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)
       '@solana/wallet-adapter-phantom': 0.9.25(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-safepal': 0.5.19(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-saifu': 0.1.16(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
@@ -31750,10 +31762,34 @@ snapshots:
       '@wallet-standard/wallet': 1.1.0
       bs58: 5.0.0
 
+  '@solana/wallet-standard-wallet-adapter-base@1.1.4(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)':
+    dependencies:
+      '@solana/wallet-adapter-base': 0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
+      '@solana/wallet-standard-chains': 1.1.1
+      '@solana/wallet-standard-features': 1.3.0
+      '@solana/wallet-standard-util': 1.1.2
+      '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@wallet-standard/app': 1.1.0
+      '@wallet-standard/base': 1.1.0
+      '@wallet-standard/features': 1.1.0
+      '@wallet-standard/wallet': 1.1.0
+      bs58: 6.0.0
+
   '@solana/wallet-standard-wallet-adapter-react@1.1.4(@solana/wallet-adapter-base@0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@5.0.0)(react@19.1.0)':
     dependencies:
       '@solana/wallet-adapter-base': 0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/wallet-standard-wallet-adapter-base': 1.1.4(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@5.0.0)
+      '@wallet-standard/app': 1.1.0
+      '@wallet-standard/base': 1.1.0
+      react: 19.1.0
+    transitivePeerDependencies:
+      - '@solana/web3.js'
+      - bs58
+
+  '@solana/wallet-standard-wallet-adapter-react@1.1.4(@solana/wallet-adapter-base@0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@19.1.0)':
+    dependencies:
+      '@solana/wallet-adapter-base': 0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
+      '@solana/wallet-standard-wallet-adapter-base': 1.1.4(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@6.0.0)
       '@wallet-standard/app': 1.1.0
       '@wallet-standard/base': 1.1.0
       react: 19.1.0
@@ -38402,7 +38438,7 @@ snapshots:
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.8.2))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.8.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.56.0)
       eslint-plugin-react: 7.37.4(eslint@8.56.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.56.0)
@@ -38446,7 +38482,7 @@ snapshots:
       tinyglobby: 0.2.12
       unrs-resolver: 1.3.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.8.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -38484,7 +38520,7 @@ snapshots:
       eslint: 9.23.0(jiti@1.21.7)
       eslint-compat-utils: 0.5.1(eslint@9.23.0(jiti@1.21.7))
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0)(eslint@8.56.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.8.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8

--- a/target_chains/ethereum/contracts/contracts/pulse/scheduler/IScheduler.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/scheduler/IScheduler.sol
@@ -14,10 +14,11 @@ interface IScheduler is SchedulerEvents {
      * @notice Adds a new subscription
      * @param subscriptionParams The parameters for the subscription
      * @return subscriptionId The ID of the newly created subscription
+     * @dev Requires msg.value to be at least the minimum balance for the subscription
      */
     function addSubscription(
         SchedulerState.SubscriptionParams calldata subscriptionParams
-    ) external returns (uint256 subscriptionId);
+    ) external payable returns (uint256 subscriptionId);
 
     /**
      * @notice Gets a subscription's parameters and status
@@ -45,11 +46,7 @@ interface IScheduler is SchedulerEvents {
         SchedulerState.SubscriptionParams calldata newSubscriptionParams
     ) external;
 
-    /**
-     * @notice Deactivates a subscription
-     * @param subscriptionId The ID of the subscription to deactivate
-     */
-    function deactivateSubscription(uint256 subscriptionId) external;
+    // Deactivation is now handled through updateSubscription by setting isActive to false
 
     /**
      * @notice Updates price feeds for a subscription.
@@ -64,16 +61,36 @@ interface IScheduler is SchedulerEvents {
         bytes32[] calldata priceIds
     ) external;
 
-    /**
-     * @notice Gets the latest prices for a subscription
-     * @param subscriptionId The ID of the subscription
-     * @param priceIds Optional array of price IDs to retrieve. If empty, returns all price feeds for the subscription.
-     * @return The latest price feeds for the requested price IDs
+    /** @notice Returns the price of a price feed without any sanity checks.
+     * @dev This function returns the most recent price update in this contract without any recency checks.
+     * This function is unsafe as the returned price update may be arbitrarily far in the past.
+     *
+     * Users of this function should check the `publishTime` in the price to ensure that the returned price is
+     * sufficiently recent for their application. If you are considering using this function, it may be
+     * safer / easier to use `getPriceNoOlderThan`.
+     * @return prices - please read the documentation of PythStructs.Price to understand how to use this safely.
      */
-    function getLatestPrices(
+    function getPricesUnsafe(
         uint256 subscriptionId,
         bytes32[] calldata priceIds
-    ) external view returns (PythStructs.PriceFeed[] memory);
+    ) external view returns (PythStructs.Price[] memory prices);
+
+    /** @notice Returns the exponentially-weighted moving average price of a price feed without any sanity checks.
+     * @dev This function returns the same price as `getEmaPrice` in the case where the price is available.
+     * However, if the price is not recent this function returns the latest available price.
+     *
+     * The returned price can be from arbitrarily far in the past; this function makes no guarantees that
+     * the returned price is recent or useful for any particular application.
+     *
+     * Users of this function should check the `publishTime` in the price to ensure that the returned price is
+     * sufficiently recent for their application. If you are considering using this function, it may be
+     * safer / easier to use either `getEmaPrice` or `getEmaPriceNoOlderThan`.
+     * @return price - please read the documentation of PythStructs.Price to understand how to use this safely.
+     */
+    function getEmaPriceUnsafe(
+        uint256 subscriptionId,
+        bytes32[] calldata priceIds
+    ) external view returns (PythStructs.Price[] memory price);
 
     /**
      * @notice Adds funds to a subscription's balance
@@ -82,23 +99,40 @@ interface IScheduler is SchedulerEvents {
     function addFunds(uint256 subscriptionId) external payable;
 
     /**
-     * @notice Withdraws funds from a subscription's balance
+     * @notice Withdraws funds from a subscription's balance.
+     * @dev A minimum balance must be maintained for active subscriptions. To withdraw past
+     * the minimum balance limit, deactivate the subscription first.
      * @param subscriptionId The ID of the subscription
      * @param amount The amount to withdraw
      */
     function withdrawFunds(uint256 subscriptionId, uint256 amount) external;
 
     /**
+     * @notice Returns the minimum balance an active subscription of a given size needs to hold.
+     * @param numPriceFeeds The number of price feeds in the subscription.
+     */
+    function getMinimumBalance(
+        uint8 numPriceFeeds
+    ) external view returns (uint256 minimumBalanceInWei);
+
+    /**
      * @notice Gets all active subscriptions with their parameters
      * @dev This function has no access control to allow keepers to discover active subscriptions
+     * @param startIndex The starting index for pagination
+     * @param maxResults The maximum number of results to return
      * @return subscriptionIds Array of active subscription IDs
      * @return subscriptionParams Array of subscription parameters for each active subscription
+     * @return totalCount Total number of active subscriptions
      */
-    function getActiveSubscriptions()
+    function getActiveSubscriptions(
+        uint256 startIndex,
+        uint256 maxResults
+    )
         external
         view
         returns (
             uint256[] memory subscriptionIds,
-            SchedulerState.SubscriptionParams[] memory subscriptionParams
+            SchedulerState.SubscriptionParams[] memory subscriptionParams,
+            uint256 totalCount
         );
 }

--- a/target_chains/ethereum/contracts/contracts/pulse/scheduler/Scheduler.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/scheduler/Scheduler.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "@openzeppelin/contracts/utils/math/SignedMath.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
+import "@pythnetwork/pyth-sdk-solidity/PythErrors.sol";
 import "./IScheduler.sol";
 import "./SchedulerState.sol";
 import "./SchedulerErrors.sol";
@@ -20,8 +21,8 @@ abstract contract Scheduler is IScheduler, SchedulerState {
     }
 
     function addSubscription(
-        SubscriptionParams calldata subscriptionParams
-    ) external override returns (uint256 subscriptionId) {
+        SubscriptionParams memory subscriptionParams
+    ) external payable override returns (uint256 subscriptionId) {
         if (subscriptionParams.priceIds.length > MAX_PRICE_IDS) {
             revert TooManyPriceIds(
                 subscriptionParams.priceIds.length,
@@ -37,13 +38,31 @@ abstract contract Scheduler is IScheduler, SchedulerState {
             revert InvalidUpdateCriteria();
         }
 
-        // Validate gas config
+        // If gas config is unset, set it to the default (100x multipliers)
         if (
-            subscriptionParams.gasConfig.maxGasPrice == 0 ||
-            subscriptionParams.gasConfig.maxGasLimit == 0
+            subscriptionParams.gasConfig.maxGasMultiplierCapPct == 0 ||
+            subscriptionParams.gasConfig.maxFeeMultiplierCapPct == 0
         ) {
-            revert InvalidGasConfig();
+            subscriptionParams
+                .gasConfig
+                .maxFeeMultiplierCapPct = DEFAULT_MAX_FEE_MULTIPLIER_CAP_PCT;
+            subscriptionParams
+                .gasConfig
+                .maxGasMultiplierCapPct = DEFAULT_MAX_GAS_MULTIPLIER_CAP_PCT;
         }
+
+        // Calculate minimum balance required for this subscription
+        uint256 minimumBalance = this.getMinimumBalance(
+            uint8(subscriptionParams.priceIds.length)
+        );
+
+        // Ensure enough funds were provided
+        if (msg.value < minimumBalance) {
+            revert InsufficientBalance();
+        }
+
+        // Set subscription to active
+        subscriptionParams.isActive = true;
 
         subscriptionId = _state.subscriptionNumber++;
 
@@ -55,10 +74,9 @@ abstract contract Scheduler is IScheduler, SchedulerState {
             subscriptionId
         ];
         status.priceLastUpdatedAt = 0;
-        status.balanceInWei = 0;
+        status.balanceInWei = msg.value;
         status.totalUpdates = 0;
         status.totalSpent = 0;
-        status.isActive = true;
 
         // Map subscription ID to manager
         _state.subscriptionManager[subscriptionId] = msg.sender;
@@ -67,77 +85,82 @@ abstract contract Scheduler is IScheduler, SchedulerState {
         return subscriptionId;
     }
 
-    function getSubscription(
-        uint256 subscriptionId
-    )
-        external
-        view
-        override
-        returns (
-            SubscriptionParams memory params,
-            SubscriptionStatus memory status
-        )
-    {
-        return (
-            _state.subscriptionParams[subscriptionId],
-            _state.subscriptionStatuses[subscriptionId]
-        );
-    }
-
     function updateSubscription(
         uint256 subscriptionId,
-        SubscriptionParams calldata newSubscriptionParams
+        SubscriptionParams memory newParams
     ) external override onlyManager(subscriptionId) {
-        if (!_state.subscriptionStatuses[subscriptionId].isActive) {
-            revert InactiveSubscription();
+        SchedulerState.SubscriptionStatus storage currentStatus = _state
+            .subscriptionStatuses[subscriptionId];
+        SchedulerState.SubscriptionParams storage currentParams = _state
+            .subscriptionParams[subscriptionId];
+        bool wasActive = currentParams.isActive;
+        bool willBeActive = newParams.isActive;
+
+        // If subscription is inactive and will remain inactive, no need to validate parameters
+        if (!wasActive && !willBeActive) {
+            // Update subscription parameters
+            _state.subscriptionParams[subscriptionId] = newParams;
+            emit SubscriptionUpdated(subscriptionId);
+            return;
         }
 
-        if (newSubscriptionParams.priceIds.length > MAX_PRICE_IDS) {
-            revert TooManyPriceIds(
-                newSubscriptionParams.priceIds.length,
-                MAX_PRICE_IDS
-            );
+        // Validate parameters for active or to-be-activated subscriptions
+        if (newParams.priceIds.length > MAX_PRICE_IDS) {
+            revert TooManyPriceIds(newParams.priceIds.length, MAX_PRICE_IDS);
         }
 
         // Validate update criteria
         if (
-            !newSubscriptionParams.updateCriteria.updateOnHeartbeat &&
-            !newSubscriptionParams.updateCriteria.updateOnDeviation
+            !newParams.updateCriteria.updateOnHeartbeat &&
+            !newParams.updateCriteria.updateOnDeviation
         ) {
             revert InvalidUpdateCriteria();
         }
 
-        // Validate gas config
+        // If gas config is unset, set it to the default (100x multipliers)
         if (
-            newSubscriptionParams.gasConfig.maxGasPrice == 0 ||
-            newSubscriptionParams.gasConfig.maxGasLimit == 0
+            newParams.gasConfig.maxGasMultiplierCapPct == 0 ||
+            newParams.gasConfig.maxFeeMultiplierCapPct == 0
         ) {
-            revert InvalidGasConfig();
+            newParams
+                .gasConfig
+                .maxFeeMultiplierCapPct = DEFAULT_MAX_FEE_MULTIPLIER_CAP_PCT;
+            newParams
+                .gasConfig
+                .maxGasMultiplierCapPct = DEFAULT_MAX_GAS_MULTIPLIER_CAP_PCT;
+        }
+
+        // Handle activation/deactivation
+        if (!wasActive && willBeActive) {
+            // Reactivating a subscription - ensure minimum balance
+            uint256 minimumBalance = this.getMinimumBalance(
+                uint8(newParams.priceIds.length)
+            );
+
+            // Check if balance meets minimum requirement
+            if (currentStatus.balanceInWei < minimumBalance) {
+                revert InsufficientBalance();
+            }
+
+            currentParams.isActive = true;
+            emit SubscriptionActivated(subscriptionId);
+        } else if (wasActive && !willBeActive) {
+            // Deactivating a subscription
+            currentParams.isActive = false;
+            emit SubscriptionDeactivated(subscriptionId);
         }
 
         // Update subscription parameters
-        _state.subscriptionParams[subscriptionId] = newSubscriptionParams;
+        _state.subscriptionParams[subscriptionId] = newParams;
 
         emit SubscriptionUpdated(subscriptionId);
-    }
-
-    function deactivateSubscription(
-        uint256 subscriptionId
-    ) external override onlyManager(subscriptionId) {
-        if (!_state.subscriptionStatuses[subscriptionId].isActive) {
-            revert InactiveSubscription();
-        }
-
-        _state.subscriptionStatuses[subscriptionId].isActive = false;
-
-        emit SubscriptionDeactivated(subscriptionId);
     }
 
     function updatePriceFeeds(
         uint256 subscriptionId,
         bytes[] calldata updateData,
         bytes32[] calldata priceIds
-    ) external override onlyPusher {
+    ) external override {
         SubscriptionStatus storage status = _state.subscriptionStatuses[
             subscriptionId
         ];
@@ -145,7 +168,7 @@ abstract contract Scheduler is IScheduler, SchedulerState {
             subscriptionId
         ];
 
-        if (!status.isActive) {
+        if (!params.isActive) {
             revert InactiveSubscription();
         }
 
@@ -309,17 +332,19 @@ abstract contract Scheduler is IScheduler, SchedulerState {
         revert UpdateConditionsNotMet();
     }
 
-    function getLatestPrices(
+    /// FETCH PRICES
+
+    /**
+     * @notice Internal helper function to retrieve price feeds for a subscription.
+     * @param subscriptionId The ID of the subscription.
+     * @param priceIds The specific price IDs requested, or empty array to get all.
+     * @return priceFeeds An array of PriceFeed structs corresponding to the requested IDs.
+     */
+    function _getPricesInternal(
         uint256 subscriptionId,
         bytes32[] calldata priceIds
-    )
-        external
-        view
-        override
-        onlyWhitelistedReader(subscriptionId)
-        returns (PythStructs.PriceFeed[] memory)
-    {
-        if (!_state.subscriptionStatuses[subscriptionId].isActive) {
+    ) internal view returns (PythStructs.PriceFeed[] memory priceFeeds) {
+        if (!_state.subscriptionParams[subscriptionId].isActive) {
             revert InactiveSubscription();
         }
 
@@ -334,9 +359,14 @@ abstract contract Scheduler is IScheduler, SchedulerState {
                     params.priceIds.length
                 );
             for (uint8 i = 0; i < params.priceIds.length; i++) {
-                allFeeds[i] = _state.priceUpdates[subscriptionId][
-                    params.priceIds[i]
-                ];
+                PythStructs.PriceFeed storage priceFeed = _state.priceUpdates[
+                    subscriptionId
+                ][params.priceIds[i]];
+                // Check if the price feed exists (price ID is valid and has been updated)
+                if (priceFeed.id == bytes32(0)) {
+                    revert InvalidPriceId(params.priceIds[i], bytes32(0));
+                }
+                allFeeds[i] = priceFeed;
             }
             return allFeeds;
         }
@@ -347,31 +377,67 @@ abstract contract Scheduler is IScheduler, SchedulerState {
                 priceIds.length
             );
         for (uint8 i = 0; i < priceIds.length; i++) {
-            // Verify the requested price ID is part of the subscription
-            bool validPriceId = false;
-            for (uint8 j = 0; j < params.priceIds.length; j++) {
-                if (priceIds[i] == params.priceIds[j]) {
-                    validPriceId = true;
-                    break;
-                }
-            }
+            PythStructs.PriceFeed storage priceFeed = _state.priceUpdates[
+                subscriptionId
+            ][priceIds[i]];
 
-            if (!validPriceId) {
-                revert InvalidPriceId(priceIds[i], params.priceIds[0]);
+            // Check if the price feed exists (price ID is valid and has been updated)
+            if (priceFeed.id == bytes32(0)) {
+                revert InvalidPriceId(priceIds[i], bytes32(0));
             }
-
-            requestedFeeds[i] = _state.priceUpdates[subscriptionId][
-                priceIds[i]
-            ];
+            requestedFeeds[i] = priceFeed;
         }
-
         return requestedFeeds;
     }
+
+    function getPricesUnsafe(
+        uint256 subscriptionId,
+        bytes32[] calldata priceIds
+    )
+        external
+        view
+        override
+        onlyWhitelistedReader(subscriptionId)
+        returns (PythStructs.Price[] memory prices)
+    {
+        PythStructs.PriceFeed[] memory priceFeeds = _getPricesInternal(
+            subscriptionId,
+            priceIds
+        );
+        prices = new PythStructs.Price[](priceFeeds.length);
+        for (uint i = 0; i < priceFeeds.length; i++) {
+            prices[i] = priceFeeds[i].price;
+        }
+        return prices;
+    }
+
+    function getEmaPriceUnsafe(
+        uint256 subscriptionId,
+        bytes32[] calldata priceIds
+    )
+        external
+        view
+        override
+        onlyWhitelistedReader(subscriptionId)
+        returns (PythStructs.Price[] memory prices)
+    {
+        PythStructs.PriceFeed[] memory priceFeeds = _getPricesInternal(
+            subscriptionId,
+            priceIds
+        );
+        prices = new PythStructs.Price[](priceFeeds.length);
+        for (uint i = 0; i < priceFeeds.length; i++) {
+            prices[i] = priceFeeds[i].emaPrice;
+        }
+        return prices;
+    }
+
+    /// BALANCE MANAGEMENT
 
     function addFunds(
         uint256 subscriptionId
     ) external payable override onlyManager(subscriptionId) {
-        if (!_state.subscriptionStatuses[subscriptionId].isActive) {
+        if (!_state.subscriptionParams[subscriptionId].isActive) {
             revert InactiveSubscription();
         }
 
@@ -385,9 +451,22 @@ abstract contract Scheduler is IScheduler, SchedulerState {
         SubscriptionStatus storage status = _state.subscriptionStatuses[
             subscriptionId
         ];
+        SubscriptionParams storage params = _state.subscriptionParams[
+            subscriptionId
+        ];
 
         if (status.balanceInWei < amount) {
             revert InsufficientBalance();
+        }
+
+        // If subscription is active, ensure minimum balance is maintained
+        if (params.isActive) {
+            uint256 minimumBalance = this.getMinimumBalance(
+                uint8(params.priceIds.length)
+            );
+            if (status.balanceInWei - amount < minimumBalance) {
+                revert InsufficientBalance();
+            }
         }
 
         status.balanceInWei -= amount;
@@ -396,51 +475,99 @@ abstract contract Scheduler is IScheduler, SchedulerState {
         require(sent, "Failed to send funds");
     }
 
+    // FETCH SUBSCRIPTIONS
+
+    function getSubscription(
+        uint256 subscriptionId
+    )
+        external
+        view
+        override
+        returns (
+            SubscriptionParams memory params,
+            SubscriptionStatus memory status
+        )
+    {
+        return (
+            _state.subscriptionParams[subscriptionId],
+            _state.subscriptionStatuses[subscriptionId]
+        );
+    }
+
     // This function is intentionally public with no access control to allow keepers to discover active subscriptions
-    function getActiveSubscriptions()
+    function getActiveSubscriptions(
+        uint256 startIndex,
+        uint256 maxResults
+    )
         external
         view
         override
         returns (
             uint256[] memory subscriptionIds,
-            SubscriptionParams[] memory subscriptionParams
+            SubscriptionParams[] memory subscriptionParams,
+            uint256 totalCount
         )
     {
-        // TODO: This is gonna be expensive because we're iterating through
-        // all subscriptions, including deactivated ones. But because its a view
-        // function maybe it's not bad? We can optimize this.
-
-        // Count active subscriptions first to determine array size
-        uint256 activeCount = 0;
+        // Count active subscriptions first to determine total count
+        // TODO: Optimize this. store numActiveSubscriptions or something.
+        totalCount = 0;
         for (uint256 i = 1; i < _state.subscriptionNumber; i++) {
-            if (_state.subscriptionStatuses[i].isActive) {
-                activeCount++;
+            if (_state.subscriptionParams[i].isActive) {
+                totalCount++;
             }
+        }
+
+        // If startIndex is beyond the total count, return empty arrays
+        if (startIndex >= totalCount) {
+            return (new uint256[](0), new SubscriptionParams[](0), totalCount);
+        }
+
+        // Calculate how many results to return (bounded by maxResults and remaining items)
+        uint256 resultCount = totalCount - startIndex;
+        if (resultCount > maxResults) {
+            resultCount = maxResults;
         }
 
         // Create arrays for subscription IDs and parameters
-        subscriptionIds = new uint256[](activeCount);
-        subscriptionParams = new SubscriptionParams[](activeCount);
+        subscriptionIds = new uint256[](resultCount);
+        subscriptionParams = new SubscriptionParams[](resultCount);
 
-        // Populate arrays with active subscription data
-        uint256 index = 0;
-        for (uint256 i = 1; i < _state.subscriptionNumber; i++) {
-            if (_state.subscriptionStatuses[i].isActive) {
-                subscriptionIds[index] = i;
-                subscriptionParams[index] = _state.subscriptionParams[i];
-                index++;
+        // Find and populate the requested page of active subscriptions
+        uint256 activeIndex = 0;
+        uint256 resultIndex = 0;
+
+        for (
+            uint256 i = 1;
+            i < _state.subscriptionNumber && resultIndex < resultCount;
+            i++
+        ) {
+            if (_state.subscriptionParams[i].isActive) {
+                if (activeIndex >= startIndex) {
+                    subscriptionIds[resultIndex] = i;
+                    subscriptionParams[resultIndex] = _state.subscriptionParams[
+                        i
+                    ];
+                    resultIndex++;
+                }
+                activeIndex++;
             }
         }
 
-        return (subscriptionIds, subscriptionParams);
+        return (subscriptionIds, subscriptionParams, totalCount);
+    }
+
+    /**
+     * @notice Returns the minimum balance an active subscription of a given size needs to hold.
+     * @param numPriceFeeds The number of price feeds in the subscription.
+     */
+    function getMinimumBalance(
+        uint8 numPriceFeeds
+    ) external pure override returns (uint256 minimumBalanceInWei) {
+        // Simple implementation - minimum balance is 0.01 ETH per price feed
+        return numPriceFeeds * 0.01 ether;
     }
 
     // ACCESS CONTROL MODIFIERS
-
-    modifier onlyPusher() {
-        // TODO: we may not make this permissioned.
-        _;
-    }
 
     modifier onlyManager(uint256 subscriptionId) {
         if (_state.subscriptionManager[subscriptionId] != msg.sender) {

--- a/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerEvents.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerEvents.sol
@@ -10,5 +10,6 @@ interface SchedulerEvents {
     );
     event SubscriptionUpdated(uint256 indexed subscriptionId);
     event SubscriptionDeactivated(uint256 indexed subscriptionId);
+    event SubscriptionActivated(uint256 indexed subscriptionId);
     event PricesUpdated(uint256 indexed subscriptionId, uint256 timestamp);
 }

--- a/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerState.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerState.sol
@@ -5,21 +5,25 @@ pragma solidity ^0.8.0;
 import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
 
 contract SchedulerState {
-    // Maximum number of price feeds per subscription
-    uint8 public constant MAX_PRICE_IDS = 10;
+    /// Maximum number of price feeds per subscription
+    uint8 public constant MAX_PRICE_IDS = 255;
+    /// Default max gas multiplier
+    uint32 public constant DEFAULT_MAX_GAS_MULTIPLIER_CAP_PCT = 10_000;
+    /// Default max fee multiplier
+    uint32 public constant DEFAULT_MAX_FEE_MULTIPLIER_CAP_PCT = 10_000;
 
     struct State {
-        // Monotonically increasing counter for subscription IDs
+        /// Monotonically increasing counter for subscription IDs
         uint256 subscriptionNumber;
-        // Pyth contract for parsing updates and verifying sigs & timestamps
+        /// Pyth contract for parsing updates and verifying sigs & timestamps
         address pyth;
-        // Sub ID -> subscription parameters (which price feeds, when to update, etc)
+        /// Sub ID -> subscription parameters (which price feeds, when to update, etc)
         mapping(uint256 => SubscriptionParams) subscriptionParams;
-        // Sub ID -> subscription status (metadata about their sub)
+        /// Sub ID -> subscription status (metadata about their sub)
         mapping(uint256 => SubscriptionStatus) subscriptionStatuses;
-        // Sub ID -> price ID -> latest parsed price update for the subscribed feed
+        /// Sub ID -> price ID -> latest parsed price update for the subscribed feed
         mapping(uint256 => mapping(bytes32 => PythStructs.PriceFeed)) priceUpdates;
-        // Sub ID -> manager address
+        /// Sub ID -> manager address
         mapping(uint256 => address) subscriptionManager;
     }
     State internal _state;
@@ -28,6 +32,7 @@ contract SchedulerState {
         bytes32[] priceIds;
         address[] readerWhitelist;
         bool whitelistEnabled;
+        bool isActive;
         UpdateCriteria updateCriteria;
         GasConfig gasConfig;
     }
@@ -37,16 +42,19 @@ contract SchedulerState {
         uint256 balanceInWei;
         uint256 totalUpdates;
         uint256 totalSpent;
-        bool isActive;
     }
 
+    /// @dev When pushing prices, providers will use a "fast gas" estimation as default.
+    /// If the gas is insufficient to land the transaction, the provider will linearly scale
+    /// gas and fee multipliers until the transaction lands. These parameters allow the subscriber
+    /// to impose limits on these multipliers.
+    /// For example, with maxGasMultiplierCapPct = 10_000 (default), the provider can
+    /// use a max of 100x (10000%) of the estimated gas as reported by the RPC.
     struct GasConfig {
-        // TODO: Figure out what controls to give users for gas strategy
-
-        // Gas price limit to prevent runaway costs in high-gas environments
-        uint256 maxGasPrice;
-        // Gas limit for update operations
-        uint256 maxGasLimit;
+        /// Gas price multiplier limit percent for update operations
+        uint32 maxGasMultiplierCapPct;
+        // Priority fee multiplier limit for update operations (EIP-1559)
+        uint32 maxFeeMultiplierCapPct;
     }
 
     struct UpdateCriteria {
@@ -54,11 +62,5 @@ contract SchedulerState {
         uint32 heartbeatSeconds;
         bool updateOnDeviation;
         uint32 deviationThresholdBps;
-
-        // TODO: add updateOnConfidenceRatio?
-
-        // TODO: add explicit "early update" support? i.e. update all feeds when at least one feed
-        //          meets the triggering conditions, rather than waiting for all feeds
-        //          to meet the conditions. Currently, "early update" is the only mode of operation.
     }
 }


### PR DESCRIPTION
## Summary and Rationale
Various improvements from PR and design doc review.

- Address PR review comments from #2572 
  - Paginate getActiveSubscriptions
  - Make addSubscription payable to allow for atomic addFunds + addSubscription
- Match IPyth signatures for the read prices functions (e.g. `getPricesUnsafe`) to make migration easier for users
- Make deactivateSubscription a special case of updateSubscription
  - Expanding `updateSubscription` to handle activating and deactivating subscriptions makes it possible to reactivate a subscription. This is better UX, since the user may want to pause and resume a subscription without modifying its balance or params.
- Enforce a minimum balance for active subscriptions
  - We now enforce a minimum balance for a subscription when withdrawing funds from an active subscription, and when adding/reactivating a subscription. This helps guard against bad actors flooding the system with subscriptions, which could cause the keepers to become overwhelmed. it also encourages users maintain enough balance to weather high gas environments. The actual balance is a placeholder value right now.
  - An effect of this is that `isActive` has moved from `SubscriptionStatus` to `SubscriptionParams`

- Remove the `onlyPusher` modifier since we will allow anyone to push updates.

- Update GasConfig to expose `maxGasMultiplierCapPct` and `maxFeeMultiplierCapPct` controls to the user. Set defaults to be very high, since most users would rather land txs at a higher cost than not land them due to limits set too low.

## How has this been tested?

- [x] Current tests cover my changes
- [x] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
