### PR TITLE
fix(pulse-scheduler): validate atomic subscription updates using slots instead of timestamps

### DIFF
--- a/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerErrors.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerErrors.sol
@@ -9,7 +9,7 @@ error InvalidPriceId(bytes32 providedPriceId, bytes32 expectedPriceId);
 error InvalidPriceIdsLength(bytes32 providedLength, bytes32 expectedLength);
 error InvalidUpdateCriteria();
 error InvalidGasConfig();
-error PriceTimestampMismatch();
+error PriceSlotMismatch();
 error TooManyPriceIds(uint256 provided, uint256 maximum);
 error UpdateConditionsNotMet();
 error TimestampOlderThanLastUpdate(

--- a/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerState.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerState.sol
@@ -8,6 +8,9 @@ contract SchedulerState {
     // Maximum number of price feeds per subscription
     uint8 public constant MAX_PRICE_IDS = 10;
 
+    uint256 public constant PAST_TIMESTAMP_GRACE_PERIOD = 1 hours;
+    uint256 public constant FUTURE_TIMESTAMP_GRACE_PERIOD = 10 seconds;
+
     struct State {
         // Monotonically increasing counter for subscription IDs
         uint256 subscriptionNumber;

--- a/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerState.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerState.sol
@@ -12,8 +12,13 @@ contract SchedulerState {
     /// Default max fee multiplier
     uint32 public constant DEFAULT_MAX_PRIORITY_FEE_MULTIPLIER_CAP_PCT = 10_000;
 
-    uint256 public constant PAST_TIMESTAMP_GRACE_PERIOD = 1 hours;
-    uint256 public constant FUTURE_TIMESTAMP_GRACE_PERIOD = 10 seconds;
+    // TODO: make these updateable via governance
+    /// Maximum time in the past (relative to current block timestamp)
+    /// for which a price update timestamp is considered valid
+    uint64 public constant PAST_TIMESTAMP_MAX_VALIDITY_PERIOD = 1 hours;
+    /// Maximum time in the future (relative to current block timestamp)
+    /// for which a price update timestamp is considered valid
+    uint64 public constant FUTURE_TIMESTAMP_MAX_VALIDITY_PERIOD = 10 seconds;
 
     struct State {
         /// Monotonically increasing counter for subscription IDs

--- a/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
@@ -112,7 +112,7 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
         }
     }
 
-    function extractWormholeMerkleHeaderDigestAndNumUpdatesAndEncodedFromAccumulatorUpdate(
+    function extractWormholeMerkleHeaderDigestAndNumUpdatesAndEncodedAndSlotFromAccumulatorUpdate(
         bytes calldata accumulatorUpdate,
         uint encodedOffset
     )
@@ -122,7 +122,8 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
             uint offset,
             bytes20 digest,
             uint8 numUpdates,
-            bytes calldata encoded
+            bytes calldata encoded,
+            uint64 slot
         )
     {
         unchecked {
@@ -175,8 +176,10 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
                     if (updateType != UpdateType.WormholeMerkle)
                         revert PythErrors.InvalidUpdateData();
 
-                    // This field is not used
-                    // uint64 slot = UnsafeBytesLib.toUint64(encodedPayload, payloadoffset);
+                    slot = UnsafeBytesLib.toUint64(
+                        encodedPayload,
+                        payloadOffset
+                    );
                     payloadOffset += 8;
 
                     // This field is not used
@@ -467,12 +470,14 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
         uint offset;
         bytes20 digest;
         bytes calldata encoded;
+        uint64 slot;
         (
             offset,
             digest,
             numUpdates,
-            encoded
-        ) = extractWormholeMerkleHeaderDigestAndNumUpdatesAndEncodedFromAccumulatorUpdate(
+            encoded,
+            slot
+        ) = extractWormholeMerkleHeaderDigestAndNumUpdatesAndEncodedAndSlotFromAccumulatorUpdate(
             accumulatorUpdate,
             encodedOffset
         );

--- a/target_chains/ethereum/contracts/contracts/pyth/PythInternalStructs.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythInternalStructs.sol
@@ -15,6 +15,26 @@ contract PythInternalStructs {
         bool checkUniqueness;
     }
 
+    /// Internal struct to hold parameters for update processing
+    /// @dev Storing these variable in a struct rather than local variables
+    /// helps reduce stack depth when passing arguments to functions.
+    struct UpdateParseContext {
+        bytes32[] priceIds;
+        ParseConfig config;
+        PythStructs.PriceFeed[] priceFeeds;
+        uint64[] slots;
+    }
+
+    /// The initial Merkle header data in an AccumulatorUpdate. The encoded bytes
+    /// are kept in calldata for gas efficiency.
+    /// @dev Storing these variable in a struct rather than local variables
+    /// helps reduce stack depth when passing arguments to functions.
+    struct MerkleData {
+        bytes20 digest;
+        uint8 numUpdates;
+        uint64 slot;
+    }
+
     struct PriceInfo {
         // slot 1
         uint64 publishTime;

--- a/target_chains/ethereum/contracts/forge-test/PulseScheduler.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/PulseScheduler.t.sol
@@ -1044,7 +1044,7 @@ contract SchedulerTest is Test, SchedulerEvents, PulseTestUtils {
         vm.prank(pusher);
         scheduler.updatePriceFeeds(subscriptionId, updateData, priceIds);
 
-        // Try to access from the non-whitelisted address (should fail)
+        // Try to access from a non-whitelisted address (should fail)
         vm.startPrank(address(0xdead));
         bytes32[] memory emptyPriceIds = new bytes32[](0);
         vm.expectRevert(abi.encodeWithSelector(Unauthorized.selector));

--- a/target_chains/ethereum/contracts/forge-test/Pyth.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Pyth.t.sol
@@ -204,7 +204,6 @@ contract PythTest is Test, WormholeTestUtils, PythTestUtils {
         );
     }
 
-    /// Testing parsePriceFeedUpdates method.
     function testParsePriceFeedUpdatesWorks(uint seed) public {
         setRandSeed(seed);
         uint numMessages = 1 + (getRandUint() % 10);
@@ -237,7 +236,6 @@ contract PythTest is Test, WormholeTestUtils, PythTestUtils {
         }
     }
 
-    /// Testing parsePriceFeedUpdatesWithSlots method.
     function testParsePriceFeedUpdatesWithSlotsWorks(uint seed) public {
         setRandSeed(seed);
         uint numMessages = 1 + (getRandUint() % 10);

--- a/target_chains/ethereum/contracts/forge-test/utils/PulseTestUtils.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/utils/PulseTestUtils.t.sol
@@ -74,6 +74,29 @@ abstract contract PulseTestUtils is Test {
         return createMockPriceFeeds(publishTime, 1)[0];
     }
 
+    // Helper function to create mock price feeds with slots
+    function createMockPriceFeedsWithSlots(
+        uint256 publishTime,
+        uint256 numFeeds
+    )
+        internal
+        pure
+        returns (
+            PythStructs.PriceFeed[] memory priceFeeds,
+            uint64[] memory slots
+        )
+    {
+        priceFeeds = createMockPriceFeeds(publishTime, numFeeds);
+        slots = new uint64[](numFeeds);
+
+        // Set all slots to the publishTime as a mock value
+        for (uint256 i = 0; i < numFeeds; i++) {
+            slots[i] = uint64(publishTime);
+        }
+
+        return (priceFeeds, slots);
+    }
+
     // Helper function to create mock price feeds with default 2 feeds
     function createMockPriceFeeds(
         uint256 publishTime
@@ -134,6 +157,30 @@ abstract contract PulseTestUtils is Test {
             expectedFee,
             abi.encodeWithSelector(IPyth.parsePriceFeedUpdates.selector),
             abi.encode(priceFeeds)
+        );
+    }
+
+    // Helper function to mock Pyth response with slots
+    function mockParsePriceFeedUpdatesWithSlots(
+        address pyth,
+        PythStructs.PriceFeed[] memory priceFeeds,
+        uint64[] memory slots
+    ) internal {
+        uint expectedFee = MOCK_PYTH_FEE_PER_FEED * priceFeeds.length;
+
+        vm.mockCall(
+            pyth,
+            abi.encodeWithSelector(IPyth.getUpdateFee.selector),
+            abi.encode(expectedFee)
+        );
+
+        vm.mockCall(
+            pyth,
+            expectedFee,
+            abi.encodeWithSelector(
+                IPyth.parsePriceFeedUpdatesWithSlots.selector
+            ),
+            abi.encode(priceFeeds, slots)
         );
     }
 

--- a/target_chains/ethereum/contracts/forge-test/utils/PythTestUtils.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/utils/PythTestUtils.t.sol
@@ -148,7 +148,7 @@ abstract contract PythTestUtils is Test, WormholeTestUtils, RandTestUtils {
         bytes memory wormholePayload = abi.encodePacked(
             uint32(0x41555756), // PythAccumulator.ACCUMULATOR_WORMHOLE_MAGIC
             uint8(PythAccumulator.UpdateType.WormholeMerkle),
-            uint64(0), // Slot, not used in target networks
+            uint64(1), // Slot, not used in target networks
             uint32(0), // Ring size, not used in target networks
             rootDigest
         );

--- a/target_chains/ethereum/sdk/solidity/AbstractPyth.sol
+++ b/target_chains/ethereum/sdk/solidity/AbstractPyth.sol
@@ -136,6 +136,23 @@ abstract contract AbstractPyth is IPyth {
         override
         returns (PythStructs.PriceFeed[] memory priceFeeds);
 
+    /// @dev Same as `parsePriceFeedUpdates`, but also returns the Pythnet slot
+    /// associated with each price update.
+    function parsePriceFeedUpdatesWithSlots(
+        bytes[] calldata updateData,
+        bytes32[] calldata priceIds,
+        uint64 minPublishTime,
+        uint64 maxPublishTime
+    )
+        external
+        payable
+        virtual
+        override
+        returns (
+            PythStructs.PriceFeed[] memory priceFeeds,
+            uint64[] memory slots
+        );
+
     function parseTwapPriceFeedUpdates(
         bytes[] calldata updateData,
         bytes32[] calldata priceIds

--- a/target_chains/ethereum/sdk/solidity/AbstractPyth.sol
+++ b/target_chains/ethereum/sdk/solidity/AbstractPyth.sol
@@ -136,8 +136,6 @@ abstract contract AbstractPyth is IPyth {
         override
         returns (PythStructs.PriceFeed[] memory priceFeeds);
 
-    /// @dev Same as `parsePriceFeedUpdates`, but also returns the Pythnet slot
-    /// associated with each price update.
     function parsePriceFeedUpdatesWithSlots(
         bytes[] calldata updateData,
         bytes32[] calldata priceIds,

--- a/target_chains/ethereum/sdk/solidity/IPyth.sol
+++ b/target_chains/ethereum/sdk/solidity/IPyth.sol
@@ -164,4 +164,26 @@ interface IPyth is IPythEvents {
         uint64 minPublishTime,
         uint64 maxPublishTime
     ) external payable returns (PythStructs.PriceFeed[] memory priceFeeds);
+
+    /// @dev Same as `parsePriceFeedUpdates`, but also returns the Pythnet slot
+    /// associated with each price update.
+    /// @param updateData Array of price update data.
+    /// @param priceIds Array of price ids.
+    /// @param minPublishTime minimum acceptable publishTime for the given `priceIds`.
+    /// @param maxPublishTime maximum acceptable publishTime for the given `priceIds`.
+    /// @return priceFeeds Array of the price feeds corresponding to the given `priceIds` (with the same order).
+    /// @return slots Array of the Pythnet slot corresponding to the given `priceIds` (with the same order).
+    /// @
+    function parsePriceFeedUpdatesWithSlots(
+        bytes[] calldata updateData,
+        bytes32[] calldata priceIds,
+        uint64 minPublishTime,
+        uint64 maxPublishTime
+    )
+        external
+        payable
+        returns (
+            PythStructs.PriceFeed[] memory priceFeeds,
+            uint64[] memory slots
+        );
 }

--- a/target_chains/ethereum/sdk/solidity/IPyth.sol
+++ b/target_chains/ethereum/sdk/solidity/IPyth.sol
@@ -173,7 +173,6 @@ interface IPyth is IPythEvents {
     /// @param maxPublishTime maximum acceptable publishTime for the given `priceIds`.
     /// @return priceFeeds Array of the price feeds corresponding to the given `priceIds` (with the same order).
     /// @return slots Array of the Pythnet slot corresponding to the given `priceIds` (with the same order).
-    /// @
     function parsePriceFeedUpdatesWithSlots(
         bytes[] calldata updateData,
         bytes32[] calldata priceIds,

--- a/target_chains/ethereum/sdk/solidity/README.md
+++ b/target_chains/ethereum/sdk/solidity/README.md
@@ -92,7 +92,7 @@ You can find a list of available price feeds [here](https://pyth.network/develop
 
 ### ABIs
 
-When making changes to a contract interface, please make sure to update the ABI files too. You can update it using `pnpm generate-abi` and it will update the ABI files in [abis](./abis) directory.
+When making changes to a contract interface, please make sure to update the ABI files too. You can update it using `pnpm turbo run build:abis` and it will update the ABI files in [abis](./abis) directory.
 
 ### Releases
 

--- a/target_chains/ethereum/sdk/solidity/abis/AbstractPyth.json
+++ b/target_chains/ethereum/sdk/solidity/abis/AbstractPyth.json
@@ -577,6 +577,106 @@
         "internalType": "bytes32[]",
         "name": "priceIds",
         "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint64",
+        "name": "minPublishTime",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "maxPublishTime",
+        "type": "uint64"
+      }
+    ],
+    "name": "parsePriceFeedUpdatesWithSlots",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "components": [
+              {
+                "internalType": "int64",
+                "name": "price",
+                "type": "int64"
+              },
+              {
+                "internalType": "uint64",
+                "name": "conf",
+                "type": "uint64"
+              },
+              {
+                "internalType": "int32",
+                "name": "expo",
+                "type": "int32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "publishTime",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct PythStructs.Price",
+            "name": "price",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "int64",
+                "name": "price",
+                "type": "int64"
+              },
+              {
+                "internalType": "uint64",
+                "name": "conf",
+                "type": "uint64"
+              },
+              {
+                "internalType": "int32",
+                "name": "expo",
+                "type": "int32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "publishTime",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct PythStructs.Price",
+            "name": "emaPrice",
+            "type": "tuple"
+          }
+        ],
+        "internalType": "struct PythStructs.PriceFeed[]",
+        "name": "priceFeeds",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint64[]",
+        "name": "slots",
+        "type": "uint64[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "updateData",
+        "type": "bytes[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "priceIds",
+        "type": "bytes32[]"
       }
     ],
     "name": "parseTwapPriceFeedUpdates",

--- a/target_chains/ethereum/sdk/solidity/abis/IPyth.json
+++ b/target_chains/ethereum/sdk/solidity/abis/IPyth.json
@@ -467,6 +467,106 @@
         "internalType": "bytes32[]",
         "name": "priceIds",
         "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint64",
+        "name": "minPublishTime",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "maxPublishTime",
+        "type": "uint64"
+      }
+    ],
+    "name": "parsePriceFeedUpdatesWithSlots",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "components": [
+              {
+                "internalType": "int64",
+                "name": "price",
+                "type": "int64"
+              },
+              {
+                "internalType": "uint64",
+                "name": "conf",
+                "type": "uint64"
+              },
+              {
+                "internalType": "int32",
+                "name": "expo",
+                "type": "int32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "publishTime",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct PythStructs.Price",
+            "name": "price",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "int64",
+                "name": "price",
+                "type": "int64"
+              },
+              {
+                "internalType": "uint64",
+                "name": "conf",
+                "type": "uint64"
+              },
+              {
+                "internalType": "int32",
+                "name": "expo",
+                "type": "int32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "publishTime",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct PythStructs.Price",
+            "name": "emaPrice",
+            "type": "tuple"
+          }
+        ],
+        "internalType": "struct PythStructs.PriceFeed[]",
+        "name": "priceFeeds",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint64[]",
+        "name": "slots",
+        "type": "uint64[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "updateData",
+        "type": "bytes[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "priceIds",
+        "type": "bytes32[]"
       }
     ],
     "name": "parseTwapPriceFeedUpdates",

--- a/target_chains/ethereum/sdk/solidity/abis/MockPyth.json
+++ b/target_chains/ethereum/sdk/solidity/abis/MockPyth.json
@@ -716,6 +716,106 @@
         "internalType": "bytes32[]",
         "name": "priceIds",
         "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint64",
+        "name": "minPublishTime",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "maxPublishTime",
+        "type": "uint64"
+      }
+    ],
+    "name": "parsePriceFeedUpdatesWithSlots",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "id",
+            "type": "bytes32"
+          },
+          {
+            "components": [
+              {
+                "internalType": "int64",
+                "name": "price",
+                "type": "int64"
+              },
+              {
+                "internalType": "uint64",
+                "name": "conf",
+                "type": "uint64"
+              },
+              {
+                "internalType": "int32",
+                "name": "expo",
+                "type": "int32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "publishTime",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct PythStructs.Price",
+            "name": "price",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "int64",
+                "name": "price",
+                "type": "int64"
+              },
+              {
+                "internalType": "uint64",
+                "name": "conf",
+                "type": "uint64"
+              },
+              {
+                "internalType": "int32",
+                "name": "expo",
+                "type": "int32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "publishTime",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct PythStructs.Price",
+            "name": "emaPrice",
+            "type": "tuple"
+          }
+        ],
+        "internalType": "struct PythStructs.PriceFeed[]",
+        "name": "feeds",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint64[]",
+        "name": "slots",
+        "type": "uint64[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "updateData",
+        "type": "bytes[]"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "priceIds",
+        "type": "bytes32[]"
       }
     ],
     "name": "parseTwapPriceFeedUpdates",

--- a/target_chains/ethereum/sdk/solidity/package.json
+++ b/target_chains/ethereum/sdk/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Read prices from the Pyth oracle",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary
This PR fixes the "atomic" subscription update guarantee (ensuring all feeds in a subscription are updated together,) by using slots instead of timestamps for the validation.

## Rationale
### Use slots instead of timestamps
The main motivation for this is that timestamps (`publishTime`) can be misleading for validating an "atomic" subscription update, as one or more assets might have closed markets, and will retain timestamps from their last trading period.
Thus, we use Pythnet slots for the atomicity validation, since they are consistent across all assets regardless of market status. 
- We still use timestamps to validate the heartbeat update condition. We now take the max of all passed in timestamps (rather than the first) to ensure that if any of the feeds need updating, we perform the update.

### Get the slots data from the Pyth parse functions
Pythnet slot number is available in the AccumulatorUpdate, but unfortunately `Pyth.parsePriceFeedUpdates` doesn't return them, just the Price[] structs. Thus, we add `parsePriceFeedUpdatesWithSlots` to the Pyth contract to expose slot information, and we consume this from the Scheduler contract.
- All the updates in a single WhMerkle message have the same slot, so technically we could have returned a `slots` array of len(updateData) rather than len(priceFeedIds), but I chose to return parallel arrays of `Price[] feeds` and `uint64[] slots` to keep things coherent for the user, especially if len(updateData) > 1.
- It turns out that `parsePriceUpdatesInternal` was already very close to the stack depth limit, and adding a `slots` array took it (quite far) over the line. Thus, this PR also contains significant refactors to that method to split it up into helper methods to reduce stack frame size. We also use structs to pass arguments instead of local variables for the same reason, since passing many arguments to functions takes up lots of stack space.

### Misc
- Expanded timestamp validity periods to 1 hour in the past and 10 seconds in the future and extracted them out to constants.

## Note to reviewers
I'd start in Pyth.sol first with the changes to parsePriceFeedUpdatesInternal. Then Scheduler.sol since it is downstream. The rest is somewhat mechanical fallout. Some of the motivations behind the changes are nonobvious, see below for the rationale.

## How has this been tested?

- [x] Current tests cover my changes
  - All existing tests were updated to work with slot-based validation
- [x] Added new tests
  - New tests were added to verify correct slot validation behavior and `Pyth.parsePriceFeedUpdatesWithSlots` behavior
- [ ] Manually tested the code
