### PR TITLE
fix(entropy): Restore old signatures for methods returning structs

### DIFF
--- a/apps/fortuna/src/command/get_request.rs
+++ b/apps/fortuna/src/command/get_request.rs
@@ -14,10 +14,7 @@ pub async fn get_request(opts: &GetRequestOptions) -> Result<()> {
         &Config::load(&opts.config.config)?.get_chain_config(&opts.chain_id)?,
     )?);
 
-    let p = contract
-        .get_provider_info(opts.provider)
-        .call()
-        .await?;
+    let p = contract.get_provider_info(opts.provider).call().await?;
 
     tracing::info!("Found provider: {:?}", p);
 

--- a/apps/fortuna/src/command/get_request.rs
+++ b/apps/fortuna/src/command/get_request.rs
@@ -14,6 +14,13 @@ pub async fn get_request(opts: &GetRequestOptions) -> Result<()> {
         &Config::load(&opts.config.config)?.get_chain_config(&opts.chain_id)?,
     )?);
 
+    let p = contract
+        .get_provider_info(opts.provider)
+        .call()
+        .await?;
+
+    tracing::info!("Found provider: {:?}", p);
+
     let r = contract
         .get_request(opts.provider, opts.sequence)
         .call()

--- a/apps/fortuna/src/command/inspect.rs
+++ b/apps/fortuna/src/command/inspect.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        chain::ethereum::{EntropyStructsV2Request, PythContract},
+        chain::ethereum::{EntropyStructsRequest, PythContract},
         config::{Config, EthereumConfig, InspectOptions},
     },
     anyhow::Result,
@@ -66,7 +66,7 @@ async fn inspect_chain(
                 );
                 current_request_number -= 1;
             }
-            let return_data: Vec<EntropyStructsV2Request> = multicall.call_array().await?;
+            let return_data: Vec<EntropyStructsRequest> = multicall.call_array().await?;
             for request in return_data {
                 process_request(rpc_provider.clone(), request).await?;
             }
