### PR TITLE
chore(lazer): remove wrong publish script from js package

### DIFF
--- a/lazer/sdk/js/package.json
+++ b/lazer/sdk/js/package.json
@@ -29,8 +29,7 @@
     "test:format": "prettier --check .",
     "fix:format": "prettier --write .",
     "example": "node --loader ts-node/esm examples/index.js",
-    "doc": "typedoc --out docs/typedoc src",
-    "publish": "pnpm run script -- publish"
+    "doc": "typedoc --out docs/typedoc src"
   },
   "devDependencies": {
     "@cprussin/eslint-config": "catalog:",


### PR DESCRIPTION
## Summary

Remove publish script.

## Rationale

The script is incorrect and was never used. It's preventing the publish now.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

Not tested.
<!-- Describe the steps you've taken to verify the changes -->
