### PR TITLE
fix(pyth-governance): add no-op for SetFeeInToken action on EVM chains and update action indices

### DIFF
--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernance.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernance.sol
@@ -99,6 +99,8 @@ abstract contract PythGovernance is
                 parseSetWormholeAddressPayload(gi.payload),
                 encodedVM
             );
+        } else if (gi.action == GovernanceAction.SetFeeInToken) {
+            // No-op for EVM chains
         } else if (gi.action == GovernanceAction.SetTransactionFee) {
             setTransactionFee(parseSetTransactionFeePayload(gi.payload));
         } else if (gi.action == GovernanceAction.WithdrawFee) {

--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
@@ -35,8 +35,9 @@ contract PythGovernanceInstructions {
         SetValidPeriod, // 4
         RequestGovernanceDataSourceTransfer, // 5
         SetWormholeAddress, // 6
-        SetTransactionFee, // 7
-        WithdrawFee // 8
+        SetFeeInToken, // 7 - No-op for EVM chains
+        SetTransactionFee, // 8
+        WithdrawFee // 9
     }
 
     struct GovernanceInstruction {
@@ -233,7 +234,7 @@ contract PythGovernanceInstructions {
             revert PythErrors.InvalidGovernanceMessage();
     }
 
-    /// @dev Parse a SetTransactionFeePayload (action 7) with minimal validation
+    /// @dev Parse a SetTransactionFeePayload (action 8) with minimal validation
     function parseSetTransactionFeePayload(
         bytes memory encodedPayload
     ) public pure returns (SetTransactionFeePayload memory stf) {
@@ -251,7 +252,7 @@ contract PythGovernanceInstructions {
             revert PythErrors.InvalidGovernanceMessage();
     }
 
-    /// @dev Parse a WithdrawFeePayload (action 8) with minimal validation
+    /// @dev Parse a WithdrawFeePayload (action 9) with minimal validation
     function parseWithdrawFeePayload(
         bytes memory encodedPayload
     ) public pure returns (WithdrawFeePayload memory wf) {


### PR DESCRIPTION
## Summary

- Added `SetFeeInToken` action (index 7) to `GovernanceAction` enum in `PythGovernanceInstructions.sol`
- Updated indices for `SetTransactionFee` (8) and `WithdrawFee` (9) to maintain alignment with TypeScript enum
- Added no-op handling for `SetFeeInToken` in `PythGovernance.sol`
- Updated function documentation comments to reflect new action indices

## Rationale

- The TypeScript `TargetAction` enum and Solidity `GovernanceAction` enum were out of sync
- `SetFeeInToken` existed in TypeScript but was missing in Solidity, causing index misalignment
- EVM chains don't need to implement `SetFeeInToken` functionality, but must recognize it as a valid action
- Maintaining consistent action indices across chains is critical for cross-chain governance

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

Testing verification:
1. Existing tests in `PythGovernanceTest.sol` continue to pass as they use the correct indices for `SetTransactionFee` (8) and `WithdrawFee` (9)
2. The `executeGovernanceInstruction` function handles the new `SetFeeInToken` action gracefully
3. No new tests needed since `SetFeeInToken` is intentionally a no-op for EVM chains

The changes are safe because:
- No functional changes to existing actions
- Added action is explicitly no-op
- Index alignment maintained with TypeScript implementation
- Existing governance message parsing and validation remains unchanged