@@ -91,9 +91,9 @@ async fn inspect_chain(
 
 async fn process_request(
     rpc_provider: Provider<Http>,
-    request: EntropyStructsV2Request,
+    request: EntropyStructsRequest,
 ) -> Result<()> {
-    if request.sequence_number != 0 && request.callback_status != 0 {
+    if request.sequence_number != 0 && request.is_request_with_callback {
         let block = rpc_provider
             .get_block(request.block_number)
             .await?

--- a/apps/fortuna/src/command/setup_provider.rs
+++ b/apps/fortuna/src/command/setup_provider.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         api::{get_register_uri, ChainId},
-        chain::ethereum::{EntropyStructsV2ProviderInfo, SignablePythContract},
+        chain::ethereum::{EntropyStructsProviderInfo, SignablePythContract},
         command::register_provider::{register_provider_from_config, CommitmentMetadata},
         config::{Config, EthereumConfig, SetupProviderOptions},
         state::{HashChainState, PebbleHashChain},
@@ -178,7 +178,7 @@ async fn setup_chain_provider(
 
 async fn sync_uri(
     contract: &Arc<SignablePythContract>,
-    provider_info: &EntropyStructsV2ProviderInfo,
+    provider_info: &EntropyStructsProviderInfo,
     uri: String,
 ) -> Result<()> {
     let uri_as_bytes: Bytes = AbiBytes::from(uri.as_str()).into();
@@ -198,7 +198,7 @@ async fn sync_uri(
 
 async fn sync_fee(
     contract: &Arc<SignablePythContract>,
-    provider_info: &EntropyStructsV2ProviderInfo,
+    provider_info: &EntropyStructsProviderInfo,
     provider_fee: u128,
 ) -> Result<()> {
     if provider_info.fee_in_wei != provider_fee {
@@ -217,7 +217,7 @@ async fn sync_fee(
 
 async fn sync_fee_manager(
     contract: &Arc<SignablePythContract>,
-    provider_info: &EntropyStructsV2ProviderInfo,
+    provider_info: &EntropyStructsProviderInfo,
     fee_manager: Address,
 ) -> Result<()> {
     if provider_info.fee_manager != fee_manager {
@@ -231,7 +231,7 @@ async fn sync_fee_manager(
 
 async fn sync_max_num_hashes(
     contract: &Arc<SignablePythContract>,
-    provider_info: &EntropyStructsV2ProviderInfo,
+    provider_info: &EntropyStructsProviderInfo,
     max_num_hashes: u32,
 ) -> Result<()> {
     if provider_info.max_num_hashes != max_num_hashes {

--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -628,6 +628,12 @@ abstract contract Entropy is IEntropy, EntropyState {
 
     function getProviderInfo(
         address provider
+    ) public view override returns (EntropyStructs.ProviderInfo memory info) {
+        info = EntropyStructConverter.toV1ProviderInfo(_state.providers[provider]);
+    }
+
+    function getProviderInfoV2(
+        address provider
     ) public view override returns (EntropyStructsV2.ProviderInfo memory info) {
         info = _state.providers[provider];
     }
@@ -642,6 +648,13 @@ abstract contract Entropy is IEntropy, EntropyState {
     }
 
     function getRequest(
+        address provider,
+        uint64 sequenceNumber
+    ) public view override returns (EntropyStructs.Request memory req) {
+        req = EntropyStructConverter.toV1Request(findRequest(provider, sequenceNumber));
+    }
+
+    function getRequestV2(
         address provider,
         uint64 sequenceNumber
     ) public view override returns (EntropyStructsV2.Request memory req) {

--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -629,7 +629,9 @@ abstract contract Entropy is IEntropy, EntropyState {
     function getProviderInfo(
         address provider
     ) public view override returns (EntropyStructs.ProviderInfo memory info) {
-        info = EntropyStructConverter.toV1ProviderInfo(_state.providers[provider]);
+        info = EntropyStructConverter.toV1ProviderInfo(
+            _state.providers[provider]
+        );
     }
 
     function getProviderInfoV2(
@@ -651,7 +653,9 @@ abstract contract Entropy is IEntropy, EntropyState {
         address provider,
         uint64 sequenceNumber
     ) public view override returns (EntropyStructs.Request memory req) {
-        req = EntropyStructConverter.toV1Request(findRequest(provider, sequenceNumber));
+        req = EntropyStructConverter.toV1Request(
+            findRequest(provider, sequenceNumber)
+        );
     }
 
     function getRequestV2(

--- a/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
@@ -176,13 +176,13 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
 
     function assertInvariants() public {
         uint expectedBalance = random
-            .getProviderInfo(provider1)
+            .getProviderInfoV2(provider1)
             .accruedFeesInWei +
-            random.getProviderInfo(provider2).accruedFeesInWei +
+            random.getProviderInfoV2(provider2).accruedFeesInWei +
             random.getAccruedPythFees();
         assertEq(address(random).balance, expectedBalance);
 
-        EntropyStructsV2.ProviderInfo memory info1 = random.getProviderInfo(
+        EntropyStructsV2.ProviderInfo memory info1 = random.getProviderInfoV2(
             provider1
         );
         assert(
@@ -191,7 +191,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         );
         assert(info1.currentCommitmentSequenceNumber < info1.sequenceNumber);
         assert(info1.sequenceNumber <= info1.endSequenceNumber);
-        EntropyStructsV2.ProviderInfo memory info2 = random.getProviderInfo(
+        EntropyStructsV2.ProviderInfo memory info2 = random.getProviderInfoV2(
             provider2
         );
         assert(
@@ -205,9 +205,9 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
     function testBasicFlow() public {
         vm.roll(17);
         uint64 sequenceNumber = request(user2, provider1, 42, false);
-        assertEq(random.getRequest(provider1, sequenceNumber).blockNumber, 17);
+        assertEq(random.getRequestV2(provider1, sequenceNumber).blockNumber, 17);
         assertEq(
-            random.getRequest(provider1, sequenceNumber).useBlockhash,
+            random.getRequestV2(provider1, sequenceNumber).useBlockhash,
             false
         );
 
@@ -220,7 +220,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             ALL_ZEROS
         );
 
-        EntropyStructsV2.Request memory reqAfterReveal = random.getRequest(
+        EntropyStructsV2.Request memory reqAfterReveal = random.getRequestV2(
             provider1,
             sequenceNumber
         );
@@ -245,9 +245,9 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             42,
             false
         );
-        assertEq(random.getRequest(provider1, sequenceNumber).blockNumber, 20);
+        assertEq(random.getRequestV2(provider1, sequenceNumber).blockNumber, 20);
         assertEq(
-            random.getRequest(provider1, sequenceNumber).useBlockhash,
+            random.getRequestV2(provider1, sequenceNumber).useBlockhash,
             false
         );
 
@@ -281,7 +281,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
 
     function testAuthorization() public {
         uint64 sequenceNumber = request(user2, provider1, 42, false);
-        assertEq(random.getRequest(provider1, sequenceNumber).requester, user2);
+        assertEq(random.getRequestV2(provider1, sequenceNumber).requester, user2);
 
         // user1 not authorized, must be user2.
         assertRevealReverts(
@@ -407,11 +407,11 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         uint64 sequenceNumber = request(user2, provider1, 42, true);
 
         assertEq(
-            random.getRequest(provider1, sequenceNumber).blockNumber,
+            random.getRequestV2(provider1, sequenceNumber).blockNumber,
             1234
         );
         assertEq(
-            random.getRequest(provider1, sequenceNumber).useBlockhash,
+            random.getRequestV2(provider1, sequenceNumber).useBlockhash,
             true
         );
 
@@ -521,7 +521,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             provider1Uri
         );
         assertInvariants();
-        EntropyStructsV2.ProviderInfo memory info1 = random.getProviderInfo(
+        EntropyStructsV2.ProviderInfo memory info1 = random.getProviderInfoV2(
             provider1
         );
         assertEq(info1.endSequenceNumber, newHashChainOffset + 10);
@@ -679,11 +679,11 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         );
 
         assertEq(
-            random.getProviderInfo(provider1).accruedFeesInWei,
+            random.getProviderInfoV2(provider1).accruedFeesInWei,
             provider1FeeInWei * 3
         );
         assertEq(
-            random.getProviderInfo(provider2).accruedFeesInWei,
+            random.getProviderInfoV2(provider2).accruedFeesInWei,
             provider2FeeInWei * 2
         );
         assertEq(random.getAccruedPythFees(), pythFeeInWei * 5 + 10000);
@@ -710,7 +710,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
 
         uint128 providerOneBalance = provider1FeeInWei * 3 + 12345;
         assertEq(
-            random.getProviderInfo(provider1).accruedFeesInWei,
+            random.getProviderInfoV2(provider1).accruedFeesInWei,
             providerOneBalance
         );
         assertInvariants();
@@ -723,7 +723,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         random.withdraw(1000);
 
         assertEq(
-            random.getProviderInfo(provider1).accruedFeesInWei,
+            random.getProviderInfoV2(provider1).accruedFeesInWei,
             providerOneBalance - 1000
         );
         assertInvariants();
@@ -733,9 +733,9 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         random.withdraw(providerOneBalance);
     }
 
-    function testGetProviderInfo() public {
+    function testgetProviderInfoV2() public {
         EntropyStructsV2.ProviderInfo memory providerInfo1 = random
-            .getProviderInfo(provider1);
+            .getProviderInfoV2(provider1);
         // These two fields aren't used by the Entropy contract itself -- they're just convenient info to store
         // on-chain -- so they aren't tested in the other tests.
         assertEq(providerInfo1.uri, provider1Uri);
@@ -743,12 +743,12 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
     }
 
     function testSetProviderFee() public {
-        assertNotEq(random.getProviderInfo(provider1).feeInWei, 1);
+        assertNotEq(random.getProviderInfoV2(provider1).feeInWei, 1);
 
         vm.prank(provider1);
         random.setProviderFee(1);
 
-        assertEq(random.getProviderInfo(provider1).feeInWei, 1);
+        assertEq(random.getProviderInfoV2(provider1).feeInWei, 1);
     }
 
     function testSetProviderFeeByUnregistered() public {
@@ -760,12 +760,12 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
     function testSetProviderUri() public {
         bytes memory newUri = bytes("https://new.com");
 
-        assertNotEq0(random.getProviderInfo(provider1).uri, newUri);
+        assertNotEq0(random.getProviderInfoV2(provider1).uri, newUri);
 
         vm.prank(provider1);
         random.setProviderUri(newUri);
 
-        assertEq0(random.getProviderInfo(provider1).uri, newUri);
+        assertEq0(random.getProviderInfoV2(provider1).uri, newUri);
     }
 
     function testSetProviderUriByUnregistered() public {
@@ -779,7 +779,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         bytes32 userRandomNumber = bytes32(uint(42));
         uint fee = random.getFee(provider1);
         EntropyStructsV2.ProviderInfo memory providerInfo = random
-            .getProviderInfo(provider1);
+            .getProviderInfoV2(provider1);
 
         vm.roll(1234);
         vm.deal(user1, fee);
@@ -816,12 +816,12 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         );
 
         assertEq(
-            random.getRequest(provider1, assignedSequenceNumber).requester,
+            random.getRequestV2(provider1, assignedSequenceNumber).requester,
             user1
         );
 
         assertEq(
-            random.getRequest(provider1, assignedSequenceNumber).provider,
+            random.getRequestV2(provider1, assignedSequenceNumber).provider,
             provider1
         );
         vm.expectRevert(EntropyErrors.InvalidRevealCall.selector);
@@ -843,7 +843,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         uint64 assignedSequenceNumber = consumer.requestEntropy{value: fee}(
             userRandomNumber
         );
-        EntropyStructsV2.Request memory req = random.getRequest(
+        EntropyStructsV2.Request memory req = random.getRequestV2(
             provider1,
             assignedSequenceNumber
         );
@@ -880,7 +880,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             )
         );
 
-        EntropyStructsV2.Request memory reqAfterReveal = random.getRequest(
+        EntropyStructsV2.Request memory reqAfterReveal = random.getRequestV2(
             provider1,
             assignedSequenceNumber
         );
@@ -896,7 +896,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             provider1,
             userRandomNumber
         );
-        EntropyStructsV2.Request memory req = random.getRequest(
+        EntropyStructsV2.Request memory req = random.getRequestV2(
             provider1,
             assignedSequenceNumber
         );
@@ -919,7 +919,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             provider1Proofs[assignedSequenceNumber]
         );
 
-        EntropyStructsV2.Request memory reqAfterReveal = random.getRequest(
+        EntropyStructsV2.Request memory reqAfterReveal = random.getRequestV2(
             provider1,
             assignedSequenceNumber
         );
@@ -928,7 +928,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
 
     function testRequestAndRevealWithCallback() public {
         uint64 sequenceNumber = request(user2, provider1, 42, false);
-        assertEq(random.getRequest(provider1, sequenceNumber).requester, user2);
+        assertEq(random.getRequestV2(provider1, sequenceNumber).requester, user2);
 
         vm.expectRevert(EntropyErrors.InvalidRevealCall.selector);
         vm.prank(user2);
@@ -973,7 +973,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         uint64 assignedSequenceNumber = consumer.requestEntropy{value: fee}(
             userRandomNumber
         );
-        EntropyStructsV2.Request memory req = random.getRequest(
+        EntropyStructsV2.Request memory req = random.getRequestV2(
             provider1,
             assignedSequenceNumber
         );
@@ -1010,7 +1010,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             )
         );
 
-        EntropyStructsV2.Request memory reqAfterReveal = random.getRequest(
+        EntropyStructsV2.Request memory reqAfterReveal = random.getRequestV2(
             provider1,
             assignedSequenceNumber
         );
@@ -1058,7 +1058,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         );
 
         // Verify request is still active after failure
-        EntropyStructsV2.Request memory reqAfterFailure = random.getRequest(
+        EntropyStructsV2.Request memory reqAfterFailure = random.getRequestV2(
             provider1,
             assignedSequenceNumber
         );
@@ -1078,7 +1078,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         );
 
         // Again, request stays active after failure
-        reqAfterFailure = random.getRequest(provider1, assignedSequenceNumber);
+        reqAfterFailure = random.getRequestV2(provider1, assignedSequenceNumber);
         assertEq(reqAfterFailure.sequenceNumber, assignedSequenceNumber);
         assertTrue(
             reqAfterFailure.callbackStatus ==
@@ -1106,7 +1106,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         );
 
         // Verify request is cleared after successful reveal
-        EntropyStructsV2.Request memory reqAfterReveal = random.getRequest(
+        EntropyStructsV2.Request memory reqAfterReveal = random.getRequestV2(
             provider1,
             assignedSequenceNumber
         );
@@ -1129,7 +1129,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         uint64 assignedSequenceNumber = consumer.requestEntropy{value: fee}(
             userRandomNumber
         );
-        EntropyStructsV2.Request memory req = random.getRequest(
+        EntropyStructsV2.Request memory req = random.getRequestV2(
             provider1,
             assignedSequenceNumber
         );
@@ -1172,7 +1172,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         );
 
         // Verify request is still active after failure
-        EntropyStructsV2.Request memory reqAfterFailure = random.getRequest(
+        EntropyStructsV2.Request memory reqAfterFailure = random.getRequestV2(
             provider1,
             assignedSequenceNumber
         );
@@ -1192,7 +1192,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         );
 
         // Again, request stays active after failure
-        reqAfterFailure = random.getRequest(provider1, assignedSequenceNumber);
+        reqAfterFailure = random.getRequestV2(provider1, assignedSequenceNumber);
         assertEq(reqAfterFailure.sequenceNumber, assignedSequenceNumber);
         assertEq(
             reqAfterFailure.callbackStatus,
@@ -1219,7 +1219,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         );
 
         // Verify request is cleared after successful reveal
-        EntropyStructsV2.Request memory reqAfterReveal = random.getRequest(
+        EntropyStructsV2.Request memory reqAfterReveal = random.getRequestV2(
             provider1,
             assignedSequenceNumber
         );
@@ -1283,7 +1283,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             request(user1, provider1, 42, false);
         }
         assertInvariants();
-        EntropyStructsV2.ProviderInfo memory info1 = random.getProviderInfo(
+        EntropyStructsV2.ProviderInfo memory info1 = random.getProviderInfoV2(
             provider1
         );
         assertEq(info1.currentCommitmentSequenceNumber, 0);
@@ -1293,7 +1293,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             updateSeqNumber,
             provider1Proofs[updateSeqNumber]
         );
-        info1 = random.getProviderInfo(provider1);
+        info1 = random.getProviderInfoV2(provider1);
         assertEq(info1.currentCommitmentSequenceNumber, updateSeqNumber);
         assertEq(info1.currentCommitment, provider1Proofs[updateSeqNumber]);
         assertEq(info1.sequenceNumber, requestCount + 1);
@@ -1353,7 +1353,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             seqNumber,
             provider1Proofs[seqNumber]
         );
-        EntropyStructsV2.ProviderInfo memory info1 = random.getProviderInfo(
+        EntropyStructsV2.ProviderInfo memory info1 = random.getProviderInfoV2(
             provider1
         );
         assertEq(info1.sequenceNumber, seqNumber + 1);
@@ -1374,7 +1374,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
     function testSetMaxNumHashes(uint32 maxNumHashes) public {
         vm.prank(provider1);
         random.setMaxNumHashes(maxNumHashes);
-        EntropyStructsV2.ProviderInfo memory info1 = random.getProviderInfo(
+        EntropyStructsV2.ProviderInfo memory info1 = random.getProviderInfoV2(
             provider1
         );
         assertEq(info1.maxNumHashes, maxNumHashes);
@@ -1427,13 +1427,13 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         uint startingBalance = manager.balance;
         vm.prank(manager);
         random.withdrawAsFeeManager(provider1, provider1FeeInWei);
-        assertEq(random.getProviderInfo(provider1).accruedFeesInWei, 0);
+        assertEq(random.getProviderInfoV2(provider1).accruedFeesInWei, 0);
         assertEq(manager.balance, startingBalance + provider1FeeInWei);
 
         // Setting provider fee updates the fee in the ProviderInfo.
         vm.prank(manager);
         random.setProviderFeeAsFeeManager(provider1, 10101);
-        assertEq(random.getProviderInfo(provider1).feeInWei, 10101);
+        assertEq(random.getProviderInfoV2(provider1).feeInWei, 10101);
 
         // Authorizing a different manager depermissions the previous one.
         address manager2 = address(13);
@@ -1455,7 +1455,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         emit ProviderDefaultGasLimitUpdated(provider1, 0, newGasLimit);
         random.setDefaultGasLimit(newGasLimit);
 
-        EntropyStructsV2.ProviderInfo memory info = random.getProviderInfo(
+        EntropyStructsV2.ProviderInfo memory info = random.getProviderInfoV2(
             provider1
         );
         assertEq(info.defaultGasLimit, newGasLimit);
@@ -1463,14 +1463,14 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         // Can reset back to 0.
         vm.prank(provider1);
         random.setDefaultGasLimit(0);
-        info = random.getProviderInfo(provider1);
+        info = random.getProviderInfoV2(provider1);
         assertEq(info.defaultGasLimit, 0);
 
         // Can set to maximum value.
         uint32 maxLimit = random.MAX_GAS_LIMIT();
         vm.prank(provider1);
         random.setDefaultGasLimit(maxLimit);
-        info = random.getProviderInfo(provider1);
+        info = random.getProviderInfoV2(provider1);
         assertEq(info.defaultGasLimit, random.MAX_GAS_LIMIT());
 
         // Reverts if max value is exceeded
@@ -1500,7 +1500,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             userRandomNumber
         );
 
-        EntropyStructsV2.Request memory req = random.getRequest(
+        EntropyStructsV2.Request memory req = random.getRequestV2(
             provider1,
             sequenceNumber
         );
@@ -1587,7 +1587,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         );
 
         uint128 startingAccruedProviderFee = random
-            .getProviderInfo(provider1)
+            .getProviderInfoV2(provider1)
             .accruedFeesInWei;
         vm.prank(user1);
         uint64 sequenceNumber = random.requestWithCallbackAndGasLimit{
@@ -1595,13 +1595,13 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         }(provider1, userRandomNumber, gasLimit);
 
         assertEq(
-            random.getProviderInfo(provider1).accruedFeesInWei -
+            random.getProviderInfoV2(provider1).accruedFeesInWei -
                 startingAccruedProviderFee,
             expectedProviderFee
         );
 
         // Check the gasLimit10k field in the request
-        EntropyStructsV2.Request memory req = random.getRequest(
+        EntropyStructsV2.Request memory req = random.getRequestV2(
             provider1,
             sequenceNumber
         );
@@ -1649,7 +1649,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
 
         consumer.setTargetGasUsage(callbackGasUsage);
 
-        EntropyStructsV2.Request memory req = random.getRequest(
+        EntropyStructsV2.Request memory req = random.getRequestV2(
             provider1,
             sequenceNumber
         );
@@ -1678,7 +1678,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             );
 
             // Verify request is still active after failure
-            EntropyStructsV2.Request memory reqAfterFailure = random.getRequest(
+            EntropyStructsV2.Request memory reqAfterFailure = random.getRequestV2(
                 provider1,
                 sequenceNumber
             );
@@ -1707,7 +1707,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             );
 
             // Verify request is cleared after successful callback
-            EntropyStructsV2.Request memory reqAfterSuccess = random.getRequest(
+            EntropyStructsV2.Request memory reqAfterSuccess = random.getRequestV2(
                 provider1,
                 sequenceNumber
             );

--- a/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
@@ -205,7 +205,10 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
     function testBasicFlow() public {
         vm.roll(17);
         uint64 sequenceNumber = request(user2, provider1, 42, false);
-        assertEq(random.getRequestV2(provider1, sequenceNumber).blockNumber, 17);
+        assertEq(
+            random.getRequestV2(provider1, sequenceNumber).blockNumber,
+            17
+        );
         assertEq(
             random.getRequestV2(provider1, sequenceNumber).useBlockhash,
             false
@@ -245,7 +248,10 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             42,
             false
         );
-        assertEq(random.getRequestV2(provider1, sequenceNumber).blockNumber, 20);
+        assertEq(
+            random.getRequestV2(provider1, sequenceNumber).blockNumber,
+            20
+        );
         assertEq(
             random.getRequestV2(provider1, sequenceNumber).useBlockhash,
             false
@@ -281,7 +287,10 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
 
     function testAuthorization() public {
         uint64 sequenceNumber = request(user2, provider1, 42, false);
-        assertEq(random.getRequestV2(provider1, sequenceNumber).requester, user2);
+        assertEq(
+            random.getRequestV2(provider1, sequenceNumber).requester,
+            user2
+        );
 
         // user1 not authorized, must be user2.
         assertRevealReverts(
@@ -928,7 +937,10 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
 
     function testRequestAndRevealWithCallback() public {
         uint64 sequenceNumber = request(user2, provider1, 42, false);
-        assertEq(random.getRequestV2(provider1, sequenceNumber).requester, user2);
+        assertEq(
+            random.getRequestV2(provider1, sequenceNumber).requester,
+            user2
+        );
 
         vm.expectRevert(EntropyErrors.InvalidRevealCall.selector);
         vm.prank(user2);
@@ -1078,7 +1090,10 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         );
 
         // Again, request stays active after failure
-        reqAfterFailure = random.getRequestV2(provider1, assignedSequenceNumber);
+        reqAfterFailure = random.getRequestV2(
+            provider1,
+            assignedSequenceNumber
+        );
         assertEq(reqAfterFailure.sequenceNumber, assignedSequenceNumber);
         assertTrue(
             reqAfterFailure.callbackStatus ==
@@ -1192,7 +1207,10 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         );
 
         // Again, request stays active after failure
-        reqAfterFailure = random.getRequestV2(provider1, assignedSequenceNumber);
+        reqAfterFailure = random.getRequestV2(
+            provider1,
+            assignedSequenceNumber
+        );
         assertEq(reqAfterFailure.sequenceNumber, assignedSequenceNumber);
         assertEq(
             reqAfterFailure.callbackStatus,
@@ -1678,10 +1696,8 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             );
 
             // Verify request is still active after failure
-            EntropyStructsV2.Request memory reqAfterFailure = random.getRequestV2(
-                provider1,
-                sequenceNumber
-            );
+            EntropyStructsV2.Request memory reqAfterFailure = random
+                .getRequestV2(provider1, sequenceNumber);
             assertEq(reqAfterFailure.sequenceNumber, sequenceNumber);
             assertEq(
                 reqAfterFailure.callbackStatus,
@@ -1707,10 +1723,8 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             );
 
             // Verify request is cleared after successful callback
-            EntropyStructsV2.Request memory reqAfterSuccess = random.getRequestV2(
-                provider1,
-                sequenceNumber
-            );
+            EntropyStructsV2.Request memory reqAfterSuccess = random
+                .getRequestV2(provider1, sequenceNumber);
             assertEq(reqAfterSuccess.sequenceNumber, 0);
         }
     }

--- a/target_chains/ethereum/entropy_sdk/solidity/IEntropy.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/IEntropy.sol
@@ -112,11 +112,20 @@ interface IEntropy is EntropyEvents {
 
     function getProviderInfo(
         address provider
+    ) external view returns (EntropyStructs.ProviderInfo memory info);
+
+    function getProviderInfoV2(
+        address provider
     ) external view returns (EntropyStructsV2.ProviderInfo memory info);
 
     function getDefaultProvider() external view returns (address provider);
 
     function getRequest(
+        address provider,
+        uint64 sequenceNumber
+    ) external view returns (EntropyStructs.Request memory req);
+
+    function getRequestV2(
         address provider,
         uint64 sequenceNumber
     ) external view returns (EntropyStructsV2.Request memory req);

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropy.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropy.json
@@ -770,6 +770,87 @@
             "internalType": "uint32",
             "name": "maxNumHashes",
             "type": "uint32"
+          }
+        ],
+        "internalType": "struct EntropyStructs.ProviderInfo",
+        "name": "info",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      }
+    ],
+    "name": "getProviderInfoV2",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint128",
+            "name": "feeInWei",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "accruedFeesInWei",
+            "type": "uint128"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "originalCommitment",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint64",
+            "name": "originalCommitmentSequenceNumber",
+            "type": "uint64"
+          },
+          {
+            "internalType": "bytes",
+            "name": "commitmentMetadata",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "uri",
+            "type": "bytes"
+          },
+          {
+            "internalType": "uint64",
+            "name": "endSequenceNumber",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "sequenceNumber",
+            "type": "uint64"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "currentCommitment",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint64",
+            "name": "currentCommitmentSequenceNumber",
+            "type": "uint64"
+          },
+          {
+            "internalType": "address",
+            "name": "feeManager",
+            "type": "address"
+          },
+          {
+            "internalType": "uint32",
+            "name": "maxNumHashes",
+            "type": "uint32"
           },
           {
             "internalType": "uint32",
@@ -799,6 +880,72 @@
       }
     ],
     "name": "getRequest",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "provider",
+            "type": "address"
+          },
+          {
+            "internalType": "uint64",
+            "name": "sequenceNumber",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint32",
+            "name": "numHashes",
+            "type": "uint32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "commitment",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint64",
+            "name": "blockNumber",
+            "type": "uint64"
+          },
+          {
+            "internalType": "address",
+            "name": "requester",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "useBlockhash",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "isRequestWithCallback",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct EntropyStructs.Request",
+        "name": "req",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "internalType": "uint64",
+        "name": "sequenceNumber",
+        "type": "uint64"
+      }
+    ],
+    "name": "getRequestV2",
     "outputs": [
       {
         "components": [


### PR DESCRIPTION
## Summary

As the description says -- it turns out that you can't decode the old struct data with the new struct format. This restores the old method signatures and adds new methods for retrieving the new versions of the structs.

I don't love that we have new methods here for retrieving requests / providers, but that's the only way I see to ensure that all users of the contract continue working.

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

I tested getting both a request and a provider from an old contract.