### PR TITLE
pyth-lazer-agent fixes

### DIFF
--- a/pyth-lazer-agent/src/main.rs
+++ b/pyth-lazer-agent/src/main.rs
@@ -16,7 +16,7 @@ mod websocket_utils;
 #[derive(Parser)]
 #[command(version)]
 struct Cli {
-    #[clap(short, long, default_value = "config.toml")]
+    #[clap(short, long, default_value = "config/config.toml")]
     config: String,
 }
 


### PR DESCRIPTION
## Summary

- backoff reset after several minutes (a pattern we use elsewhere)
- use broadcast::channel instead of mpsc::channel to fan out to relayers at Ali's suggestion
- default config file fix
- drain pending updates vector

## Rationale

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
