### PR TITLE
refactor(pulse-scheduler): improve SubscriptionParams validation

### DIFF
--- a/target_chains/ethereum/contracts/contracts/pulse/scheduler/Scheduler.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/scheduler/Scheduler.sol
@@ -671,8 +671,9 @@ abstract contract Scheduler is IScheduler, SchedulerState {
     function getMinimumBalance(
         uint8 numPriceFeeds
     ) external pure override returns (uint256 minimumBalanceInWei) {
-        // Simple implementation - minimum balance is 0.01 ETH per price feed
-        return numPriceFeeds * 0.01 ether;
+        // Placeholder implementation
+        // TODO: make this governable
+        return uint256(numPriceFeeds) * 0.01 ether;
     }
 
     // ACCESS CONTROL MODIFIERS

--- a/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerErrors.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerErrors.sol
@@ -2,18 +2,31 @@
 
 pragma solidity ^0.8.0;
 
+// Authorization errors
+error Unauthorized();
+
+// Subscription state errors
 error InactiveSubscription();
 error InsufficientBalance();
-error Unauthorized();
+error IllegalPermanentSubscriptionModification();
+
+// Price feed errors
 error InvalidPriceId(bytes32 providedPriceId, bytes32 expectedPriceId);
 error InvalidPriceIdsLength(bytes32 providedLength, bytes32 expectedLength);
+error EmptyPriceIds();
+error TooManyPriceIds(uint256 provided, uint256 maximum);
+error DuplicatePriceId(bytes32 priceId);
+error PriceSlotMismatch();
+
+// Update criteria errors
 error InvalidUpdateCriteria();
 error InvalidGasConfig();
-error PriceSlotMismatch();
-error TooManyPriceIds(uint256 provided, uint256 maximum);
 error UpdateConditionsNotMet();
-error IllegalPermanentSubscriptionModification();
 error TimestampOlderThanLastUpdate(
     uint256 providedUpdateTimestamp,
     uint256 lastUpdatedAt
 );
+
+// Whitelist errors
+error TooManyWhitelistedReaders(uint256 provided, uint256 maximum);
+error DuplicateWhitelistAddress(address addr);

--- a/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerErrors.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerErrors.sol
@@ -22,7 +22,6 @@ error PriceSlotMismatch();
 error InvalidUpdateCriteria();
 error InvalidGasConfig();
 error UpdateConditionsNotMet();
-error IllegalPermanentSubscriptionModification();
 error TimestampOlderThanLastUpdate(
     uint256 providedUpdateTimestamp,
     uint256 lastUpdatedAt

--- a/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerErrors.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerErrors.sol
@@ -12,6 +12,7 @@ error InvalidGasConfig();
 error PriceSlotMismatch();
 error TooManyPriceIds(uint256 provided, uint256 maximum);
 error UpdateConditionsNotMet();
+error IllegalPermanentSubscriptionModification();
 error TimestampOlderThanLastUpdate(
     uint256 providedUpdateTimestamp,
     uint256 lastUpdatedAt

--- a/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerState.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerState.sol
@@ -41,6 +41,7 @@ contract SchedulerState {
         address[] readerWhitelist;
         bool whitelistEnabled;
         bool isActive;
+        bool isPermanent;
         UpdateCriteria updateCriteria;
         GasConfig gasConfig;
     }

--- a/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerState.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerState.sol
@@ -7,6 +7,8 @@ import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
 contract SchedulerState {
     /// Maximum number of price feeds per subscription
     uint8 public constant MAX_PRICE_IDS_PER_SUBSCRIPTION = 255;
+    /// Maximum number of addresses in the reader whitelist
+    uint8 public constant MAX_READER_WHITELIST_SIZE = 255;
     /// Default max gas multiplier
     uint32 public constant DEFAULT_MAX_BASE_FEE_MULTIPLIER_CAP_PCT = 10_000;
     /// Default max fee multiplier

--- a/target_chains/ethereum/contracts/forge-test/PulseScheduler.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/PulseScheduler.t.sol
@@ -97,33 +97,10 @@ contract SchedulerTest is Test, SchedulerEvents, PulseTestUtils {
     }
 
     function testCreateSubscription() public {
-        // Create subscription parameters
-        bytes32[] memory priceIds = createPriceIds();
-        address[] memory readerWhitelist = new address[](1);
-        readerWhitelist[0] = address(reader);
-
-        SchedulerState.UpdateCriteria memory updateCriteria = SchedulerState
-            .UpdateCriteria({
-                updateOnHeartbeat: true,
-                heartbeatSeconds: 60,
-                updateOnDeviation: true,
-                deviationThresholdBps: 100
-            });
-
-        SchedulerState.GasConfig memory gasConfig = SchedulerState.GasConfig({
-            maxBaseFeeMultiplierCapPct: 10_000,
-            maxPriorityFeeMultiplierCapPct: 10_000
-        });
-
-        SchedulerState.SubscriptionParams memory params = SchedulerState
-            .SubscriptionParams({
-                priceIds: priceIds,
-                readerWhitelist: readerWhitelist,
-                whitelistEnabled: true,
-                isActive: true,
-                updateCriteria: updateCriteria,
-                gasConfig: gasConfig
-            });
+        uint256 numFeeds = 2; // Corresponds to default createPriceIds()
+        SchedulerState.SubscriptionParams
+            memory params = _createDefaultSubscriptionParams(numFeeds);
+        bytes32[] memory priceIds = params.priceIds; // Get the generated price IDs
 
         // Calculate minimum balance
         uint256 minimumBalance = scheduler.getMinimumBalance(
@@ -152,28 +129,28 @@ contract SchedulerTest is Test, SchedulerEvents, PulseTestUtils {
         );
         assertEq(
             storedParams.readerWhitelist.length,
-            readerWhitelist.length,
+            params.readerWhitelist.length,
             "Whitelist length mismatch"
         );
         assertEq(
             storedParams.whitelistEnabled,
-            true,
-            "whitelistEnabled should be true"
+            params.whitelistEnabled,
+            "whitelistEnabled should match"
         );
         assertTrue(storedParams.isActive, "Subscription should be active");
         assertEq(
             storedParams.updateCriteria.heartbeatSeconds,
-            60,
+            params.updateCriteria.heartbeatSeconds,
             "Heartbeat seconds mismatch"
         );
         assertEq(
             storedParams.updateCriteria.deviationThresholdBps,
-            100,
+            params.updateCriteria.deviationThresholdBps,
             "Deviation threshold mismatch"
         );
         assertEq(
             storedParams.gasConfig.maxBaseFeeMultiplierCapPct,
-            10_000,
+            params.gasConfig.maxBaseFeeMultiplierCapPct,
             "Max gas multiplier mismatch"
         );
 
@@ -214,6 +191,7 @@ contract SchedulerTest is Test, SchedulerEvents, PulseTestUtils {
                 readerWhitelist: newReaderWhitelist,
                 whitelistEnabled: false, // Changed from true
                 isActive: true,
+                isPermanent: false,
                 updateCriteria: newUpdateCriteria,
                 gasConfig: newGasConfig
             });
@@ -349,37 +327,13 @@ contract SchedulerTest is Test, SchedulerEvents, PulseTestUtils {
     }
 
     function testcreateSubscriptionWithInsufficientFundsReverts() public {
-        // Create subscription parameters
-        bytes32[] memory priceIds = createPriceIds();
-        address[] memory readerWhitelist = new address[](1);
-        readerWhitelist[0] = address(reader);
-
-        SchedulerState.UpdateCriteria memory updateCriteria = SchedulerState
-            .UpdateCriteria({
-                updateOnHeartbeat: true,
-                heartbeatSeconds: 60,
-                updateOnDeviation: true,
-                deviationThresholdBps: 100
-            });
-
-        SchedulerState.GasConfig memory gasConfig = SchedulerState.GasConfig({
-            maxBaseFeeMultiplierCapPct: 10_000,
-            maxPriorityFeeMultiplierCapPct: 10_000
-        });
-
-        SchedulerState.SubscriptionParams memory params = SchedulerState
-            .SubscriptionParams({
-                priceIds: priceIds,
-                readerWhitelist: readerWhitelist,
-                whitelistEnabled: true,
-                isActive: true,
-                updateCriteria: updateCriteria,
-                gasConfig: gasConfig
-            });
+        uint256 numFeeds = 2;
+        SchedulerState.SubscriptionParams
+            memory params = _createDefaultSubscriptionParams(numFeeds);
 
         // Calculate minimum balance
         uint256 minimumBalance = scheduler.getMinimumBalance(
-            uint8(priceIds.length)
+            uint8(params.priceIds.length)
         );
 
         // Try to add subscription with insufficient funds
@@ -388,40 +342,11 @@ contract SchedulerTest is Test, SchedulerEvents, PulseTestUtils {
     }
 
     function testActivateDeactivateSubscription() public {
-        // First add a subscription with minimum balance
-        bytes32[] memory priceIds = createPriceIds();
-        address[] memory readerWhitelist = new address[](1);
-        readerWhitelist[0] = address(reader);
+        uint256 subscriptionId = addTestSubscription();
 
-        SchedulerState.UpdateCriteria memory updateCriteria = SchedulerState
-            .UpdateCriteria({
-                updateOnHeartbeat: true,
-                heartbeatSeconds: 60,
-                updateOnDeviation: true,
-                deviationThresholdBps: 100
-            });
-
-        SchedulerState.GasConfig memory gasConfig = SchedulerState.GasConfig({
-            maxBaseFeeMultiplierCapPct: 10_000,
-            maxPriorityFeeMultiplierCapPct: 10_000
-        });
-
-        SchedulerState.SubscriptionParams memory params = SchedulerState
-            .SubscriptionParams({
-                priceIds: priceIds,
-                readerWhitelist: readerWhitelist,
-                whitelistEnabled: true,
-                isActive: true,
-                updateCriteria: updateCriteria,
-                gasConfig: gasConfig
-            });
-
-        uint256 minimumBalance = scheduler.getMinimumBalance(
-            uint8(priceIds.length)
-        );
-        uint256 subscriptionId = scheduler.createSubscription{
-            value: minimumBalance
-        }(params);
+        // Get current params
+        (SchedulerState.SubscriptionParams memory params, ) = scheduler
+            .getSubscription(subscriptionId);
 
         // Deactivate subscription using updateSubscription
         params.isActive = false;
@@ -486,41 +411,13 @@ contract SchedulerTest is Test, SchedulerEvents, PulseTestUtils {
     }
 
     function testWithdrawFunds() public {
-        // First add a subscription with minimum balance
-        bytes32[] memory priceIds = createPriceIds();
+        // Add a subscription and get the parameters
+        uint256 subscriptionId = addTestSubscription();
+        (SchedulerState.SubscriptionParams memory params, ) = scheduler
+            .getSubscription(subscriptionId);
         uint256 minimumBalance = scheduler.getMinimumBalance(
-            uint8(priceIds.length)
+            uint8(params.priceIds.length)
         );
-
-        address[] memory readerWhitelist = new address[](1);
-        readerWhitelist[0] = address(reader);
-
-        SchedulerState.UpdateCriteria memory updateCriteria = SchedulerState
-            .UpdateCriteria({
-                updateOnHeartbeat: true,
-                heartbeatSeconds: 60,
-                updateOnDeviation: true,
-                deviationThresholdBps: 100
-            });
-
-        SchedulerState.GasConfig memory gasConfig = SchedulerState.GasConfig({
-            maxBaseFeeMultiplierCapPct: 10_000,
-            maxPriorityFeeMultiplierCapPct: 10_000
-        });
-
-        SchedulerState.SubscriptionParams memory params = SchedulerState
-            .SubscriptionParams({
-                priceIds: priceIds,
-                readerWhitelist: readerWhitelist,
-                whitelistEnabled: true,
-                isActive: true,
-                updateCriteria: updateCriteria,
-                gasConfig: gasConfig
-            });
-
-        uint256 subscriptionId = scheduler.createSubscription{
-            value: minimumBalance
-        }(params);
 
         // Add extra funds
         uint256 extraFunds = 1 ether;
@@ -565,6 +462,153 @@ contract SchedulerTest is Test, SchedulerEvents, PulseTestUtils {
             status.balanceInWei,
             0,
             "Balance should be 0 after withdrawing all funds"
+        );
+    }
+
+    function testPermanentSubscription() public {
+        uint256 subscriptionId = addTestSubscription();
+
+        // Verify subscription was created as non-permanent initially
+        (SchedulerState.SubscriptionParams memory params, ) = scheduler
+            .getSubscription(subscriptionId);
+        assertFalse(params.isPermanent, "Should not be permanent initially");
+
+        // Make it permanent
+        params.isPermanent = true;
+        scheduler.updateSubscription(subscriptionId, params);
+
+        // Verify subscription is now permanent
+        (SchedulerState.SubscriptionParams memory storedParams, ) = scheduler
+            .getSubscription(subscriptionId);
+        assertTrue(
+            storedParams.isPermanent,
+            "Subscription should be permanent"
+        );
+
+        // Test 1: Cannot disable isPermanent flag
+        SchedulerState.SubscriptionParams memory updatedParams = storedParams;
+        updatedParams.isPermanent = false;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IllegalPermanentSubscriptionModification.selector
+            )
+        );
+        scheduler.updateSubscription(subscriptionId, updatedParams);
+
+        // Test 2: Cannot remove price feeds
+        updatedParams = storedParams;
+        bytes32[] memory reducedPriceIds = new bytes32[](
+            params.priceIds.length - 1
+        );
+        for (uint i = 0; i < reducedPriceIds.length; i++) {
+            reducedPriceIds[i] = params.priceIds[i];
+        }
+        updatedParams.priceIds = reducedPriceIds;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IllegalPermanentSubscriptionModification.selector
+            )
+        );
+        scheduler.updateSubscription(subscriptionId, updatedParams);
+
+        // Test 3: Cannot withdraw funds
+        uint256 extraFunds = 1 ether;
+        vm.deal(address(0x123), extraFunds);
+
+        // Anyone can add funds (not just manager)
+        vm.prank(address(0x123));
+        scheduler.addFunds{value: extraFunds}(subscriptionId);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IllegalPermanentSubscriptionModification.selector
+            )
+        );
+        scheduler.withdrawFunds(subscriptionId, 0.1 ether);
+
+        // Test 4: Can still add more price feeds
+        updatedParams = storedParams;
+        bytes32[] memory expandedPriceIds = new bytes32[](
+            params.priceIds.length + 1
+        );
+        for (uint i = 0; i < params.priceIds.length; i++) {
+            expandedPriceIds[i] = params.priceIds[i];
+        }
+        expandedPriceIds[params.priceIds.length] = bytes32(
+            uint256(keccak256(abi.encodePacked("additional-price-id")))
+        );
+        updatedParams.priceIds = expandedPriceIds;
+        updatedParams.isPermanent = true; // Ensure we keep isPermanent flag set to true
+
+        scheduler.updateSubscription(subscriptionId, updatedParams);
+
+        // Verify price feeds were added
+        (storedParams, ) = scheduler.getSubscription(subscriptionId);
+        assertEq(
+            storedParams.priceIds.length,
+            params.priceIds.length + 1,
+            "Should be able to add price feeds to permanent subscription"
+        );
+    }
+
+    function testMakeExistingSubscriptionPermanent() public {
+        // First create a non-permanent subscription
+        uint256 subscriptionId = addTestSubscription();
+
+        // Verify it's not permanent
+        (SchedulerState.SubscriptionParams memory params, ) = scheduler
+            .getSubscription(subscriptionId);
+
+        assertFalse(
+            params.isPermanent,
+            "Subscription should not be permanent initially"
+        );
+
+        // Make it permanent
+        params.isPermanent = true;
+        scheduler.updateSubscription(subscriptionId, params);
+
+        // Verify it's now permanent
+        (params, ) = scheduler.getSubscription(subscriptionId);
+        assertTrue(params.isPermanent, "Subscription should now be permanent");
+
+        // Verify we can't make it non-permanent again
+        params.isPermanent = false;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IllegalPermanentSubscriptionModification.selector
+            )
+        );
+        scheduler.updateSubscription(subscriptionId, params);
+    }
+
+    function testAnyoneCanAddFunds() public {
+        // Create a subscription
+        uint256 subscriptionId = addTestSubscription();
+
+        // Get initial balance
+        (, SchedulerState.SubscriptionStatus memory initialStatus) = scheduler
+            .getSubscription(subscriptionId);
+        uint256 initialBalance = initialStatus.balanceInWei;
+
+        // Have a different address add funds
+        address funder = address(0x123);
+        uint256 fundAmount = 1 ether;
+        vm.deal(funder, fundAmount);
+
+        vm.prank(funder);
+        scheduler.addFunds{value: fundAmount}(subscriptionId);
+
+        // Verify funds were added
+        (, SchedulerState.SubscriptionStatus memory status) = scheduler
+            .getSubscription(subscriptionId);
+
+        assertEq(
+            status.balanceInWei,
+            initialBalance + fundAmount,
+            "Balance should be increased by the funded amount"
         );
     }
 
