### PR TITLE
feat(Entropy): Include gas limits and gas usage in events

### DIFF
--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -600,6 +600,7 @@ abstract contract Entropy is IEntropy, EntropyState {
                     randomNumber,
                     false,
                     ret,
+                    SafeCast.toUint32(startingGas - gasleft()),
                     bytes("")
                 );
                 clearRequest(provider, sequenceNumber);
@@ -629,6 +630,7 @@ abstract contract Entropy is IEntropy, EntropyState {
                     randomNumber,
                     true,
                     ret,
+                    SafeCast.toUint32(startingGas - gasleft()),
                     bytes("")
                 );
                 req.callbackStatus = EntropyStatusConstants.CALLBACK_FAILED;
@@ -656,6 +658,7 @@ abstract contract Entropy is IEntropy, EntropyState {
                 randomNumber,
                 false,
                 bytes(""),
+                0, // gas usage not tracked in the old no-gas-limit flow.
                 bytes("")
             );
 

--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -369,6 +369,7 @@ abstract contract Entropy is IEntropy, EntropyState {
             req.requester,
             req.sequenceNumber,
             userRandomNumber,
+            uint32(req.gasLimit10k) * TEN_THOUSAND,
             bytes("")
         );
         return req.sequenceNumber;

--- a/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
@@ -825,6 +825,7 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents, EntropyEventsV2 {
             user1,
             providerInfo.sequenceNumber,
             userRandomNumber,
+            0,
             bytes("")
         );
         vm.roll(1234);
@@ -1018,6 +1019,15 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents, EntropyEventsV2 {
         uint fee = random.getFee(provider1);
         EntropyConsumer consumer = new EntropyConsumer(address(random), false);
         vm.deal(user1, fee);
+        vm.expectEmit(false, false, false, true, address(random));
+        emit EntropyEventsV2.Requested(
+            provider1,
+            user1,
+            0,
+            userRandomNumber,
+            100000,
+            bytes("")
+        );
         vm.prank(user1);
         uint64 assignedSequenceNumber = consumer.requestEntropy{value: fee}(
             userRandomNumber
@@ -1718,9 +1728,18 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents, EntropyEventsV2 {
             gasLimit
         );
 
-        uint128 startingAccruedProviderFee = random
-            .getProviderInfoV2(provider1)
-            .accruedFeesInWei;
+        EntropyStructsV2.ProviderInfo memory providerInfo = random.getProviderInfoV2(provider1);
+
+        uint128 startingAccruedProviderFee = providerInfo.accruedFeesInWei;
+        vm.expectEmit(false, false, false, true, address(random));
+        emit EntropyEventsV2.Requested(
+            provider1,
+            user1,
+            providerInfo.sequenceNumber,
+            userRandomNumber,
+            uint32(expectedGasLimit10k) * 10000,
+            bytes("")
+        );            
         vm.prank(user1);
         uint64 sequenceNumber = random.requestWithCallbackAndGasLimit{
             value: fee

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyEventsV2.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyEventsV2.sol
@@ -56,7 +56,7 @@ interface EntropyEventsV2 {
         bytes32 randomNumber,
         bool callbackFailed,
         bytes callbackReturnValue,
-        uint32 callbackGasUsed,        
+        uint32 callbackGasUsed,
         bytes extraArgs
     );
 

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyEventsV2.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyEventsV2.sol
@@ -46,6 +46,7 @@ interface EntropyEventsV2 {
      * @param callbackReturnValue Return value from the callback. If the callback failed, this field contains
      * the error code and any additional returned data. Note that "" often indicates an out-of-gas error.
      * If the callback returns more than 256 bytes, only the first 256 bytes of the callback return value are included.
+     * @param callbackGasUsed How much gas the callback used.
      * @param extraArgs A field for extra data for forward compatibility.
      */
     event Revealed(
@@ -55,6 +56,7 @@ interface EntropyEventsV2 {
         bytes32 randomNumber,
         bool callbackFailed,
         bytes callbackReturnValue,
+        uint32 callbackGasUsed,        
         bytes extraArgs
     );
 

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyEventsV2.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyEventsV2.sol
@@ -24,6 +24,7 @@ interface EntropyEventsV2 {
      * @param caller The address of the user requesting the random number
      * @param sequenceNumber A unique identifier for this request
      * @param userRandomNumber A random number provided by the user for additional entropy
+     * @param gasLimit The gas limit for the callback.
      * @param extraArgs A field for extra data for forward compatibility.
      */
     event Requested(
@@ -31,6 +32,7 @@ interface EntropyEventsV2 {
         address indexed caller,
         uint64 indexed sequenceNumber,
         bytes32 userRandomNumber,
+        uint32 gasLimit,
         bytes extraArgs
     );
 

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropy.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropy.json
@@ -506,6 +506,12 @@
       },
       {
         "indexed": false,
+        "internalType": "uint32",
+        "name": "gasLimit",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
         "internalType": "bytes",
         "name": "extraArgs",
         "type": "bytes"
@@ -710,6 +716,12 @@
         "internalType": "bytes",
         "name": "callbackReturnValue",
         "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "callbackGasUsed",
+        "type": "uint32"
       },
       {
         "indexed": false,


### PR DESCRIPTION
## Summary

As the PR title says

## Rationale

Showing the gas limit and usage will be useful for users to see if their callback is using too much gas, and also to adjust their usage.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
