### PR TITLE
Add verifier to pyth evm contract

### DIFF
--- a/doc/code-guidelines.md
+++ b/doc/code-guidelines.md
@@ -7,9 +7,9 @@
 # Make your services as resilient to errors as possible
 
 - Perform more benchmarking/add benchmarking tests through our codebase. Currently
-there are portions of the codebase that we have unknown performance for that
-may become more important as we scale. Most languages have benchmark test
-capability, rust has it built in for example.
+  there are portions of the codebase that we have unknown performance for that
+  may become more important as we scale. Most languages have benchmark test
+  capability, rust has it built in for example.
 - Implement error recovery even for unlikely cases. Think about how the service can continue to work after different failures.
 - The service should continue to work (if possible) if its dependencies are unavailable or broken.
 - Avoid the possibility of leaving the service in a state where it no longer able to start or work properly. The service should be able to recover from things like invalid files or unexpected database state. If that is not possible, provide clear error messages that explain what should be done to fix it.
@@ -19,225 +19,225 @@ capability, rust has it built in for example.
 # Set up essential tooling
 
 - Use strongest lint settings. It is better to have at minimum pedantic warnings
-on all projects. Good examples of bad settings: allowing `any` globally in
-typescript, ignoring integer clippy type warnings in Rust, etc.
+  on all projects. Good examples of bad settings: allowing `any` globally in
+  typescript, ignoring integer clippy type warnings in Rust, etc.
 - Add extensive logging, metrics and tracing capability early, much of our code is missing
-metrics, good log handling, or ability to do introspection on code that has
-failed in retrospect. Good example: hermes launch.
+  metrics, good log handling, or ability to do introspection on code that has
+  failed in retrospect. Good example: hermes launch.
 
 # Keep the code readable and maintainable
 
 - Make heavy use of types to define behaviour. In general introducing a type can be
-thought of as introducing a unit test. For example:
+  thought of as introducing a unit test. For example:
 
-    ```rust
-    struct PositiveTime(i64);
+      ```rust
+      struct PositiveTime(i64);
 
-    impl TryFrom<i64> for PositiveTime {
-        type Err = ();
-        fn try_from(n: i64) -> Result<Self, Self::Err> {
-            if n < 0 {
-                return Err(());
-            }
-            return Ok(Self(n));
-        }
-    }
+      impl TryFrom<i64> for PositiveTime {
+          type Err = ();
+          fn try_from(n: i64) -> Result<Self, Self::Err> {
+              if n < 0 {
+                  return Err(());
+              }
+              return Ok(Self(n));
+          }
+      }
 
-    ```
+      ```
 
-    This can be thought of reducing the valid range of i64 to one we prefer
-    (given that i64 is the native Linux time type but often we do not want these)
-    that we can enforce a compile-time. The benefit in types over unit tests is
-    simply use-at-site of a type ensure behaviour everywhere and reducing the
-    amount of unwanted behaviour in a codebase.
+      This can be thought of reducing the valid range of i64 to one we prefer
+      (given that i64 is the native Linux time type but often we do not want these)
+      that we can enforce a compile-time. The benefit in types over unit tests is
+      simply use-at-site of a type ensure behaviour everywhere and reducing the
+      amount of unwanted behaviour in a codebase.
 
-    Currently we do not try hard enough to isolate behaviours through types.
+      Currently we do not try hard enough to isolate behaviours through types.
 
 - Avoid monolithic event handlers, and avoid state handling in logic. Some
-stateful code in our repos mixes the logic handling with the state handle
-code which produces very long, hard to reason about code which ends up as
-a rather large inline state machine:
+  stateful code in our repos mixes the logic handling with the state handle
+  code which produces very long, hard to reason about code which ends up as
+  a rather large inline state machine:
 
-    Good:
+      Good:
 
-    ```tsx
-    function handleEvent(e, state) {
-        switch(e.type) {
-            case Event.Websocket: handleWebsocketEvent(e, state.websockets);
-            case Event.PythNet:   handlePythnetEvent(e, state.pyth_handle);
-            case ...
-        }
-    }
+      ```tsx
+      function handleEvent(e, state) {
+          switch(e.type) {
+              case Event.Websocket: handleWebsocketEvent(e, state.websockets);
+              case Event.PythNet:   handlePythnetEvent(e, state.pyth_handle);
+              case ...
+          }
+      }
 
-    ```
+      ```
 
-    Bad:
+      Bad:
 
-    ```tsx
-    function handleEvent(e) {
-        // Many inlined state tracking vars. Not much better than globals.
-        var latstPythNetupdateTime = DateTime.now();
-        var clientsWaiting         = {};
-        var ...
+      ```tsx
+      function handleEvent(e) {
+          // Many inlined state tracking vars. Not much better than globals.
+          var latstPythNetupdateTime = DateTime.now();
+          var clientsWaiting         = {};
+          var ...
 
-        switch(e.type) {
-           // lots of inline handling
-        }
-    }
+          switch(e.type) {
+             // lots of inline handling
+          }
+      }
 
-    ```
+      ```
 
 - Avoid catch-all modules, I.E: `types/`, `utils/`
 - Favor Immutability and Idempotency. Both are a huge source of reducing logic bugs.
 - State should whenever possible flow top-down, I.E: create at entry point and
-flow to other components. Global state should be avoided and no state should be
-hidden in separate modules.
+  flow to other components. Global state should be avoided and no state should be
+  hidden in separate modules.
 
-    Good:
+      Good:
 
-    ```tsx
-    // main.ts
-    function main() {
-        const db = db.init();
-        initDb(db);
-    }
+      ```tsx
+      // main.ts
+      function main() {
+          const db = db.init();
+          initDb(db);
+      }
 
-    ```
+      ```
 
-    Bad:
+      Bad:
 
