### PR TITLE
Fix missed FeedId anchor serialization patch

### DIFF
--- a/target_chains/solana/Cargo.lock
+++ b/target_chains/solana/Cargo.lock
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-solana-receiver-sdk"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anchor-lang",
  "bytemuck_derive",

--- a/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
+++ b/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-solana-receiver-sdk"
-version = "0.6.0"
+version = "0.6.1"
 description = "SDK for the Pyth Solana Receiver program"
 authors = ["Pyth Data Association"]
 repository = "https://github.com/pyth-network/pyth-crosschain"

--- a/target_chains/solana/pyth_solana_receiver_sdk/src/price_update.rs
+++ b/target_chains/solana/pyth_solana_receiver_sdk/src/price_update.rs
@@ -160,7 +160,8 @@ impl TwapUpdate {
 /// This type is used to persist the calculated TWAP in TwapUpdate accounts on Solana.
 #[derive(AnchorSerialize, AnchorDeserialize, Copy, Clone, PartialEq, BorshSchema, Debug)]
 pub struct TwapPrice {
-    pub feed_id: FeedId,
+    /// `FeedId` but avoid the type alias because of compatibility issues with Anchor's `idl-build` feature.
+    pub feed_id: [u8; 32],
     pub start_time: i64,
     pub end_time: i64,
     pub price: i64,


### PR DESCRIPTION
## Summary

Anchor does not handle the FeedId type for the AnchorSerialize trait. 

## Rationale

<!-- Why are these changes necessary? -->

This was already patched for pythnet_sdk in https://github.com/pyth-network/pyth-crosschain/blob/main/pythnet/pythnet_sdk/src/messages.rs#L94-L95

This patch reflects that same fix in the solana_receiver_sdk

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
