### PR TITLE
feat(fortuna): json format on prod

### DIFF
--- a/apps/fortuna/Cargo.lock
+++ b/apps/fortuna/Cargo.lock
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "fortuna"
-version = "7.6.4"
+version = "7.6.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -4751,6 +4751,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4760,12 +4770,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/apps/fortuna/Cargo.toml
+++ b/apps/fortuna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortuna"
-version = "7.6.4"
+version = "7.6.5"
 edition = "2021"
 
 [lib]
@@ -32,7 +32,7 @@ sha3 = "0.10.8"
 tokio = { version = "1.33.0", features = ["full"] }
 tower-http = { version = "0.4.0", features = ["cors"] }
 tracing = { version = "0.1.37", features = ["log"] }
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }
 utoipa = { version = "3.4.0", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "3.1.4", features = ["axum"] }
 once_cell = "1.18.0"

--- a/apps/fortuna/src/main.rs
+++ b/apps/fortuna/src/main.rs
@@ -17,16 +17,17 @@ use {
 #[tracing::instrument]
 async fn main() -> Result<()> {
     // Initialize a Tracing Subscriber
-    tracing::subscriber::set_global_default(
-        tracing_subscriber::fmt()
-            .compact()
-            .with_file(false)
-            .with_line_number(true)
-            .with_thread_ids(true)
-            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-            .with_ansi(std::io::stderr().is_terminal())
-            .finish(),
-    )?;
+    let fmt_builder = tracing_subscriber::fmt()
+        .with_file(false)
+        .with_line_number(true)
+        .with_thread_ids(true)
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_ansi(std::io::stderr().is_terminal());
+    if std::io::stderr().is_terminal() {
+        tracing::subscriber::set_global_default(fmt_builder.compact().finish())?;
+    } else {
+        tracing::subscriber::set_global_default(fmt_builder.json().finish())?;
+    }
 
     match config::Options::parse() {
         config::Options::GetRequest(opts) => command::get_request(&opts).await,


### PR DESCRIPTION
## Summary

Uses another log format when not running in shell

## Rationale

Some alerts are not working properly because the error log is multiline and we can't capture the chain_id of the error log

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

This is exactly how hermes sets up the logging.