-    ```tsx
-    // main.ts
-    const { db } = require('db');
-    function() {
-        initDb(); // Databaes not passed, implies global use.
-    }
+      ```tsx
+      // main.ts
+      const { db } = require('db');
+      function() {
+          initDb(); // Databaes not passed, implies global use.
+      }
 
-    ```
+      ```
 
 - For types/functions that are only used once, keep them close to the
-definition. If they are re-used, try and lift them only up to a common
-parent, in the following example types/functions only lift as far
-as they are useful:
+  definition. If they are re-used, try and lift them only up to a common
+  parent, in the following example types/functions only lift as far
+  as they are useful:
 
-    Example File Hierarchy:
+      Example File Hierarchy:
 
-    ```
-    lib/routes.rs:validateUserId()
-    lib/routes/user.rs:type RequestUser
-    lib/routes/user/register.rs:generateRandomUsername()
+      ```
+      lib/routes.rs:validateUserId()
+      lib/routes/user.rs:type RequestUser
+      lib/routes/user/register.rs:generateRandomUsername()
 
-    ```
+      ```
 
-    Good:
+      Good:
 
-    ```tsx
-    // Definition only applies to this function, keep locality.
-    type FeedResponse = {
-        id:   FeedId,
-        feed: Feed,
-    };
+      ```tsx
+      // Definition only applies to this function, keep locality.
+      type FeedResponse = {
+          id:   FeedId,
+          feed: Feed,
+      };
 
-    // Note the distinction between FeedResponse/Feed for DDD.
-    function getFeed(id: FeedId, db: Db): FeedResponse {
-        let feed: Feed = db.execute(FEED_QUERY, [id]);
-        return { id, feed: feed, }
-    }
+      // Note the distinction between FeedResponse/Feed for DDD.
+      function getFeed(id: FeedId, db: Db): FeedResponse {
+          let feed: Feed = db.execute(FEED_QUERY, [id]);
+          return { id, feed: feed, }
+      }
 
-    ```
+      ```
 
-    Bad:
+      Bad:
 
-    ```tsx
-    import { FeedResponse } from 'types';
-    function getFeed(id: FeedId, db: Db): FeedResponse {
-        let feed = db.execute(FEED_QUERY, [id]);
-        return { id, feed: feed, }
-    }
+      ```tsx
+      import { FeedResponse } from 'types';
+      function getFeed(id: FeedId, db: Db): FeedResponse {
+          let feed = db.execute(FEED_QUERY, [id]);
+          return { id, feed: feed, }
+      }
 
-    ```
+      ```
 
 - Map functionality into submodules when a module defines a category of handlers.
-This help emphasise where code re-use should happen, for example:
+  This help emphasise where code re-use should happen, for example:
 
-    Good:
+      Good:
 
-    ```
-    src/routes/user/register.ts
-    src/routes/user/login.ts
-    src/routes/user/add_role.ts
-    src/routes/index.ts
+      ```
+      src/routes/user/register.ts
+      src/routes/user/login.ts
+      src/routes/user/add_role.ts
+      src/routes/index.ts
 
-    ```
+      ```
 
-    Bad:
+      Bad:
 
-    ```tsx
-    // src/index.ts
-    function register() { ... }
-    function login() { ... }
-    function addRole() { ... }
-    function index() { ... }
+      ```tsx
+      // src/index.ts
+      function register() { ... }
+      function login() { ... }
+      function addRole() { ... }
+      function index() { ... }
 
-    ```
+      ```
 
-    Not only does this make large unwieldy files but it encourages things like
-    `types/` catch alls, or unnecessary sharing of functionality. For example
-    imagine a `usernameAsBase58` function thrown into this file, that then
-    looks useful within an unrelated to users function, it can be tempting to
-    abuse the utility function or move it to a vague catch-all location. Focus
-    on clear, API boundaries even within our own codebase.
+      Not only does this make large unwieldy files but it encourages things like
+      `types/` catch alls, or unnecessary sharing of functionality. For example
+      imagine a `usernameAsBase58` function thrown into this file, that then
+      looks useful within an unrelated to users function, it can be tempting to
+      abuse the utility function or move it to a vague catch-all location. Focus
+      on clear, API boundaries even within our own codebase.
 
 - When possible use layered architecture (onion/hexagonal/domain driven design) where
-we separate API processing, business logic, and data logic. The benefit of this
-is it defines API layers within the application itself:
+  we separate API processing, business logic, and data logic. The benefit of this
+  is it defines API layers within the application itself:
 
-    Good:
+      Good:
 
-    ```tsx
-    // web/user/register.ts
-    import { registerUser, User } from 'api/user/register.ts';
+      ```tsx
+      // web/user/register.ts
+      import { registerUser, User } from 'api/user/register.ts';
 
