### PR TITLE
feat(pulse-scheduler): optimize gas when querying active subscriptions

### DIFF
--- a/target_chains/ethereum/contracts/contracts/pulse/scheduler/IScheduler.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/scheduler/IScheduler.sol
@@ -48,7 +48,7 @@ interface IScheduler is SchedulerEvents {
 
     /**
      * @notice Updates price feeds for a subscription.
-     * Verifies the updateData using the Pyth contract and validates that all feeds have the same timestamp.
+     * @dev Internally, this verifies the updateData using the Pyth contract and validates update conditions.
      * @param subscriptionId The ID of the subscription
      * @param updateData The price update data from Pyth
      * @param priceIds The IDs of the price feeds to update
@@ -73,7 +73,8 @@ interface IScheduler is SchedulerEvents {
         bytes32[] calldata priceIds
     ) external view returns (PythStructs.Price[] memory prices);
 
-    /** @notice Returns the exponentially-weighted moving average price of a price feed without any sanity checks.
+    /**
+     * @notice Returns the exponentially-weighted moving average price of a price feed without any sanity checks.
      * @dev This function returns the same price as `getEmaPrice` in the case where the price is available.
      * However, if the price is not recent this function returns the latest available price.
      *
@@ -114,10 +115,12 @@ interface IScheduler is SchedulerEvents {
     ) external view returns (uint256 minimumBalanceInWei);
 
     /**
-     * @notice Gets all active subscriptions with their parameters
-     * @dev This function has no access control to allow keepers to discover active subscriptions
-     * @param startIndex The starting index for pagination
-     * @param maxResults The maximum number of results to return
+     * @notice Gets all active subscriptions with their parameters, paginated.
+     * @dev This function has no access control to allow keepers to discover active subscriptions.
+     * @dev Note that the order of subscription IDs returned may not be sequential and can change
+     *      when subscriptions are deactivated or reactivated.
+     * @param startIndex The starting index within the list of active subscriptions (NOT the subscription ID).
+     * @param maxResults The maximum number of results to return starting from startIndex.
      * @return subscriptionIds Array of active subscription IDs
      * @return subscriptionParams Array of subscription parameters for each active subscription
      * @return totalCount Total number of active subscriptions

--- a/target_chains/ethereum/contracts/contracts/pulse/scheduler/Scheduler.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/scheduler/Scheduler.sol
@@ -784,6 +784,8 @@ abstract contract Scheduler is IScheduler, SchedulerState {
         // Only add if not already in the list
         if (_state.activeSubscriptionIndex[subscriptionId] == 0) {
             _state.activeSubscriptionIds.push(subscriptionId);
+
+            // Store the index as 1-based, 0 means not in the list
             _state.activeSubscriptionIndex[subscriptionId] = _state
                 .activeSubscriptionIds
                 .length;

--- a/target_chains/ethereum/contracts/contracts/pulse/scheduler/Scheduler.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/scheduler/Scheduler.sol
@@ -56,6 +56,8 @@ abstract contract Scheduler is IScheduler, SchedulerState {
         // Map subscription ID to manager
         _state.subscriptionManager[subscriptionId] = msg.sender;
 
+        _addToActiveSubscriptions(subscriptionId);
+
         emit SubscriptionCreated(subscriptionId, msg.sender);
         return subscriptionId;
     }
@@ -100,10 +102,12 @@ abstract contract Scheduler is IScheduler, SchedulerState {
             }
 
             currentParams.isActive = true;
+            _addToActiveSubscriptions(subscriptionId);
             emit SubscriptionActivated(subscriptionId);
         } else if (wasActive && !willBeActive) {
             // Deactivating a subscription
             currentParams.isActive = false;
+            _removeFromActiveSubscriptions(subscriptionId);
             emit SubscriptionDeactivated(subscriptionId);
         }
 
@@ -691,14 +695,7 @@ abstract contract Scheduler is IScheduler, SchedulerState {
             uint256 totalCount
         )
     {
-        // Count active subscriptions first to determine total count
-        // TODO: Optimize this. store numActiveSubscriptions or something.
-        totalCount = 0;
-        for (uint256 i = 1; i < _state.subscriptionNumber; i++) {
-            if (_state.subscriptionParams[i].isActive) {
-                totalCount++;
-            }
-        }
+        totalCount = _state.activeSubscriptionIds.length;
 
         // If startIndex is beyond the total count, return empty arrays
         if (startIndex >= totalCount) {
@@ -715,25 +712,13 @@ abstract contract Scheduler is IScheduler, SchedulerState {
         subscriptionIds = new uint256[](resultCount);
         subscriptionParams = new SubscriptionParams[](resultCount);
 
-        // Find and populate the requested page of active subscriptions
-        uint256 activeIndex = 0;
-        uint256 resultIndex = 0;
-
-        for (
-            uint256 i = 1;
-            i < _state.subscriptionNumber && resultIndex < resultCount;
-            i++
-        ) {
-            if (_state.subscriptionParams[i].isActive) {
-                if (activeIndex >= startIndex) {
-                    subscriptionIds[resultIndex] = i;
-                    subscriptionParams[resultIndex] = _state.subscriptionParams[
-                        i
-                    ];
-                    resultIndex++;
-                }
-                activeIndex++;
-            }
+        // Populate the arrays with the requested page of active subscriptions
+        for (uint256 i = 0; i < resultCount; i++) {
+            uint256 subscriptionId = _state.activeSubscriptionIds[
+                startIndex + i
+            ];
+            subscriptionIds[i] = subscriptionId;
+            subscriptionParams[i] = _state.subscriptionParams[subscriptionId];
         }
 
         return (subscriptionIds, subscriptionParams, totalCount);
@@ -789,5 +774,46 @@ abstract contract Scheduler is IScheduler, SchedulerState {
             revert Unauthorized();
         }
         _;
+    }
+
+    /**
+     * @notice Adds a subscription to the active subscriptions list.
+     * @param subscriptionId The ID of the subscription to add.
+     */
+    function _addToActiveSubscriptions(uint256 subscriptionId) internal {
+        // Only add if not already in the list
+        if (_state.activeSubscriptionIndex[subscriptionId] == 0) {
+            _state.activeSubscriptionIds.push(subscriptionId);
+            _state.activeSubscriptionIndex[subscriptionId] = _state
+                .activeSubscriptionIds
+                .length;
+        }
+    }
+
+    /**
+     * @notice Removes a subscription from the active subscriptions list.
+     * @param subscriptionId The ID of the subscription to remove.
+     */
+    function _removeFromActiveSubscriptions(uint256 subscriptionId) internal {
+        uint256 index = _state.activeSubscriptionIndex[subscriptionId];
+
+        // Only remove if it's in the list
+        if (index > 0) {
+            // Adjust index to be 0-based instead of 1-based
+            index = index - 1;
+
+            // If it's not the last element, move the last element to its position
+            if (index < _state.activeSubscriptionIds.length - 1) {
+                uint256 lastId = _state.activeSubscriptionIds[
+                    _state.activeSubscriptionIds.length - 1
+                ];
+                _state.activeSubscriptionIds[index] = lastId;
+                _state.activeSubscriptionIndex[lastId] = index + 1; // 1-based index
+            }
+
+            // Remove the last element
+            _state.activeSubscriptionIds.pop();
+            _state.activeSubscriptionIndex[subscriptionId] = 0;
+        }
     }
 }