@@ -939,35 +983,17 @@ contract SchedulerTest is Test, SchedulerEvents, PulseTestUtils {
     }
 
     function testDisabledWhitelistAllowsUnrestrictedReads() public {
-        // Add a subscription with whitelistEnabled = false
-        bytes32[] memory priceIds = createPriceIds();
-        SchedulerState.UpdateCriteria memory updateCriteria = SchedulerState
-            .UpdateCriteria({
-                updateOnHeartbeat: true,
-                heartbeatSeconds: 60,
-                updateOnDeviation: true,
-                deviationThresholdBps: 100
-            });
+        uint256 subscriptionId = addTestSubscription();
 
-        SchedulerState.GasConfig memory gasConfig = SchedulerState.GasConfig({
-            maxBaseFeeMultiplierCapPct: 10_000,
-            maxPriorityFeeMultiplierCapPct: 10_000
-        });
+        // Get params and modify them
+        (SchedulerState.SubscriptionParams memory params, ) = scheduler
+            .getSubscription(subscriptionId);
+        params.whitelistEnabled = false;
+        params.readerWhitelist = new address[](0);
+        scheduler.updateSubscription(subscriptionId, params);
 
-        SchedulerState.SubscriptionParams memory params = SchedulerState
-            .SubscriptionParams({
-                priceIds: priceIds,
-                readerWhitelist: new address[](0),
-                whitelistEnabled: false, // No whitelist
-                isActive: true,
-                updateCriteria: updateCriteria,
-                gasConfig: gasConfig
-            });
-
-        // Create subscription and fund the subscription with enough to update it
-        uint256 subscriptionId = scheduler.createSubscription{value: 1 ether}(
-            params
-        );
+        // Fund the subscription with enough to update it
+        scheduler.addFunds{value: 1 ether}(subscriptionId);
 
         // Update price feeds for the subscription
         uint64 publishTime = SafeCast.toUint64(block.timestamp);
@@ -976,6 +1002,7 @@ contract SchedulerTest is Test, SchedulerEvents, PulseTestUtils {
         (priceFeeds, slots) = createMockPriceFeedsWithSlots(publishTime, 2);
         mockParsePriceFeedUpdatesWithSlots(pyth, priceFeeds, slots);
         bytes[] memory updateData = createMockUpdateData(priceFeeds);
+        bytes32[] memory priceIds = params.priceIds;
 
         vm.prank(pusher);
         scheduler.updatePriceFeeds(subscriptionId, updateData, priceIds);
@@ -997,38 +1024,15 @@ contract SchedulerTest is Test, SchedulerEvents, PulseTestUtils {
     }
 
     function testEnabledWhitelistEnforcesOnlyAuthorizedReads() public {
-        // Add a subscription with whitelistEnabled = true
-        bytes32[] memory priceIds = createPriceIds(2);
-        address[] memory readerWhitelist = new address[](1);
-        readerWhitelist[0] = address(reader); // Only the test's reader is whitelisted
+        uint256 subscriptionId = addTestSubscription();
 
-        SchedulerState.UpdateCriteria memory updateCriteria = SchedulerState
-            .UpdateCriteria({
-                updateOnHeartbeat: true,
-                heartbeatSeconds: 60,
-                updateOnDeviation: true,
-                deviationThresholdBps: 100
-            });
+        // Fund the subscription with enough to update it
+        scheduler.addFunds{value: 1 ether}(subscriptionId);
 
-        SchedulerState.GasConfig memory gasConfig = SchedulerState.GasConfig({
-            maxBaseFeeMultiplierCapPct: 10_000,
-            maxPriorityFeeMultiplierCapPct: 10_000
-        });
-
-        SchedulerState.SubscriptionParams memory params = SchedulerState
-            .SubscriptionParams({
-                priceIds: priceIds,
-                readerWhitelist: readerWhitelist,
-                whitelistEnabled: true, // Whitelist IS enabled
-                isActive: true,
-                updateCriteria: updateCriteria,
-                gasConfig: gasConfig
-            });
-
-        // Create subscription and fund the subscription with enough to update it
-        uint256 subscriptionId = scheduler.createSubscription{value: 1 ether}(
-            params
-        );
+        // Get the price IDs from the created subscription
+        (SchedulerState.SubscriptionParams memory params, ) = scheduler
+            .getSubscription(subscriptionId);
+        bytes32[] memory priceIds = params.priceIds;
 
         // Update price feeds for the subscription
         uint64 publishTime = SafeCast.toUint64(block.timestamp + 10); // Slightly different time
@@ -1166,6 +1170,7 @@ contract SchedulerTest is Test, SchedulerEvents, PulseTestUtils {
                 readerWhitelist: emptyWhitelist,
                 whitelistEnabled: false,
                 isActive: true,
+                isPermanent: false,
                 updateCriteria: updateCriteria,
                 gasConfig: gasConfig
             });
@@ -1251,79 +1256,29 @@ contract SchedulerTest is Test, SchedulerEvents, PulseTestUtils {
         assertEq(emptyPageTotal, 3, "Total count should still be 3");
     }
 
-    // Helper function to add a test subscription
+    /// Helper function to add a test subscription with 2 price IDs
     function addTestSubscription() internal returns (uint256) {
-        bytes32[] memory priceIds = createPriceIds();
-        address[] memory readerWhitelist = new address[](1);
-        readerWhitelist[0] = address(reader);
-
-        SchedulerState.UpdateCriteria memory updateCriteria = SchedulerState
-            .UpdateCriteria({
-                updateOnHeartbeat: true,
-                heartbeatSeconds: 60,
-                updateOnDeviation: true,
-                deviationThresholdBps: 100
-            });
-
-        SchedulerState.GasConfig memory gasConfig = SchedulerState.GasConfig({
-            maxBaseFeeMultiplierCapPct: 10_000,
-            maxPriorityFeeMultiplierCapPct: 10_000
-        });
-
-        SchedulerState.SubscriptionParams memory params = SchedulerState
-            .SubscriptionParams({
-                priceIds: priceIds,
-                readerWhitelist: readerWhitelist,
-                whitelistEnabled: true,
-                isActive: true,
-                updateCriteria: updateCriteria,
-                gasConfig: gasConfig
-            });
-
+        SchedulerState.SubscriptionParams
+            memory params = _createDefaultSubscriptionParams(2);
         uint256 minimumBalance = scheduler.getMinimumBalance(
-            uint8(priceIds.length)
+            uint8(params.priceIds.length)
         );
         return scheduler.createSubscription{value: minimumBalance}(params);
     }
 
-    // Helper function to add a test subscription with variable number of feeds
+    /// Helper function to add a test subscription with variable number of feeds
     function addTestSubscriptionWithFeeds(
         uint256 numFeeds
     ) internal returns (uint256) {
-        bytes32[] memory priceIds = createPriceIds(numFeeds);
-        address[] memory readerWhitelist = new address[](1);
-        readerWhitelist[0] = address(reader);
-
-        SchedulerState.UpdateCriteria memory updateCriteria = SchedulerState
-            .UpdateCriteria({
-                updateOnHeartbeat: true,
-                heartbeatSeconds: 60,
-                updateOnDeviation: true,
-                deviationThresholdBps: 100
-            });
-
-        SchedulerState.GasConfig memory gasConfig = SchedulerState.GasConfig({
-            maxBaseFeeMultiplierCapPct: 10_000,
-            maxPriorityFeeMultiplierCapPct: 10_000
-        });
-
-        SchedulerState.SubscriptionParams memory params = SchedulerState
-            .SubscriptionParams({
-                priceIds: priceIds,
-                readerWhitelist: readerWhitelist,
-                whitelistEnabled: true,
-                isActive: true,
-                updateCriteria: updateCriteria,
-                gasConfig: gasConfig
-            });
-
+        SchedulerState.SubscriptionParams
+            memory params = _createDefaultSubscriptionParams(numFeeds);
         uint256 minimumBalance = scheduler.getMinimumBalance(
-            uint8(priceIds.length)
+            uint8(params.priceIds.length)
         );
         return scheduler.createSubscription{value: minimumBalance}(params);
     }
 
-    // Helper function to add a test subscription with specific update criteria
+    /// Helper function to add a test subscription with specific update criteria
     function addTestSubscriptionWithUpdateCriteria(
         SchedulerState.UpdateCriteria memory updateCriteria
     ) internal returns (uint256) {
@@ -1342,6 +1297,7 @@ contract SchedulerTest is Test, SchedulerEvents, PulseTestUtils {
                 readerWhitelist: readerWhitelist,
                 whitelistEnabled: true,
                 isActive: true,
+                isPermanent: false,
                 updateCriteria: updateCriteria, // Use provided criteria
                 gasConfig: gasConfig
             });
@@ -1350,6 +1306,39 @@ contract SchedulerTest is Test, SchedulerEvents, PulseTestUtils {
             uint8(priceIds.length)
         );
         return scheduler.createSubscription{value: minimumBalance}(params);
+    }
+
+    // Helper function to create default subscription parameters
+    function _createDefaultSubscriptionParams(
+        uint256 numFeeds
+    ) internal view returns (SchedulerState.SubscriptionParams memory) {
+        bytes32[] memory priceIds = createPriceIds(numFeeds);
+        address[] memory readerWhitelist = new address[](1);
+        readerWhitelist[0] = address(reader);
+
+        SchedulerState.UpdateCriteria memory updateCriteria = SchedulerState
+            .UpdateCriteria({
+                updateOnHeartbeat: true,
+                heartbeatSeconds: 60,
+                updateOnDeviation: true,
+                deviationThresholdBps: 100
+            });
+
+        SchedulerState.GasConfig memory gasConfig = SchedulerState.GasConfig({
+            maxBaseFeeMultiplierCapPct: 10_000,
+            maxPriorityFeeMultiplierCapPct: 10_000
+        });
+
+        return
+            SchedulerState.SubscriptionParams({
+                priceIds: priceIds,
+                readerWhitelist: readerWhitelist,
+                whitelistEnabled: true,
+                isActive: true,
+                isPermanent: false,
+                updateCriteria: updateCriteria,
+                gasConfig: gasConfig
+            });
     }
 
     // Required to receive ETH when withdrawing funds

--- a/target_chains/ethereum/contracts/forge-test/PulseSchedulerGasBenchmark.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/PulseSchedulerGasBenchmark.t.sol
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
+import "../contracts/pulse/scheduler/SchedulerUpgradeable.sol";
+import "../contracts/pulse/scheduler/IScheduler.sol";
+import "../contracts/pulse/scheduler/SchedulerState.sol";
+import "../contracts/pulse/scheduler/SchedulerEvents.sol";
+import "../contracts/pulse/scheduler/SchedulerErrors.sol";
+import "./utils/PulseSchedulerTestUtils.t.sol";
+
+contract PulseSchedulerGasBenchmark is Test, PulseSchedulerTestUtils {
+    ERC1967Proxy public proxy;
+    SchedulerUpgradeable public scheduler;
+    address public manager;
+    address public admin;
+    address public pyth;
+
+    function setUp() public {
+        manager = address(1);
+        admin = address(2);
+        pyth = address(3);
+
+        SchedulerUpgradeable _scheduler = new SchedulerUpgradeable();
+        proxy = new ERC1967Proxy(address(_scheduler), "");
+        scheduler = SchedulerUpgradeable(address(proxy));
+
+        scheduler.initialize(manager, admin, pyth);
+
+        // Start tests at a high timestamp to avoid underflow when we set
+        // `minPublishTime = timestamp - 1 hour` in updatePriceFeeds
+        vm.warp(100000);
+
+        // Give manager 1000 ETH for testing
+        vm.deal(manager, 1000 ether);
+    }
+
+    // Helper function to run the price feed update benchmark with a specified number of feeds
+    function _runUpdateAndQueryPriceFeedsBenchmark(uint8 numFeeds) internal {
+        // Setup: Create subscription and perform initial update
+        vm.prank(manager);
+        uint256 subscriptionId = _setupSubscriptionWithInitialUpdate(numFeeds);
+        (SchedulerState.SubscriptionParams memory params, ) = scheduler
+            .getSubscription(subscriptionId);
+
+        // Advance time to meet heartbeat criteria
+        vm.warp(block.timestamp + 100);
+
+        // Create new price feed updates with updated timestamp
+        uint64 newPublishTime = SafeCast.toUint64(block.timestamp);
+        PythStructs.PriceFeed[] memory newPriceFeeds;
+        uint64[] memory newSlots;
+
+        (newPriceFeeds, newSlots) = createMockPriceFeedsWithSlots(
+            newPublishTime,
+            numFeeds
+        );
+
+        // Mock Pyth response for the benchmark
+        mockParsePriceFeedUpdatesWithSlots(pyth, newPriceFeeds, newSlots);
+
+        // Actual benchmark: Measure gas for updating price feeds
+        uint256 startGas = gasleft();
+        scheduler.updatePriceFeeds(
+            subscriptionId,
+            createMockUpdateData(newPriceFeeds),
+            params.priceIds
+        );
+        uint256 updateGasUsed = startGas - gasleft();
+
+        console.log(
+            "Gas used for updating %s feeds: %s",
+            vm.toString(numFeeds),
+            vm.toString(updateGasUsed)
+        );
+
+        // Benchmark querying the price feeds after updating
+        uint256 queryStartGas = gasleft();
+        scheduler.getPricesUnsafe(subscriptionId, params.priceIds);
+        uint256 queryGasUsed = queryStartGas - gasleft();
+
+        console.log(
+            "Gas used for querying %s feeds: %s",
+            vm.toString(numFeeds),
+            vm.toString(queryGasUsed)
+        );
+        console.log(
+            "Total gas used for updating and querying %s feeds: %s",
+            vm.toString(numFeeds),
+            vm.toString(updateGasUsed + queryGasUsed)
+        );
+    }
+
+    // Helper function to set up a subscription with initial price update
+    function _setupSubscriptionWithInitialUpdate(
+        uint8 numFeeds
+    ) internal returns (uint256) {
+        uint256 subscriptionId = addTestSubscriptionWithFeeds(
+            scheduler,
+            numFeeds,
+            address(manager)
+        );
+
+        // Fetch the price IDs
+        (SchedulerState.SubscriptionParams memory params, ) = scheduler
+            .getSubscription(subscriptionId);
+
+        // Create initial price feed updates
+        uint64 publishTime = SafeCast.toUint64(block.timestamp);
+        PythStructs.PriceFeed[] memory priceFeeds;
+        uint64[] memory slots;
+
+        (priceFeeds, slots) = createMockPriceFeedsWithSlots(
+            publishTime,
+            numFeeds
+        );
+
+        mockParsePriceFeedUpdatesWithSlots(pyth, priceFeeds, slots);
+        bytes[] memory updateData = createMockUpdateData(priceFeeds);
+
+        // Update the price feeds. We should have enough balance to cover the update
+        // because we funded the subscription with the minimum balance during creation.
+        scheduler.updatePriceFeeds(subscriptionId, updateData, params.priceIds);
+        return subscriptionId;
+    }
+
+    // Helper function to create updated price feeds for benchmark
+    function _createUpdatedPriceFeeds(
+        uint8 numFeeds
+    ) internal returns (PythStructs.PriceFeed[] memory, uint64[] memory) {}
+
+    /// Helper function for benchmarking querying active subscriptions with a specified number of total subscriptions.
+    /// Half of them will be inactive to simulate gaps in the subscriptions list.
+    /// Keepers will poll this function to get the list of active subscriptions.
+    function _runGetActiveSubscriptionsBenchmark(
+        uint256 numSubscriptions
+    ) internal {
+        // Setup: As manager, create subscriptions and then deactivate every other one.
+        vm.startPrank(manager);
+
+        // Array to store subscription IDs
+        uint256[] memory subscriptionIds = new uint256[](numSubscriptions);
+
+        // First create all subscriptions as active (with default 2 price feeds)
+        for (uint256 i = 0; i < numSubscriptions; i++) {
+            subscriptionIds[i] = addTestSubscription(
+                scheduler,
+                address(manager)
+            );
+        }
+
+        // Deactivate every other subscription
+        for (uint256 i = 0; i < numSubscriptions; i++) {
+            if (i % 2 == 1) {
+                (SchedulerState.SubscriptionParams memory params, ) = scheduler
+                    .getSubscription(subscriptionIds[i]);
+                params.isActive = false;
+                scheduler.updateSubscription(subscriptionIds[i], params);
+            }
+        }
+        vm.stopPrank();
+
+        // Actual benchmark: Measure gas for fetching active subscriptions
+        uint256 startGas = gasleft();
+        scheduler.getActiveSubscriptions(0, numSubscriptions);
+        uint256 gasUsed = startGas - gasleft();
+
+        console.log(
+            "Gas used for fetching %s active subscriptions out of %s total: %s",
+            vm.toString((numSubscriptions + 1) / 2),
+            vm.toString(numSubscriptions),
+            vm.toString(gasUsed)
+        );
+    }
+
+    // Benchmark tests for the basic flow: updating and reading price feeds with different feed counts
+    // NOTE: run these tests with -vv to see the gas usage for the operations under test, without setup costs
+
+    function testUpdateAndQueryPriceFeeds01Feed() public {
+        _runUpdateAndQueryPriceFeedsBenchmark(1);
+    }
+
+    function testUpdateAndQueryPriceFeeds02Feeds() public {
+        _runUpdateAndQueryPriceFeedsBenchmark(2);
+    }
+
+    function testUpdateAndQueryPriceFeeds04Feeds() public {
+        _runUpdateAndQueryPriceFeedsBenchmark(4);
+    }
+
+    function testUpdateAndQueryPriceFeeds08Feeds() public {
+        _runUpdateAndQueryPriceFeedsBenchmark(8);
+    }
+
+    function testUpdateAndQueryPriceFeeds10Feeds() public {
+        _runUpdateAndQueryPriceFeedsBenchmark(10);
+    }
+
+    function testUpdateAndQueryPriceFeeds20Feeds() public {
+        _runUpdateAndQueryPriceFeedsBenchmark(20);
+    }
+
+    // Benchmark tests for fetching active subscriptions with different counts
+    // NOTE: run these tests with -vv to see the gas usage for the operations under test, without setup costs
+
+    function testGetActiveSubscriptions010() public {
+        _runGetActiveSubscriptionsBenchmark(10);
+    }
+
+    function testGetActiveSubscriptions100() public {
+        _runGetActiveSubscriptionsBenchmark(100);
+    }
+
+    function testGetActiveSubscriptions1000() public {
+        _runGetActiveSubscriptionsBenchmark(1000);
+    }
+}

--- a/target_chains/ethereum/contracts/forge-test/utils/PulseSchedulerTestUtils.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/utils/PulseSchedulerTestUtils.t.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
+import "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import "../../contracts/pulse/IPulse.sol";
+import "../../contracts/pulse/scheduler/SchedulerState.sol";
+import "./PulseTestUtils.t.sol";
+import "../../contracts/pulse/scheduler/SchedulerUpgradeable.sol";
+
+abstract contract PulseSchedulerTestUtils is Test, PulseTestUtils {
+    /// Helper function to add a test subscription with 2 price IDs
+    function addTestSubscription(
+        SchedulerUpgradeable scheduler,
+        address whitelistedReader
+    ) internal returns (uint256) {
+        SchedulerState.SubscriptionParams
+            memory params = createDefaultSubscriptionParams(
+                2,
+                whitelistedReader
+            );
+        uint256 minimumBalance = scheduler.getMinimumBalance(
+            uint8(params.priceIds.length)
+        );
+        return scheduler.createSubscription{value: minimumBalance}(params);
+    }
+
+    /// Helper function to add a test subscription with variable number of feeds
+    function addTestSubscriptionWithFeeds(
+        SchedulerUpgradeable scheduler,
+        uint8 numFeeds,
+        address whitelistedReader
+    ) internal returns (uint256) {
+        SchedulerState.SubscriptionParams
+            memory params = createDefaultSubscriptionParams(
+                numFeeds,
+                whitelistedReader
+            );
+        uint256 minimumBalance = scheduler.getMinimumBalance(
+            uint8(params.priceIds.length)
+        );
+        return scheduler.createSubscription{value: minimumBalance}(params);
+    }
+
+    /// Helper function to add a test subscription with specific update criteria
+    function addTestSubscriptionWithUpdateCriteria(
+        SchedulerUpgradeable scheduler,
+        SchedulerState.UpdateCriteria memory updateCriteria,
+        address whitelistedReader
+    ) internal returns (uint256) {
+        bytes32[] memory priceIds = createPriceIds();
+        address[] memory readerWhitelist = new address[](1);
+        readerWhitelist[0] = whitelistedReader;
+
+        SchedulerState.GasConfig memory gasConfig = SchedulerState.GasConfig({
+            maxBaseFeeMultiplierCapPct: 10_000,
+            maxPriorityFeeMultiplierCapPct: 10_000
+        });
+
+        SchedulerState.SubscriptionParams memory params = SchedulerState
+            .SubscriptionParams({
+                priceIds: priceIds,
+                readerWhitelist: readerWhitelist,
+                whitelistEnabled: true,
+                isActive: true,
+                isPermanent: false,
+                updateCriteria: updateCriteria,
+                gasConfig: gasConfig
+            });
+
+        uint256 minimumBalance = scheduler.getMinimumBalance(
+            uint8(priceIds.length)
+        );
+        return scheduler.createSubscription{value: minimumBalance}(params);
+    }
+
+    // Helper function to create default subscription parameters
+    function createDefaultSubscriptionParams(
+        uint8 numFeeds,
+        address whitelistedReader
+    ) internal pure returns (SchedulerState.SubscriptionParams memory) {
+        bytes32[] memory priceIds = createPriceIds(numFeeds);
+        address[] memory readerWhitelist = new address[](1);
+        readerWhitelist[0] = whitelistedReader;
+
+        SchedulerState.UpdateCriteria memory updateCriteria = SchedulerState
+            .UpdateCriteria({
+                updateOnHeartbeat: true,
+                heartbeatSeconds: 60,
+                updateOnDeviation: true,
+                deviationThresholdBps: 100
+            });
+
+        SchedulerState.GasConfig memory gasConfig = SchedulerState.GasConfig({
+            maxBaseFeeMultiplierCapPct: 10_000,
+            maxPriorityFeeMultiplierCapPct: 10_000
+        });
+
+        return
+            SchedulerState.SubscriptionParams({
+                priceIds: priceIds,
+                readerWhitelist: readerWhitelist,
+                whitelistEnabled: true,
+                isActive: true,
+                isPermanent: false,
+                updateCriteria: updateCriteria,
+                gasConfig: gasConfig
+            });
+    }
+}

--- a/target_chains/ethereum/contracts/forge-test/utils/PulseTestUtils.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/utils/PulseTestUtils.t.sol
@@ -50,19 +50,30 @@ abstract contract PulseTestUtils is Test {
     function createPriceIds(
         uint256 numFeeds
     ) internal pure returns (bytes32[] memory) {
-        require(numFeeds <= 10, "Too many price feeds requested");
         bytes32[] memory priceIds = new bytes32[](numFeeds);
 
-        if (numFeeds > 0) priceIds[0] = BTC_PRICE_FEED_ID;
-        if (numFeeds > 1) priceIds[1] = ETH_PRICE_FEED_ID;
-        if (numFeeds > 2) priceIds[2] = SOL_PRICE_FEED_ID;
-        if (numFeeds > 3) priceIds[3] = AVAX_PRICE_FEED_ID;
-        if (numFeeds > 4) priceIds[4] = MELANIA_PRICE_FEED_ID;
-        if (numFeeds > 5) priceIds[5] = PYTH_PRICE_FEED_ID;
-        if (numFeeds > 6) priceIds[6] = UNI_PRICE_FEED_ID;
-        if (numFeeds > 7) priceIds[7] = AAVE_PRICE_FEED_ID;
-        if (numFeeds > 8) priceIds[8] = DOGE_PRICE_FEED_ID;
-        if (numFeeds > 9) priceIds[9] = ADA_PRICE_FEED_ID;
+        // First assign our predefined price feed IDs
+        uint256 predefinedCount = 10;
+        uint256 assignCount = numFeeds < predefinedCount
+            ? numFeeds
+            : predefinedCount;
+
+        if (assignCount > 0) priceIds[0] = BTC_PRICE_FEED_ID;
+        if (assignCount > 1) priceIds[1] = ETH_PRICE_FEED_ID;
+        if (assignCount > 2) priceIds[2] = SOL_PRICE_FEED_ID;
+        if (assignCount > 3) priceIds[3] = AVAX_PRICE_FEED_ID;
+        if (assignCount > 4) priceIds[4] = MELANIA_PRICE_FEED_ID;
+        if (assignCount > 5) priceIds[5] = PYTH_PRICE_FEED_ID;
+        if (assignCount > 6) priceIds[6] = UNI_PRICE_FEED_ID;
+        if (assignCount > 7) priceIds[7] = AAVE_PRICE_FEED_ID;
+        if (assignCount > 8) priceIds[8] = DOGE_PRICE_FEED_ID;
+        if (assignCount > 9) priceIds[9] = ADA_PRICE_FEED_ID;
+
+        // For any additional feeds beyond our predefined ones, generate derived IDs
+        for (uint256 i = predefinedCount; i < numFeeds; i++) {
+            // Derive new price IDs by incrementing the last predefined price ID
+            priceIds[i] = bytes32(uint256(ADA_PRICE_FEED_ID) + (i - 9));
+        }
 
         return priceIds;
     }
@@ -109,7 +120,6 @@ abstract contract PulseTestUtils is Test {
         uint256 publishTime,
         uint256 numFeeds
     ) internal pure returns (PythStructs.PriceFeed[] memory) {
-        require(numFeeds <= 10, "Too many price feeds requested");
         PythStructs.PriceFeed[] memory priceFeeds = new PythStructs.PriceFeed[](
             numFeeds
         );


### PR DESCRIPTION
## Summary & Rationale
- Extract duplicated SubscriptionParam validations into a `_validateAndPrepareSubscriptionParams` helper function.
- Improve validations to prevent undesirable state and behavior:
  - Disallow subscriptions with zero feeds, since this will blow up later when indexing into empty arrays.
  - Disallow duplicate price IDs in a subscription, since this will pollute the mappings and make removal logic ambiguous.
  - Disallow duplicate whitelisted readers, enforce a maximum whitelist size to prevent maliciously large whitelists.
  - Ensure that `heartbeatSeconds` and `deviationThresholdBps` are non-zero when those UpdateCriteria are enabled, since those would evaluate to always-true conditions.
  - Ensure `minPublishTime` is clamped to zero to avoid integer underflow. This should be unlikely since `block.timestamp` will be a high number, but it's potentially possible in a new network.

## How has this been tested?

- [ ] Current tests cover my changes
- [x] Added new tests
- [ ] Manually tested the code
