### PR TITLE
feat(entropy): Event V2 spec

### DIFF
--- a/apps/fortuna/src/chain/ethereum.rs
+++ b/apps/fortuna/src/chain/ethereum.rs
@@ -83,7 +83,7 @@ impl<T: JsonRpcClient + 'static + Clone> SignablePythContractInner<T> {
         {
             // Extract Log from TransactionReceipt.
             let l: RawLog = r.logs[0].clone().into();
-            if let PythRandomEvents::RequestedFilter(r) = PythRandomEvents::decode_log(&l)? {
+            if let PythRandomEvents::Requested1Filter(r) = PythRandomEvents::decode_log(&l)? {
                 Ok(r.request.sequence_number)
             } else {
                 Err(anyhow!("No log with sequence number"))
@@ -147,7 +147,7 @@ impl<T: JsonRpcClient + 'static + Clone> SignablePythContractInner<T> {
             .await?
             .await?
         {
-            if let PythRandomEvents::RevealedFilter(r) =
+            if let PythRandomEvents::Revealed1Filter(r) =
                 PythRandomEvents::decode_log(&r.logs[0].clone().into())?
             {
                 Ok(r.random_number)

--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -150,7 +150,9 @@ abstract contract Entropy is IEntropy, EntropyState {
 
         provider.sequenceNumber += 1;
 
-        emit EntropyEvents.Registered(EntropyStructConverter.toV1ProviderInfo(provider));
+        emit EntropyEvents.Registered(
+            EntropyStructConverter.toV1ProviderInfo(provider)
+        );
         emit EntropyEventsV2.Registered(msg.sender, bytes(""));
     }
 
@@ -174,7 +176,12 @@ abstract contract Entropy is IEntropy, EntropyState {
         require(sent, "withdrawal to msg.sender failed");
 
         emit EntropyEvents.Withdrawal(msg.sender, msg.sender, amount);
-        emit EntropyEventsV2.Withdrawal(msg.sender, msg.sender, amount, bytes(""));
+        emit EntropyEventsV2.Withdrawal(
+            msg.sender,
+            msg.sender,
+            amount,
+            bytes("")
+        );
     }
 
     function withdrawAsFeeManager(
@@ -205,7 +212,12 @@ abstract contract Entropy is IEntropy, EntropyState {
         require(sent, "withdrawal to msg.sender failed");
 
         emit EntropyEvents.Withdrawal(provider, msg.sender, amount);
-        emit EntropyEventsV2.Withdrawal(provider, msg.sender, amount, bytes(""));
+        emit EntropyEventsV2.Withdrawal(
+            provider,
+            msg.sender,
+            amount,
+            bytes("")
+        );
     }
 
     // requestHelper allocates and returns a new request for the given provider.
@@ -769,7 +781,12 @@ abstract contract Entropy is IEntropy, EntropyState {
         uint128 oldFeeInWei = provider.feeInWei;
         provider.feeInWei = newFeeInWei;
         emit ProviderFeeUpdated(msg.sender, oldFeeInWei, newFeeInWei);
-        emit EntropyEventsV2.ProviderFeeUpdated(msg.sender, oldFeeInWei, newFeeInWei, bytes(""));
+        emit EntropyEventsV2.ProviderFeeUpdated(
+            msg.sender,
+            oldFeeInWei,
+            newFeeInWei,
+            bytes("")
+        );
     }
 
     function setProviderFeeAsFeeManager(
@@ -792,7 +809,12 @@ abstract contract Entropy is IEntropy, EntropyState {
         providerInfo.feeInWei = newFeeInWei;
 
         emit ProviderFeeUpdated(provider, oldFeeInWei, newFeeInWei);
-        emit EntropyEventsV2.ProviderFeeUpdated(provider, oldFeeInWei, newFeeInWei, bytes(""));
+        emit EntropyEventsV2.ProviderFeeUpdated(
+            provider,
+            oldFeeInWei,
+            newFeeInWei,
+            bytes("")
+        );
     }
 
     // Set provider uri. It will revert if provider is not registered.
@@ -806,7 +828,12 @@ abstract contract Entropy is IEntropy, EntropyState {
         bytes memory oldUri = provider.uri;
         provider.uri = newUri;
         emit ProviderUriUpdated(msg.sender, oldUri, newUri);
-        emit EntropyEventsV2.ProviderUriUpdated(msg.sender, oldUri, newUri, bytes(""));
+        emit EntropyEventsV2.ProviderUriUpdated(
+            msg.sender,
+            oldUri,
+            newUri,
+            bytes("")
+        );
     }
 
     function setFeeManager(address manager) external override {
@@ -820,7 +847,12 @@ abstract contract Entropy is IEntropy, EntropyState {
         address oldFeeManager = provider.feeManager;
         provider.feeManager = manager;
         emit ProviderFeeManagerUpdated(msg.sender, oldFeeManager, manager);
-        emit EntropyEventsV2.ProviderFeeManagerUpdated(msg.sender, oldFeeManager, manager, bytes(""));
+        emit EntropyEventsV2.ProviderFeeManagerUpdated(
+            msg.sender,
+            oldFeeManager,
+            manager,
+            bytes("")
+        );
     }
 
     // Set the maximum number of hashes to record in a request. This should be set according to the maximum gas limit

--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -150,7 +150,8 @@ abstract contract Entropy is IEntropy, EntropyState {
 
         provider.sequenceNumber += 1;
 
-        emit Registered(EntropyStructConverter.toV1ProviderInfo(provider));
+        emit EntropyEvents.Registered(EntropyStructConverter.toV1ProviderInfo(provider));
+        emit EntropyEventsV2.Registered(msg.sender, bytes(""));
     }
 
     // Withdraw a portion of the accumulated fees for the provider msg.sender.
@@ -172,7 +173,8 @@ abstract contract Entropy is IEntropy, EntropyState {
         (bool sent, ) = msg.sender.call{value: amount}("");
         require(sent, "withdrawal to msg.sender failed");
 
-        emit Withdrawal(msg.sender, msg.sender, amount);
+        emit EntropyEvents.Withdrawal(msg.sender, msg.sender, amount);
+        emit EntropyEventsV2.Withdrawal(msg.sender, msg.sender, amount, bytes(""));
     }
 
     function withdrawAsFeeManager(
@@ -202,7 +204,8 @@ abstract contract Entropy is IEntropy, EntropyState {
         (bool sent, ) = msg.sender.call{value: amount}("");
         require(sent, "withdrawal to msg.sender failed");
 
-        emit Withdrawal(provider, msg.sender, amount);
+        emit EntropyEvents.Withdrawal(provider, msg.sender, amount);
+        emit EntropyEventsV2.Withdrawal(provider, msg.sender, amount, bytes(""));
     }
 
     // requestHelper allocates and returns a new request for the given provider.
@@ -348,6 +351,13 @@ abstract contract Entropy is IEntropy, EntropyState {
             req.sequenceNumber,
             userRandomNumber,
             EntropyStructConverter.toV1Request(req)
+        );
+        emit EntropyEventsV2.Requested(
+            provider,
+            req.requester,
+            req.sequenceNumber,
+            userRandomNumber,
+            bytes("")
         );
         return req.sequenceNumber;
     }
@@ -570,6 +580,15 @@ abstract contract Entropy is IEntropy, EntropyState {
                     providerRevelation,
                     randomNumber
                 );
+                emit EntropyEventsV2.Revealed(
+                    provider,
+                    req.requester,
+                    req.sequenceNumber,
+                    randomNumber,
+                    false,
+                    bytes(""),
+                    bytes("")
+                );
                 clearRequest(provider, sequenceNumber);
             } else if (
                 ret.length > 0 ||
@@ -590,6 +609,15 @@ abstract contract Entropy is IEntropy, EntropyState {
                     randomNumber,
                     ret
                 );
+                emit EntropyEventsV2.Revealed(
+                    provider,
+                    req.requester,
+                    sequenceNumber,
+                    randomNumber,
+                    true,
+                    ret,
+                    bytes("")
+                );
                 req.callbackStatus = EntropyStatusConstants.CALLBACK_FAILED;
             } else {
                 // Callback reverted by (potentially) running out of gas, but the calling context did not have enough gas
@@ -607,6 +635,15 @@ abstract contract Entropy is IEntropy, EntropyState {
                 userRandomNumber,
                 providerRevelation,
                 randomNumber
+            );
+            emit EntropyEventsV2.Revealed(
+                provider,
+                req.requester,
+                req.sequenceNumber,
+                randomNumber,
+                false,
+                bytes(""),
+                bytes("")
             );
 
             clearRequest(provider, sequenceNumber);
@@ -732,6 +769,7 @@ abstract contract Entropy is IEntropy, EntropyState {
         uint128 oldFeeInWei = provider.feeInWei;
         provider.feeInWei = newFeeInWei;
         emit ProviderFeeUpdated(msg.sender, oldFeeInWei, newFeeInWei);
+        emit EntropyEventsV2.ProviderFeeUpdated(msg.sender, oldFeeInWei, newFeeInWei, bytes(""));
     }
 
     function setProviderFeeAsFeeManager(
@@ -754,6 +792,7 @@ abstract contract Entropy is IEntropy, EntropyState {
         providerInfo.feeInWei = newFeeInWei;
 
         emit ProviderFeeUpdated(provider, oldFeeInWei, newFeeInWei);
+        emit EntropyEventsV2.ProviderFeeUpdated(provider, oldFeeInWei, newFeeInWei, bytes(""));
     }
 
     // Set provider uri. It will revert if provider is not registered.
@@ -767,6 +806,7 @@ abstract contract Entropy is IEntropy, EntropyState {
         bytes memory oldUri = provider.uri;
         provider.uri = newUri;
         emit ProviderUriUpdated(msg.sender, oldUri, newUri);
+        emit EntropyEventsV2.ProviderUriUpdated(msg.sender, oldUri, newUri, bytes(""));
     }
 
     function setFeeManager(address manager) external override {
@@ -780,6 +820,7 @@ abstract contract Entropy is IEntropy, EntropyState {
         address oldFeeManager = provider.feeManager;
         provider.feeManager = manager;
         emit ProviderFeeManagerUpdated(msg.sender, oldFeeManager, manager);
+        emit EntropyEventsV2.ProviderFeeManagerUpdated(msg.sender, oldFeeManager, manager, bytes(""));
     }
 
     // Set the maximum number of hashes to record in a request. This should be set according to the maximum gas limit
@@ -799,6 +840,12 @@ abstract contract Entropy is IEntropy, EntropyState {
             oldMaxNumHashes,
             maxNumHashes
         );
+        emit EntropyEventsV2.ProviderMaxNumHashesAdvanced(
+            msg.sender,
+            oldMaxNumHashes,
+            maxNumHashes,
+            bytes("")
+        );
     }
 
     // Set the default gas limit for a request.
@@ -817,6 +864,12 @@ abstract contract Entropy is IEntropy, EntropyState {
         uint32 oldGasLimit = provider.defaultGasLimit;
         provider.defaultGasLimit = gasLimit;
         emit ProviderDefaultGasLimitUpdated(msg.sender, oldGasLimit, gasLimit);
+        emit EntropyEventsV2.ProviderDefaultGasLimitUpdated(
+            msg.sender,
+            oldGasLimit,
+            gasLimit,
+            bytes("")
+        );
     }
 
     function constructUserCommitment(

--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -598,7 +598,7 @@ abstract contract Entropy is IEntropy, EntropyState {
                     req.sequenceNumber,
                     randomNumber,
                     false,
-                    bytes(""),
+                    ret,
                     bytes("")
                 );
                 clearRequest(provider, sequenceNumber);

--- a/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
@@ -12,10 +12,11 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "./utils/EntropyTestUtils.t.sol";
 import "../contracts/entropy/EntropyUpgradable.sol";
 import "@pythnetwork/entropy-sdk-solidity/EntropyStatusConstants.sol";
+import "@pythnetwork/entropy-sdk-solidity/EntropyEventsV2.sol";
 
 // TODO
 // - fuzz test?
-contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
+contract EntropyTest is Test, EntropyTestUtils, EntropyEvents, EntropyEventsV2 {
     ERC1967Proxy public proxy;
     EntropyUpgradable public random;
 
@@ -742,7 +743,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         random.withdraw(providerOneBalance);
     }
 
-    function testgetProviderInfoV2() public {
+    function testGetProviderInfoV2() public {
         EntropyStructsV2.ProviderInfo memory providerInfo1 = random
             .getProviderInfoV2(provider1);
         // These two fields aren't used by the Entropy contract itself -- they're just convenient info to store
@@ -818,6 +819,14 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
                 isRequestWithCallback: true
             })
         );
+        vm.expectEmit(false, false, false, true, address(random));
+        emit EntropyEventsV2.Requested(
+            provider1,
+            user1,
+            providerInfo.sequenceNumber,
+            userRandomNumber,
+            bytes("")
+        );
         vm.roll(1234);
         uint64 assignedSequenceNumber = random.requestWithCallback{value: fee}(
             provider1,
@@ -867,6 +876,20 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
                 provider1Proofs[assignedSequenceNumber],
                 0
             )
+        );
+        vm.expectEmit(false, false, false, true, address(random));
+        emit EntropyEventsV2.Revealed(
+            provider1,
+            req.requester,
+            req.sequenceNumber,
+            random.combineRandomValues(
+                userRandomNumber,
+                provider1Proofs[assignedSequenceNumber],
+                0
+            ),
+            false,
+            bytes(""),
+            bytes("")
         );
         vm.prank(user1);
         random.revealWithCallback(
@@ -920,6 +943,20 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
                 provider1Proofs[assignedSequenceNumber],
                 0
             )
+        );
+        vm.expectEmit(false, false, false, true, address(random));
+        emit EntropyEventsV2.Revealed(
+            provider1,
+            req.requester,
+            req.sequenceNumber,
+            random.combineRandomValues(
+                userRandomNumber,
+                provider1Proofs[assignedSequenceNumber],
+                0
+            ),
+            false,
+            bytes(""),
+            bytes("")
         );
         random.revealWithCallback(
             provider1,
@@ -1004,6 +1041,20 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
                 0
             )
         );
+        vm.expectEmit(false, false, false, true, address(random));
+        emit EntropyEventsV2.Revealed(
+            provider1,
+            req.requester,
+            req.sequenceNumber,
+            random.combineRandomValues(
+                userRandomNumber,
+                provider1Proofs[assignedSequenceNumber],
+                0
+            ),
+            false,
+            bytes(""),
+            bytes("")
+        );
         random.revealWithCallback(
             provider1,
             assignedSequenceNumber,
@@ -1062,6 +1113,20 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             ),
             revertReason
         );
+        vm.expectEmit(false, false, false, true, address(random));
+        emit EntropyEventsV2.Revealed(
+            provider1,
+            address(consumer),
+            assignedSequenceNumber,
+            random.combineRandomValues(
+                userRandomNumber,
+                provider1Proofs[assignedSequenceNumber],
+                0
+            ),
+            true,
+            revertReason,
+            bytes("")
+        );
         random.revealWithCallback(
             provider1,
             assignedSequenceNumber,
@@ -1112,6 +1177,20 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
                 provider1Proofs[assignedSequenceNumber],
                 0
             )
+        );
+        vm.expectEmit(false, false, false, true, address(random));
+        emit EntropyEventsV2.Revealed(
+            provider1,
+            reqAfterFailure.requester,
+            reqAfterFailure.sequenceNumber,
+            random.combineRandomValues(
+                userRandomNumber,
+                provider1Proofs[assignedSequenceNumber],
+                0
+            ),
+            false,
+            bytes(""),
+            bytes("")
         );
         random.revealWithCallback(
             provider1,
@@ -1179,6 +1258,20 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
             // out-of-gas reverts have an empty bytes array as the return value.
             ""
         );
+        vm.expectEmit(false, false, false, true, address(random));
+        emit EntropyEventsV2.Revealed(
+            provider1,
+            address(consumer),
+            assignedSequenceNumber,
+            random.combineRandomValues(
+                userRandomNumber,
+                provider1Proofs[assignedSequenceNumber],
+                0
+            ),
+            true,
+            "",
+            ""
+        );
         random.revealWithCallback(
             provider1,
             assignedSequenceNumber,
@@ -1228,6 +1321,20 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
                 provider1Proofs[assignedSequenceNumber],
                 0
             )
+        );
+        vm.expectEmit(false, false, false, true, address(random));
+        emit EntropyEventsV2.Revealed(
+            provider1,
+            address(consumer),
+            assignedSequenceNumber,
+            random.combineRandomValues(
+                userRandomNumber,
+                provider1Proofs[assignedSequenceNumber],
+                0
+            ),
+            false,
+            "",
+            ""
         );
         random.revealWithCallback(
             provider1,
@@ -1471,6 +1578,13 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
         vm.prank(provider1);
         vm.expectEmit(false, false, false, true, address(random));
         emit ProviderDefaultGasLimitUpdated(provider1, 0, newGasLimit);
+        vm.expectEmit(false, false, false, true, address(random));
+        emit EntropyEventsV2.ProviderDefaultGasLimitUpdated(
+            provider1,
+            0,
+            newGasLimit,
+            bytes("")
+        );
         random.setDefaultGasLimit(newGasLimit);
 
         EntropyStructsV2.ProviderInfo memory info = random.getProviderInfoV2(
@@ -1688,6 +1802,20 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
                 // out-of-gas reverts have an empty bytes array as the return value.
                 ""
             );
+            vm.expectEmit(false, false, false, true, address(random));
+            emit EntropyEventsV2.Revealed(
+                provider1,
+                address(consumer),
+                sequenceNumber,
+                random.combineRandomValues(
+                    userRandomNumber,
+                    provider1Proofs[sequenceNumber],
+                    0
+                ),
+                true,
+                bytes(""),
+                bytes("")
+            );
             random.revealWithCallback(
                 provider1,
                 sequenceNumber,
@@ -1714,6 +1842,20 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents {
                     provider1Proofs[sequenceNumber],
                     0
                 )
+            );
+            vm.expectEmit(false, false, false, true, address(random));
+            emit EntropyEventsV2.Revealed(
+                provider1,
+                req.requester,
+                req.sequenceNumber,
+                random.combineRandomValues(
+                    userRandomNumber,
+                    provider1Proofs[sequenceNumber],
+                    0
+                ),
+                false,
+                bytes(""),
+                bytes("")
             );
             random.revealWithCallback(
                 provider1,

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyEventsV2.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyEventsV2.sol
@@ -14,9 +14,9 @@ interface EntropyEventsV2 {
     /**
      * @notice Emitted when a new provider registers with the Entropy system
      * @param provider The address of the registered provider
-     * @param dummy Additional data field (unused)
+     * @param extraArgs A field for extra data for forward compatibility.
      */
-    event Registered(address indexed provider, bytes dummy);
+    event Registered(address indexed provider, bytes extraArgs);
 
     /**
      * @notice Emitted when a user requests a random number from a provider
@@ -24,14 +24,14 @@ interface EntropyEventsV2 {
      * @param caller The address of the user requesting the random number
      * @param sequenceNumber A unique identifier for this request
      * @param userRandomNumber A random number provided by the user for additional entropy
-     * @param dummy Additional data field (unused)
+     * @param extraArgs A field for extra data for forward compatibility.
      */
     event Requested(
         address indexed provider,
         address indexed caller,
         uint64 indexed sequenceNumber,
         bytes32 userRandomNumber,
-        bytes dummy
+        bytes extraArgs
     );
 
     /**
@@ -41,9 +41,10 @@ interface EntropyEventsV2 {
      * @param sequenceNumber The unique identifier of the request
      * @param randomNumber The generated random number
      * @param callbackFailed Whether the callback to the caller failed
-     * @param callbackErrorCode If the callback failed, the error code from the callback. Note
-     * that "" often indicates an out-of-gas error.
-     * @param dummy Additional data field (unused)
+     * @param callbackReturnValue Return value from the callback. If the callback failed, this field contains
+     * the error code and any additional returned data. Note that "" often indicates an out-of-gas error.
+     * If the callback returns more than 256 bytes, only the first 256 bytes of the callback return value are included.
+     * @param extraArgs A field for extra data for forward compatibility.
      */
     event Revealed(
         address indexed provider,
@@ -51,8 +52,8 @@ interface EntropyEventsV2 {
         uint64 indexed sequenceNumber,
         bytes32 randomNumber,
         bool callbackFailed,
-        bytes callbackErrorCode,
-        bytes dummy
+        bytes callbackReturnValue,
+        bytes extraArgs
     );
 
     /**
@@ -60,13 +61,13 @@ interface EntropyEventsV2 {
      * @param provider The address of the provider updating their fee
      * @param oldFee The previous fee amount
      * @param newFee The new fee amount
-     * @param dummy Additional data field (unused)
+     * @param extraArgs A field for extra data for forward compatibility.
      */
     event ProviderFeeUpdated(
         address indexed provider,
         uint128 oldFee,
         uint128 newFee,
-        bytes dummy
+        bytes extraArgs
     );
 
     /**
@@ -74,13 +75,13 @@ interface EntropyEventsV2 {
      * @param provider The address of the provider updating their gas limit
      * @param oldDefaultGasLimit The previous default gas limit
      * @param newDefaultGasLimit The new default gas limit
-     * @param dummy Additional data field (unused)
+     * @param extraArgs A field for extra data for forward compatibility.
      */
     event ProviderDefaultGasLimitUpdated(
         address indexed provider,
         uint32 oldDefaultGasLimit,
         uint32 newDefaultGasLimit,
-        bytes dummy
+        bytes extraArgs
     );
 
     /**
@@ -88,13 +89,13 @@ interface EntropyEventsV2 {
      * @param provider The address of the provider updating their URI
      * @param oldUri The previous URI
      * @param newUri The new URI
-     * @param dummy Additional data field (unused)
+     * @param extraArgs A field for extra data for forward compatibility.
      */
     event ProviderUriUpdated(
         address indexed provider,
         bytes oldUri,
         bytes newUri,
-        bytes dummy
+        bytes extraArgs
     );
 
     /**
@@ -102,13 +103,13 @@ interface EntropyEventsV2 {
      * @param provider The address of the provider updating their fee manager
      * @param oldFeeManager The previous fee manager address
      * @param newFeeManager The new fee manager address
-     * @param dummy Additional data field (unused)
+     * @param extraArgs A field for extra data for forward compatibility.
      */
     event ProviderFeeManagerUpdated(
         address indexed provider,
         address oldFeeManager,
         address newFeeManager,
-        bytes dummy
+        bytes extraArgs
     );
 
     /**
@@ -116,13 +117,13 @@ interface EntropyEventsV2 {
      * @param provider The address of the provider updating their max hashes
      * @param oldMaxNumHashes The previous maximum number of hashes
      * @param newMaxNumHashes The new maximum number of hashes
-     * @param dummy Additional data field (unused)
+     * @param extraArgs A field for extra data for forward compatibility.
      */
     event ProviderMaxNumHashesAdvanced(
         address indexed provider,
         uint32 oldMaxNumHashes,
         uint32 newMaxNumHashes,
-        bytes dummy
+        bytes extraArgs
     );
 
     /**
@@ -130,12 +131,12 @@ interface EntropyEventsV2 {
      * @param provider The address of the provider withdrawing fees
      * @param recipient The address receiving the withdrawn fees
      * @param withdrawnAmount The amount of fees withdrawn
-     * @param dummy Additional data field (unused)
+     * @param extraArgs A field for extra data for forward compatibility.
      */
     event Withdrawal(
         address indexed provider,
         address indexed recipient,
         uint128 withdrawnAmount,
-        bytes dummy
+        bytes extraArgs
     );
 }

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyEventsV2.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyEventsV2.sol
@@ -3,9 +3,29 @@ pragma solidity ^0.8.0;
 
 import "./EntropyStructs.sol";
 
+/**
+ * @title EntropyEventsV2
+ * @notice Interface defining events for the Entropy V2 system, which handles random number generation
+ * and provider management on Ethereum.
+ * @dev This interface is used to emit events that track the lifecycle of random number requests,
+ * provider registrations, and system configurations.
+ */
 interface EntropyEventsV2 {
+    /**
+     * @notice Emitted when a new provider registers with the Entropy system
+     * @param provider The address of the registered provider
+     * @param dummy Additional data field (unused)
+     */
     event Registered(address indexed provider, bytes dummy);
 
+    /**
+     * @notice Emitted when a user requests a random number from a provider
+     * @param provider The address of the provider handling the request
+     * @param caller The address of the user requesting the random number
+     * @param sequenceNumber A unique identifier for this request
+     * @param userRandomNumber A random number provided by the user for additional entropy
+     * @param dummy Additional data field (unused)
+     */
     event Requested(
         address indexed provider,
         address indexed caller,
@@ -14,6 +34,17 @@ interface EntropyEventsV2 {
         bytes dummy
     );
 
+    /**
+     * @notice Emitted when a provider reveals the generated random number
+     * @param provider The address of the provider that generated the random number
+     * @param caller The address of the user who requested the random number (and who receives a callback)
+     * @param sequenceNumber The unique identifier of the request
+     * @param randomNumber The generated random number
+     * @param callbackFailed Whether the callback to the caller failed
+     * @param callbackErrorCode If the callback failed, the error code from the callback. Note
+     * that "" often indicates an out-of-gas error.
+     * @param dummy Additional data field (unused)
+     */
     event Revealed(
         address indexed provider,
         address indexed caller,
@@ -24,8 +55,27 @@ interface EntropyEventsV2 {
         bytes dummy
     );
 
-    event ProviderFeeUpdated(address indexed provider, uint128 oldFee, uint128 newFee, bytes dummy);
+    /**
+     * @notice Emitted when a provider updates their fee
+     * @param provider The address of the provider updating their fee
+     * @param oldFee The previous fee amount
+     * @param newFee The new fee amount
+     * @param dummy Additional data field (unused)
+     */
+    event ProviderFeeUpdated(
+        address indexed provider,
+        uint128 oldFee,
+        uint128 newFee,
+        bytes dummy
+    );
 
+    /**
+     * @notice Emitted when a provider updates their default gas limit
+     * @param provider The address of the provider updating their gas limit
+     * @param oldDefaultGasLimit The previous default gas limit
+     * @param newDefaultGasLimit The new default gas limit
+     * @param dummy Additional data field (unused)
+     */
     event ProviderDefaultGasLimitUpdated(
         address indexed provider,
         uint32 oldDefaultGasLimit,
@@ -33,14 +83,41 @@ interface EntropyEventsV2 {
         bytes dummy
     );
 
-    event ProviderUriUpdated(address indexed provider, bytes oldUri, bytes newUri, bytes dummy);
+    /**
+     * @notice Emitted when a provider updates their URI
+     * @param provider The address of the provider updating their URI
+     * @param oldUri The previous URI
+     * @param newUri The new URI
+     * @param dummy Additional data field (unused)
+     */
+    event ProviderUriUpdated(
+        address indexed provider,
+        bytes oldUri,
+        bytes newUri,
+        bytes dummy
+    );
 
+    /**
+     * @notice Emitted when a provider updates their fee manager address
+     * @param provider The address of the provider updating their fee manager
+     * @param oldFeeManager The previous fee manager address
+     * @param newFeeManager The new fee manager address
+     * @param dummy Additional data field (unused)
+     */
     event ProviderFeeManagerUpdated(
         address indexed provider,
         address oldFeeManager,
         address newFeeManager,
         bytes dummy
     );
+
+    /**
+     * @notice Emitted when a provider updates their maximum number of hashes that can be advanced
+     * @param provider The address of the provider updating their max hashes
+     * @param oldMaxNumHashes The previous maximum number of hashes
+     * @param newMaxNumHashes The new maximum number of hashes
+     * @param dummy Additional data field (unused)
+     */
     event ProviderMaxNumHashesAdvanced(
         address indexed provider,
         uint32 oldMaxNumHashes,
@@ -48,6 +125,13 @@ interface EntropyEventsV2 {
         bytes dummy
     );
 
+    /**
+     * @notice Emitted when a provider withdraws their accumulated fees
+     * @param provider The address of the provider withdrawing fees
+     * @param recipient The address receiving the withdrawn fees
+     * @param withdrawnAmount The amount of fees withdrawn
+     * @param dummy Additional data field (unused)
+     */
     event Withdrawal(
         address indexed provider,
         address indexed recipient,

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyEventsV2.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyEventsV2.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "./EntropyStructs.sol";
+
+interface EntropyEventsV2 {
+    event Registered(address indexed provider, bytes dummy);
+
+    event Requested(
+        address indexed provider,
+        address indexed caller,
+        uint64 indexed sequenceNumber,
+        bytes32 userRandomNumber,
+        bytes dummy
+    );
+
+    event Revealed(
+        address indexed provider,
+        address indexed caller,
+        uint64 indexed sequenceNumber,
+        bytes32 randomNumber,
+        bool callbackFailed,
+        bytes callbackErrorCode,
+        bytes dummy
+    );
+
+    event ProviderFeeUpdated(address indexed provider, uint128 oldFee, uint128 newFee, bytes dummy);
+
+    event ProviderDefaultGasLimitUpdated(
+        address indexed provider,
+        uint32 oldDefaultGasLimit,
+        uint32 newDefaultGasLimit,
+        bytes dummy
+    );
+
+    event ProviderUriUpdated(address indexed provider, bytes oldUri, bytes newUri, bytes dummy);
+
+    event ProviderFeeManagerUpdated(
+        address indexed provider,
+        address oldFeeManager,
+        address newFeeManager,
+        bytes dummy
+    );
+    event ProviderMaxNumHashesAdvanced(
+        address indexed provider,
+        uint32 oldMaxNumHashes,
+        uint32 newMaxNumHashes,
+        bytes dummy
+    );
+
+    event Withdrawal(
+        address indexed provider,
+        address indexed recipient,
+        uint128 withdrawnAmount,
+        bytes dummy
+    );
+}

--- a/target_chains/ethereum/entropy_sdk/solidity/IEntropy.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/IEntropy.sol
@@ -2,9 +2,10 @@
 pragma solidity ^0.8.0;
 
 import "./EntropyEvents.sol";
+import "./EntropyEventsV2.sol";
 import "./EntropyStructsV2.sol";
 
-interface IEntropy is EntropyEvents {
+interface IEntropy is EntropyEvents, EntropyEventsV2 {
     // Register msg.sender as a randomness provider. The arguments are the provider's configuration parameters
     // and initial commitment. Re-registering the same provider rotates the provider's commitment (and updates
     // the feeInWei).

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropy.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropy.json
@@ -77,6 +77,37 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "oldDefaultGasLimit",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "newDefaultGasLimit",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "dummy",
+        "type": "bytes"
+      }
+    ],
+    "name": "ProviderDefaultGasLimitUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": false,
         "internalType": "address",
         "name": "provider",
@@ -93,6 +124,37 @@
         "internalType": "address",
         "name": "newFeeManager",
         "type": "address"
+      }
+    ],
+    "name": "ProviderFeeManagerUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldFeeManager",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newFeeManager",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "dummy",
+        "type": "bytes"
       }
     ],
     "name": "ProviderFeeManagerUpdated",
@@ -127,6 +189,37 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "oldFee",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "newFee",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "dummy",
+        "type": "bytes"
+      }
+    ],
+    "name": "ProviderFeeUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": false,
         "internalType": "address",
         "name": "provider",
@@ -152,6 +245,37 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "oldMaxNumHashes",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "newMaxNumHashes",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "dummy",
+        "type": "bytes"
+      }
+    ],
+    "name": "ProviderMaxNumHashesAdvanced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": false,
         "internalType": "address",
         "name": "provider",
@@ -167,6 +291,37 @@
         "indexed": false,
         "internalType": "bytes",
         "name": "newUri",
+        "type": "bytes"
+      }
+    ],
+    "name": "ProviderUriUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "oldUri",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "newUri",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "dummy",
         "type": "bytes"
       }
     ],
