### PR TITLE
feat(entropy): Split out V2 interface into separate file.

### DIFF
--- a/target_chains/ethereum/entropy_sdk/solidity/IEntropy.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/IEntropy.sol
@@ -4,8 +4,9 @@ pragma solidity ^0.8.0;
 import "./EntropyEvents.sol";
 import "./EntropyEventsV2.sol";
 import "./EntropyStructsV2.sol";
+import "./IEntropyV2.sol";
 
-interface IEntropy is EntropyEvents, EntropyEventsV2 {
+interface IEntropy is EntropyEvents, EntropyEventsV2, IEntropyV2 {
     // Register msg.sender as a randomness provider. The arguments are the provider's configuration parameters
     // and initial commitment. Re-registering the same provider rotates the provider's commitment (and updates
     // the feeInWei).
@@ -28,96 +29,6 @@ interface IEntropy is EntropyEvents, EntropyEventsV2 {
     // Calling this function will transfer `amount` wei to the caller (provided that they have accrued a sufficient
     // balance of fees in the contract).
     function withdrawAsFeeManager(address provider, uint128 amount) external;
-
-    /// @notice Request a random number using the default provider with default gas limit
-    /// @return assignedSequenceNumber A unique identifier for this request
-    /// @dev The address calling this function should be a contract that inherits from the IEntropyConsumer interface.
-    /// The `entropyCallback` method on that interface will receive a callback with the returned sequence number and
-    /// the generated random number.
-    ///
-    /// `entropyCallback` will be run with the `gasLimit` provided to this function.
-    /// The `gasLimit` will be rounded up to a multiple of 10k (e.g., 19000 -> 20000), and furthermore is lower bounded
-    /// by the provider's configured default limit.
-    ///
-    /// This method will revert unless the caller provides a sufficient fee (at least `getFeeV2()`) as msg.value.
-    /// Note that the fee can change over time. Callers of this method should explicitly compute `getFeeV2()`
-    /// prior to each invocation (as opposed to hardcoding a value). Further note that excess value is *not* refunded to the caller.
-    ///
-    /// Note that this method uses an in-contract PRNG to generate the user's portion of the random number.
-    /// Users must trust this PRNG in order to prove the result is random. If you wish to avoid this trust assumption,
-    /// call a variant of `requestV2` that accepts a `userRandomNumber` parameter.
-    function requestV2()
-        external
-        payable
-        returns (uint64 assignedSequenceNumber);
-
-    /// @notice Request a random number using the default provider with specified gas limit
-    /// @param gasLimit The gas limit for the callback function.
-    /// @return assignedSequenceNumber A unique identifier for this request
-    /// @dev The address calling this function should be a contract that inherits from the IEntropyConsumer interface.
-    /// The `entropyCallback` method on that interface will receive a callback with the returned sequence number and
-    /// the generated random number.
-    ///
-    /// `entropyCallback` will be run with the `gasLimit` provided to this function.
-    /// The `gasLimit` will be rounded up to a multiple of 10k (e.g., 19000 -> 20000), and furthermore is lower bounded
-    /// by the provider's configured default limit.
-    ///
-    /// This method will revert unless the caller provides a sufficient fee (at least `getFeeV2(gasLimit)`) as msg.value.
-    /// Note that the fee can change over time. Callers of this method should explicitly compute `getFeeV2(gasLimit)`
-    /// prior to each invocation (as opposed to hardcoding a value). Further note that excess value is *not* refunded to the caller.
-    ///
-    /// Note that this method uses an in-contract PRNG to generate the user's portion of the random number.
-    /// Users must trust this PRNG in order to prove the result is random. If you wish to avoid this trust assumption,
-    /// call a variant of `requestV2` that accepts a `userRandomNumber` parameter.
-    function requestV2(
-        uint32 gasLimit
-    ) external payable returns (uint64 assignedSequenceNumber);
-
-    /// @notice Request a random number from a specific provider with specified gas limit
-    /// @param provider The address of the provider to request from
-    /// @param gasLimit The gas limit for the callback function
-    /// @return assignedSequenceNumber A unique identifier for this request
-    /// @dev The address calling this function should be a contract that inherits from the IEntropyConsumer interface.
-    /// The `entropyCallback` method on that interface will receive a callback with the returned sequence number and
-    /// the generated random number.
-    ///
-    /// `entropyCallback` will be run with the `gasLimit` provided to this function.
-    /// The `gasLimit` will be rounded up to a multiple of 10k (e.g., 19000 -> 20000), and furthermore is lower bounded
-    /// by the provider's configured default limit.
-    ///
-    /// This method will revert unless the caller provides a sufficient fee (at least `getFeeV2(provider, gasLimit)`) as msg.value.
-    /// Note that provider fees can change over time. Callers of this method should explicitly compute `getFeeV2(provider, gasLimit)`
-    /// prior to each invocation (as opposed to hardcoding a value). Further note that excess value is *not* refunded to the caller.
-    ///
-    /// Note that this method uses an in-contract PRNG to generate the user's portion of the random number.
-    /// Users must trust this PRNG in order to prove the result is random. If you wish to avoid this trust assumption,
-    /// call a variant of `requestV2` that accepts a `userRandomNumber` parameter.
-    function requestV2(
-        address provider,
-        uint32 gasLimit
-    ) external payable returns (uint64 assignedSequenceNumber);
-
-    /// @notice Request a random number from a specific provider with a user-provided random number and gas limit
-    /// @param provider The address of the provider to request from
-    /// @param userRandomNumber A random number provided by the user for additional entropy
-    /// @param gasLimit The gas limit for the callback function
-    /// @return assignedSequenceNumber A unique identifier for this request
-    /// @dev The address calling this function should be a contract that inherits from the IEntropyConsumer interface.
-    /// The `entropyCallback` method on that interface will receive a callback with the returned sequence number and
-    /// the generated random number.
-    ///
-    /// `entropyCallback` will be run with the `gasLimit` provided to this function.
-    /// The `gasLimit` will be rounded up to a multiple of 10k (e.g., 19000 -> 20000), and furthermore is lower bounded
-    /// by the provider's configured default limit.
-    ///
-    /// This method will revert unless the caller provides a sufficient fee (at least `getFeeV2(provider, gasLimit)`) as msg.value.
-    /// Note that provider fees can change over time. Callers of this method should explicitly compute `getFeeV2(provider, gasLimit)`
-    /// prior to each invocation (as opposed to hardcoding a value). Further note that excess value is *not* refunded to the caller.
-    function requestV2(
-        address provider,
-        bytes32 userRandomNumber,
-        uint32 gasLimit
-    ) external payable returns (uint64 assignedSequenceNumber);
 
     // As a user, request a random number from `provider`. Prior to calling this method, the user should
     // generate a random number x and keep it secret. The user should then compute hash(x) and pass that
@@ -185,42 +96,14 @@ interface IEntropy is EntropyEvents, EntropyEventsV2 {
         address provider
     ) external view returns (EntropyStructs.ProviderInfo memory info);
 
-    function getProviderInfoV2(
-        address provider
-    ) external view returns (EntropyStructsV2.ProviderInfo memory info);
-
-    function getDefaultProvider() external view returns (address provider);
-
     function getRequest(
         address provider,
         uint64 sequenceNumber
     ) external view returns (EntropyStructs.Request memory req);
 
-    function getRequestV2(
-        address provider,
-        uint64 sequenceNumber
-    ) external view returns (EntropyStructsV2.Request memory req);
-
     // Get the fee charged by provider for a request with the default gasLimit (`request` or `requestWithCallback`).
     // If you are calling any of the `requestV2` methods, please use `getFeeV2`.
     function getFee(address provider) external view returns (uint128 feeAmount);
-
-    // Get the fee charged by the default provider for the default gas limit.
-    // Use this function to determine the fee to pass to `requestV2`.
-    function getFeeV2() external view returns (uint128 feeAmount);
-
-    // Get the fee charged by the default provider for the specified gas limit.
-    // Use this function to determine the fee to pass to `requestV2`.
-    function getFeeV2(
-        uint32 gasLimit
-    ) external view returns (uint128 feeAmount);
-
-    // Get the fee charged by `provider` for a request with a specific `gasLimit`.
-    // Use this function to determine the fee to pass to `requestV2`.
-    function getFeeV2(
-        address provider,
-        uint32 gasLimit
-    ) external view returns (uint128 feeAmount);
 
     function getAccruedPythFees()
         external

--- a/target_chains/ethereum/entropy_sdk/solidity/IEntropyV2.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/IEntropyV2.sol
@@ -96,6 +96,11 @@ interface IEntropyV2 is EntropyEventsV2 {
         uint32 gasLimit
     ) external payable returns (uint64 assignedSequenceNumber);
 
+    /// @notice Get information about a specific entropy provider
+    /// @param provider The address of the provider to query
+    /// @return info The provider information including configuration, fees, and operational status
+    /// @dev This method returns detailed information about a provider's configuration and capabilities.
+    /// The returned ProviderInfo struct contains information such as the provider's fee structure and gas limits.
     function getProviderInfoV2(
         address provider
     ) external view returns (EntropyStructsV2.ProviderInfo memory info);

--- a/target_chains/ethereum/entropy_sdk/solidity/IEntropyV2.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/IEntropyV2.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache 2
+pragma solidity ^0.8.0;
+
+import "./EntropyEvents.sol";
+import "./EntropyEventsV2.sol";
+import "./EntropyStructsV2.sol";
+
+interface IEntropyV2 is EntropyEventsV2 {
+    /// @notice Request a random number using the default provider with default gas limit
+    /// @return assignedSequenceNumber A unique identifier for this request
+    /// @dev The address calling this function should be a contract that inherits from the IEntropyConsumer interface.
+    /// The `entropyCallback` method on that interface will receive a callback with the returned sequence number and
+    /// the generated random number.
+    ///
+    /// `entropyCallback` will be run with the `gasLimit` provided to this function.
+    /// The `gasLimit` will be rounded up to a multiple of 10k (e.g., 19000 -> 20000), and furthermore is lower bounded
+    /// by the provider's configured default limit.
+    ///
+    /// This method will revert unless the caller provides a sufficient fee (at least `getFeeV2()`) as msg.value.
+    /// Note that the fee can change over time. Callers of this method should explicitly compute `getFeeV2()`
+    /// prior to each invocation (as opposed to hardcoding a value). Further note that excess value is *not* refunded to the caller.
+    ///
+    /// Note that this method uses an in-contract PRNG to generate the user's portion of the random number.
+    /// Users must trust this PRNG in order to prove the result is random. If you wish to avoid this trust assumption,
+    /// call a variant of `requestV2` that accepts a `userRandomNumber` parameter.
+    function requestV2()
+        external
+        payable
+        returns (uint64 assignedSequenceNumber);
+
+    /// @notice Request a random number using the default provider with specified gas limit
+    /// @param gasLimit The gas limit for the callback function.
+    /// @return assignedSequenceNumber A unique identifier for this request
+    /// @dev The address calling this function should be a contract that inherits from the IEntropyConsumer interface.
+    /// The `entropyCallback` method on that interface will receive a callback with the returned sequence number and
+    /// the generated random number.
+    ///
+    /// `entropyCallback` will be run with the `gasLimit` provided to this function.
+    /// The `gasLimit` will be rounded up to a multiple of 10k (e.g., 19000 -> 20000), and furthermore is lower bounded
+    /// by the provider's configured default limit.
+    ///
+    /// This method will revert unless the caller provides a sufficient fee (at least `getFeeV2(gasLimit)`) as msg.value.
+    /// Note that the fee can change over time. Callers of this method should explicitly compute `getFeeV2(gasLimit)`
+    /// prior to each invocation (as opposed to hardcoding a value). Further note that excess value is *not* refunded to the caller.
+    ///
+    /// Note that this method uses an in-contract PRNG to generate the user's portion of the random number.
+    /// Users must trust this PRNG in order to prove the result is random. If you wish to avoid this trust assumption,
+    /// call a variant of `requestV2` that accepts a `userRandomNumber` parameter.
+    function requestV2(
+        uint32 gasLimit
+    ) external payable returns (uint64 assignedSequenceNumber);
+
+    /// @notice Request a random number from a specific provider with specified gas limit
+    /// @param provider The address of the provider to request from
+    /// @param gasLimit The gas limit for the callback function
+    /// @return assignedSequenceNumber A unique identifier for this request
+    /// @dev The address calling this function should be a contract that inherits from the IEntropyConsumer interface.
+    /// The `entropyCallback` method on that interface will receive a callback with the returned sequence number and
+    /// the generated random number.
+    ///
+    /// `entropyCallback` will be run with the `gasLimit` provided to this function.
+    /// The `gasLimit` will be rounded up to a multiple of 10k (e.g., 19000 -> 20000), and furthermore is lower bounded
+    /// by the provider's configured default limit.
+    ///
+    /// This method will revert unless the caller provides a sufficient fee (at least `getFeeV2(provider, gasLimit)`) as msg.value.
+    /// Note that provider fees can change over time. Callers of this method should explicitly compute `getFeeV2(provider, gasLimit)`
+    /// prior to each invocation (as opposed to hardcoding a value). Further note that excess value is *not* refunded to the caller.
+    ///
+    /// Note that this method uses an in-contract PRNG to generate the user's portion of the random number.
+    /// Users must trust this PRNG in order to prove the result is random. If you wish to avoid this trust assumption,
+    /// call a variant of `requestV2` that accepts a `userRandomNumber` parameter.
+    function requestV2(
+        address provider,
+        uint32 gasLimit
+    ) external payable returns (uint64 assignedSequenceNumber);
+
+    /// @notice Request a random number from a specific provider with a user-provided random number and gas limit
+    /// @param provider The address of the provider to request from
+    /// @param userRandomNumber A random number provided by the user for additional entropy
+    /// @param gasLimit The gas limit for the callback function. Pass 0 to get a sane default value -- see note below.
+    /// @return assignedSequenceNumber A unique identifier for this request
+    /// @dev The address calling this function should be a contract that inherits from the IEntropyConsumer interface.
+    /// The `entropyCallback` method on that interface will receive a callback with the returned sequence number and
+    /// the generated random number.
+    ///
+    /// `entropyCallback` will be run with the `gasLimit` provided to this function.
+    /// The `gasLimit` will be rounded up to a multiple of 10k (e.g., 19000 -> 20000), and furthermore is lower bounded
+    /// by the provider's configured default limit.
+    ///
+    /// This method will revert unless the caller provides a sufficient fee (at least `getFeeV2(provider, gasLimit)`) as msg.value.
+    /// Note that provider fees can change over time. Callers of this method should explicitly compute `getFeeV2(provider, gasLimit)`
+    /// prior to each invocation (as opposed to hardcoding a value). Further note that excess value is *not* refunded to the caller.
+    function requestV2(
+        address provider,
+        bytes32 userRandomNumber,
+        uint32 gasLimit
+    ) external payable returns (uint64 assignedSequenceNumber);
+
+    function getProviderInfoV2(
+        address provider
+    ) external view returns (EntropyStructsV2.ProviderInfo memory info);
+
+    /// @notice Get the address of the default entropy provider
+    /// @return provider The address of the default provider
+    /// @dev This method returns the address of the provider that will be used when no specific provider is specified
+    /// in the requestV2 calls. The default provider can be used to get the base fee and gas limit information.
+    function getDefaultProvider() external view returns (address provider);
+
+    /// @notice Get information about a specific request
+    /// @param provider The address of the provider that handled the request
+    /// @param sequenceNumber The unique identifier of the request
+    /// @return req The request information including status, random number, and other metadata
+    /// @dev This method allows querying the state of a previously made request. The returned Request struct
+    /// contains information about whether the request was fulfilled, the generated random number (if available),
+    /// and other metadata about the request.
+    function getRequestV2(
+        address provider,
+        uint64 sequenceNumber
+    ) external view returns (EntropyStructsV2.Request memory req);
+
+    /// @notice Get the fee charged by the default provider for the default gas limit
+    /// @return feeAmount The fee amount in wei
+    /// @dev This method returns the base fee required to make a request using the default provider with
+    /// the default gas limit. This fee should be passed as msg.value when calling requestV2().
+    /// The fee can change over time, so this method should be called before each request.
+    function getFeeV2() external view returns (uint128 feeAmount);
+
+    /// @notice Get the fee charged by the default provider for a specific gas limit
+    /// @param gasLimit The gas limit for the callback function
+    /// @return feeAmount The fee amount in wei
+    /// @dev This method returns the fee required to make a request using the default provider with
+    /// the specified gas limit. This fee should be passed as msg.value when calling requestV2(gasLimit).
+    /// The fee can change over time, so this method should be called before each request.
+    function getFeeV2(
+        uint32 gasLimit
+    ) external view returns (uint128 feeAmount);
+
+    /// @notice Get the fee charged by a specific provider for a request with a given gas limit
+    /// @param provider The address of the provider to query
+    /// @param gasLimit The gas limit for the callback function
+    /// @return feeAmount The fee amount in wei
+    /// @dev This method returns the fee required to make a request using the specified provider with
+    /// the given gas limit. This fee should be passed as msg.value when calling requestV2(provider, gasLimit)
+    /// or requestV2(provider, userRandomNumber, gasLimit). The fee can change over time, so this method
+    /// should be called before each request.
+    function getFeeV2(
+        address provider,
+        uint32 gasLimit
+    ) external view returns (uint128 feeAmount);
+}

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyEventsV2.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyEventsV2.json
@@ -1,0 +1,305 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "oldDefaultGasLimit",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "newDefaultGasLimit",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraArgs",
+        "type": "bytes"
+      }
+    ],
+    "name": "ProviderDefaultGasLimitUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldFeeManager",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newFeeManager",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraArgs",
+        "type": "bytes"
+      }
+    ],
+    "name": "ProviderFeeManagerUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "oldFee",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "newFee",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraArgs",
+        "type": "bytes"
+      }
+    ],
+    "name": "ProviderFeeUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "oldMaxNumHashes",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "newMaxNumHashes",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraArgs",
+        "type": "bytes"
+      }
+    ],
+    "name": "ProviderMaxNumHashesAdvanced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "oldUri",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "newUri",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraArgs",
+        "type": "bytes"
+      }
+    ],
+    "name": "ProviderUriUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraArgs",
+        "type": "bytes"
+      }
+    ],
+    "name": "Registered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "sequenceNumber",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "userRandomNumber",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "gasLimit",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraArgs",
+        "type": "bytes"
+      }
+    ],
+    "name": "Requested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "sequenceNumber",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "randomNumber",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "callbackFailed",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "callbackReturnValue",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "callbackGasUsed",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraArgs",
+        "type": "bytes"
+      }
+    ],
+    "name": "Revealed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "withdrawnAmount",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraArgs",
+        "type": "bytes"
+      }
+    ],
+    "name": "Withdrawal",
+    "type": "event"
+  }
+]

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropyV2.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropyV2.json
@@ -1,0 +1,616 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "oldDefaultGasLimit",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "newDefaultGasLimit",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraArgs",
+        "type": "bytes"
+      }
+    ],
+    "name": "ProviderDefaultGasLimitUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldFeeManager",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newFeeManager",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraArgs",
+        "type": "bytes"
+      }
+    ],
+    "name": "ProviderFeeManagerUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "oldFee",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "newFee",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraArgs",
+        "type": "bytes"
+      }
+    ],
+    "name": "ProviderFeeUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "oldMaxNumHashes",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "newMaxNumHashes",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraArgs",
+        "type": "bytes"
+      }
+    ],
+    "name": "ProviderMaxNumHashesAdvanced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "oldUri",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "newUri",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraArgs",
+        "type": "bytes"
+      }
+    ],
+    "name": "ProviderUriUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraArgs",
+        "type": "bytes"
+      }
+    ],
+    "name": "Registered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "sequenceNumber",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "userRandomNumber",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "gasLimit",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraArgs",
+        "type": "bytes"
+      }
+    ],
+    "name": "Requested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "sequenceNumber",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "randomNumber",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "callbackFailed",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "callbackReturnValue",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "callbackGasUsed",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraArgs",
+        "type": "bytes"
+      }
+    ],
+    "name": "Revealed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "withdrawnAmount",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "extraArgs",
+        "type": "bytes"
+      }
+    ],
+    "name": "Withdrawal",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "getDefaultProvider",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "gasLimit",
+        "type": "uint32"
+      }
+    ],
+    "name": "getFeeV2",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "feeAmount",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getFeeV2",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "feeAmount",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "gasLimit",
+        "type": "uint32"
+      }
+    ],
+    "name": "getFeeV2",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "feeAmount",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      }
+    ],
+    "name": "getProviderInfoV2",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint128",
+            "name": "feeInWei",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "accruedFeesInWei",
+            "type": "uint128"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "originalCommitment",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint64",
+            "name": "originalCommitmentSequenceNumber",
+            "type": "uint64"
+          },
+          {
+            "internalType": "bytes",
+            "name": "commitmentMetadata",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "uri",
+            "type": "bytes"
+          },
+          {
+            "internalType": "uint64",
+            "name": "endSequenceNumber",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "sequenceNumber",
+            "type": "uint64"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "currentCommitment",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint64",
+            "name": "currentCommitmentSequenceNumber",
+            "type": "uint64"
+          },
+          {
+            "internalType": "address",
+            "name": "feeManager",
+            "type": "address"
+          },
+          {
+            "internalType": "uint32",
+            "name": "maxNumHashes",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "defaultGasLimit",
+            "type": "uint32"
+          }
+        ],
+        "internalType": "struct EntropyStructsV2.ProviderInfo",
+        "name": "info",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "internalType": "uint64",
+        "name": "sequenceNumber",
+        "type": "uint64"
+      }
+    ],
+    "name": "getRequestV2",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "provider",
+            "type": "address"
+          },
+          {
+            "internalType": "uint64",
+            "name": "sequenceNumber",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint32",
+            "name": "numHashes",
+            "type": "uint32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "commitment",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint64",
+            "name": "blockNumber",
+            "type": "uint64"
+          },
+          {
+            "internalType": "address",
+            "name": "requester",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "useBlockhash",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint8",
+            "name": "callbackStatus",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint16",
+            "name": "gasLimit10k",
+            "type": "uint16"
+          }
+        ],
+        "internalType": "struct EntropyStructsV2.Request",
+        "name": "req",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "gasLimit",
+        "type": "uint32"
+      }
+    ],
+    "name": "requestV2",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "assignedSequenceNumber",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "gasLimit",
+        "type": "uint32"
+      }
+    ],
+    "name": "requestV2",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "assignedSequenceNumber",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "requestV2",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "assignedSequenceNumber",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "userRandomNumber",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "gasLimit",
+        "type": "uint32"
+      }
+    ],
+    "name": "requestV2",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "assignedSequenceNumber",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  }
+]

--- a/target_chains/ethereum/entropy_sdk/solidity/package.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "test:format": "prettier --check .",
     "fix:format": "prettier --write .",
-    "build": "generate-abis IEntropy IEntropyConsumer EntropyErrors EntropyEvents EntropyEventsV2 EntropyStructs EntropyStructsV2 EntropyStatusConstants PRNG",
+    "build": "generate-abis IEntropy IEntropyV2 IEntropyConsumer EntropyErrors EntropyEvents EntropyEventsV2 EntropyStructs EntropyStructsV2 EntropyStatusConstants PRNG",
     "test": "git diff --exit-code abis"
   },
   "keywords": [

--- a/target_chains/ethereum/entropy_sdk/solidity/package.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/entropy-sdk-solidity",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "Generate secure random numbers with Pyth Entropy",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary

Split out the V2 functionality into a separate file. The intention is that developers can interact exclusively with the IEntropyV2 interface. This interface hides internal methods for providers etc that users don't need to know about. Meanwhile, we retain the IEntropy interface (which has the old functions + provider functions + inherits the V2 functions) as the full interface the contract implements.

## Rationale

These changes should make it easier for users to identify the functionality they need

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
