### PR TITLE
Update eslint and turbo configs for devhub

### DIFF
--- a/apps/developer-hub/eslint.config.js
+++ b/apps/developer-hub/eslint.config.js
@@ -1,1 +1,8 @@
-export { nextjs as default } from "@cprussin/eslint-config";
+import { nextjs } from "@cprussin/eslint-config";
+
+export default [
+  ...nextjs,
+  {
+    ignores: [".source/**"],
+  },
+];

--- a/apps/developer-hub/turbo.json
+++ b/apps/developer-hub/turbo.json
@@ -13,12 +13,14 @@
     "fix:lint": {
       "dependsOn": [
         "//#install:modules",
+        "^build",
+        "build",
         "fix:lint:eslint",
         "fix:lint:stylelint"
       ]
     },
     "fix:lint:eslint": {
-      "dependsOn": ["//#install:modules", "^build"],
+      "dependsOn": ["//#install:modules", "^build", "build"],
       "cache": false
     },
     "fix:lint:stylelint": {
@@ -32,7 +34,7 @@
       "dependsOn": ["test:lint:eslint", "test:lint:stylelint"]
     },
     "test:lint:eslint": {
-      "dependsOn": ["//#install:modules", "^build"]
+      "dependsOn": ["//#install:modules", "^build", "build"]
     },
     "test:lint:stylelint": {
       "dependsOn": ["//#install:modules"]


### PR DESCRIPTION
## Summary

Update Turbo so that it builds the app before running eslint as the linting requires some generated code. Then update the eslint config to ignore the generated code as it should not be linted. 

## Rationale

Separating this out from PR #2735 so we can get it merged faster and unblock folks
