### PR TITLE
fix(lazer/solana): add mut annotation on treasury account

### DIFF
--- a/lazer/Cargo.lock
+++ b/lazer/Cargo.lock
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-solana-contract"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anchor-lang",
  "bytemuck",

--- a/lazer/contracts/solana/programs/pyth-lazer-solana-contract/Cargo.toml
+++ b/lazer/contracts/solana/programs/pyth-lazer-solana-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-solana-contract"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Pyth Lazer Solana contract and SDK."
 license = "Apache-2.0"

--- a/lazer/contracts/solana/programs/pyth-lazer-solana-contract/src/lib.rs
+++ b/lazer/contracts/solana/programs/pyth-lazer-solana-contract/src/lib.rs
@@ -261,6 +261,7 @@ pub struct VerifyMessage<'info> {
     )]
     pub storage: Account<'info, Storage>,
     /// CHECK: this account doesn't need additional constraints.
+    #[account(mut)]
     pub treasury: AccountInfo<'info>,
     pub system_program: Program<'info, System>,
     /// CHECK: account ID is checked in Solana SDK during calls
@@ -280,6 +281,7 @@ pub struct VerifyEcdsaMessage<'info> {
     )]
     pub storage: Account<'info, Storage>,
     /// CHECK: this account doesn't need additional constraints.
+    #[account(mut)]
     pub treasury: AccountInfo<'info>,
     pub system_program: Program<'info, System>,
 }


### PR DESCRIPTION
## Rationale

The lack of mut annotation is not causing any security risk (because if you pass it as readable it'll fail later when being used as writable). However, it breaks downstream users who rely on the published lib crate of the contract when making CPI to the contract.

## How has this been tested?

- [x] Manually tested the code: the example anchor contract passes tests with this change.
