### PR TITLE
feat(entropy): Minor items to prep for testnet deployments

### DIFF
--- a/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
+++ b/target_chains/ethereum/contracts/forge-test/Entropy.t.sol
@@ -888,6 +888,8 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents, EntropyEventsV2 {
                 provider1Proofs[assignedSequenceNumber],
                 0
             ),
+            userRandomNumber,
+            provider1Proofs[assignedSequenceNumber],
             false,
             bytes(""),
             0,
@@ -956,6 +958,8 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents, EntropyEventsV2 {
                 provider1Proofs[assignedSequenceNumber],
                 0
             ),
+            userRandomNumber,
+            provider1Proofs[assignedSequenceNumber],
             false,
             bytes(""),
             0,
@@ -1063,6 +1067,8 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents, EntropyEventsV2 {
                 provider1Proofs[assignedSequenceNumber],
                 0
             ),
+            userRandomNumber,
+            provider1Proofs[assignedSequenceNumber],
             false,
             bytes(""),
             0,
@@ -1136,6 +1142,8 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents, EntropyEventsV2 {
                 provider1Proofs[assignedSequenceNumber],
                 0
             ),
+            userRandomNumber,
+            provider1Proofs[assignedSequenceNumber],
             true,
             revertReason,
             0,
@@ -1202,6 +1210,8 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents, EntropyEventsV2 {
                 provider1Proofs[assignedSequenceNumber],
                 0
             ),
+            userRandomNumber,
+            provider1Proofs[assignedSequenceNumber],
             false,
             bytes(""),
             0,
@@ -1283,6 +1293,8 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents, EntropyEventsV2 {
                 provider1Proofs[assignedSequenceNumber],
                 0
             ),
+            userRandomNumber,
+            provider1Proofs[assignedSequenceNumber],
             true,
             "",
             0,
@@ -1348,6 +1360,8 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents, EntropyEventsV2 {
                 provider1Proofs[assignedSequenceNumber],
                 0
             ),
+            userRandomNumber,
+            provider1Proofs[assignedSequenceNumber],
             false,
             "",
             0,
