### PR TITLE
Price pusher/fix evm

### DIFF
--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "9.3.3",
+  "version": "9.3.4",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/apps/price_pusher/src/evm/command.ts
+++ b/apps/price_pusher/src/evm/command.ts
@@ -110,7 +110,6 @@ export default {
       enableMetrics,
       metricsPort,
     } = argv;
-    console.log("***** priceServiceEndpoint *****", priceServiceEndpoint);
 
     const logger = pino({
       level: logLevel,

--- a/apps/price_pusher/src/evm/evm.ts
+++ b/apps/price_pusher/src/evm/evm.ts
@@ -235,6 +235,12 @@ export class EvmPricePusher implements IPricePusher {
 
     const priceIdsWith0x = priceIds.map((priceId) => addLeading0x(priceId));
 
+    // Update lastAttempt
+    this.lastPushAttempt = {
+      nonce: txNonce,
+      gasPrice: gasPrice,
+    };
+
     try {
       const { request } =
         await this.pythContract.simulate.updatePriceFeedsIfNecessary(
@@ -383,18 +389,13 @@ export class EvmPricePusher implements IPricePusher {
       );
       throw err;
     }
-
-    // Update lastAttempt
-    this.lastPushAttempt = {
-      nonce: txNonce,
-      gasPrice: gasPrice,
-    };
   }
 
   private async waitForTransactionReceipt(hash: `0x${string}`): Promise<void> {
     try {
       const receipt = await this.client.waitForTransactionReceipt({
         hash: hash,
+        timeout: 10000,
       });
 
       switch (receipt.status) {

--- a/contract_manager/store/chains/EvmChains.yaml
+++ b/contract_manager/store/chains/EvmChains.yaml
@@ -857,7 +857,7 @@
 - id: berachain_mainnet
   mainnet: true
   networkId: 80094
-  rpcUrl: https://fluent-thrilling-scion.furtim-network.quiknode.pro/$ENV_RABECHAIN_API_KEY
+  rpcUrl: https://rpc.berachain.com
   type: EvmChain
 - id: story
   mainnet: true


### PR DESCRIPTION
## Summary

When we cannot land a transaction, in the error handling we return or throw the errors and it never sets the last tx attempt data that is a necessary data for gas overriding. This change fixes it by bringing up before the transaction push block. 

This PR has a few other changes:
- updates berachain rpc (the public rpc has a generous ratelimit)
- updates docs about confidence check

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code