### PR TITLE
fix(apps/price_pusher) handle price feed removal more gracefully

### DIFF
--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "9.3.3",
+  "version": "9.3.4",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/apps/price_pusher/src/aptos/aptos.ts
+++ b/apps/price_pusher/src/aptos/aptos.ts
@@ -109,6 +109,7 @@ export class AptosPricePusher implements IPricePusher {
   async getPriceFeedsUpdateData(priceIds: string[]): Promise<number[][]> {
     const response = await this.hermesClient.getLatestPriceUpdates(priceIds, {
       encoding: "base64",
+      ignoreInvalidPriceIds: true,
     });
     return response.binary.data.map((data) =>
       Array.from(Buffer.from(data, "base64")),

--- a/apps/price_pusher/src/fuel/fuel.ts
+++ b/apps/price_pusher/src/fuel/fuel.ts
@@ -101,6 +101,7 @@ export class FuelPricePusher implements IPricePusher {
     try {
       const response = await this.hermesClient.getLatestPriceUpdates(priceIds, {
         encoding: "base64",
+        ignoreInvalidPriceIds: true,
       });
       priceFeedUpdateData = response.binary.data;
     } catch (err: any) {

--- a/apps/price_pusher/src/injective/injective.ts
+++ b/apps/price_pusher/src/injective/injective.ts
@@ -301,6 +301,7 @@ export class InjectivePricePusher implements IPricePusher {
     try {
       const response = await this.hermesClient.getLatestPriceUpdates(priceIds, {
         encoding: "base64",
+        ignoreInvalidPriceIds: true,
       });
       const vaas = response.binary.data;
 

--- a/apps/price_pusher/src/near/near.ts
+++ b/apps/price_pusher/src/near/near.ts
@@ -131,6 +131,7 @@ export class NearPricePusher implements IPricePusher {
   ): Promise<string[]> {
     const response = await this.hermesClient.getLatestPriceUpdates(priceIds, {
       encoding: "base64",
+      ignoreInvalidPriceIds: true,
     });
     return response.binary.data;
   }

--- a/apps/price_pusher/src/price-config.ts
+++ b/apps/price_pusher/src/price-config.ts
@@ -96,9 +96,12 @@ export function shouldUpdate(
 ): UpdateCondition {
   const priceId = priceConfig.id;
 
-  // There is no price to update the target with.
+  // There is no price to update the target with. So we should not update it.
   if (sourceLatestPrice === undefined) {
-    return UpdateCondition.YES;
+    logger.info(
+      `${priceConfig.alias} (${priceId}) is not available on the source network. Ignoring it.`,
+    );
+    return UpdateCondition.NO;
   }
 
   // It means that price never existed there. So we should push the latest price feed.
@@ -140,7 +143,7 @@ export function shouldUpdate(
       }%? / early: < ${priceConfig.earlyUpdatePriceDeviation}%?) OR ` +
       `Confidence ratio: ${confidenceRatioPct.toFixed(5)}% (< ${
         priceConfig.confidenceRatio
-      }%? / early: < ${priceConfig.earlyUpdatePriceDeviation}%?)`,
+      }%? / early: < ${priceConfig.earlyUpdateConfidenceRatio}%?)`,
   );
 
   if (

--- a/apps/price_pusher/src/solana/solana.ts
+++ b/apps/price_pusher/src/solana/solana.ts
@@ -118,6 +118,7 @@ export class SolanaPricePusher implements IPricePusher {
         shuffledPriceIds,
         {
           encoding: "base64",
+          ignoreInvalidPriceIds: true,
         },
       );
       priceFeedUpdateData = response.binary.data;

--- a/apps/price_pusher/src/sui/sui.ts
+++ b/apps/price_pusher/src/sui/sui.ts
@@ -225,6 +225,7 @@ export class SuiPricePusher implements IPricePusher {
           priceIdChunk,
           {
             encoding: "base64",
+            ignoreInvalidPriceIds: true,
           },
         );
         if (response.binary.data.length !== 1) {

--- a/apps/price_pusher/src/ton/ton.ts
+++ b/apps/price_pusher/src/ton/ton.ts
@@ -98,6 +98,7 @@ export class TonPricePusher implements IPricePusher {
     try {
       const response = await this.hermesClient.getLatestPriceUpdates(priceIds, {
         encoding: "base64",
+        ignoreInvalidPriceIds: true,
       });
       priceFeedUpdateData = response.binary.data;
     } catch (err: any) {


### PR DESCRIPTION
## Summary

The price pusher in many networks would throw an error if a feed doesn't exist and the behaviour was there to prevent config errors but it falls short when we remove a feed. This change adds a warning for non existent feeds but lets the pusher keep functioning (for the remaining feeds).

## How has this been tested?

- [x] Manually tested the code: tested missing feeds (another code path errors it) and tested hermes reconnections.

p.s: evm pusher already had the flag to ignore invalid feeds.