### PR TITLE
fix(entropy): Use the block number of event instead of request data for revelation api

### DIFF
--- a/apps/entropy-debugger/src/lib/revelation.ts
+++ b/apps/entropy-debugger/src/lib/revelation.ts
@@ -62,7 +62,7 @@ export async function getRevelation(
 ) {
   const deployment = EntropyDeployments[chain];
   const url = new URL(
-    `/v1/chains/${chain}/revelations/${blockNumber.toString()}/${sequenceNumber.toString()}`,
+    `/v1/chains/${chain}/revelations/${sequenceNumber.toString()}?blockNumber=${blockNumber.toString()}`,
     deployment.network === "mainnet"
       ? "https://fortuna.dourolabs.app"
       : "https://fortuna-staging.dourolabs.app",

--- a/apps/entropy-debugger/src/lib/revelation.ts
+++ b/apps/entropy-debugger/src/lib/revelation.ts
@@ -10,11 +10,13 @@ export async function requestCallback(
   chain: keyof typeof EntropyDeployments,
 ): Promise<string> {
   const deployment = EntropyDeployments[chain];
-  const { provider, sequenceNumber, userRandomNumber } = await fetchInfoFromTx(
-    txHash,
-    deployment,
+  const { provider, sequenceNumber, userRandomNumber, blockNumber } =
+    await fetchInfoFromTx(txHash, deployment);
+  const revelation = await getRevelation(
+    chain,
+    blockNumber,
+    Number(sequenceNumber),
   );
-  const revelation = await getRevelation(chain, Number(sequenceNumber));
 
   return `cast send ${deployment.address} 'revealWithCallback(address, uint64, bytes32, bytes32)' ${provider} ${sequenceNumber.toString()} ${userRandomNumber} ${revelation.value.data} -r ${deployment.rpc} --private-key <YOUR_PRIVATE_KEY>`;
 }
@@ -40,7 +42,12 @@ export async function fetchInfoFromTx(
   const firstLog = logs[0];
   if (firstLog) {
     const { provider, sequenceNumber, userRandomNumber } = firstLog.args;
-    return { provider, sequenceNumber, userRandomNumber };
+    return {
+      provider,
+      sequenceNumber,
+      userRandomNumber,
+      blockNumber: receipt.blockNumber,
+    };
   } else {
     throw new Error(
       `No logs found for ${txHash}. Are you sure you send the requestCallback Transaction?`,
@@ -50,11 +57,12 @@ export async function fetchInfoFromTx(
 
 export async function getRevelation(
   chain: keyof typeof EntropyDeployments,
+  blockNumber: number,
   sequenceNumber: number,
 ) {
   const deployment = EntropyDeployments[chain];
   const url = new URL(
-    `/v1/chains/${chain}/revelations/${sequenceNumber.toString()}`,
+    `/v1/chains/${chain}/revelations/${blockNumber.toString()}/${sequenceNumber.toString()}`,
     deployment.network === "mainnet"
       ? "https://fortuna.dourolabs.app"
       : "https://fortuna-staging.dourolabs.app",

--- a/apps/entropy-debugger/src/lib/revelation.ts
+++ b/apps/entropy-debugger/src/lib/revelation.ts
@@ -57,7 +57,7 @@ export async function fetchInfoFromTx(
 
 export async function getRevelation(
   chain: keyof typeof EntropyDeployments,
-  blockNumber: number,
+  blockNumber: bigint,
   sequenceNumber: number,
 ) {
   const deployment = EntropyDeployments[chain];

--- a/apps/entropy-debugger/src/lib/revelation.ts
+++ b/apps/entropy-debugger/src/lib/revelation.ts
@@ -62,7 +62,7 @@ export async function getRevelation(
 ) {
   const deployment = EntropyDeployments[chain];
   const url = new URL(
-    `/v1/chains/${chain}/revelations/${sequenceNumber.toString()}?blockNumber=${blockNumber.toString()}`,
+    `/v1/chains/${chain}/revelations/${sequenceNumber.toString()}?block_number=${blockNumber.toString()}`,
     deployment.network === "mainnet"
       ? "https://fortuna.dourolabs.app"
       : "https://fortuna-staging.dourolabs.app",

--- a/apps/fortuna/Cargo.lock
+++ b/apps/fortuna/Cargo.lock
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "fortuna"
-version = "7.4.10"
+version = "7.5.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/fortuna/Cargo.toml
+++ b/apps/fortuna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortuna"
-version = "7.4.10"
+version = "7.5.0"
 edition = "2021"
 
 [lib]

--- a/apps/fortuna/src/api.rs
+++ b/apps/fortuna/src/api.rs
@@ -154,7 +154,7 @@ pub fn routes(state: ApiState) -> Router<(), Body> {
         .route("/ready", get(ready))
         .route("/v1/chains", get(chain_ids))
         .route(
-            "/v1/chains/:chain_id/revelations/:sequence",
+            "/v1/chains/:chain_id/revelations/:block_number/:sequence",
             get(revelation),
         )
         .with_state(state)

--- a/apps/fortuna/src/api.rs
+++ b/apps/fortuna/src/api.rs
@@ -154,7 +154,7 @@ pub fn routes(state: ApiState) -> Router<(), Body> {
         .route("/ready", get(ready))
         .route("/v1/chains", get(chain_ids))
         .route(
-            "/v1/chains/:chain_id/revelations/:block_number/:sequence",
+            "/v1/chains/:chain_id/revelations/:sequence",
             get(revelation),
         )
         .with_state(state)

--- a/apps/fortuna/src/api/revelation.rs
+++ b/apps/fortuna/src/api/revelation.rs
@@ -30,11 +30,11 @@ params(RevelationPathParams, RevelationQueryParams)
 )]
 pub async fn revelation(
     State(state): State<crate::api::ApiState>,
-    Path(RevelationPathParams {
-        chain_id,
-        sequence,
-    }): Path<RevelationPathParams>,
-    Query(RevelationQueryParams { encoding, block_number }): Query<RevelationQueryParams>,
+    Path(RevelationPathParams { chain_id, sequence }): Path<RevelationPathParams>,
+    Query(RevelationQueryParams {
+        encoding,
+        block_number,
+    }): Query<RevelationQueryParams>,
 ) -> Result<Json<GetRandomValueResponse>, RestError> {
     state
         .metrics
@@ -86,8 +86,11 @@ pub async fn revelation(
 
             match maybe_request {
                 Some(r)
-                if current_block_number.saturating_sub(state.reveal_delay_blocks) >= r.block_number =>
-                    { Ok(()) }
+                    if current_block_number.saturating_sub(state.reveal_delay_blocks)
+                        >= r.block_number =>
+                {
+                    Ok(())
+                }
                 Some(_) => Err(RestError::PendingConfirmation),
                 None => Err(RestError::NoPendingRequest),
             }?;

--- a/apps/fortuna/src/chain/ethereum.rs
+++ b/apps/fortuna/src/chain/ethereum.rs
@@ -276,9 +276,14 @@ impl<T: JsonRpcClient + 'static> EntropyReader for PythRandom<Provider<T>> {
         &self,
         from_block: BlockNumber,
         to_block: BlockNumber,
+        provider: Address,
     ) -> Result<Vec<RequestedWithCallbackEvent>> {
         let mut event = self.requested_with_callback_filter();
-        event.filter = event.filter.from_block(from_block).to_block(to_block);
+        event.filter = event
+            .filter
+            .from_block(from_block)
+            .to_block(to_block)
+            .topic1(provider);
 
         let res: Vec<RequestedWithCallbackFilter> = event.query().await?;
 
@@ -289,6 +294,7 @@ impl<T: JsonRpcClient + 'static> EntropyReader for PythRandom<Provider<T>> {
                 user_random_number: r.user_random_number,
                 provider_address: r.request.provider,
             })
+            .filter(|r| r.provider_address == provider)
             .collect())
     }
 

--- a/apps/fortuna/src/chain/reader.rs
+++ b/apps/fortuna/src/chain/reader.rs
@@ -51,6 +51,7 @@ pub trait EntropyReader: Send + Sync {
         &self,
         from_block: BlockNumber,
         to_block: BlockNumber,
+        provider: Address,
     ) -> Result<Vec<RequestedWithCallbackEvent>>;
 
     /// Estimate the gas required to reveal a random number with a callback.
@@ -166,6 +167,7 @@ pub mod mock {
             &self,
             _from_block: BlockNumber,
             _to_block: BlockNumber,
+            _provider: Address,
         ) -> Result<Vec<super::RequestedWithCallbackEvent>> {
             Ok(vec![])
         }

--- a/apps/fortuna/src/keeper/block.rs
+++ b/apps/fortuna/src/keeper/block.rs
@@ -122,7 +122,11 @@ pub async fn process_single_block_batch(
     loop {
         let events_res = chain_state
             .contract
-            .get_request_with_callback_events(block_range.from, block_range.to)
+            .get_request_with_callback_events(
+                block_range.from,
+                block_range.to,
+                chain_state.provider_address,
+            )
             .await;
 
         match events_res {


### PR DESCRIPTION
## Summary

Improve revelations api for arbitrum based chains

## Rationale

Current revelations api doesn't work well where `block.number` on-chain is different from what rpc returns. In arbitrum based chains, one points to the L1 block and the other to the L2 block.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
