### PR TITLE
feat(pyth-lazer-publisher-sdk): Add Public key to Transactions

### DIFF
--- a/lazer/publisher_sdk/proto/pyth_lazer_transaction.proto
+++ b/lazer/publisher_sdk/proto/pyth_lazer_transaction.proto
@@ -13,7 +13,7 @@ import "governance_instruction.proto";
 // The signed lazer transaction is encoded as bytes and sent to Pyth Lazer Relayer.
 message SignedLazerTransaction {
     // [required] signature with public key
-    optional SignatureWithPublicKey signature_with_public_key = 1;
+    optional SignatureData signature_data = 1;
 
     // [required] lazer transaction encoded as bytes through protobuf
     optional bytes payload = 2;
@@ -23,9 +23,9 @@ message SignedLazerTransaction {
 // Public key should successfully verify payload
 // Pyth Lazer will maintain a list of valid public keys
 // Passed public key should be present in publisher's list of valid keys
-message SignatureWithPublicKey {
+message SignatureData {
     // [required] type of signature, which determines included data needed for verifying
-    oneof signing_type {
+    oneof data {
         Ed25519 ed25519 = 1;
     };
 }

--- a/lazer/publisher_sdk/proto/pyth_lazer_transaction.proto
+++ b/lazer/publisher_sdk/proto/pyth_lazer_transaction.proto
@@ -26,13 +26,13 @@ message SignedLazerTransaction {
 message SignatureData {
     // [required] type of signature, which determines included data needed for verifying
     oneof data {
-        Ed25519 ed25519 = 1;
+        Ed25519SignatureData ed25519 = 1;
     };
 }
 
 // ED25519 style signature. Should include a single signature and a single public key
 // Signature will be verified using public key after determining public key is valid
-message Ed25519 {
+message Ed25519SignatureData {
     // [required] 64 byte signature
     optional bytes signature = 1;
 

--- a/lazer/publisher_sdk/proto/pyth_lazer_transaction.proto
+++ b/lazer/publisher_sdk/proto/pyth_lazer_transaction.proto
@@ -19,14 +19,24 @@ message SignedLazerTransaction {
     optional bytes payload = 2;
 }
 
+// Signature for encoded payload along with the relevant public keys to verify against it
+// Public key should successfully verify payload
+// Pyth Lazer will maintain a list of valid public keys
+// Passed public key should be present in publisher's list of valid keys
 message SignatureWithPublicKey {
+    // [required] type of signature, which determines included data needed for verifying
     oneof signing_type {
         Ed25519 ed25519 = 1;
     };
 }
 
+// ED25519 style signature. Should include a single signature and a single public key
+// Signature will be verified using public key after determining public key is valid
 message Ed25519 {
+    // [required] 64 byte signature
     optional bytes signature = 1;
+
+    // [required] 32 byte public key
     optional bytes public_key = 2;
 }
 

--- a/lazer/publisher_sdk/proto/pyth_lazer_transaction.proto
+++ b/lazer/publisher_sdk/proto/pyth_lazer_transaction.proto
@@ -12,22 +12,22 @@ import "governance_instruction.proto";
 // Resulting bytes should then be signed with the signature scheme specified.
 // The signed lazer transaction is encoded as bytes and sent to Pyth Lazer Relayer.
 message SignedLazerTransaction {
-    // [required] specifies the type of signature used to sign the payload
-    optional TransactionSignatureType signature_type = 1;
-
-    // [required] signature derived from signing payload bytes
-    optional bytes signature = 2;
+    // [required] signature with public key
+    optional SignatureWithPublicKey signature_with_public_key = 1;
 
     // [required] lazer transaction encoded as bytes through protobuf
-    optional bytes payload = 3;
-
-    // TODO: Add public key
+    optional bytes payload = 2;
 }
 
-// Types of signatures supported by Pyth Lazer
-enum TransactionSignatureType {
-    // signature is 64 bytes long
-    ed25519 = 0;
+message SignatureWithPublicKey {
+    oneof signing_type {
+        Ed25519 ed25519 = 1;
+    };
+}
+
+message Ed25519 {
+    optional bytes signature = 1;
+    optional bytes public_key = 2;
 }
 
 // Transaction contianing one of the valid Lazer Transactions


### PR DESCRIPTION
## Summary

Adds public key to transacitons. Expanded signature format to support a much greater set of possible signatures. 

## Rationale

We are eliminating access tokens in pyth lazer so we need publishers to send public keys to establish identity. 

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code


