### PR TITLE
fix(apps/hermes): use last ip in the headers

### DIFF
--- a/apps/hermes/server/Cargo.lock
+++ b/apps/hermes/server/Cargo.lock
@@ -1868,7 +1868,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/hermes/server/Cargo.toml
+++ b/apps/hermes/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "hermes"
-version     = "0.8.5"
+version     = "0.8.6"
 description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
 edition     = "2021"
 

--- a/apps/hermes/server/src/api/ws.rs
+++ b/apps/hermes/server/src/api/ws.rs
@@ -189,7 +189,9 @@ where
     let requester_ip = headers
         .get(state.ws.requester_ip_header_name.as_str())
         .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.split(',').next()) // Only take the first ip if there are multiple
+        // Only take the last ip if there are multiple. Note: if the service is behind multiple load balancers,
+        // this will be the ip the last balancer sees.
+        .and_then(|value| value.split(',').last())
         .and_then(|value| value.parse().ok());
 
     ws.max_message_size(MAX_CLIENT_MESSAGE_SIZE)


### PR DESCRIPTION
## Rationale

In the current implementation we use the first IP in the specified header to detect the user IP but some load balancers always append the IP to it and the first IP can be provider by the user.