--- a/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerState.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/scheduler/SchedulerState.sol
@@ -35,6 +35,12 @@ contract SchedulerState {
         mapping(uint256 => mapping(bytes32 => PythStructs.PriceFeed)) priceUpdates;
         /// Sub ID -> manager address
         mapping(uint256 => address) subscriptionManager;
+        /// Array of active subscription IDs.
+        /// Gas optimization to avoid scanning through all subscriptions when querying for all active ones.
+        uint256[] activeSubscriptionIds;
+        /// Sub ID -> index in activeSubscriptionIds array + 1 (0 means not in array).
+        /// This lets us avoid a linear scan of `activeSubscriptionIds` when deactivating a subscription.
+        mapping(uint256 => uint256) activeSubscriptionIndex;
     }
     State internal _state;
 


### PR DESCRIPTION
## Summary

Optimize gas usage when querying for all active subscriptions.

## Rationale

This is one the most frequent access patterns in scheduler, since keepers need to poll the set of active subscriptions periodically to keep their state consistent. It's a view function so it will just be simulated, but since we could potentially store thousands of subscriptions, we still want to make it efficient.

This optimization sacrifices a bit of gas when activating/deactivating subscriptions (which should be relatively uncommon), for efficiency gains in the `getActiveSubscriptions` function. Previously we needed to iterate through all subscriptions to collect the active ones. This doesn't scale well as more subscriptions get deactivated. 

Now, we store the active subscriptions in an `activeSubscriptionIds` array for efficient querying and paging, and store a map of `sub id -> index in activeSubscriptionIds` for efficient removal when deactivating subscriptions.

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

### Gas benchmark results

Test case | Original gas | Optimized gas | Delta
|--------|--------|--------|--------|
| Query 5 active subscriptions (out of 10) | 110,317 | 82,547 | -25%
| Query 50 active subscriptions (out of 100) | 1,104,981 | 818,371 | -26%
| Query 500 active subscriptions (out of 1000) | 16,622,552 | 13,747,542 | -17%