@@ -1822,57 +1836,22 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents, EntropyEventsV2 {
 
             assertEq(entries.length, 2);
             // first entry is CallbackFailed which we aren't going to check.
-            // Unfortunately event.selector was added in Solidity 0.8.15 and we're on 0.8.4 so we have to copy this spec here.
-            assertEq(
-                entries[1].topics[0],
-                keccak256(
-                    "Revealed(address,address,uint64,bytes32,bool,bytes,uint32,bytes)"
-                )
-            );
-            // Verify the topics match the expected values
-            assertEq(
-                entries[1].topics[1],
-                bytes32(uint256(uint160(provider1)))
-            );
-            assertEq(
-                entries[1].topics[2],
-                bytes32(uint256(uint160(address(consumer))))
-            );
-            assertEq(entries[1].topics[3], bytes32(uint256(sequenceNumber)));
-
-            // Verify the data field contains the expected values (per event ABI)
-            (
-                bytes32 randomNumber,
-                bool callbackFailed,
-                bytes memory callbackErrorCode,
-                uint32 callbackGasUsed,
-                bytes memory extraArgs
-            ) = abi.decode(
-                    entries[1].data,
-                    (bytes32, bool, bytes, uint32, bytes)
-                );
-
-            assertEq(
-                randomNumber,
+            assertRevealedEvent(
+                entries[1],
+                provider1,
+                address(consumer),
+                sequenceNumber,
                 random.combineRandomValues(
                     userRandomNumber,
                     provider1Proofs[sequenceNumber],
                     0
-                )
+                ),
+                userRandomNumber,
+                provider1Proofs[sequenceNumber],
+                true,
+                bytes(""),
+                callbackGasUsage
             );
-            assertEq(callbackFailed, true);
-            assertEq(callbackErrorCode, bytes(""));
-
-            // callback gas usage is approximate
-            assertTrue(
-                random.getProviderInfoV2(provider1).defaultGasLimit == 0 ||
-                    ((callbackGasUsage * 90) / 100 < callbackGasUsed)
-            );
-            assertTrue(
-                random.getProviderInfoV2(provider1).defaultGasLimit == 0 ||
-                    (callbackGasUsed < (callbackGasUsage * 110) / 100)
-            );
-            assertEq(extraArgs, bytes(""));
 
             // Verify request is still active after failure
             EntropyStructsV2.Request memory reqAfterFailure = random
@@ -1894,61 +1873,77 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents, EntropyEventsV2 {
             Vm.Log[] memory entries = vm.getRecordedLogs();
 
             assertEq(entries.length, 2);
-            // first entry is CallbackFailed which we aren't going to check.
-            // Unfortunately event.selector was added in Solidity 0.8.15 and we're on 0.8.4 so we have to copy this spec here.
-            assertEq(
-                entries[1].topics[0],
-                keccak256(
-                    "Revealed(address,address,uint64,bytes32,bool,bytes,uint32,bytes)"
-                )
-            );
-
-            // Verify the topics match the expected values
-            assertEq(
-                entries[1].topics[1],
-                bytes32(uint256(uint160(provider1)))
-            );
-            assertEq(
-                entries[1].topics[2],
-                bytes32(uint256(uint160(req.requester)))
-            );
-            assertEq(
-                entries[1].topics[3],
-                bytes32(uint256(req.sequenceNumber))
-            );
-
-            // Verify the data field contains the expected values (per event ABI)
-            (
-                bytes32 randomNumber,
-                bool callbackFailed,
-                bytes memory callbackErrorCode,
-                uint32 callbackGasUsed,
-                bytes memory extraArgs
-            ) = abi.decode(
-                    entries[1].data,
-                    (bytes32, bool, bytes, uint32, bytes)
-                );
-
-            assertEq(
-                randomNumber,
+            assertRevealedEvent(
+                entries[1],
+                provider1,
+                req.requester,
+                req.sequenceNumber,
                 random.combineRandomValues(
                     userRandomNumber,
                     provider1Proofs[sequenceNumber],
                     0
-                )
+                ),
+                userRandomNumber,
+                provider1Proofs[sequenceNumber],
+                false,
+                bytes(""),
+                callbackGasUsage
             );
-            assertEq(callbackFailed, false);
-            assertEq(callbackErrorCode, bytes(""));
-            // callback gas usage is approximate
-            assertTrue((callbackGasUsage * 90) / 100 < callbackGasUsed);
-            assertTrue(callbackGasUsed < (callbackGasUsage * 110) / 100);
-            assertEq(extraArgs, bytes(""));
 
             // Verify request is cleared after successful callback
             EntropyStructsV2.Request memory reqAfterSuccess = random
                 .getRequestV2(provider1, sequenceNumber);
             assertEq(reqAfterSuccess.sequenceNumber, 0);
         }
+    }
+
+    // Helper method to check the Revealed event
+    function assertRevealedEvent(
+        Vm.Log memory entry,
+        address expectedProvider,
+        address expectedRequester,
+        uint64 expectedSequenceNumber,
+        bytes32 expectedRandomNumber,
+        bytes32 expectedUserContribution,
+        bytes32 expectedProviderContribution,
+        bool expectedCallbackFailed,
+        bytes memory expectedCallbackErrorCode,
+        uint32 expectedCallbackGasUsage
+    ) internal {
+        // Check event topic
+        assertEq(
+            entry.topics[0],
+            keccak256(
+                "Revealed(address,address,uint64,bytes32,bytes32,bytes32,bool,bytes,uint32,bytes)"
+            )
+        );
+
+        // Check event topics
+        assertEq(entry.topics[1], bytes32(uint256(uint160(expectedProvider))));
+        assertEq(entry.topics[2], bytes32(uint256(uint160(expectedRequester))));
+        assertEq(entry.topics[3], bytes32(uint256(expectedSequenceNumber)));
+
+        // Decode and check event data
+        (
+            bytes32 randomNumber,
+            bytes32 userContribution,
+            bytes32 providerContribution,
+            bool callbackFailed,
+            bytes memory callbackErrorCode,
+            uint32 callbackGasUsed,
+            bytes memory extraArgs
+        ) = abi.decode(
+                entry.data,
+                (bytes32, bytes32, bytes32, bool, bytes, uint32, bytes)
+            );
+
+        assertEq(randomNumber, expectedRandomNumber);
+        assertEq(callbackFailed, expectedCallbackFailed);
+        assertEq(callbackErrorCode, expectedCallbackErrorCode);
+        // callback gas usage is approximate
+        assertTrue((expectedCallbackGasUsage * 90) / 100 < callbackGasUsed);
+        assertTrue(callbackGasUsed < (expectedCallbackGasUsage * 110) / 100);
+        assertEq(extraArgs, bytes(""));
     }
 }
 

