### PR TITLE
feat(pyth-lazer-stk): correctly handle connection drops + other improvements

### DIFF
--- a/lazer/sdk/js/examples/index.ts
+++ b/lazer/sdk/js/examples/index.ts
@@ -7,18 +7,22 @@ import { PythLazerClient } from "../src/index.js";
 console.debug = () => {};
 
 const client = await PythLazerClient.create({
-    urls: ["wss://pyth-lazer-0.dourolabs.app/v1/stream", "wss://pyth-lazer-1.dourolabs.app/v1/stream"],
-    token: "you-access-token-here", // Replace with your actual access token
-    numConnections: 4, // Optionally specify number of parallel redundant connections to reduce the chance of dropped messages. The connections will round-robin across the provided URLs. Default is 4.
-    logger: console, // Optionally log socket operations (to the console in this case.)
-    onError: (error) => {
-      console.error("WebSocket error:", error);
-    },
-    rwsConfig: { // Optional configuration for resilient WebSocket connections
-      heartbeatTimeoutDurationMs: 5000, // Optional heartbeat timeout duration in milliseconds
-      maxRetryDelayMs: 1000, // Optional maximum retry delay in milliseconds
-      logAfterRetryCount: 10, // Optional log after how many retries
-    }
+  urls: [
+    "wss://pyth-lazer-0.dourolabs.app/v1/stream",
+    "wss://pyth-lazer-1.dourolabs.app/v1/stream",
+  ],
+  token: "you-access-token-here", // Replace with your actual access token
+  numConnections: 4, // Optionally specify number of parallel redundant connections to reduce the chance of dropped messages. The connections will round-robin across the provided URLs. Default is 4.
+  logger: console, // Optionally log socket operations (to the console in this case.)
+  onError: (error) => {
+    console.error("WebSocket error:", error);
+  },
+  // Optional configuration for resilient WebSocket connections
+  rwsConfig: {
+    heartbeatTimeoutDurationMs: 5000, // Optional heartbeat timeout duration in milliseconds
+    maxRetryDelayMs: 1000, // Optional maximum retry delay in milliseconds
+    logAfterRetryCount: 10, // Optional log after how many retries
+  },
 });
 
 // Read and process messages from the Lazer stream

--- a/lazer/sdk/js/examples/index.ts
+++ b/lazer/sdk/js/examples/index.ts
@@ -6,12 +6,20 @@ import { PythLazerClient } from "../src/index.js";
 // Ignore debug messages
 console.debug = () => {};
 
