### PR TITLE
fix: use agave releases instead of solana labs

### DIFF
--- a/.github/workflows/ci-message-buffer.yml
+++ b/.github/workflows/ci-message-buffer.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
           sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
-          sh -c "$(curl -sSfL https://release.solana.com/v1.14.18/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/v1.17.34/install)"
           echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       - name: Install Anchor
         run: |

--- a/.github/workflows/ci-remote-executor.yml
+++ b/.github/workflows/ci-remote-executor.yml
@@ -27,7 +27,7 @@ jobs:
           workspaces: "governance/remote_executor -> target"
       - name: Install Solana
         run: |
-          sh -c "$(curl -sSfL https://release.solana.com/v1.18.23/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/v1.18.23/install)"
           echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       - name: Format check
         run: cargo fmt --all -- --check

--- a/.github/workflows/ci-solana-contract.yml
+++ b/.github/workflows/ci-solana-contract.yml
@@ -31,7 +31,7 @@ jobs:
           override: true
       - name: Install Solana
         run: |
-          sh -c "$(curl -sSfL https://release.solana.com/v1.16.20/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/v1.17.34/install)"
           echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       - name: Format check
         run: cargo fmt --all -- --check


### PR DESCRIPTION
## Summary

Switch from solana to agave releases when install solana. Solana releases URL seems down.

## Rationale

CI is crashing without these changes.

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

