### PR TITLE
feat(fortuna): add result count to results

### DIFF
--- a/apps/fortuna/src/command/run.rs
+++ b/apps/fortuna/src/command/run.rs
@@ -45,6 +45,7 @@ pub async fn run_api(
     crate::api::Blob,
     crate::api::BinaryEncoding,
     crate::api::StateTag,
+    crate::api::ExplorerResponse,
     )
     ),
     tags(


### PR DESCRIPTION
## Summary

Add a total result count field to the fortuna logs response

## Rationale

This is necessary so we can implement a paginator on the UI since we need to know how many pages there are (or at the very least, we need to know if there's a next page).

## How has this been tested?

- [x] Current tests cover my changes
- [x] Added new tests
- [x] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
