### PR TITLE
feat(pulse): keeper payment

### DIFF
--- a/target_chains/ethereum/contracts/contracts/pulse/SchedulerErrors.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/SchedulerErrors.sol
@@ -12,7 +12,7 @@ error CannotUpdatePermanentSubscription();
 
 // Price feed errors
 error InvalidPriceId(bytes32 providedPriceId, bytes32 expectedPriceId);
-error InvalidPriceIdsLength(bytes32 providedLength, bytes32 expectedLength);
+error InvalidPriceIdsLength(uint256 providedLength, uint256 expectedLength);
 error EmptyPriceIds();
 error TooManyPriceIds(uint256 provided, uint256 maximum);
 error DuplicatePriceId(bytes32 priceId);
@@ -29,3 +29,6 @@ error TimestampOlderThanLastUpdate(
 // Whitelist errors
 error TooManyWhitelistedReaders(uint256 provided, uint256 maximum);
 error DuplicateWhitelistAddress(address addr);
+
+// Payment errors
+error KeeperPaymentFailed();

--- a/target_chains/ethereum/contracts/contracts/pulse/SchedulerState.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/SchedulerState.sol
@@ -17,6 +17,9 @@ contract SchedulerState {
     /// Maximum time in the future (relative to current block timestamp)
     /// for which a price update timestamp is considered valid
     uint64 public constant FUTURE_TIMESTAMP_MAX_VALIDITY_PERIOD = 10 seconds;
+    /// Fixed gas overhead component used in keeper fee calculation.
+    /// This is a rough estimate of the tx overhead for a keeper to call updatePriceFeeds.
+    uint256 public constant GAS_OVERHEAD = 30000;
 
     struct State {
         /// Monotonically increasing counter for subscription IDs

--- a/target_chains/ethereum/contracts/forge-test/PulseSchedulerGasBenchmark.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/PulseSchedulerGasBenchmark.t.sol
@@ -227,4 +227,7 @@ contract PulseSchedulerGasBenchmark is Test, PulseSchedulerTestUtils {
     function testGetActiveSubscriptions1000() public {
         _runGetActiveSubscriptionsBenchmark(1000);
     }
+
+    // Allow the contract to receive Ether (for keeper payments during tests)
+    receive() external payable {}
 }


### PR DESCRIPTION
## Summary

Add keeper payment in `updatePriceFeeds`

## Rationale

Keepers are permissionless and we pay them in-band if they successfully call `updatePriceFeeds`. If the trigger condition isn't satisfied or the subscription doesn't have enough funds, they won't get paid.

This is a temporary payment model, the long term goal is to add a monthly subscription to make it easy for users to consume the service, rather than keeping their balance topped up. However, the basic mechanism of paying the keeper for successful updates will be the same, just the fee calculation will change.

## How has this been tested?

- [ ] Current tests cover my changes
- [x] Added new tests
- [ ] Manually tested the code