### PR TITLE
fix(apps/hermes/server): allow subscriptions with empty price feed ids

### DIFF
--- a/apps/hermes/server/Cargo.lock
+++ b/apps/hermes/server/Cargo.lock
@@ -1868,7 +1868,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/hermes/server/Cargo.toml
+++ b/apps/hermes/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "hermes"
-version     = "0.9.0"
+version     = "0.9.1"
 description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
 edition     = "2021"
 

--- a/apps/hermes/server/src/api/ws.rs
+++ b/apps/hermes/server/src/api/ws.rs
@@ -588,18 +588,6 @@ where
                         )
                         .await?;
                     return Ok(());
-                } else if found_price_ids.is_empty() {
-                    self.sender
-                        .send(
-                            serde_json::to_string(&ServerMessage::Response(
-                                ServerResponseMessage::Err {
-                                    error: "No price feeds available".to_string(),
-                                },
-                            ))?
-                            .into(),
-                        )
-                        .await?;
-                    return Ok(());
                 } else {
                     for price_id in found_price_ids {
                         self.price_feeds_with_config.insert(


### PR DESCRIPTION
## Summary

The previous change in #2599 has added a side effect that doesn't allow empty subscriptions anymore and that has broken some of downstream users. This change removes the new behaviour. If we need we can only have this behaviour when the flag of ignore invalid ids is set.

## How has this been tested?

- [x] Manually tested the code

