### PR TITLE
fix(component-library): mark no results page as a client component

### DIFF
--- a/packages/component-library/src/NoResults/index.tsx
+++ b/packages/component-library/src/NoResults/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { MagnifyingGlass } from "@phosphor-icons/react/dist/ssr/MagnifyingGlass";
 import clsx from "clsx";
 import type { ReactNode } from "react";


### PR DESCRIPTION
## Summary

Mark NoResults as a client component

## Rationale

Because we run react compiler in the component library now, all components must be marked as client components.  I forgot to add the marker to this file.

In general we don't need to worry about automating / tooling this as components will be obviously broken if this marker isn't added, but in this case I didn't catch it because I just turned on react compiler.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