-const client = await PythLazerClient.create(
-  ["wss://pyth-lazer.dourolabs.app/v1/stream"],
-  "access_token",
-  3, // Optionally specify number of parallel redundant connections to reduce the chance of dropped messages. The connections will round-robin across the provided URLs. Default is 3.
-  console, // Optionally log socket operations (to the console in this case.)
-);
+const client = await PythLazerClient.create({
+    urls: ["wss://pyth-lazer-0.dourolabs.app/v1/stream", "wss://pyth-lazer-1.dourolabs.app/v1/stream"],
+    token: "you-access-token-here", // Replace with your actual access token
+    numConnections: 4, // Optionally specify number of parallel redundant connections to reduce the chance of dropped messages. The connections will round-robin across the provided URLs. Default is 4.
+    logger: console, // Optionally log socket operations (to the console in this case.)
+    onError: (error) => {
+      console.error("WebSocket error:", error);
+    },
+    rwsConfig: { // Optional configuration for resilient WebSocket connections
+      heartbeatTimeoutDurationMs: 5000, // Optional heartbeat timeout duration in milliseconds
+      maxRetryDelayMs: 1000, // Optional maximum retry delay in milliseconds
+      logAfterRetryCount: 10, // Optional log after how many retries
+    }
+});
 
 // Read and process messages from the Lazer stream
 client.addMessageListener((message) => {
@@ -47,7 +55,7 @@ client.addAllConnectionsDownListener(() => {
 });
 
 // Create and remove one or more subscriptions on the fly
-await client.subscribe({
+client.subscribe({
   type: "subscribe",
   subscriptionId: 1,
   priceFeedIds: [1, 2],
@@ -58,7 +66,7 @@ await client.subscribe({
   parsed: false,
   jsonBinaryEncoding: "base64",
 });
-await client.subscribe({
+client.subscribe({
   type: "subscribe",
   subscriptionId: 2,
   priceFeedIds: [1, 2, 3, 4, 5],
@@ -72,6 +80,6 @@ await client.subscribe({
 
 await new Promise((resolve) => setTimeout(resolve, 10_000));
 
-await client.unsubscribe(1);
-await client.unsubscribe(2);
+client.unsubscribe(1);
+client.unsubscribe(2);
 client.shutdown();

--- a/lazer/sdk/js/package.json
+++ b/lazer/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-lazer-sdk",
-  "version": "0.5.1",
+  "version": "1.0.0",
   "description": "Pyth Lazer SDK",
   "publishConfig": {
     "access": "public"

--- a/lazer/sdk/js/src/client.ts
+++ b/lazer/sdk/js/src/client.ts
@@ -2,8 +2,8 @@ import WebSocket from "isomorphic-ws";
 
 import type { ParsedPayload, Request, Response } from "./protocol.js";
 import { BINARY_UPDATE_FORMAT_MAGIC_LE, FORMAT_MAGICS_LE } from "./protocol.js";
-import type {WebSocketPoolConfig} from "./socket/websocket-pool.js";
-import { WebSocketPool  } from "./socket/websocket-pool.js";
+import type { WebSocketPoolConfig } from "./socket/websocket-pool.js";
+import { WebSocketPool } from "./socket/websocket-pool.js";
 
 export type BinaryResponse = {
   subscriptionId: number;
@@ -34,9 +34,7 @@ export class PythLazerClient {
    * @param numConnections - The number of parallel WebSocket connections to establish (default: 3). A higher number gives a more reliable stream. The connections will round-robin across the provided URLs.
    * @param logger - Optional logger to get socket level logs. Compatible with most loggers such as the built-in console and `bunyan`.
    */
-  static async create(
-    config: WebSocketPoolConfig
-  ): Promise<PythLazerClient> {
+  static async create(config: WebSocketPoolConfig): Promise<PythLazerClient> {
     const wsp = await WebSocketPool.create(config);
     return new PythLazerClient(wsp);
   }

--- a/lazer/sdk/js/src/client.ts
+++ b/lazer/sdk/js/src/client.ts
@@ -1,10 +1,9 @@
 import WebSocket from "isomorphic-ws";
-import type { Logger } from "ts-log";
-import { dummyLogger } from "ts-log";
 
 import type { ParsedPayload, Request, Response } from "./protocol.js";
 import { BINARY_UPDATE_FORMAT_MAGIC_LE, FORMAT_MAGICS_LE } from "./protocol.js";
-import { WebSocketPool } from "./socket/websocket-pool.js";
+import type {WebSocketPoolConfig} from "./socket/websocket-pool.js";
+import { WebSocketPool  } from "./socket/websocket-pool.js";
 
 export type BinaryResponse = {
   subscriptionId: number;
@@ -36,12 +35,9 @@ export class PythLazerClient {
    * @param logger - Optional logger to get socket level logs. Compatible with most loggers such as the built-in console and `bunyan`.
    */
   static async create(
-    urls: string[],
-    token: string,
-    numConnections = 3,
-    logger: Logger = dummyLogger,
+    config: WebSocketPoolConfig
   ): Promise<PythLazerClient> {
-    const wsp = await WebSocketPool.create(urls, token, numConnections, logger);
+    const wsp = await WebSocketPool.create(config);
     return new PythLazerClient(wsp);
   }
 

--- a/lazer/sdk/js/src/client.ts
+++ b/lazer/sdk/js/src/client.ts
@@ -102,19 +102,19 @@ export class PythLazerClient {
     });
   }
 
-  async subscribe(request: Request): Promise<void> {
+  subscribe(request: Request) {
     if (request.type !== "subscribe") {
       throw new Error("Request must be a subscribe request");
     }
-    await this.wsp.addSubscription(request);
+    this.wsp.addSubscription(request);
   }
 
-  async unsubscribe(subscriptionId: number): Promise<void> {
-    await this.wsp.removeSubscription(subscriptionId);
+  unsubscribe(subscriptionId: number) {
+    this.wsp.removeSubscription(subscriptionId);
   }
 
-  async send(request: Request): Promise<void> {
-    await this.wsp.sendRequest(request);
+  send(request: Request) {
+    this.wsp.sendRequest(request);
   }
 
   /**

--- a/lazer/sdk/js/src/socket/resilient-websocket.ts
+++ b/lazer/sdk/js/src/socket/resilient-websocket.ts
@@ -16,7 +16,7 @@ export type ResilientWebSocketConfig = {
   heartbeatTimeoutDurationMs?: number;
   maxRetryDelayMs?: number;
   logAfterRetryCount?: number;
-}
+};
 
 export class ResilientWebSocket {
   private endpoint: string;
@@ -49,17 +49,14 @@ export class ResilientWebSocket {
   onMessage: (data: WebSocket.Data) => void;
   onReconnect: () => void;
 
-  constructor(
-    config: ResilientWebSocketConfig,
-  ) {
+  constructor(config: ResilientWebSocketConfig) {
     this.endpoint = config.endpoint;
     this.wsOptions = config.wsOptions;
     this.logger = config.logger ?? dummyLogger;
     this.heartbeatTimeoutDurationMs =
       config.heartbeatTimeoutDurationMs ??
       DEFAULT_HEARTBEAT_TIMEOUT_DURATION_MS;
-    this.maxRetryDelayMs =
-      config.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS;
+    this.maxRetryDelayMs = config.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS;
     this.logAfterRetryCount =
       config.logAfterRetryCount ?? DEFAULT_LOG_AFTER_RETRY_COUNT;
 
@@ -90,7 +87,7 @@ export class ResilientWebSocket {
   startWebSocket() {
     if (this.wsUserClosed) {
       this.logger.error("Connection was explicitly close. Won't reconnect.");
-      return
+      return;
     }
 
     if (this.wsClient !== undefined) {
@@ -119,7 +116,9 @@ export class ResilientWebSocket {
 
     this.wsClient.addEventListener("close", (e) => {
       if (this.wsUserClosed) {
-        this.logger.info(`WebSocket connection to ${this.endpoint} closed by user`);
+        this.logger.info(
+          `WebSocket connection to ${this.endpoint} closed by user`,
+        );
       } else {
         if (this.shouldLogRetry()) {
           this.logger.warn(
@@ -161,7 +160,9 @@ export class ResilientWebSocket {
 
   private handleReconnect() {
     if (this.wsUserClosed) {
-      this.logger.info("WebSocket connection closed by user, not reconnecting.");
+      this.logger.info(
+        "WebSocket connection closed by user, not reconnecting.",
+      );
       return;
     }
 
@@ -173,7 +174,6 @@ export class ResilientWebSocket {
       clearTimeout(this.retryTimeout);
     }
 
-   
     this.wsFailedAttempts += 1;
     this.wsClient = undefined;
 
@@ -189,7 +189,7 @@ export class ResilientWebSocket {
 
     this.retryTimeout = setTimeout(() => {
       this.startWebSocket();
-    }, this.retryDelayMs());    
+    }, this.retryDelayMs());
   }
 
   closeWebSocket(): void {

--- a/lazer/sdk/js/src/socket/resilient-websocket.ts
+++ b/lazer/sdk/js/src/socket/resilient-websocket.ts
@@ -86,7 +86,9 @@ export class ResilientWebSocket {
 
   startWebSocket() {
     if (this.wsUserClosed) {
-      this.logger.error("Connection was explicitly closed by user. Will not reconnect.");
+      this.logger.error(
+        "Connection was explicitly closed by user. Will not reconnect.",
+      );
       return;
     }
 

--- a/lazer/sdk/js/src/socket/resilient-websocket.ts
+++ b/lazer/sdk/js/src/socket/resilient-websocket.ts
@@ -201,18 +201,17 @@ export class ResilientWebSocket {
   }
 
   /**
-   * Calculates the delay in milliseconds for exponential backoff based on the number of attempts.
+   * Calculates the delay in milliseconds for exponential backoff based on the number of failed attempts.
    *
-   * The delay increases exponentially with each attempt, starting at 200ms for the first attempt,
-   * and is capped at 60,000ms (60 seconds) for attempts greater than 10.
+   * The delay increases exponentially with each attempt, starting at 20ms for the first attempt,
+   * and is capped at maxRetryDelayMs for attempts greater than or equal to 10.
    *
-   * @param attempts - The number of retry attempts made so far.
    * @returns The calculated delay in milliseconds before the next retry.
    */
   private retryDelayMs(): number {
     if (this.wsFailedAttempts >= 10) {
       return this.maxRetryDelayMs;
     }
-    return 2 ** this.wsFailedAttempts * 10;
+    return Math.min(2 ** this.wsFailedAttempts * 10, this.maxRetryDelayMs);
   }
 }

--- a/lazer/sdk/js/src/socket/resilient-websocket.ts
+++ b/lazer/sdk/js/src/socket/resilient-websocket.ts
@@ -33,7 +33,7 @@ export class ResilientWebSocket {
   private retryTimeout?: NodeJS.Timeout | undefined;
   private _isReconnecting = false;
 
-  get isReconnecting(): boolean {
+  isReconnecting(): boolean {
     return this._isReconnecting;
   }
 

--- a/lazer/sdk/js/src/socket/resilient-websocket.ts
+++ b/lazer/sdk/js/src/socket/resilient-websocket.ts
@@ -86,7 +86,7 @@ export class ResilientWebSocket {
 
   startWebSocket() {
     if (this.wsUserClosed) {
-      this.logger.error("Connection was explicitly close. Won't reconnect.");
+      this.logger.error("Connection was explicitly closed by user. Will not reconnect.");
       return;
     }
 

--- a/lazer/sdk/js/src/socket/resilient-websocket.ts
+++ b/lazer/sdk/js/src/socket/resilient-websocket.ts
@@ -66,9 +66,6 @@ export class ResilientWebSocket {
     this.wsFailedAttempts = 0;
     this.onError = (error: ErrorEvent) => {
       void error;
-      // if (this.wsFailedAttempts > LOG_AFTER_RETRY_COUNT) {
-      //   this.logger.error(error.error);
-      // }
     };
     this.onMessage = (data: WebSocket.Data): void => {
       void data;

--- a/lazer/sdk/js/src/socket/websocket-pool.ts
+++ b/lazer/sdk/js/src/socket/websocket-pool.ts
@@ -60,7 +60,7 @@ export class WebSocketPool {
           Authorization: `Bearer ${token}`,
         },
       };
-      const rws = new ResilientWebSocket(url, wsOptions, logger);
+      const rws = new ResilientWebSocket({endpoint: url, wsOptions, logger});
 
       // If a websocket client unexpectedly disconnects, ResilientWebSocket will reestablish
       // the connection and call the onReconnect callback.

--- a/lazer/sdk/js/src/socket/websocket-pool.ts
+++ b/lazer/sdk/js/src/socket/websocket-pool.ts
@@ -198,7 +198,7 @@ export class WebSocketPool {
   }
 
   private areAllConnectionsDown(): boolean {
-    return this.rwsPool.every((ws) => !ws.isConnected() || ws.isReconnecting);
+    return this.rwsPool.every((ws) => !ws.isConnected() || ws.isReconnecting());
   }
 
   private isAnyConnectionEstablished(): boolean {

--- a/lazer/sdk/js/src/socket/websocket-pool.ts
+++ b/lazer/sdk/js/src/socket/websocket-pool.ts
@@ -1,4 +1,5 @@
 import TTLCache from "@isaacs/ttlcache";
+import type { ErrorEvent } from "isomorphic-ws";
 import WebSocket from "isomorphic-ws";
 import type { Logger } from "ts-log";
 import { dummyLogger } from "ts-log";
@@ -15,6 +16,7 @@ export type WebSocketPoolConfig = {
   numConnections?: number;
   logger?: Logger;
   rwsConfig?: Omit<ResilientWebSocketConfig, 'logger' | 'endpoint'>;
+  onError?: (error: ErrorEvent) => void;
 };
 
 export class WebSocketPool {
@@ -94,6 +96,9 @@ export class WebSocketPool {
         }
       };
 
+      if (config.onError) {
+        rws.onError = config.onError;
+      }
       // Handle all client messages ourselves. Dedupe before sending to registered message handlers.
       rws.onMessage = pool.dedupeHandler;
       pool.rwsPool.push(rws);

--- a/lazer/sdk/js/src/socket/websocket-pool.ts
+++ b/lazer/sdk/js/src/socket/websocket-pool.ts
@@ -5,8 +5,8 @@ import type { Logger } from "ts-log";
 import { dummyLogger } from "ts-log";
 
 import type { Request, Response } from "../protocol.js";
-import type {ResilientWebSocketConfig} from "./resilient-websocket.js";
-import { ResilientWebSocket  } from "./resilient-websocket.js";
+import type { ResilientWebSocketConfig } from "./resilient-websocket.js";
+import { ResilientWebSocket } from "./resilient-websocket.js";
 
 const DEFAULT_NUM_CONNECTIONS = 4;
 
@@ -15,7 +15,7 @@ export type WebSocketPoolConfig = {
   token: string;
   numConnections?: number;
   logger?: Logger;
-  rwsConfig?: Omit<ResilientWebSocketConfig, 'logger' | 'endpoint'>;
+  rwsConfig?: Omit<ResilientWebSocketConfig, "logger" | "endpoint">;
   onError?: (error: ErrorEvent) => void;
 };
 
@@ -49,9 +49,7 @@ export class WebSocketPool {
    * @param numConnections - Number of parallel WebSocket connections to maintain (default: 3)
    * @param logger - Optional logger to get socket level logs. Compatible with most loggers such as the built-in console and `bunyan`.
    */
-  static async create(
-    config: WebSocketPoolConfig,
-  ): Promise<WebSocketPool> {
+  static async create(config: WebSocketPoolConfig): Promise<WebSocketPool> {
     if (config.urls.length === 0) {
       throw new Error("No URLs provided");
     }
@@ -75,7 +73,7 @@ export class WebSocketPool {
         ...config.rwsConfig,
         endpoint: url,
         wsOptions,
-        logger
+        logger,
       });
 
       // If a websocket client unexpectedly disconnects, ResilientWebSocket will reestablish
@@ -115,7 +113,7 @@ export class WebSocketPool {
 
     pool.logger.info(
       `At least one WebSocket connection is established. WebSocketPool is ready.`,
-    )
+    );
 
     return pool;
   }

--- a/lazer/sdk/js/src/socket/websocket-pool.ts
+++ b/lazer/sdk/js/src/socket/websocket-pool.ts
@@ -8,7 +8,7 @@ import type { Request, Response } from "../protocol.js";
 import type {ResilientWebSocketConfig} from "./resilient-websocket.js";
 import { ResilientWebSocket  } from "./resilient-websocket.js";
 
-const DEFAULT_NUM_CONNECTIONS = 3;
+const DEFAULT_NUM_CONNECTIONS = 4;
 
 export type WebSocketPoolConfig = {
   urls: string[];


### PR DESCRIPTION
## Summary

This PR refactors the PythLazerClient and the underlying components, WebSocketPool and ResilientWebSocket.
* When connecting initially it avoids crashing and retries until it can connect to at east one url
* When a connection drops, it avoids crashing and keep retrying the connection
* The config has been improved to get the parameters with hard-coded defaults. (compared hard coded configs)
* Unnecessary async functions have been changed to sync
* Logging has been improved to show important events and avoid spamming
* Increases the default number of connections to 4 to balance the number of connections per url

## Rationale

The current client is broken, it crashed at the beginning if it can't connect to all the urls and if one of the connections drops it also crashes.
This caused some of our used to have downtime, even though only 1 endpoint was not working correctly.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

Manually tested the code with local routers and tested crashing and recovering routers while monitoring the behavior of the client.
