### PR TITLE
fix(pulse): use memory instead of storage for priceUpdates struct

### DIFF
--- a/target_chains/ethereum/contracts/contracts/pulse/Scheduler.sol
+++ b/target_chains/ethereum/contracts/contracts/pulse/Scheduler.sol
@@ -451,7 +451,7 @@ abstract contract Scheduler is IScheduler, SchedulerState {
                     params.priceIds.length
                 );
             for (uint8 i = 0; i < params.priceIds.length; i++) {
-                PythStructs.PriceFeed storage priceFeed = _state.priceUpdates[
+                PythStructs.PriceFeed memory priceFeed = _state.priceUpdates[
                     subscriptionId
                 ][params.priceIds[i]];
                 // Check if the price feed exists (price ID is valid and has been updated)
@@ -469,7 +469,7 @@ abstract contract Scheduler is IScheduler, SchedulerState {
                 priceIds.length
             );
         for (uint8 i = 0; i < priceIds.length; i++) {
-            PythStructs.PriceFeed storage priceFeed = _state.priceUpdates[
+            PythStructs.PriceFeed memory priceFeed = _state.priceUpdates[
                 subscriptionId
             ][priceIds[i]];
 


### PR DESCRIPTION
## Summary

Use `priceUpdates` from `memory` instead of `storage` in `_getPricesInternal`

## Rationale

Cheaper to iterate through memory, although this doesn't apply for large structs, as the initial copy from storage into memory is expensive.

Optimization saves 16k gas querying for a sub with 20 feeds: https://app.warp.dev/block/YEc8EQ1MBKjhbm38Ft5TLj

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
