### PR TITLE
fix: fix developer hub vercel build command

### DIFF
--- a/apps/developer-hub/vercel.json
+++ b/apps/developer-hub/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "turbo run build:vercel --filter @pythnetwork/developer-hub"
+  "buildCommand": "turbo run build --filter @pythnetwork/developer-hub"
 }


### PR DESCRIPTION
## Summary

The turbo task name was updated but the vercel config wasn't updated to match, this PR fixes that.

## Rationale

So vercel can build properly.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
