### PR TITLE
fix: improve deactivating script

### DIFF
--- a/governance/xc_admin/packages/xc_admin_cli/src/index.ts
+++ b/governance/xc_admin/packages/xc_admin_cli/src/index.ts
@@ -414,6 +414,7 @@ multisigCommand(
         voteAccounts.map((voteAccount: PublicKey) =>
           fetchStakeAccounts(
             new Connection(getPythClusterApiUrl(cluster)),
+            authorizedPubkey,
             voteAccount,
           ),
         ),

--- a/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/SolanaStakingMultisigInstruction.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/SolanaStakingMultisigInstruction.ts
@@ -124,6 +124,7 @@ export class SolanaStakingMultisigInstruction implements MultisigInstruction {
 
 export async function fetchStakeAccounts(
   connection: Connection,
+  staker: PublicKey,
   voterAccount: PublicKey,
 ) {
   const stakeAccounts = await connection.getProgramAccounts(
@@ -139,8 +140,20 @@ export async function fetchStakeAccounts(
         },
         {
           memcmp: {
+            offset: 12,
+            bytes: staker.toBase58(),
+          },
+        },
+        {
+          memcmp: {
             offset: 124,
             bytes: voterAccount.toBase58(),
+          },
+        },
+        {
+          memcmp: {
+            offset: 172,
+            bytes: bs58.encode(Buffer.from("ff".repeat(8), "hex")), // account is active
           },
         },
       ],


### PR DESCRIPTION
## Summary

Filter out stake accounts that are not managed by governance and that are already unstaking.

## Rationale

So that bad proposals that can't be executed don't get created.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
