### PR TITLE
feat(fortuna): better logging + avoid unnecessary fee syncs

### DIFF
--- a/apps/fortuna/Cargo.lock
+++ b/apps/fortuna/Cargo.lock
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "fortuna"
-version = "7.6.0"
+version = "7.6.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/fortuna/Cargo.toml
+++ b/apps/fortuna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortuna"
-version = "7.6.0"
+version = "7.6.1"
 edition = "2021"
 
 [lib]

--- a/apps/fortuna/config.sample.yaml
+++ b/apps/fortuna/config.sample.yaml
@@ -32,6 +32,9 @@ chains:
     # How much to charge in fees
     fee: 1500000000000000
 
+    # Set this temporarily to false if you have changed the fees and want to apply a new baseline fee.
+    sync_fee_only_on_register: true
+
     # Configuration for dynamic fees under high gas prices. The keeper will set
     # on-chain fees to make between [min_profit_pct, max_profit_pct] of the max callback
     # cost in profit per transaction.

--- a/apps/fortuna/src/command/run.rs
+++ b/apps/fortuna/src/command/run.rs
@@ -222,7 +222,11 @@ async fn setup_chain_state(
             .cmp(&c2.original_commitment_sequence_number)
     });
 
-    let provider_info = contract.get_provider_info(*provider).call().await?;
+    let provider_info = contract
+        .get_provider_info(*provider)
+        .call()
+        .await
+        .map_err(|e| anyhow!("Failed to get provider info: {}", e))?;
     let latest_metadata = bincode::deserialize::<CommitmentMetadata>(
         &provider_info.commitment_metadata,
     )

--- a/apps/fortuna/src/command/setup_provider.rs
+++ b/apps/fortuna/src/command/setup_provider.rs
@@ -149,7 +149,7 @@ async fn setup_chain_provider(
 
     let provider_info = contract.get_provider_info(provider_address).call().await?;
 
-    if register || !chain_config.sync_only_on_register {
+    if register || !chain_config.sync_fee_only_on_register {
         sync_fee(&contract, &provider_info, chain_config.fee)
             .in_current_span()
             .await?;

--- a/apps/fortuna/src/command/setup_provider.rs
+++ b/apps/fortuna/src/command/setup_provider.rs
@@ -149,9 +149,11 @@ async fn setup_chain_provider(
 
     let provider_info = contract.get_provider_info(provider_address).call().await?;
 
-    sync_fee(&contract, &provider_info, chain_config.fee)
-        .in_current_span()
-        .await?;
+    if register || !chain_config.sync_only_on_register {
+        sync_fee(&contract, &provider_info, chain_config.fee)
+            .in_current_span()
+            .await?;
+    }
 
     let uri = get_register_uri(&provider_config.uri, chain_id)?;
     sync_uri(&contract, &provider_info, uri)

--- a/apps/fortuna/src/config.rs
+++ b/apps/fortuna/src/config.rs
@@ -172,6 +172,11 @@ pub struct EthereumConfig {
     #[serde(default)]
     pub fee: u128,
 
+    /// Only set the provider's fee when the provider is registered for the first time. Default is true.
+    /// This is useful to avoid resetting the fees on service restarts.
+    #[serde(default = "default_sync_only_on_register")]
+    pub sync_only_on_register: bool,
+
     /// Historical commitments made by the provider.
     pub commitments: Option<Vec<Commitment>>,
 
@@ -184,6 +189,10 @@ pub struct EthereumConfig {
     /// at each specified delay. For example: [5, 10, 20].
     #[serde(default = "default_block_delays")]
     pub block_delays: Vec<u64>,
+}
+
+fn default_sync_only_on_register() -> bool {
+    true
 }
 
 fn default_block_delays() -> Vec<u64> {

--- a/apps/fortuna/src/config.rs
+++ b/apps/fortuna/src/config.rs
@@ -174,8 +174,8 @@ pub struct EthereumConfig {
 
     /// Only set the provider's fee when the provider is registered for the first time. Default is true.
     /// This is useful to avoid resetting the fees on service restarts.
-    #[serde(default = "default_sync_only_on_register")]
-    pub sync_only_on_register: bool,
+    #[serde(default = "default_sync_fee_only_on_register")]
+    pub sync_fee_only_on_register: bool,
 
     /// Historical commitments made by the provider.
     pub commitments: Option<Vec<Commitment>>,
@@ -191,7 +191,7 @@ pub struct EthereumConfig {
     pub block_delays: Vec<u64>,
 }
 
-fn default_sync_only_on_register() -> bool {
+fn default_sync_fee_only_on_register() -> bool {
     true
 }
 

--- a/apps/fortuna/src/eth_utils/utils.rs
+++ b/apps/fortuna/src/eth_utils/utils.rs
@@ -187,7 +187,7 @@ pub async fn submit_tx_with_backoff<T: Middleware + NonceManaged + 'static>(
         },
         |e, dur| {
             let retry_number = num_retries.load(std::sync::atomic::Ordering::Relaxed);
-            tracing::error!(
+            tracing::warn!(
                 "Error on retry {} at duration {:?}: {}",
                 retry_number,
                 dur,

--- a/apps/fortuna/src/keeper/commitment.rs
+++ b/apps/fortuna/src/keeper/commitment.rs
@@ -42,7 +42,13 @@ pub async fn update_commitments_if_necessary(
         .block(latest_safe_block) // To ensure we are not revealing sooner than we should
         .call()
         .await
-        .map_err(|e| anyhow!("Error while getting provider info. error: {:?}", e))?;
+        .map_err(|e| {
+            anyhow!(
+                "Error while getting provider info at block {}. error: {:?}",
+                latest_safe_block,
+                e
+            )
+        })?;
     if provider_info.max_num_hashes == 0 {
         return Ok(());
     }


### PR DESCRIPTION
## Summary

- Add a new config that disables fee syncs if the chain is already registered.
- Improve logging:
  - Change retry log levels from ERROR to WARN
  - Add more info on some other logs

## Rationale

Whenever we deploy a new version or change some configuration, the setup script is executed and fees are synced to the default value. This is unnecessary and can cause problems for some of the requests made within the duration that the fee is reset (if the users are paying for the fee and the value sent to our contract is the tx value signed by user).

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code