### PR TITLE
feat(entropy-tester): set timeout for total testLatency function

### DIFF
--- a/apps/entropy-tester/package.json
+++ b/apps/entropy-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/entropy-tester",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Utility to test entropy provider callbacks",
   "type": "module",
   "main": "dist/index.js",

--- a/apps/entropy-tester/src/index.ts
+++ b/apps/entropy-tester/src/index.ts
@@ -181,7 +181,18 @@ export const main = function () {
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           while (true) {
             try {
-              await testLatency(contract, privateKey, child);
+              await Promise.race([
+                testLatency(contract, privateKey, child),
+                new Promise((_, reject) =>
+                  setTimeout(() => {
+                    reject(
+                      new Error(
+                        "Timeout: 120s passed but testLatency function was not resolved",
+                      ),
+                    );
+                  }, 120_000),
+                ),
+              ]);
             } catch (error) {
               child.error(error, "Error testing latency");
             }


### PR DESCRIPTION
## Summary

As the title

## Rationale

In case any of the rpc requests freeze in a bad state

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code
