### PR TITLE
fix invalid documentation warning in price.move

### DIFF
--- a/target_chains/sui/contracts/sources/price.move
+++ b/target_chains/sui/contracts/sources/price.move
@@ -6,7 +6,7 @@ module pyth::price {
     /// The confidence interval roughly corresponds to the standard error of a normal distribution.
     /// Both the price and confidence are stored in a fixed-point numeric representation,
     /// `x * (10^expo)`, where `expo` is the exponent.
-    //
+    ///
     /// Please refer to the documentation at https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices for how
     /// to how this price safely.
     struct Price has copy, drop, store {


### PR DESCRIPTION
## Summary

Adds a missing `/` to a documentation comment.

## Rationale

Sui projects that depend on Pyth are getting a lengthy warning every time they `sui move build` or `sui move test`:

![error](https://github.com/user-attachments/assets/ac7a0060-ef13-47a9-8351-3ae160f18d8d)

## How has this been tested?

- [x] Current tests cover my changes
- [x] I changed my `Pyth` dependency in `Move.toml` from `git` to `local` to confirm that the warning is gone.
