### PR TITLE
Lazer protocol/expose channel ids

### DIFF
--- a/lazer/Cargo.lock
+++ b/lazer/Cargo.lock
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-solana-contract"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anchor-lang",
  "bytemuck",

--- a/lazer/Cargo.lock
+++ b/lazer/Cargo.lock
@@ -3843,7 +3843,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-protocol"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "alloy-primitives",
  "anyhow",

--- a/lazer/contracts/solana/programs/pyth-lazer-solana-contract/Cargo.toml
+++ b/lazer/contracts/solana/programs/pyth-lazer-solana-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-solana-contract"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Pyth Lazer Solana contract and SDK."
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]
-pyth-lazer-protocol = { path = "../../../../sdk/rust/protocol", version = "0.7.0" }
+pyth-lazer-protocol = { path = "../../../../sdk/rust/protocol", version = "0.7.2" }
 
 anchor-lang = "0.30.1"
 bytemuck = "1.20.0"

--- a/lazer/sdk/rust/protocol/Cargo.toml
+++ b/lazer/sdk/rust/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-protocol"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "Pyth Lazer SDK - protocol types."
 license = "Apache-2.0"

--- a/lazer/sdk/rust/protocol/src/router.rs
+++ b/lazer/sdk/rust/protocol/src/router.rs
@@ -246,7 +246,7 @@ impl Serialize for Channel {
     }
 }
 
-mod channel_ids {
+pub mod channel_ids {
     use super::ChannelId;
 
     pub const FIXED_RATE_1: ChannelId = ChannelId(1);


### PR DESCRIPTION
## Summary

Expose channel id constants publicly. It's useful when you want to hardcode it.