--- a/target_chains/ethereum/entropy_sdk/solidity/EntropyEventsV2.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/EntropyEventsV2.sol
@@ -23,7 +23,7 @@ interface EntropyEventsV2 {
      * @param provider The address of the provider handling the request
      * @param caller The address of the user requesting the random number
      * @param sequenceNumber A unique identifier for this request
-     * @param userRandomNumber A random number provided by the user for additional entropy
+     * @param userContribution The user's contribution to the random number
      * @param gasLimit The gas limit for the callback.
      * @param extraArgs A field for extra data for forward compatibility.
      */
@@ -31,7 +31,7 @@ interface EntropyEventsV2 {
         address indexed provider,
         address indexed caller,
         uint64 indexed sequenceNumber,
-        bytes32 userRandomNumber,
+        bytes32 userContribution,
         uint32 gasLimit,
         bytes extraArgs
     );
@@ -42,6 +42,8 @@ interface EntropyEventsV2 {
      * @param caller The address of the user who requested the random number (and who receives a callback)
      * @param sequenceNumber The unique identifier of the request
      * @param randomNumber The generated random number
+     * @param userContribution The user's contribution to the random number
+     * @param providerContribution The provider's contribution to the random number
      * @param callbackFailed Whether the callback to the caller failed
      * @param callbackReturnValue Return value from the callback. If the callback failed, this field contains
      * the error code and any additional returned data. Note that "" often indicates an out-of-gas error.
@@ -54,6 +56,8 @@ interface EntropyEventsV2 {
         address indexed caller,
         uint64 indexed sequenceNumber,
         bytes32 randomNumber,
+        bytes32 userContribution,
+        bytes32 providerContribution,
         bool callbackFailed,
         bytes callbackReturnValue,
         uint32 callbackGasUsed,

--- a/target_chains/ethereum/entropy_sdk/solidity/IEntropyV2.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/IEntropyV2.sol
@@ -20,8 +20,10 @@ interface IEntropyV2 is EntropyEventsV2 {
     /// Note that the fee can change over time. Callers of this method should explicitly compute `getFeeV2()`
     /// prior to each invocation (as opposed to hardcoding a value). Further note that excess value is *not* refunded to the caller.
     ///
-    /// Note that this method uses an in-contract PRNG to generate the user's portion of the random number.
-    /// Users must trust this PRNG in order to prove the result is random. If you wish to avoid this trust assumption,
+    /// Note that this method uses an in-contract PRNG to generate the user's contribution to the random number.
+    /// This approach modifies the security guarantees such that a dishonest validator and provider can
+    /// collude to manipulate the result (as opposed to a malicious user and provider). That is, the user
+    /// now trusts the validator honestly draw a random number. If you wish to avoid this trust assumption,
     /// call a variant of `requestV2` that accepts a `userRandomNumber` parameter.
     function requestV2()
         external
@@ -43,8 +45,10 @@ interface IEntropyV2 is EntropyEventsV2 {
     /// Note that the fee can change over time. Callers of this method should explicitly compute `getFeeV2(gasLimit)`
     /// prior to each invocation (as opposed to hardcoding a value). Further note that excess value is *not* refunded to the caller.
     ///
-    /// Note that this method uses an in-contract PRNG to generate the user's portion of the random number.
-    /// Users must trust this PRNG in order to prove the result is random. If you wish to avoid this trust assumption,
+    /// Note that this method uses an in-contract PRNG to generate the user's contribution to the random number.
+    /// This approach modifies the security guarantees such that a dishonest validator and provider can
+    /// collude to manipulate the result (as opposed to a malicious user and provider). That is, the user
+    /// now trusts the validator honestly draw a random number. If you wish to avoid this trust assumption,
     /// call a variant of `requestV2` that accepts a `userRandomNumber` parameter.
     function requestV2(
         uint32 gasLimit
@@ -66,8 +70,10 @@ interface IEntropyV2 is EntropyEventsV2 {
     /// Note that provider fees can change over time. Callers of this method should explicitly compute `getFeeV2(provider, gasLimit)`
     /// prior to each invocation (as opposed to hardcoding a value). Further note that excess value is *not* refunded to the caller.
     ///
-    /// Note that this method uses an in-contract PRNG to generate the user's portion of the random number.
-    /// Users must trust this PRNG in order to prove the result is random. If you wish to avoid this trust assumption,
+    /// Note that this method uses an in-contract PRNG to generate the user's contribution to the random number.
+    /// This approach modifies the security guarantees such that a dishonest validator and provider can
+    /// collude to manipulate the result (as opposed to a malicious user and provider). That is, the user
+    /// now trusts the validator honestly draw a random number. If you wish to avoid this trust assumption,
     /// call a variant of `requestV2` that accepts a `userRandomNumber` parameter.
     function requestV2(
         address provider,

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyEventsV2.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/EntropyEventsV2.json
@@ -197,7 +197,7 @@
       {
         "indexed": false,
         "internalType": "bytes32",
-        "name": "userRandomNumber",
+        "name": "userContribution",
         "type": "bytes32"
       },
       {
@@ -241,6 +241,18 @@
         "indexed": false,
         "internalType": "bytes32",
         "name": "randomNumber",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "userContribution",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "providerContribution",
         "type": "bytes32"
       },
       {

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropy.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropy.json
@@ -501,7 +501,7 @@
       {
         "indexed": false,
         "internalType": "bytes32",
-        "name": "userRandomNumber",
+        "name": "userContribution",
         "type": "bytes32"
       },
       {
@@ -703,6 +703,18 @@
         "indexed": false,
         "internalType": "bytes32",
         "name": "randomNumber",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "userContribution",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "providerContribution",
         "type": "bytes32"
       },
       {

--- a/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropyV2.json
+++ b/target_chains/ethereum/entropy_sdk/solidity/abis/IEntropyV2.json
@@ -197,7 +197,7 @@
       {
         "indexed": false,
         "internalType": "bytes32",
-        "name": "userRandomNumber",
+        "name": "userContribution",
         "type": "bytes32"
       },
       {
@@ -241,6 +241,18 @@
         "indexed": false,
         "internalType": "bytes32",
         "name": "randomNumber",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "userContribution",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "providerContribution",
         "type": "bytes32"
       },
       {


### PR DESCRIPTION
## Summary

Three minor changes:
1. rename "providerRandomNumber" and "userRandomNumber" to xContribution for clarity.
2. emit these contributions in the new EventsV2 revealed event (so users can generate a retry call in forge from the event, without hitting the fortuna API)
3. update docs around how the protocol works and security assumptions (this was a comment from AR) 


## How has this been tested?

- [x] Current tests cover my changes
- [x] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
