### PR TITLE
feat(fortuna): Add timeout for rpc calls

### DIFF
--- a/apps/fortuna/Cargo.lock
+++ b/apps/fortuna/Cargo.lock
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "fortuna"
-version = "7.5.1"
+version = "7.5.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/fortuna/Cargo.toml
+++ b/apps/fortuna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortuna"
-version = "7.5.1"
+version = "7.5.2"
 edition = "2021"
 
 [lib]

--- a/apps/fortuna/src/eth_utils/traced_client.rs
+++ b/apps/fortuna/src/eth_utils/traced_client.rs
@@ -1,6 +1,3 @@
-use reqwest::Client;
-use std::time::Duration;
-use url::Url;
 use {
     crate::api::ChainId,
     anyhow::Result,
@@ -14,8 +11,10 @@ use {
         metrics::{counter::Counter, family::Family, histogram::Histogram},
         registry::Registry,
     },
-    std::sync::Arc,
+    reqwest::Client,
+    std::{sync::Arc, time::Duration},
     tokio::{sync::RwLock, time::Instant},
+    url::Url,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, EncodeLabelSet)]


### PR DESCRIPTION
## Summary
As the title suggests. 

## Rationale

erpc should handle long request issues with hedging and timeout configs but if the connection to erpc is dead for whatever reason, the keeper becomes stuck. This change will fix that, there is no need for a timeout config here as it should exist in erpc configs.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code
