### PR TITLE
feat: add amount to stake in the flow to stake new validators via governance

### DIFF
--- a/governance/xc_admin/packages/xc_admin_cli/src/index.ts
+++ b/governance/xc_admin/packages/xc_admin_cli/src/index.ts
@@ -483,6 +483,11 @@ multisigCommand(
     "-d, --vote-pubkeys <comma_separated_voter_pubkeys>",
     "vote account to delegate to",
   )
+  .option(
+    "-a, --amount <number>",
+    "Amount of stake to assign (in SOL)",
+    "100000",
+  )
   .action(async (options: any) => {
     const vault = await loadVaultFromOptions(options);
     const cluster: PythCluster = options.cluster;
@@ -492,6 +497,8 @@ multisigCommand(
     const votePubkeys: PublicKey[] = options.votePubkeys
       ? options.votePubkeys.split(",").map((m: string) => new PublicKey(m))
       : [];
+
+    const amount = Number(options.amount);
 
     const instructions: TransactionInstruction[] = [];
 
@@ -515,7 +522,7 @@ multisigCommand(
           seed: seed,
           fromPubkey: authorizedPubkey,
           newAccountPubkey: stakePubkey,
-          lamports: 100000 * LAMPORTS_PER_SOL,
+          lamports: amount * LAMPORTS_PER_SOL,
           space: StakeProgram.space,
           programId: StakeProgram.programId,
         }),


### PR DESCRIPTION
## Summary

Now the amount to stake is customizable (defaults to the traditional value of 100,000 PGAS)

## Rationale

We need to stake some validators with a lower amount.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

