### PR TITLE
feat(staking): add devnet switch to wallet tester

### DIFF
--- a/apps/staking/src/components/WalletTester/index.tsx
+++ b/apps/staking/src/components/WalletTester/index.tsx
@@ -21,8 +21,10 @@ import {
   StateType as UseAsyncStateType,
 } from "../../hooks/use-async";
 import { useData, StateType as UseDataStateType } from "../../hooks/use-data";
+import { useNetwork } from "../../hooks/use-network";
 import { useToast } from "../../hooks/use-toast";
 import { Button } from "../Button";
+import { Switch } from "../Switch";
 
 const MAX_TEST_RETRIES = 10;
 
@@ -65,13 +67,14 @@ const ConnectWallet = ({ isLoading }: { isLoading?: boolean | undefined }) => {
   const showModal = useCallback(() => {
     modal.setVisible(true);
   }, [modal]);
+  const { isMainnet, toggleMainnet } = useNetwork();
 
   return (
     <>
       <Description className="mb-10 text-neutral-400">
         Please connect your wallet to get started.
       </Description>
-      <div className="flex justify-center">
+      <div className="flex flex-col items-center gap-4">
         <Button
           className="px-10 py-4"
           size="nopad"
@@ -87,6 +90,14 @@ const ConnectWallet = ({ isLoading }: { isLoading?: boolean | undefined }) => {
             </>
           )}
         </Button>
+        <Switch
+          isSelected={isMainnet}
+          postLabel="Mainnet"
+          preLabel="Devnet"
+          className="px-4 py-1"
+          size="small"
+          onChange={toggleMainnet}
+        />
       </div>
     </>
   );


### PR DESCRIPTION
## Summary

Add a network switch to the wallet tester.

## Rationale

We have an MDP who would like to run through the wallet test using a devnet fireblocks workspace.  However, it seems that the way walletconnect or fireblocks works prevents even connecting in the wrong network (other wallets will let you connect and switch networks after connecting).

To unblock this user, I'm adding a network switch so they can switch to testnet before connecting their wallet.  I'm only adding it in the wallet tester although probably it makes sense to eventually replace the wallet connect modal from `@solana/wallet-adapter` with a custom one so we can offer this option anywhere that the wallet connection UI flow shows up instead.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code