### PR TITLE
feat(pyth-lazer/publisher-sdk): Move Transaction Envelope Definitions to SDK

### DIFF
--- a/.github/workflows/publish-rust-lazer-publisher-sdk.yml
+++ b/.github/workflows/publish-rust-lazer-publisher-sdk.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "30.2"
 
       - run: ./publish.sh
         env:

--- a/lazer/Cargo.lock
+++ b/lazer/Cargo.lock
@@ -3843,7 +3843,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-protocol"
-version = "0.7.3"
+version = "0.7.2"
 dependencies = [
  "alloy-primitives",
  "anyhow",

--- a/lazer/Cargo.lock
+++ b/lazer/Cargo.lock
@@ -3864,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-publisher-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "protobuf",
  "protobuf-codegen",

--- a/lazer/Cargo.lock
+++ b/lazer/Cargo.lock
@@ -3843,7 +3843,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-protocol"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "alloy-primitives",
  "anyhow",

--- a/lazer/publisher_sdk/proto/publisher_update.proto
+++ b/lazer/publisher_sdk/proto/publisher_update.proto
@@ -4,52 +4,60 @@ import "google/protobuf/timestamp.proto";
 
 package pyth_lazer_transaction;
 
-// PublisherUpdate contains an array of individual updates and a timestamp
+// All optional fields should always be set unless documented otherwise.
+
+// Publisher update included in transaction
+//
+// Each publisher update contains a batch of feed updates from publisher.
+// The publisher uses Pyth Agent on their side that handles batching.
+// Each feed update specifies a single update type (price, funding rate, etc.)
 message PublisherUpdate {
-  // Array of updates, each of which target a single feed
-  repeated FeedUpdate updates = 1;
+    // [required] array of feed updates, each of which target a single feed
+    // order of updates are preserved between encoding/decoding
+    repeated FeedUpdate updates = 1;
 
-  // Timestamp when this message was created
-  optional google.protobuf.Timestamp publisher_timestamp = 2;
+    // [required] timestamp when batch of feed updates was collected
+    optional google.protobuf.Timestamp publisher_timestamp = 2;
 }
 
-// Update to a feed. May contain different types of data depending on what kind of update it is
+// A single feed update containing one type of update
 message FeedUpdate {
-  // Feed which the update should be applied to
-  // Should match a feed id recognized by PythLazer
-  optional uint32 feed_id = 1;
+    // [required] id of the lazer feed to be updated
+    // should match the ids of feeds recognized by pyth lazer
+    optional uint32 feed_id = 1;
 
-  // Timestamp when this data was first acquired or generated
-  optional google.protobuf.Timestamp source_timestamp = 2;
+    // [required] timestamp when this data was first acquired or generated
+    optional google.protobuf.Timestamp source_timestamp = 2;
 
-  // one of the valid updates allowed by publishers for a lazer feed
-  oneof update {
-    PriceUpdate price_update = 3;
-    FundingRateUpdate funding_rate_update = 4;
-  };
+    // [required] one type of update containing specific data 
+    oneof update {
+      PriceUpdate price_update = 3;
+      FundingRateUpdate funding_rate_update = 4;
+    };
 }
 
+// feed update containing data for the core price, bid, and ask prices
 message PriceUpdate {
-  // Price for the symbol as an integer
-  // Should be produced with a matching exponent to the configured exponent value in PythLazer
-  // May be missing if no price data is available
-  optional int64 price = 1;
+    // [optional] price for the feed as an integer
+    // should be produced with a matching exponent to the configured exponent value in pyth lazer
+    optional int64 price = 1;
 
-  // Best Bid Price for the symbol as an integer
-  // Should be produced with a matching exponent to the configured exponent value in PythLazer
-  // May be missing if no data is available
-  optional int64 best_bid_price = 2;
+    // [optional] best bid price for the feed as an integer
+    // should be produced with a matching exponent to the configured exponent value in pyth lazer
+    // may be missing if no data is available
+    optional int64 best_bid_price = 2;
 
-  // Best Ask Price for the symbol as an integer
-  // Should be produced with a matching exponent to the configured exponent value in PythLazer
-  // May be missing if no data is available
-  optional int64 best_ask_price = 3;
+    // [optional] best ask price for the feed as an integer
+    // should be produced with a matching exponent to the configured exponent value in pyth lazer
+    // may be missing if no data is available
+    optional int64 best_ask_price = 3;
 }
 
+// feed update containing data relating to funding rate
 message FundingRateUpdate {
-  // Price for which the funding rate applies to
-  optional int64 price = 1;
+    // [optional] price for which the funding rate applies to
+    optional int64 price = 1;
 
-  // Perpetual Future funding rate
-  optional int64 rate = 2;
+    // [optional] perpetual future funding rate
+    optional int64 rate = 2;
 }

--- a/lazer/publisher_sdk/proto/publisher_update.proto
+++ b/lazer/publisher_sdk/proto/publisher_update.proto
@@ -9,12 +9,8 @@ message PublisherUpdate {
   // Array of updates, each of which target a single feed
   repeated FeedUpdate updates = 1;
 
-  // ID of the Publisher that is sending the update
-  // Should match ID stored in Pyth Lazer
-  optional uint32 publisher_id = 2;
-
   // Timestamp when this message was created
-  optional google.protobuf.Timestamp publisher_timestamp = 3;
+  optional google.protobuf.Timestamp publisher_timestamp = 2;
 }
 
 // Update to a feed. May contain different types of data depending on what kind of update it is

--- a/lazer/publisher_sdk/proto/publisher_update.proto
+++ b/lazer/publisher_sdk/proto/publisher_update.proto
@@ -1,10 +1,9 @@
 syntax = "proto3";
+package pyth_lazer_transaction;
 
 import "google/protobuf/timestamp.proto";
 
-package pyth_lazer_transaction;
-
-// All optional fields should always be set unless documented otherwise.
+// if any fields marked as [required] are missing, feed/publisher update will be rejected
 
 // Publisher update included in transaction
 //

--- a/lazer/publisher_sdk/proto/pyth_lazer_transaction.proto
+++ b/lazer/publisher_sdk/proto/pyth_lazer_transaction.proto
@@ -1,8 +1,10 @@
 syntax = "proto3";
-
 package pyth_lazer_transaction;
 
 import "publisher_update.proto";
+
+// if any fields marked as [required] are missing, transaction will be rejected
+// if signature does not match payload bytes, transaction will be rejected
 
 // Signed transaction for lazer
 // Payload should be created on the publisher side and encoded as bytes.

--- a/lazer/publisher_sdk/proto/pyth_lazer_transaction.proto
+++ b/lazer/publisher_sdk/proto/pyth_lazer_transaction.proto
@@ -19,6 +19,8 @@ message SignedLazerTransaction {
 
     // [required] lazer transaction encoded as bytes through protobuf
     optional bytes payload = 3;
+    
+    // TODO: Add public key
 }
 
 // Types of signatures supported by Pyth Lazer

--- a/lazer/publisher_sdk/proto/pyth_lazer_transaction.proto
+++ b/lazer/publisher_sdk/proto/pyth_lazer_transaction.proto
@@ -4,31 +4,32 @@ package pyth_lazer_transaction;
 
 import "publisher_update.proto";
 
-// Types of Signatures allowed for signing Lazer Transactions
-enum TransactionSignatureType {
-  // signature is 64 bytes long
-  ed25519 = 0;
+// Signed transaction for lazer
+// Payload should be created on the publisher side and encoded as bytes.
+// Resulting bytes should then be signed with the signature scheme specified.
+// The signed lazer transaction is encoded as bytes and sent to Pyth Lazer Relayer.
+message SignedLazerTransaction {
+    // [required] specifies the type of signature used to sign the payload
+    optional TransactionSignatureType signature_type = 1;
+
+    // [required] signature derived from signing payload bytes
+    optional bytes signature = 2;
+
+    // [required] lazer transaction encoded as bytes through protobuf
+    optional bytes payload = 3;
 }
 
-// Signed lazer transaction payload
-// This is what Pyth Lazer expects as input to the system
-message SignedLazerTransaction {
-  // Type and signature should match
-  optional TransactionSignatureType signature_type = 1;
-
-  // Signature derived by signing payload with private key
-  optional bytes signature = 2;
-
-  // a LazerTransaction message which is already encoded with protobuf as bytes
-  // The encoded bytes are what should be signed
-  optional bytes payload = 3;
+// Types of signatures supported by Pyth Lazer
+enum TransactionSignatureType {
+    // signature is 64 bytes long
+    ed25519 = 0;
 }
 
 // Transaction contianing one of the valid Lazer Transactions
 message LazerTransaction {
-  oneof payload {
-    // Expected transaction sent by Publishers
-    // May contain many individual updates to various feeds
-    PublisherUpdate publisher_update = 1;
-  }
+    // [required] valid transaction types supported by pyth lazer
+    oneof payload {
+      // updates to feeds, sent by authorized publishers
+      PublisherUpdate publisher_update = 1;
+    }
 }

--- a/lazer/publisher_sdk/proto/transaction_envelope.proto
+++ b/lazer/publisher_sdk/proto/transaction_envelope.proto
@@ -18,24 +18,24 @@ message TransactionEnvelope {
 // Has different context data depending on the type of transaction.
 // Submitted over Message Queue to be read by rest of Pyth Lazer service.
 message PayloadContext {
-    // [required] ID of publisher based on the access token used to connect
-    optional uint32 publisher_id = 1;
-
     // [required] timestamp wwhen relayer received the signed transaction
-    optional google.protobuf.Timestamp relayer_receive_timestamp = 2;
+    optional google.protobuf.Timestamp relayer_receive_timestamp = 1;
 
     // [required] context set based on type of transaction
     oneof context {
-        PublisherUpdateContext publisher_update_context = 3;
+        PublisherUpdateContext publisher_update_context = 2;
     }
 }
 
 // Context contains status of each feed update found in transaction
 message PublisherUpdateContext {
+    // [required] ID of publisher based on the access token used to connect
+    optional uint32 publisher_id = 1;
+
     // [required] context for each feed update
     // must exactly match length and order of feed updates
     // order of updates are preserved between encoding/decoding
-    repeated FeedUpdateContext feed_update_context = 1;
+    repeated FeedUpdateContext feed_update_context = 2;
 }
 
 // State for each feed update.

--- a/lazer/publisher_sdk/proto/transaction_envelope.proto
+++ b/lazer/publisher_sdk/proto/transaction_envelope.proto
@@ -4,42 +4,47 @@ package pyth_lazer_transaction;
 import "google/protobuf/timestamp.proto";
 import "pyth_lazer_transaction.proto";
 
-// Used by Pyth Lazer Relayer
-// Envelope containing the signed transaction already encoded in bytes and some auxiliary information about the transaction set by Relayer
+// Envelope containing signed transaction and context attached by Pyth Lazer.
+// Created by Pyth Lazer Relayers, which also generate and attach the context.
 message TransactionEnvelope {
-    // Signed transaction message encoded with protobuf
+    // [required] signed transaction encoded with protobuf
     optional SignedLazerTransaction signed_transaction = 1;
 
-    // context attached by Relayer for the payload within the transaction
-    // the type of context is set based on the type of payload
+    // [required] context attached by pyth lazer relayer
     optional PayloadContext payload_context = 2;
 }
 
+// Context attached by Pyth Lazer Relayer containing information necessary for processing transaction.
+// Has different context data depending on the type of transaction.
+// Submitted over Message Queue to be read by rest of Pyth Lazer service.
 message PayloadContext {
-    // Publisher ID for which the signed transaction applies to
+    // [required] ID of publisher based on the access token used to connect
     optional uint32 publisher_id = 1;
 
-    // time at which relayer received the signed transaction message
+    // [required] timestamp wwhen relayer received the signed transaction
     optional google.protobuf.Timestamp relayer_receive_timestamp = 2;
 
+    // [required] context set based on type of transaction
     oneof context {
         PublisherUpdateContext publisher_update_context = 3;
     }
 }
 
-// contains context for each feed update inside the publisher update
+// Context contains status of each feed update found in transaction
 message PublisherUpdateContext {
+    // [required] context for each feed update
+    // must exactly match length and order of feed updates
+    // order of updates are preserved between encoding/decoding
     repeated FeedUpdateContext feed_update_context = 1;
 }
 
-// state for each publisher update, if transaction is of type publisher update
-// update_index corresponds to the index of the feed update inside the publisher update
+// State for each feed update.
+// Each feed update is validated and may be marked as rejected by Relayer.
 message FeedUpdateContext {
-    // array ordering is preserved when encoded and decoded
-    uint64 update_index = 1;
+    // [required] status of feed update
     oneof status {
-        Accepted accepted = 2;
-        Rejected rejected = 3;
+        Accepted accepted = 1;
+        Rejected rejected = 2;
     }
 }
 
@@ -48,6 +53,7 @@ message Accepted {}
 
 // Rejected publisher update and its reason for being rejected
 message Rejected {
+    // [required] reason for rejection
     RejectReason reject_reason = 1;
 }
 

--- a/lazer/publisher_sdk/proto/transaction_envelope.proto
+++ b/lazer/publisher_sdk/proto/transaction_envelope.proto
@@ -1,0 +1,61 @@
+syntax = "proto3";
+package pyth_lazer_transaction;
+
+import "google/protobuf/timestamp.proto";
+import "pyth_lazer_transaction.proto";
+
+// Used by Pyth Lazer Relayer
+// Envelope containing the signed transaction already encoded in bytes and some auxiliary information about the transaction set by Relayer
+message TransactionEnvelope {
+    // Signed transaction message encoded with protobuf
+    optional SignedLazerTransaction signed_transaction = 1;
+
+    // context attached by Relayer for the payload within the transaction
+    // the type of context is set based on the type of payload
+    optional PayloadContext payload_context = 2;
+}
+
+message PayloadContext {
+    // Publisher ID for which the signed transaction applies to
+    optional uint32 publisher_id = 1;
+
+    // time at which relayer received the signed transaction message
+    optional google.protobuf.Timestamp relayer_receive_timestamp = 2;
+
+    oneof context {
+        PublisherUpdateContext publisher_update_context = 3;
+    }
+}
+
+// contains context for each feed update inside the publisher update
+message PublisherUpdateContext {
+    repeated FeedUpdateContext feed_update_context = 1;
+}
+
+// state for each publisher update, if transaction is of type publisher update
+// update_index corresponds to the index of the feed update inside the publisher update
+message FeedUpdateContext {
+    // array ordering is preserved when encoded and decoded
+    uint64 update_index = 1;
+    oneof status {
+        Accepted accepted = 2;
+        Rejected rejected = 3;
+    }
+}
+
+// Accepted publisher update
+message Accepted {}
+
+// Rejected publisher update and its reason for being rejected
+message Rejected {
+    RejectReason reject_reason = 1;
+}
+
+// The reasons that a publisher update might be rejected for
+enum RejectReason {
+    InvalidTimestamp = 0;
+    PriceDeviation = 1;
+    PriceOverflow = 2;
+    InvalidFeedId = 3;
+    MissingFields = 4;
+}

--- a/lazer/publisher_sdk/rust/Cargo.toml
+++ b/lazer/publisher_sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-publisher-sdk"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Pyth Lazer Publisher SDK types."
 license = "Apache-2.0"

--- a/lazer/publisher_sdk/rust/build.rs
+++ b/lazer/publisher_sdk/rust/build.rs
@@ -8,12 +8,12 @@ fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=../proto/");
 
     protobuf_codegen::Codegen::new()
-        .pure()
         .include("../proto")
         .input("../proto/publisher_update.proto")
         .input("../proto/pyth_lazer_transaction.proto")
         .input("../proto/transaction_envelope.proto")
         .cargo_out_dir("protobuf")
+        .protoc_extra_arg("--include_source_info")
         .run_from_script();
 
     Ok(())

--- a/lazer/publisher_sdk/rust/build.rs
+++ b/lazer/publisher_sdk/rust/build.rs
@@ -12,6 +12,7 @@ fn main() -> Result<()> {
         .include("../proto")
         .input("../proto/publisher_update.proto")
         .input("../proto/pyth_lazer_transaction.proto")
+        .input("../proto/transaction_envelope.proto")
         .cargo_out_dir("protobuf")
         .run_from_script();
 

--- a/lazer/publisher_sdk/rust/build.rs
+++ b/lazer/publisher_sdk/rust/build.rs
@@ -8,12 +8,13 @@ fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=../proto/");
 
     protobuf_codegen::Codegen::new()
+        .protoc()
+        .protoc_extra_arg("--include_source_info")
         .include("../proto")
         .input("../proto/publisher_update.proto")
         .input("../proto/pyth_lazer_transaction.proto")
         .input("../proto/transaction_envelope.proto")
         .cargo_out_dir("protobuf")
-        .protoc_extra_arg("--include_source_info")
         .run_from_script();
 
     Ok(())

--- a/lazer/publisher_sdk/rust/src/lib.rs
+++ b/lazer/publisher_sdk/rust/src/lib.rs
@@ -1,3 +1,7 @@
+pub mod transaction_envelope {
+    pub use crate::protobuf::transaction_envelope::*;
+}
+
 pub mod transaction {
     pub use crate::protobuf::pyth_lazer_transaction::*;
 }

--- a/lazer/sdk/rust/protocol/Cargo.toml
+++ b/lazer/sdk/rust/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-protocol"
-version = "0.7.3"
+version = "0.7.2"
 edition = "2021"
 description = "Pyth Lazer SDK - protocol types."
 license = "Apache-2.0"

--- a/lazer/sdk/rust/protocol/Cargo.toml
+++ b/lazer/sdk/rust/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-protocol"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Pyth Lazer SDK - protocol types."
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Removes the publisher ID field from the publisher update sent by publishers. Publishers don't need know what their ID is, and its better to not ask them to self report it. 
- Removes update index from feed update context. It's unnecessary, and I will make assertions to make sure the ordering and length of the array match the publisher updates vec exactly. 
- Moved transaction envelope definition to publisher SDK to skip one decode step. Also added comments, adopting Pavel's comment styling in the Pyth Lazer repo.
- Switched the parser to use protoc and then added the argument to generate rust docs for the generated types, as per Pavel's [PR](https://github.com/pyth-network/pyth-lazer/pull/346). 

## Rationale

Reduces some burden on publishers by not requiring them to know their own IDs. The update index field was also confusing. It's better to write thoroughly tested code and make some assumptions instead. The added rust docs should also help with understanding the generated types. 

## How has this been tested?

- [x] Current tests cover my changes
- [x] Added new tests
- [x] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
