### PR TITLE
New PF Council signers: Anton and Mario

### DIFF
--- a/governance/xc_admin/packages/xc_admin_frontend/mappings/signers.json
+++ b/governance/xc_admin/packages/xc_admin_frontend/mappings/signers.json
@@ -22,5 +22,7 @@
   "5X8etNCroWSpcWbVAqNpyyqqahvBVQPhbMdzYdB7YWWu": "Matt",
   "4bvLh1EoJcoN1eCm1JF2p4fjisWrHARdCcDHxrV7VWFG": "Nicolas",
   "D3iheBiy1EC3zde86bhU5X1Wmqj6XhJqnRAQ7W2emPr": "John",
+  "23wnKNMEaKxvPmzWkX71SxdGtnh8Rhq1nCv1EtCYu9Hj": "Mario",
+  "GQFhjSDRPb5uqErdXHE6qNEtfJNWQzufVCkWUJ7pBY8e": "Anton",
   "ACzP6RC98vcBk9oTeAwcH1o5HJvtBzU59b5nqdwc7Cxy": "Price Feed Ops"
 }


### PR DESCRIPTION
## Summary

Adding Anton's and Mario's names to list of signers, following the DAO confirming the composition of the 3rd iteration of the Price Feed Council.

## Rationale

To easily identify proposal voters, as is currently done for existing signers.

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
Checked the JSON structure visually and verified correctness of the information taken from forum submissions of the candidates that won (Anton and Mario).