### PR TITLE
fix(pulse): enforce min bal for all active updated subs

### DIFF
--- a/target_chains/ethereum/contracts/contracts/pulse/Scheduler.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/Scheduler.sol
@@ -102,11 +102,8 @@ abstract contract Scheduler is IScheduler, SchedulerState {
         // Validate the new parameters, including setting default gas config
         _validateAndPrepareSubscriptionParams(newParams);
 
-        // Check minimum balance if number of feeds increases and subscription remains active
-        if (
-            willBeActive &&
-            newParams.priceIds.length > currentParams.priceIds.length
-        ) {
+        // Check minimum balance if subscription remains active
+        if (willBeActive) {
             uint256 minimumBalance = this.getMinimumBalance(
                 uint8(newParams.priceIds.length)
             );

--- a/target_chains/ethereum/contracts/forge-test/PulseScheduler.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/PulseScheduler.t.sol
@@ -1381,10 +1381,12 @@ contract SchedulerTest is Test, SchedulerEvents, PulseSchedulerTestUtils {
         uint256 additionalFunds = minBalanceForOneFeed -
             status_reduce.balanceInWei +
             0.01 ether;
-        scheduler.addFunds{value: additionalFunds}(subId_reduce);
 
         // Now the update should succeed
-        scheduler.updateSubscription(subId_reduce, newParams_reduce);
+        scheduler.updateSubscription{value: additionalFunds}(
+            subId_reduce,
+            newParams_reduce
+        );
 
         // Verify the subscription now has 1 feed
         (


### PR DESCRIPTION
## Summary

Enforce minimum balance in updateSubscription even when reducing or keeping the number of feeds the same.

## Rationale

Initially we didn't enforce the check if the user is decreasing their feed count or keeping it the same. The thought was to be friendly to the user in case they are trying to reduce their funds burn rate. However, this is inconsistent behavior and might actually confuse the user, and it's safer to always check. Now, in all cases where the sub is getting updated and remaining active, the check is enforced.

## How has this been tested?

- [x] Current tests cover my changes
- [x] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
