### PR TITLE
fix(lazer-publisher-sdk): Allow dirty for publishing

### DIFF
--- a/lazer/publisher_sdk/rust/publish.sh
+++ b/lazer/publisher_sdk/rust/publish.sh
@@ -35,4 +35,4 @@ replace_mod_protobuf('${PACKAGE_DIR}/src/lib.rs')
 "
 
 echo "publishing package"
-cargo publish --token ${CARGO_REGISTRY_TOKEN}
+cargo publish --token ${CARGO_REGISTRY_TOKEN} --allow-dirty


### PR DESCRIPTION
## Summary

Publish complains since new files are not committed. Need to set allow dirty,

## Rationale

workflow fails

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
Set a random token to make sure publish does through as far as it can. 