-    // Note locality: one place use functions stay near, no utils/
-    function verifyUsername( ...
-    function verifyPassword( ...
+      // Note locality: one place use functions stay near, no utils/
+      function verifyUsername( ...
+      function verifyPassword( ...
 
-    // Locality again.
-    type RegisterRequest = {
-        ...
-    };
+      // Locality again.
+      type RegisterRequest = {
+          ...
+      };
 
-    function register(req: RegisterRequest): void {
-        // Validation Logic Only
-        verifyUsername(req.username);
-        verifyPassword(req.password);
+      function register(req: RegisterRequest): void {
+          // Validation Logic Only
+          verifyUsername(req.username);
+          verifyPassword(req.password);
 
-        // Business Logic Separate
-        registerUser({
-            username: req.username,
-            password: req.password,
-        });
-    }
+          // Business Logic Separate
+          registerUser({
+              username: req.username,
+              password: req.password,
+          });
+      }
 
-    ```
+      ```
 
-    ```tsx
-    // api/user/register.ts
-    import { storeUser, DbUser } from 'db/user';
+      ```tsx
+      // api/user/register.ts
+      import { storeUser, DbUser } from 'db/user';
 
-    function registerUser(user: User) {
-        const user = fetchByUsername(user.username);
-        if (user) {
-            throw "User Exists;
-        }
+      function registerUser(user: User) {
+          const user = fetchByUsername(user.username);
+          if (user) {
+              throw "User Exists;
+          }
 
-        // Note again that the type used here differs from User (DbUser) which
-        // prevents code breakage (such as if the schema is updated but the
-        // code is not.
-        storeUser({
-            username: user.username,
-            password: hash(user.password),
-        });
-    }
+          // Note again that the type used here differs from User (DbUser) which
+          // prevents code breakage (such as if the schema is updated but the
+          // code is not.
+          storeUser({
+              username: user.username,
+              password: hash(user.password),
+          });
+      }
 
-    ```
+      ```

--- a/doc/rust-code-guidelines.md
+++ b/doc/rust-code-guidelines.md
@@ -14,48 +14,47 @@ Note: general [Code Guidelines](code-guidelines.md) also apply.
 
 - (expand to see clippy configuration)
 
-    ```toml
-    [lints.rust]
-    unsafe_code = "deny"
+  ```toml
+  [lints.rust]
+  unsafe_code = "deny"
 
-    [lints.clippy]
-    wildcard_dependencies = "deny"
+  [lints.clippy]
+  wildcard_dependencies = "deny"
 
-    collapsible_if = "allow"
-    collapsible_else_if = "allow"
+  collapsible_if = "allow"
+  collapsible_else_if = "allow"
 
-    allow_attributes_without_reason = "warn"
+  allow_attributes_without_reason = "warn"
 
-    # Panics
-    expect_used = "warn"
-    fallible_impl_from = "warn"
-    indexing_slicing = "warn"
-    panic = "warn"
-    panic_in_result_fn = "warn"
-    string_slice = "warn"
-    todo = "warn"
-    unchecked_duration_subtraction = "warn"
-    unreachable = "warn"
-    unwrap_in_result = "warn"
-    unwrap_used = "warn"
+  # Panics
+  expect_used = "warn"
+  fallible_impl_from = "warn"
+  indexing_slicing = "warn"
+  panic = "warn"
+  panic_in_result_fn = "warn"
+  string_slice = "warn"
+  todo = "warn"
+  unchecked_duration_subtraction = "warn"
+  unreachable = "warn"
+  unwrap_in_result = "warn"
+  unwrap_used = "warn"
 
-    # Correctness
-    cast_lossless = "warn"
-    cast_possible_truncation = "warn"
-    cast_possible_wrap = "warn"
-    cast_sign_loss = "warn"
-    collection_is_never_read = "warn"
-    match_wild_err_arm = "warn"
-    path_buf_push_overwrite = "warn"
-    read_zero_byte_vec = "warn"
-    same_name_method = "warn"
-    suspicious_operation_groupings = "warn"
-    suspicious_xor_used_as_pow = "warn"
-    unused_self = "warn"
-    used_underscore_binding = "warn"
-    while_float = "warn"
-    ```
-
+  # Correctness
+  cast_lossless = "warn"
+  cast_possible_truncation = "warn"
+  cast_possible_wrap = "warn"
+  cast_sign_loss = "warn"
+  collection_is_never_read = "warn"
+  match_wild_err_arm = "warn"
+  path_buf_push_overwrite = "warn"
+  read_zero_byte_vec = "warn"
+  same_name_method = "warn"
+  suspicious_operation_groupings = "warn"
+  suspicious_xor_used_as_pow = "warn"
+  unused_self = "warn"
+  used_underscore_binding = "warn"
+  while_float = "warn"
+  ```
 
 The recommendations on this page should help with dealing with these lints.
 
@@ -92,9 +91,10 @@ Panics are dangerous because they can arise from concise code constructions (suc
 **Common sources of panics:**
 
 | Source of panic | Non-panicking alternatives |
-| --- | --- |
+| --------------- | -------------------------- |
+
 | `.unwrap()`, `.expect(...)`,
-`panic!()`, `assert*!()`  | `Result`-based handling using `anyhow` crate:
+`panic!()`, `assert*!()` | `Result`-based handling using `anyhow` crate:
 `.context()?` , `.with_context()?` ,
 `bail!()`, `ensure!()`. |
 | `unimplemented!()`, `todo!()`, `unreachable!()` | — |
@@ -103,7 +103,7 @@ Panics are dangerous because they can arise from concise code constructions (suc
 | Indexing a `HashMap` or `BTreeMap` on a non-existing key: `&map[key]` | `.get()`, `.get_mut()`, `.entry()` |
 | Indexing a non-ASCII string not at char boundaries: `&"😢😢😢"[0..1]` | `.get()`, `.get_mut()` |
 | `Vec` methods: `.insert()`, `.remove()`, `.drain()`, `.split_off()` and many more | There are checked alternatives for some but not all of them. |
-| Division by zero: `a / b`, `a % b` | `.checked_div()`, `.checked_rem()`, `/ NonZero*`  |
+| Division by zero: `a / b`, `a % b` | `.checked_div()`, `.checked_rem()`, `/ NonZero*` |
 
 Think about the cases that could cause your code to panic. Try to rewrite the code in a way that avoids a possible panic.
 
@@ -111,239 +111,238 @@ Here are some tips to solve `clippy` warnings and avoid panics:
 
 - **Use `Result` type and return the error to the caller.** Use `.context()` or `.with_context()` from `anyhow` crate to add relevant information to the error. Use `.ok_or_else()` or `.context()` to convert `Option` to `Result`.
 
-    ⛔ Bad:
+  ⛔ Bad:
 
-    ```rust
-    pub fn best_bid(response: &Response) -> String {
-        response.bids[0].clone()
-    }
-    ```
+  ```rust
+  pub fn best_bid(response: &Response) -> String {
+      response.bids[0].clone()
+  }
+  ```
 
-    ✅ Good:
+  ✅ Good:
 
-    ```rust
-    pub fn best_bid(response: &Response) -> anyhow::Result<String> {
-        Ok(response.bids.first().context("expected 1 item in bids, got 0")?.clone())
-    }
-    ```
+  ```rust
+  pub fn best_bid(response: &Response) -> anyhow::Result<String> {
+      Ok(response.bids.first().context("expected 1 item in bids, got 0")?.clone())
+  }
+  ```
 
 - **If propagation with `?` doesn’t work because of error type, convert the error type with `.map_err()`.**
 
-    ✅ Good (`binary_search` returns `Err(index)` instead of a well-formed error, so we create our own error value):
+  ✅ Good (`binary_search` returns `Err(index)` instead of a well-formed error, so we create our own error value):
 
-    ```rust
-        items
-            .binary_search(&needle)
-            .map_err(|_| anyhow!("item not found: {:?}", needle))?;
-    ```
+  ```rust
+      items
+          .binary_search(&needle)
+          .map_err(|_| anyhow!("item not found: {:?}", needle))?;
+  ```
 
-    ✅ Good (`?` can’t convert from `Box<dyn Error>` to `anyhow::Error`, but there is a function that converts it):
+  ✅ Good (`?` can’t convert from `Box<dyn Error>` to `anyhow::Error`, but there is a function that converts it):
 
-    ```rust
-    let info = message.info().map_err(anyhow::Error::from_boxed)?;
-    ```
+  ```rust
+  let info = message.info().map_err(anyhow::Error::from_boxed)?;
+  ```
 
 - **If the error is in a non-Result function inside an iterator chain (e.g. `.map()`) or a combinator (e.g. `.unwrap_or_else()`), consider rewriting it as a plain `for` loop or `match`/`if let` to allow error propagation.** (If you’re determined to make iterators work, `fallible-iterator` crate may also be useful.)
 
-    ⛔ Bad (unwraps the error just because `?` doesn’t work):
+  ⛔ Bad (unwraps the error just because `?` doesn’t work):
 
-    ```rust
-    fn check_files(paths: &[&Path]) -> anyhow::Result<()> {
-        let good_paths: Vec<&Path> = paths
-            .iter()
-            .copied()
-            .filter(|path| fs::read_to_string(path).unwrap().contains("magic"))
-            .collect();
-        //...
-    }
-    ```
+  ```rust
+  fn check_files(paths: &[&Path]) -> anyhow::Result<()> {
+      let good_paths: Vec<&Path> = paths
+          .iter()
+          .copied()
+          .filter(|path| fs::read_to_string(path).unwrap().contains("magic"))
+          .collect();
+      //...
+  }
+  ```
 
-    ✅ Good:
+  ✅ Good:
 
-    ```rust
-    fn check_files(paths: &[&Path]) -> anyhow::Result<()> {
-        let mut good_paths = Vec::new();
-        for path in paths {
-            if fs::read_to_string(path)?.contains("magic") {
-                good_paths.push(path);
-            }
-        }
-        //...
-    }
-    ```
+  ```rust
+  fn check_files(paths: &[&Path]) -> anyhow::Result<()> {
+      let mut good_paths = Vec::new();
+      for path in paths {
+          if fs::read_to_string(path)?.contains("magic") {
+              good_paths.push(path);
+          }
+      }
+      //...
+  }
+  ```
 
 - **Log the error and return early or skip an item.**
 
-    ⛔ Bad (panics if we add too many publishers):
+  ⛔ Bad (panics if we add too many publishers):
 
-    ```rust
-    let publisher_count = u16::try_from(prices.len())
-        .expect("too many publishers");
-    ```
+  ```rust
+  let publisher_count = u16::try_from(prices.len())
+      .expect("too many publishers");
+  ```
 
-    ✅ Good:
+  ✅ Good:
 
-    ```rust
-    let Ok(publisher_count) = u16::try_from(prices.len()) else {
-        error!("too many publishers ({})", prices.len());
-        return Default::default();
-    };
-    ```
+  ```rust
+  let Ok(publisher_count) = u16::try_from(prices.len()) else {
+      error!("too many publishers ({})", prices.len());
+      return Default::default();
+  };
+  ```
 
-    ⛔ Bad (terminates on error) (and yes, [it can fail](https://www.greyblake.com/blog/when-serde-json-to-string-fails/)):
+  ⛔ Bad (terminates on error) (and yes, [it can fail](https://www.greyblake.com/blog/when-serde-json-to-string-fails/)):
 
-    ```rust
-    loop {
-        //...
-        yield Ok(
-            serde_json::to_string(&response).expect("should not fail") + "\n"
-        );
-    }
-    ```
+  ```rust
+  loop {
+      //...
+      yield Ok(
+          serde_json::to_string(&response).expect("should not fail") + "\n"
+      );
+  }
+  ```
 
-    ✅ Good (`return` instead of `continue` could also be reasonable):
+  ✅ Good (`return` instead of `continue` could also be reasonable):
 
-    ```rust
-    loop {
-        //...
-        match serde_json::to_string(&response) {
-            Ok(json) => {
-                yield Ok(json + "\n");
-            }
-            Err(err) => {
-                error!("json serialization error for {:?}: {}", response, err);
-                continue;
-            }
-        }
-    }
-    ```
+  ```rust
+  loop {
+      //...
+      match serde_json::to_string(&response) {
+          Ok(json) => {
+              yield Ok(json + "\n");
+          }
+          Err(err) => {
+              error!("json serialization error for {:?}: {}", response, err);
+              continue;
+          }
+      }
+  }
+  ```
 
 - **Supply a sensible default:**
 
-    ⛔ Bad:
+  ⛔ Bad:
 
-    ```rust
-    let interval_us: u64 = snapshot_interval
-        .as_micros()
-        .try_into()
-        .expect("snapshot_interval overflow");
-    ```
+  ```rust
+  let interval_us: u64 = snapshot_interval
+      .as_micros()
+      .try_into()
+      .expect("snapshot_interval overflow");
+  ```
 
-    ✅ Better:
+  ✅ Better:
 
-    ```rust
-    let interval_us =
-        u64::try_from(snapshot_interval.as_micros()).unwrap_or_else(|_| {
-            error!(
-                "invalid snapshot_interval in config: {:?}, defaulting to 1 min",
-                snapshot_interval
-            );
-            60_000_000 // 1 min
-        });
-    ```
+  ```rust
+  let interval_us =
+      u64::try_from(snapshot_interval.as_micros()).unwrap_or_else(|_| {
+          error!(
+              "invalid snapshot_interval in config: {:?}, defaulting to 1 min",
+              snapshot_interval
+          );
+          60_000_000 // 1 min
+      });
+  ```
 
 - **Avoid checking a condition and then unwrapping.** Instead, combine the check and access to the value using `match`, `if let`, and combinators such as `map_or`, `some_or`, etc.
 
-    🟡 Not recommended:
+  🟡 Not recommended:
 
-    ```rust
-    if !values.is_empty() {
-    		process_one(&values[0]);
-    }
-    ```
+  ```rust
+  if !values.is_empty() {
+  		process_one(&values[0]);
+  }
+  ```
 
-    ✅ Good:
+  ✅ Good:
 
-    ```rust
-    if let Some(first_value) = values.first() {
-        process_one(first_value);
-    }
-    ```
+  ```rust
+  if let Some(first_value) = values.first() {
+      process_one(first_value);
+  }
+  ```
 
-    🟡 Not recommended:
+  🟡 Not recommended:
 
-    ```rust
-    .filter(|price| {
-        median_price.is_none() || price < &median_price.expect("should not fail")
-    })
-    ```
+  ```rust
+  .filter(|price| {
+      median_price.is_none() || price < &median_price.expect("should not fail")
+  })
+  ```
 
-    ✅ Good:
+  ✅ Good:
 
-    ```rust
-    .filter(|price| median_price.is_none_or(|median_price| price < &median_price))
-    ```
+  ```rust
+  .filter(|price| median_price.is_none_or(|median_price| price < &median_price))
+  ```
 
-    🟡 Not recommended:
+  🟡 Not recommended:
 
-    ```rust
-    if data.len() < header_len {
-        bail!("data too short");
-    }
-    let header = &data[..header_len];
-    let payload = &data[header_len..];
-    ```
+  ```rust
+  if data.len() < header_len {
+      bail!("data too short");
+  }
+  let header = &data[..header_len];
+  let payload = &data[header_len..];
+  ```
 
-    ✅ Good:
+  ✅ Good:
 
-    ```rust
-    let (header, payload) = data
-        .split_at_checked(header_len)
-        .context("data too short")?;
-    ```
+  ```rust
+  let (header, payload) = data
+      .split_at_checked(header_len)
+      .context("data too short")?;
+  ```
 
 - **Avoid the panic by introducing a constant or move the panic inside the constant initialization.** Panicking in const initializers is safe because it happens at compile time.
 
-    🟡 Not recommended:
+  🟡 Not recommended:
 
-    ```rust
-    price.unwrap_or(Price::new(PRICE_FEED_EPS).expect("should never fail"))
-    ```
+  ```rust
+  price.unwrap_or(Price::new(PRICE_FEED_EPS).expect("should never fail"))
+  ```
 
-    ✅ Good:
+  ✅ Good:
 
-    ```rust
-    #[allow(clippy::unwrap_used, reason = "safe in const")]
-    const MIN_POSITIVE_PRICE: Price =
-        Price(NonZeroI64::new(PRICE_FEED_EPS).unwrap());
-    ```
+  ```rust
+  #[allow(clippy::unwrap_used, reason = "safe in const")]
+  const MIN_POSITIVE_PRICE: Price =
+      Price(NonZeroI64::new(PRICE_FEED_EPS).unwrap());
+  ```
 
 - **If it’s not possible to refactor the code, allow the lint and specify the reason why the code cannot fail. Prefer `.expect()` over `.unwrap()` and specify the failure in the argument.** This is reasonable if the failure is truly impossible or if a failure would be so critical that the service cannot continue working.
 
-    🟡 Not recommended:
+  🟡 Not recommended:
 
-    ```rust
-    Some(prices[prices.len() / 2])
-    ```
+  ```rust
+  Some(prices[prices.len() / 2])
+  ```
 
-    ✅ Good:
+  ✅ Good:
 
-    ```rust
-    #[allow(
-        clippy::indexing_slicing,
-        reason = "prices are not empty, prices.len() / 2 < prices.len()"
-    )]
-    Some(prices[prices.len() / 2])
-    ```
+  ```rust
+  #[allow(
+      clippy::indexing_slicing,
+      reason = "prices are not empty, prices.len() / 2 < prices.len()"
+  )]
+  Some(prices[prices.len() / 2])
+  ```
 
-    🟡 Not recommended:
+  🟡 Not recommended:
 
-    ```rust
-    let expiry_time = expiry_times.get(self.active_index).unwrap();
-    ```
+  ```rust
+  let expiry_time = expiry_times.get(self.active_index).unwrap();
+  ```
 
-    ✅ Better:
+  ✅ Better:
 
-    ```rust
-    #[allow(
-        clippy::expect_used,
-        reason = "we only assign valid indexes to `self.active_index`"
-    )]
-    let expiry_time = expiry_times
-        .get(self.active_index)
-        .expect("invalid active index");
-    ```
-
+  ```rust
+  #[allow(
+      clippy::expect_used,
+      reason = "we only assign valid indexes to `self.active_index`"
+  )]
+  let expiry_time = expiry_times
+      .get(self.active_index)
+      .expect("invalid active index");
+  ```
 
 # Avoid unchecked arithmetic operations
 
@@ -382,7 +381,7 @@ You can catch unchecked arithmetic operations with `clippy::arithmetic_side_effe
 
 # Avoid implicit wrapping and truncation with `as`
 
-Limit the use of `as` keyword for converting values between numeric types. While `as` is often the most convenient option, it’s quite bad at expressing intent. `as` can do conversions with  different semantics. In the case of integers, it can do both **lossless conversions** (e.g. from `u8` to `u32`; from `u32` to `i64`) and **lossy conversions** (e.g. `258_u32 as u8` evaluates to 2; `200_u8 as i8` evaluates to -56).
+Limit the use of `as` keyword for converting values between numeric types. While `as` is often the most convenient option, it’s quite bad at expressing intent. `as` can do conversions with different semantics. In the case of integers, it can do both **lossless conversions** (e.g. from `u8` to `u32`; from `u32` to `i64`) and **lossy conversions** (e.g. `258_u32 as u8` evaluates to 2; `200_u8 as i8` evaluates to -56).
 
 - Always use `.into()` and `T::from()` instead of `as` for lossless conversions. This makes the intent more clear.
 - Only use `as` for lossy conversions when you specifically intend to perform a lossy conversion and are aware of how it affects the value. Add an `#[allow]` attribute and specify the reason.
@@ -433,81 +432,80 @@ Other recommendations:
 
 - The error message should contain relevant context that can help understand the issue.
 
-    ⛔ Bad:
+  ⛔ Bad:
 
-    ```rust
-    let timestamp = args.timestamp.try_into()?;
-    ```
+  ```rust
+  let timestamp = args.timestamp.try_into()?;
+  ```
 
-    ✅ Good (using `anyhow::Context`):
+  ✅ Good (using `anyhow::Context`):
 
-    ```rust
-    let timestamp = args
-        .timestamp
-        .try_into()
-        .with_context(|| {
-            format!("invalid timestamp received from Hermes: {:?}", args.timestamp)
-        })?;
-    ```
+  ```rust
+  let timestamp = args
+      .timestamp
+      .try_into()
+      .with_context(|| {
+          format!("invalid timestamp received from Hermes: {:?}", args.timestamp)
+      })?;
+  ```
 
-    ⛔ Bad:
+  ⛔ Bad:
 
-    ```rust
-    let exponent = config.feeds.get(feed_id).context("missing feed")?.exponent;
-    ```
+  ```rust
+  let exponent = config.feeds.get(feed_id).context("missing feed")?.exponent;
+  ```
 
-    ✅ Good:
+  ✅ Good:
 
-    ```rust
-    let exponent = config
-        .feeds
-        .get(feed_id)
-        .with_context(|| {
-    			format!("missing feed {:?} in config", feed_id)
-        })?
-        .exponent;
-    ```
+  ```rust
+  let exponent = config
+      .feeds
+      .get(feed_id)
+      .with_context(|| {
+  			format!("missing feed {:?} in config", feed_id)
+      })?
+      .exponent;
+  ```
 
 - When wrapping another error or converting error type, preserve the error source instead of converting it to `String`. Especially avoid calling `to_string()` on `anyhow::Error` or formatting it with `{}` because it erases context and backtrace information.
 
-    ⛔ Bad (loses information about source errors and backtrace):
+  ⛔ Bad (loses information about source errors and backtrace):
 
-    ```rust
-    if let Err(err) = parse(data) {
-        bail!("parsing failed: {err}");
-    }
-    // OR
-    parse(data).map_err(|err| format!("parsing failed: {err}"))?;
-    ```
+  ```rust
+  if let Err(err) = parse(data) {
+      bail!("parsing failed: {err}");
+  }
+  // OR
+  parse(data).map_err(|err| format!("parsing failed: {err}"))?;
+  ```
 
-    ⛔ Better but still bad (preserves source errors and backtrace, but the error will have two backtraces now):
+  ⛔ Better but still bad (preserves source errors and backtrace, but the error will have two backtraces now):
 
-    ```rust
-    if let Err(err) = parse(data) {
-        bail!("parsing failed for {data:?}: {err:?}");
-    }
-    ```
+  ```rust
+  if let Err(err) = parse(data) {
+      bail!("parsing failed for {data:?}: {err:?}");
+  }
+  ```
 
-    ✅ Good (returns an error with proper source and backtrace):
+  ✅ Good (returns an error with proper source and backtrace):
 
-    ```rust
-    parse(data).with_context(|| format!("failed to parse {data:?}"))?;
-    ```
+  ```rust
+  parse(data).with_context(|| format!("failed to parse {data:?}"))?;
+  ```
 
-    ⛔ Bad (loses information about source errors and backtrace):
+  ⛔ Bad (loses information about source errors and backtrace):
 
-    ```rust
-    warn!(%err, ?data, "parsing failed");
-    // OR
-    warn!("parsing failed: {}", err);
-    ```
+  ```rust
+  warn!(%err, ?data, "parsing failed");
+  // OR
+  warn!("parsing failed: {}", err);
+  ```
 
-    ✅ Better (returns full information about the error in a structured way):
+  ✅ Better (returns full information about the error in a structured way):
 
-    ```rust
-    warn!(?err, ?data, "parsing failed");
-    ```
-
+  ```rust
+  warn!(?err, ?data, "parsing failed");
+  ```
 
 # Other recommendations
 

--- a/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
@@ -25,9 +25,11 @@ abstract contract Pyth is
         bytes32 governanceEmitterAddress,
         uint64 governanceInitialSequence,
         uint validTimePeriodSeconds,
-        uint singleUpdateFeeInWei
+        uint singleUpdateFeeInWei,
+        address verifier
     ) internal {
         setWormhole(wormhole);
+        setVerifier(verifier);
 
         if (
             dataSourceEmitterChainIds.length !=

--- a/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythAccumulator.sol
@@ -37,7 +37,15 @@ abstract contract PythAccumulator is PythGetters, PythSetters, AbstractPyth {
         {
             bool valid;
             (vm, valid, ) = wormhole().parseAndVerifyVM(encodedVm);
-            if (!valid) revert PythErrors.InvalidWormholeVaa();
+            if (!valid) {
+                if (address(verifier()) == address(0)) {
+                    revert PythErrors.InvalidUpdateData();
+                }
+                (vm, valid, ) = verifier().parseAndVerifyVM(encodedVm);
+                if (!valid) {
+                    revert PythErrors.InvalidUpdateData();
+                }
+            }
         }
 
         if (!isValidDataSource(vm.emitterChainId, vm.emitterAddress))

--- a/target_chains/ethereum/contracts/contracts/pyth/PythGetters.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGetters.sol
@@ -95,4 +95,8 @@ contract PythGetters is PythState {
     function transactionFeeInWei() public view returns (uint) {
         return _state.transactionFeeInWei;
     }
+
+    function verifier() public view returns (IWormhole) {
+        return IWormhole(_state.verifier);
+    }
 }

--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernance.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernance.sol
@@ -40,15 +40,33 @@ abstract contract PythGovernance is
     );
     event TransactionFeeSet(uint oldFee, uint newFee);
     event FeeWithdrawn(address targetAddress, uint fee);
+    event VerifierAddressSet(
+        address oldVerifierAddress,
+        address newVerifierAddress
+    );
+
+    // Check whether the encodedVM is signed by either the Wormhole or the Verifier.
+    function validateVm(
+        bytes memory encodedVM
+    ) internal view returns (IWormhole.VM memory parsedVM) {
+        (IWormhole.VM memory vm, bool valid, ) = wormhole().parseAndVerifyVM(
+            encodedVM
+        );
+        if (valid) return vm;
+
+        if (address(verifier()) != address(0)) {
+            (IWormhole.VM memory vmv, bool validv, ) = verifier()
+                .parseAndVerifyVM(encodedVM);
+            if (validv) return vmv;
+        }
+
+        revert PythErrors.InvalidWormholeVaa();
+    }
 
     function verifyGovernanceVM(
         bytes memory encodedVM
     ) internal returns (IWormhole.VM memory parsedVM) {
-        (IWormhole.VM memory vm, bool valid, ) = wormhole().parseAndVerifyVM(
-            encodedVM
-        );
-
-        if (!valid) revert PythErrors.InvalidWormholeVaa();
+        IWormhole.VM memory vm = validateVm(encodedVM);
 
         if (!isValidGovernanceDataSource(vm.emitterChainId, vm.emitterAddress))
             revert PythErrors.InvalidGovernanceDataSource();
@@ -105,6 +123,13 @@ abstract contract PythGovernance is
             setTransactionFee(parseSetTransactionFeePayload(gi.payload));
         } else if (gi.action == GovernanceAction.WithdrawFee) {
             withdrawFee(parseWithdrawFeePayload(gi.payload));
+        } else if (gi.action == GovernanceAction.SetVerifierAddress) {
+            if (gi.targetChainId == 0)
+                revert PythErrors.InvalidGovernanceTarget();
+            setVerifierAddress(
+                parseSetVerifierAddressPayload(gi.payload),
+                encodedVM
+            );
         } else {
             revert PythErrors.InvalidGovernanceMessage();
         }
@@ -131,11 +156,8 @@ abstract contract PythGovernance is
         // Make sure the claimVaa is a valid VAA with RequestGovernanceDataSourceTransfer governance message
         // If it's valid then its emitter can take over the governance from the current emitter.
         // The VAA is checked here to ensure that the new governance data source is valid and can send message
-        // through wormhole.
-        (IWormhole.VM memory vm, bool valid, ) = wormhole().parseAndVerifyVM(
-            payload.claimVaa
-        );
-        if (!valid) revert PythErrors.InvalidWormholeVaa();
+        // through wormhole or verifier.
+        IWormhole.VM memory vm = validateVm(payload.claimVaa);
 
         GovernanceInstruction memory gi = parseGovernanceInstruction(
             vm.payload
@@ -210,6 +232,8 @@ abstract contract PythGovernance is
         emit ValidPeriodSet(oldValidPeriod, validTimePeriodSeconds());
     }
 
+    // If the VAA was created by Verifier, this will revert,
+    // because it assumes that the new Wormhole is able to parse and verify the governance VAA.
     function setWormholeAddress(
         SetWormholeAddressPayload memory payload,
         bytes memory encodedVM
@@ -269,5 +293,49 @@ abstract contract PythGovernance is
         require(success, "Failed to withdraw fees");
 
         emit FeeWithdrawn(payload.targetAddress, payload.fee);
+    }
+
+    // If the VAA was created by Wormhole, this will revert,
+    // because it assumes that the new Verifier is able to parse and verify the governance VAA.
+    function setVerifierAddress(
+        SetVerifierAddressPayload memory payload,
+        bytes memory encodedVM
+    ) internal {
+        address oldVerifierAddress = address(verifier());
+        setVerifier(payload.newVerifierAddress);
+
+        // We want to verify that the new verifier address is valid, so we make sure that it can
+        // parse and verify the same governance VAA that is used to set it.
+        (IWormhole.VM memory vm, bool valid, ) = verifier().parseAndVerifyVM(
+            encodedVM
+        );
+
+        if (!valid) revert PythErrors.InvalidGovernanceMessage();
+
+        if (!isValidGovernanceDataSource(vm.emitterChainId, vm.emitterAddress))
+            revert PythErrors.InvalidGovernanceMessage();
+
+        if (vm.sequence != lastExecutedGovernanceSequence())
+            revert PythErrors.InvalidVerifierAddressToSet();
+
+        GovernanceInstruction memory gi = parseGovernanceInstruction(
+            vm.payload
+        );
+
+        if (gi.action != GovernanceAction.SetVerifierAddress)
+            revert PythErrors.InvalidVerifierAddressToSet();
+
+        // Purposefully, we don't check whether the chainId is the same as the current chainId because
+        // we might want to change the chain id of the verifier contract.
+
+        // The following check is not necessary for security, but is a sanity check that the new verifier
+        // contract parses the payload correctly.
+        SetVerifierAddressPayload
+            memory newPayload = parseSetVerifierAddressPayload(gi.payload);
+
+        if (newPayload.newVerifierAddress != payload.newVerifierAddress)
+            revert PythErrors.InvalidVerifierAddressToSet();
+
+        emit VerifierAddressSet(oldVerifierAddress, address(verifier()));
     }
 }

--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
@@ -37,7 +37,8 @@ contract PythGovernanceInstructions {
         SetWormholeAddress, // 6
         SetFeeInToken, // 7 - No-op for EVM chains
         SetTransactionFee, // 8
-        WithdrawFee // 9
+        WithdrawFee, // 9
+        SetVerifierAddress // 10
     }
 
     struct GovernanceInstruction {
@@ -88,6 +89,10 @@ contract PythGovernanceInstructions {
         address targetAddress;
         // Fee in wei, matching the native uint256 type used for address.balance in EVM
         uint256 fee;
+    }
+
+    struct SetVerifierAddressPayload {
+        address newVerifierAddress;
     }
 
     /// @dev Parse a GovernanceInstruction
@@ -268,6 +273,19 @@ contract PythGovernanceInstructions {
         index += 8;
 
         wf.fee = uint256(val) * uint256(10) ** uint256(expo);
+
+        if (encodedPayload.length != index)
+            revert PythErrors.InvalidGovernanceMessage();
+    }
+
+    /// @dev Parse a UpdateVerifierAddressPayload (action 10) with minimal validation
+    function parseSetVerifierAddressPayload(
+        bytes memory encodedPayload
+    ) public pure returns (SetVerifierAddressPayload memory sv) {
+        uint index = 0;
+
+        sv.newVerifierAddress = address(encodedPayload.toAddress(index));
+        index += 20;
 
         if (encodedPayload.length != index)
             revert PythErrors.InvalidGovernanceMessage();

--- a/target_chains/ethereum/contracts/contracts/pyth/PythSetters.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythSetters.sol
@@ -52,4 +52,8 @@ contract PythSetters is PythState, IPythEvents {
     function setTransactionFeeInWei(uint fee) internal {
         _state.transactionFeeInWei = fee;
     }
+
+    function setVerifier(address vf) internal {
+        _state.verifier = payable(vf);
+    }
 }

--- a/target_chains/ethereum/contracts/contracts/pyth/PythState.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythState.sol
@@ -40,6 +40,8 @@ contract PythStorage {
         mapping(bytes32 => PythInternalStructs.PriceInfo) latestPriceInfo;
         // Fee charged per transaction, in addition to per-update fees
         uint transactionFeeInWei;
+        // Verifier address for verifying VAA signatures
+        address verifier;
     }
 }
 

--- a/target_chains/ethereum/contracts/contracts/pyth/PythUpgradable.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythUpgradable.sol
@@ -28,7 +28,8 @@ contract PythUpgradable is
         bytes32 governanceEmitterAddress,
         uint64 governanceInitialSequence,
         uint validTimePeriodSeconds,
-        uint singleUpdateFeeInWei
+        uint singleUpdateFeeInWei,
+        address verifier
     ) public initializer {
         __Ownable_init();
         __UUPSUpgradeable_init();
@@ -41,7 +42,8 @@ contract PythUpgradable is
             governanceEmitterAddress,
             governanceInitialSequence,
             validTimePeriodSeconds,
-            singleUpdateFeeInWei
+            singleUpdateFeeInWei,
+            verifier
         );
 
         renounceOwnership();

--- a/target_chains/ethereum/sdk/solidity/PythErrors.sol
+++ b/target_chains/ethereum/sdk/solidity/PythErrors.sol
@@ -49,4 +49,7 @@ library PythErrors {
     error InvalidTwapUpdateData();
     // The twap update data set is invalid.
     error InvalidTwapUpdateDataSet();
+    // The verifier address to set in SetVerifierAddress governance is invalid.
+    // Signature: 0xab8af376
+    error InvalidVerifierAddressToSet();
 }

--- a/target_chains/ethereum/sdk/solidity/abis/PythErrors.json
+++ b/target_chains/ethereum/sdk/solidity/abis/PythErrors.json
@@ -46,6 +46,11 @@
   },
   {
     "inputs": [],
+    "name": "InvalidVerifierAddressToSet",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "InvalidWormholeAddressToSet",
     "type": "error"
   },


### PR DESCRIPTION
## Summary

This PR introduces support for a backup verifier in the Pyth EVM contract to enhance reliability when verifying VAAs.

## Rationale

Pyth currently verifies VAAs exclusively using Wormhole. This creates a single point of failure: if Wormhole becomes unavailable or its guardians are unable to sign messages, Pyth will be unable to verify updates, potentially causing disruptions.

To address this, we’ve integrated a backup verifier into the contract. If Wormhole fails, the new verifier—with its own guardian set—can independently approve and verify VAAs. As a result, Pyth can continue to function even if Wormhole is down. Only if both the Wormhole and backup verifier guardian sets are unavailable will VAA verification become impossible.

This change improves the resilience and fault tolerance of the system without affecting current functionality.

## How has this been tested?

- [ ] Current tests cover my changes
- [X] Added new tests
- [ ] Manually tested the code