### PR TITLE
feat(apps/hermes): add connection timeout for SSE & WebSocket connections

### DIFF
--- a/apps/hermes/server/Cargo.lock
+++ b/apps/hermes/server/Cargo.lock
@@ -1868,7 +1868,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/hermes/server/Cargo.toml
+++ b/apps/hermes/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "hermes"
-version     = "0.8.5"
+version     = "0.8.6"
 description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
 edition     = "2021"
 

--- a/apps/hermes/server/src/api/rest/v2/sse.rs
+++ b/apps/hermes/server/src/api/rest/v2/sse.rs
@@ -26,7 +26,7 @@ use {
 };
 
 // Constants
-const MAX_CONNECTION_DURATION: Duration = Duration::from_secs(10); // 24 hours
+const MAX_CONNECTION_DURATION: Duration = Duration::from_secs(24 * 60 * 60); // 24 hours
 
 #[derive(Debug, Deserialize, IntoParams)]
 #[into_params(parameter_in = Query)]

--- a/apps/hermes/server/src/api/rest/v2/sse.rs
+++ b/apps/hermes/server/src/api/rest/v2/sse.rs
@@ -78,6 +78,9 @@ fn default_true() -> bool {
     params(StreamPriceUpdatesQueryParams)
 )]
 /// SSE route handler for streaming price updates.
+///
+/// The connection will automatically close after 24 hours to prevent resource leaks.
+/// Clients should implement reconnection logic to maintain continuous price updates.
 pub async fn price_stream_sse_handler<S>(
     State(state): State<ApiState<S>>,
     QsQuery(params): QsQuery<StreamPriceUpdatesQueryParams>,

--- a/apps/hermes/server/src/api/rest/v2/sse.rs
+++ b/apps/hermes/server/src/api/rest/v2/sse.rs
@@ -103,9 +103,7 @@ where
     let start_time = Instant::now();
 
     let sse_stream = stream
-        .take_while(move |_| {
-            start_time.elapsed() < MAX_CONNECTION_DURATION
-        })
+        .take_while(move |_| start_time.elapsed() < MAX_CONNECTION_DURATION)
         .then(move |message| {
             let state_clone = state.clone(); // Clone again to use inside the async block
             let price_ids_clone = price_ids.clone(); // Clone again for use inside the async block

--- a/apps/hermes/server/src/api/rest/v2/sse.rs
+++ b/apps/hermes/server/src/api/rest/v2/sse.rs
@@ -105,8 +105,8 @@ where
             now < connection_deadline
         })
         .then(move |message| {
-            let state_clone = state.clone();
-            let price_ids_clone = price_ids.clone();
+            let state_clone = state.clone(); // Clone again to use inside the async block
+            let price_ids_clone = price_ids.clone(); // Clone again for use inside the async block
             async move {
                 match message {
                     Ok(event) => {

--- a/apps/hermes/server/src/api/rest/v2/sse.rs
+++ b/apps/hermes/server/src/api/rest/v2/sse.rs
@@ -96,13 +96,12 @@ where
     // Convert the broadcast receiver into a Stream
     let stream = BroadcastStream::new(update_rx);
 
-    // Set connection deadline
-    let connection_deadline = Instant::now() + MAX_CONNECTION_DURATION;
+    // Set connection start time
+    let start_time = Instant::now();
 
     let sse_stream = stream
         .take_while(move |_| {
-            let now = Instant::now();
-            now < connection_deadline
+            start_time.elapsed() < MAX_CONNECTION_DURATION
         })
         .then(move |message| {
             let state_clone = state.clone(); // Clone again to use inside the async block

--- a/apps/hermes/server/src/api/ws.rs
+++ b/apps/hermes/server/src/api/ws.rs
@@ -45,6 +45,7 @@ use {
 
 const PING_INTERVAL_DURATION: Duration = Duration::from_secs(30);
 const MAX_CLIENT_MESSAGE_SIZE: usize = 100 * 1024; // 100 KiB
+const MAX_CONNECTION_DURATION: Duration = Duration::from_secs(24 * 60 * 60); // 24 hours
 
 /// The maximum number of bytes that can be sent per second per IP address.
 /// If the limit is exceeded, the connection is closed.
@@ -252,6 +253,7 @@ pub struct Subscriber<S> {
     sender: SplitSink<WebSocket, Message>,
     price_feeds_with_config: HashMap<PriceIdentifier, PriceFeedClientConfig>,
     ping_interval: tokio::time::Interval,
+    connection_timeout: tokio::time::Sleep,
     exit: watch::Receiver<bool>,
     responded_to_ping: bool,
 }
@@ -280,6 +282,7 @@ where
             sender,
             price_feeds_with_config: HashMap::new(),
             ping_interval: tokio::time::interval(PING_INTERVAL_DURATION),
+            connection_timeout: tokio::time::sleep(MAX_CONNECTION_DURATION),
             exit: crate::EXIT.subscribe(),
             responded_to_ping: true, // We start with true so we don't close the connection immediately
         }
@@ -324,6 +327,26 @@ where
                 self.responded_to_ping = false;
                 self.sender.send(Message::Ping(vec![])).await?;
                 Ok(())
+            },
+            _ = &mut self.connection_timeout => {
+                tracing::info!(
+                    id = self.id,
+                    ip = ?self.ip_addr,
+                    "Connection timeout reached (24h). Closing connection.",
+                );
+                self.sender
+                    .send(
+                        serde_json::to_string(&ServerMessage::Response(
+                            ServerResponseMessage::Err {
+                                error: "Connection timeout reached (24h)".to_string(),
+                            },
+                        ))?
+                        .into(),
+                    )
+                    .await?;
+                self.sender.close().await?;
+                self.closed = true;
+                return Ok(());
             },
             _ = self.exit.changed() => {
                 self.sender.close().await?;

--- a/apps/hermes/server/src/api/ws.rs
+++ b/apps/hermes/server/src/api/ws.rs
@@ -349,7 +349,7 @@ where
                     .await?;
                 self.sender.close().await?;
                 self.closed = true;
-                return Ok(());
+                Ok(())
             },
             _ = self.exit.changed() => {
                 self.sender.close().await?;


### PR DESCRIPTION
## Summary

- Added a 24-hour connection timeout for SSE endpoint
- Added a 24-hour connection timeout for WS endpoint
- Each client connection will automatically disconnect after 24 hours of continuous connection, with a proper error message sent before closing.

## Rationale

- Prevents resource leaks from indefinite connections
- Ensures proper cleanup of long-running connections
- Each client gets their own independent 24h window from their connection time
- Provides clear error messaging to clients about connection termination

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

Testing steps:
1. Verified that each new SSE/WS client connection gets its own independent 24h timeout
2. Confirmed that the timeout message is properly sent before connection close
3. Tested that the stream properly terminates after the timeout period
4. Verified that existing functionality (price updates, error handling) continues to work during the connection lifetime
5. Tested that multiple concurrent clients have independent timeouts based on their individual connection times
