### PR TITLE
feat(lazer) Add response messages for lazer transactions

### DIFF
--- a/lazer/Cargo.lock
+++ b/lazer/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -329,7 +329,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "syn 1.0.109",
  "thiserror 1.0.69",
 ]
@@ -1730,7 +1730,7 @@ dependencies = [
  "ed25519 2.2.3",
  "rand_core 0.6.4",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1744,7 +1744,7 @@ dependencies = [
  "derivation-path",
  "ed25519-dalek 1.0.1",
  "hmac 0.12.1",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2746,7 +2746,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3891,7 +3891,7 @@ dependencies = [
  "protobuf-codegen",
  "pyth-lazer-protocol",
  "serde-value",
- "tracing",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4738,9 +4738,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -5203,7 +5203,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "solana-frozen-abi-macro",
  "subtle",
  "thiserror 1.0.69",
@@ -5371,7 +5371,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3 0.10.8",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
@@ -5701,7 +5701,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3 0.10.8",
  "siphasher",
  "solana-frozen-abi",
@@ -6087,7 +6087,7 @@ checksum = "18fea7be851bd98d10721782ea958097c03a0c2a07d8d4997041d0ece6319a63"
 dependencies = [
  "proc-macro2",
  "quote",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "syn 2.0.87",
  "thiserror 1.0.69",
 ]
@@ -6135,7 +6135,7 @@ checksum = "1845dfe71fd68f70382232742e758557afe973ae19e6c06807b2c30f5d5cb474"
 dependencies = [
  "proc-macro2",
  "quote",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "syn 2.0.87",
 ]
 

--- a/lazer/publisher_sdk/proto/pyth_lazer_transaction.proto
+++ b/lazer/publisher_sdk/proto/pyth_lazer_transaction.proto
@@ -88,3 +88,26 @@ message LazerTransaction {
         GovernanceInstruction governance_instruction = 2;
     }
 }
+
+// Response to SignedLazerTransactionResponse from the relayer
+message SignedLazerTransactionResponse {
+    // [required] The ID of a transaction derived as sha256 of the payload.
+    optional bytes transaction_id = 1;
+
+    // [required] Status of the transaction received by the relayer
+    oneof status {
+        // The transaction was accepted by the relayer
+        SignedLazerTransactionAccepted accepted = 2;
+        // The transaction was rejected by the relayer
+        SignedLazerTransactionRejected rejected = 3;
+    }
+
+    // Message containing additional details for accepted transactions
+    message SignedLazerTransactionAccepted {}
+
+    // Message containing details why the transaction was rejected
+    message SignedLazerTransactionRejected {
+        // [required] Human readable error message
+        optional string message = 1;
+    }
+}

--- a/lazer/publisher_sdk/rust/Cargo.toml
+++ b/lazer/publisher_sdk/rust/Cargo.toml
@@ -11,8 +11,8 @@ pyth-lazer-protocol = { version = "0.7.2", path = "../../sdk/rust/protocol" }
 anyhow = "1.0.98"
 protobuf = "3.7.2"
 serde-value = "0.7.0"
+ sha2 = "0.10.9"
 humantime = "2.2.0"
-tracing = "0.1.41"
 
 [build-dependencies]
 fs-err = "3.1.0"


### PR DESCRIPTION
## Summary
Add new message types to represent responses from the relayer to lazer transactions. Initially only include a very simple structure that we will expand upon later. Also add a synthetic transaction_id derived as sha256 hash of the message payload. Note that this is not a stable ID across proto versions and should only be used by the clients to identify responses to transactions over the same connection they were sent to.

## Rationale
The relayers receive two types of transactions: governance instructions, and publisher updates. Both deserve having an acknowledgment or otherwise a response explain what the error is to allow clients to fix it.  

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
