### PR TITLE
fix: vesting logic to match rust

### DIFF
--- a/governance/pyth_staking_sdk/src/utils/vesting.ts
+++ b/governance/pyth_staking_sdk/src/utils/vesting.ts
@@ -57,7 +57,9 @@ export const getPeriodicUnlockSchedule = (options: {
     if (currentTimeStamp < unlockTimeStamp || includePastPeriods) {
       unlockSchedule.push({
         date: new Date(unlockTimeStamp * 1000),
-        amount: balance / numPeriods,
+        amount:
+          ((numPeriods - BigInt(i)) * balance) / numPeriods -
+          ((numPeriods - BigInt(i + 1)) * balance) / numPeriods,
       });
     }
   }


### PR DESCRIPTION
## Summary

Fix the vesting schedule logic to match rust.

## Rationale

Some users have been running in to error when trying to withdraw the max amount because Javascript underestimated the number of locked tokens.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [X ] Manually tested the code

I have Sherlocked with a wallet that has this issue.