### PR TITLE
fix(hermes): remove unwrap for product account header

### DIFF
--- a/apps/hermes/server/Cargo.lock
+++ b/apps/hermes/server/Cargo.lock
@@ -1868,7 +1868,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/hermes/server/Cargo.toml
+++ b/apps/hermes/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "hermes"
-version     = "0.9.2"
+version     = "0.9.3"
 description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
 edition     = "2021"
 

--- a/apps/hermes/server/src/network/pythnet.rs
+++ b/apps/hermes/server/src/network/pythnet.rs
@@ -279,8 +279,9 @@ async fn fetch_price_feeds_metadata(
                 filters: Some(vec![RpcFilterType::Memcmp(Memcmp::new(
                     0, // offset
                     // Product account header: <magic:u32le:0xa1b2c3d4> <version:u32le:0x02> <account_type:u32le:0x02>
-                    // The string literal in hex::decode is represented as be (big endian).
-                    MemcmpEncodedBytes::Bytes(hex::decode("d4c3b2a10200000002000000").unwrap()),
+                    MemcmpEncodedBytes::Bytes(
+                        b"\xd4\xc3\xb2\xa1\x02\x00\x00\x00\x02\x00\x00\x00".to_vec(),
+                    ),
                 ))]),
                 account_config: RpcAccountInfoConfig {
                     encoding: Some(UiAccountEncoding::Base64Zstd),


### PR DESCRIPTION
## Summary

Since we are programmatically banning panics in our code, this PR removes an unwrap() by replacing the product account header string with its bytes representation.

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code
  - Verified we can fetch the product account