@@ -252,6 +407,25 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "dummy",
+        "type": "bytes"
+      }
+    ],
+    "name": "Registered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "components": [
           {
             "internalType": "address",
@@ -298,6 +472,43 @@
         "internalType": "struct EntropyStructs.Request",
         "name": "request",
         "type": "tuple"
+      }
+    ],
+    "name": "Requested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "sequenceNumber",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "userRandomNumber",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "dummy",
+        "type": "bytes"
       }
     ],
     "name": "Requested",
@@ -465,6 +676,55 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "sequenceNumber",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "randomNumber",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "callbackFailed",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "callbackErrorCode",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "dummy",
+        "type": "bytes"
+      }
+    ],
+    "name": "Revealed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "components": [
           {
             "internalType": "address",
@@ -554,6 +814,37 @@
         "internalType": "uint128",
         "name": "withdrawnAmount",
         "type": "uint128"
+      }
+    ],
+    "name": "Withdrawal",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "withdrawnAmount",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "dummy",
+        "type": "bytes"
       }
     ],
     "name": "Withdrawal",

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropy.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropy.json
@@ -97,7 +97,7 @@
       {
         "indexed": false,
         "internalType": "bytes",
-        "name": "dummy",
+        "name": "extraArgs",
         "type": "bytes"
       }
     ],
