### PR TITLE
feat(entropy): Add gas tracking for the callback recovery flow

### DIFF
--- a/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
@@ -1778,7 +1778,6 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents, EntropyEventsV2 {
         // can never cause a callback to fail because it runs out of gas.
         vm.prank(provider1);
         random.setDefaultGasLimit(0);
-
         assertCallbackResult(0, 190000, true);
         assertCallbackResult(0, 210000, true);
         assertCallbackResult(300000, 290000, true);
@@ -1864,12 +1863,13 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents, EntropyEventsV2 {
             assertEq(callbackFailed, true);
             assertEq(callbackErrorCode, bytes(""));
 
-            // callback gas usage is approximate and only triggered when the provider has set a gas limit.
-            // Note: this condition is somewhat janky, but we hit the stack limit so can't put in any more local variables :(
-            assertTrue(                
+            // callback gas usage is approximate
+            assertTrue(
+                random.getProviderInfoV2(provider1).defaultGasLimit == 0 ||
                     ((callbackGasUsage * 90) / 100 < callbackGasUsed)
             );
-            assertTrue(                
+            assertTrue(
+                random.getProviderInfoV2(provider1).defaultGasLimit == 0 ||
                     (callbackGasUsed < (callbackGasUsage * 110) / 100)
             );
             assertEq(extraArgs, bytes(""));
@@ -1939,16 +1939,9 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents, EntropyEventsV2 {
             );
             assertEq(callbackFailed, false);
             assertEq(callbackErrorCode, bytes(""));
-            // callback gas usage is approximate and only triggered when the provider has set a gas limit
-            // Note: this condition is somewhat janky, but we hit the stack limit so can't put in any more local variables :(
-            assertTrue(
-                random.getProviderInfoV2(provider1).defaultGasLimit == 0 ||
-                    ((callbackGasUsage * 90) / 100 < callbackGasUsed)
-            );
-            assertTrue(
-                random.getProviderInfoV2(provider1).defaultGasLimit == 0 ||
-                    (callbackGasUsed < (callbackGasUsage * 110) / 100)
-            );
+            // callback gas usage is approximate
+            assertTrue((callbackGasUsage * 90) / 100 < callbackGasUsed);
+            assertTrue(callbackGasUsed < (callbackGasUsage * 110) / 100);
             assertEq(extraArgs, bytes(""));
 
             // Verify request is cleared after successful callback

--- a/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
@@ -1866,12 +1866,10 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents, EntropyEventsV2 {
 
             // callback gas usage is approximate and only triggered when the provider has set a gas limit.
             // Note: this condition is somewhat janky, but we hit the stack limit so can't put in any more local variables :(
-            assertTrue(
-                random.getProviderInfoV2(provider1).defaultGasLimit == 0 ||
+            assertTrue(                
                     ((callbackGasUsage * 90) / 100 < callbackGasUsed)
             );
-            assertTrue(
-                random.getProviderInfoV2(provider1).defaultGasLimit == 0 ||
+            assertTrue(                
                     (callbackGasUsed < (callbackGasUsage * 110) / 100)
             );
             assertEq(extraArgs, bytes(""));


### PR DESCRIPTION
## Summary

As the title says. Track gas usage and emit it in the event.

## Rationale

I previously omitted gas tracking in this recovery flow (which is identical to the old callback flow). However, I realized tracking gas will be useful here -- if a user's callback fails and they recover it, they probably want to know how much gas it used so they can set the gas limit better next time.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
