### PR TITLE
fix(stylus): fix stylus ci

### DIFF
--- a/.github/workflows/ci-stylus-check.yml
+++ b/.github/workflows/ci-stylus-check.yml
@@ -15,6 +15,7 @@ on:
   pull_request:
     paths:
       - target_chains/ethereum/sdk/stylus/**
+      - .github/workflows/ci-stylus-check.yml
   push:
     branches:
       - main
@@ -40,7 +41,7 @@ jobs:
         # Check out `rustfmt.toml` to see which ones.
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2024-09-05
           components: rustfmt
           rustflags: ""
 


### PR DESCRIPTION
## Summary

Fix broken stylus CI.  It appears this is happening because the toolchain installed by `setup-rust-toolchain` doesn't match the one used by the package.

## Rationale

This fails on every merge to main

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