@@ -153,7 +153,7 @@
       {
         "indexed": false,
         "internalType": "bytes",
-        "name": "dummy",
+        "name": "extraArgs",
         "type": "bytes"
       }
     ],
@@ -209,7 +209,7 @@
       {
         "indexed": false,
         "internalType": "bytes",
-        "name": "dummy",
+        "name": "extraArgs",
         "type": "bytes"
       }
     ],
@@ -265,7 +265,7 @@
       {
         "indexed": false,
         "internalType": "bytes",
-        "name": "dummy",
+        "name": "extraArgs",
         "type": "bytes"
       }
     ],
@@ -321,7 +321,7 @@
       {
         "indexed": false,
         "internalType": "bytes",
-        "name": "dummy",
+        "name": "extraArgs",
         "type": "bytes"
       }
     ],
@@ -415,7 +415,7 @@
       {
         "indexed": false,
         "internalType": "bytes",
-        "name": "dummy",
+        "name": "extraArgs",
         "type": "bytes"
       }
     ],
@@ -507,7 +507,7 @@
       {
         "indexed": false,
         "internalType": "bytes",
-        "name": "dummy",
+        "name": "extraArgs",
         "type": "bytes"
       }
     ],
@@ -708,13 +708,13 @@
       {
         "indexed": false,
         "internalType": "bytes",
-        "name": "callbackErrorCode",
+        "name": "callbackReturnValue",
         "type": "bytes"
       },
       {
         "indexed": false,
         "internalType": "bytes",
-        "name": "dummy",
+        "name": "extraArgs",
         "type": "bytes"
       }
     ],
@@ -843,7 +843,7 @@
       {
         "indexed": false,
         "internalType": "bytes",
-        "name": "dummy",
+        "name": "extraArgs",
         "type": "bytes"
       }
     ],

--- a/target_chains/ethereum/entropy_sdk/solidity/package.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "test:format": "prettier --check .",
     "fix:format": "prettier --write .",
-    "build": "generate-abis IEntropy IEntropyConsumer EntropyErrors EntropyEvents EntropyStructs EntropyStructsV2 EntropyStatusConstants PRNG",
+    "build": "generate-abis IEntropy IEntropyConsumer EntropyErrors EntropyEvents EntropyEventsV2 EntropyStructs EntropyStructsV2 EntropyStatusConstants PRNG",
     "test": "git diff --exit-code abis"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

Add a new set of EntropyEvents to improve on the previous spec. Specifically, add indexing for the salient attributes, stop depending on struct definitions (which, if changed, break the event signature), and add dummy bytes for future extensibility.

In the process, I have omitted events for code paths that we are going to kill off (like the old pull flow).

## How has this been tested?

- [x] Current tests cover my changes
- [x] Added new tests
- [ ] Manually tested the code
