### PR TITLE
chore(target_chains/ethereum): add new networks

### DIFF
--- a/contract_manager/store/chains/EvmChains.yaml
+++ b/contract_manager/store/chains/EvmChains.yaml
@@ -866,7 +866,7 @@
   type: EvmChain
 - id: converge_testnet
   mainnet: false
-  rpcUrl: https://rpc-converge-testnet-0.t.conduit.xyz
+  rpcUrl: https://rpc-converge-testnet-1.t.conduit.xyz
   networkId: 52085144
   type: EvmChain
 - id: worldchain
@@ -888,4 +888,19 @@
   mainnet: true
   rpcUrl: https://swell-mainnet.alt.technology
   networkId: 1923
+  type: EvmChain
+- id: mezo_testnet
+  mainnet: false
+  rpcUrl: https://rpc.test.mezo.org
+  networkId: 31611
+  type: EvmChain
+- id: mezo
+  mainnet: true
+  rpcUrl: https://rpc.mezo.org
+  networkId: 31612
+  type: EvmChain
+- id: hemi_testnet
+  mainnet: false
+  rpcUrl: https://testnet.rpc.hemi.network/rpc
+  networkId: 743111
   type: EvmChain

--- a/contract_manager/store/contracts/EvmPriceFeedContracts.yaml
+++ b/contract_manager/store/contracts/EvmPriceFeedContracts.yaml
@@ -481,9 +481,6 @@
 - chain: megaeth_testnet
   address: "0x2880aB155794e7179c9eE2e38200202908C17B43"
   type: EvmPriceFeedContract
-- chain: converge_testnet
-  address: "0x2880aB155794e7179c9eE2e38200202908C17B43"
-  type: EvmPriceFeedContract
 - chain: worldchain
   address: "0xe9d69CdD6Fe41e7B621B4A688C5D1a68cB5c8ADc"
   type: EvmPriceFeedContract
@@ -495,4 +492,10 @@
   type: EvmPriceFeedContract
 - chain: worldchain_testnet
   address: "0x2880aB155794e7179c9eE2e38200202908C17B43"
+  type: EvmPriceFeedContract
+- chain: hemi_testnet
+  address: "0x2880aB155794e7179c9eE2e38200202908C17B43"
+  type: EvmPriceFeedContract
+- chain: converge_testnet
+  address: "0x87047526937246727E4869C5f76A347160e08672"
   type: EvmPriceFeedContract

--- a/contract_manager/store/contracts/EvmWormholeContracts.yaml
+++ b/contract_manager/store/contracts/EvmWormholeContracts.yaml
@@ -475,9 +475,6 @@
 - chain: megaeth_testnet
   address: "0xb27e5ca259702f209a29225d0eDdC131039C9933"
   type: EvmWormholeContract
-- chain: converge_testnet
-  address: "0xb27e5ca259702f209a29225d0eDdC131039C9933"
-  type: EvmWormholeContract
 - chain: worldchain
   address: "0x66E9cBa5529824a03B5Bc9931d9c63637101D0F7"
   type: EvmWormholeContract
@@ -489,4 +486,13 @@
   type: EvmWormholeContract
 - chain: worldchain_testnet
   address: "0xb27e5ca259702f209a29225d0eDdC131039C9933"
+  type: EvmWormholeContract
+- chain: mezo_testnet
+  address: "0xb27e5ca259702f209a29225d0eDdC131039C9933"
+  type: EvmWormholeContract
+- chain: hemi_testnet
+  address: "0xb27e5ca259702f209a29225d0eDdC131039C9933"
+  type: EvmWormholeContract
+- chain: converge_testnet
+  address: "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a"
   type: EvmWormholeContract

--- a/governance/xc_admin/packages/xc_admin_common/src/chains.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/chains.ts
@@ -111,7 +111,7 @@ export const RECEIVER_CHAINS = {
   xion: 60081,
   worldchain: 60082,
   swellchain: 60083,
-  // empty chain id 60084
+  mezo: 60084,
   iota_sui_mainnet: 60085,
 
   // Testnets as a separate chain ids (to use stable data sources and governance for them)
@@ -243,6 +243,8 @@ export const RECEIVER_CHAINS = {
   converge_testnet: 50121,
   swellchain_testnet: 50122,
   worldchain_testnet: 50123,
+  mezo_testnet: 50124,
+  hemi_testnet: 50125,
 };
 
 // If there is any overlapping value the receiver chain will replace the wormhole

--- a/target_chains/ethereum/contracts/foundry.toml
+++ b/target_chains/ethereum/contracts/foundry.toml
@@ -1,5 +1,6 @@
 [profile.default]
 solc_version = '0.8.29'
+evm_version = "paris"
 optimizer = true
 optimizer_runs = 200
 src = 'contracts'

--- a/target_chains/ethereum/contracts/hardhat.config.ts
+++ b/target_chains/ethereum/contracts/hardhat.config.ts
@@ -113,6 +113,7 @@ module.exports = {
   },
   solidity: {
     version: "0.8.29",
+    evmVersion: "paris",
     settings: {
       optimizer: {
         enabled: true,

--- a/target_chains/ethereum/contracts/truffle-config.js
+++ b/target_chains/ethereum/contracts/truffle-config.js
@@ -34,6 +34,7 @@ module.exports = {
   compilers: {
     solc: {
       version: "0.8.29",
+      evmVersion: "paris",
       settings: {
         optimizer: {
           enabled: true,


### PR DESCRIPTION
## Summary

Add evm new networks and update the compiler to use `paris` evm version (= the evm instructions at the merge) as some newer instructions in newer versions are not supported in all chains.