### PR TITLE
fix(ci): Node types catalog

### DIFF
--- a/apps/entropy-tester/package.json
+++ b/apps/entropy-tester/package.json
@@ -39,6 +39,7 @@
     "@cprussin/prettier-config": "catalog:",
     "@cprussin/tsconfig": "catalog:",
     "@types/express": "^4.17.21",
+    "@types/node": "catalog:",
     "@types/yargs": "^17.0.10",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -70,6 +70,7 @@
     "@storybook/react": "catalog:",
     "@svgr/webpack": "catalog:",
     "@types/jest": "catalog:",
+    "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "autoprefixer": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -822,6 +822,9 @@ importers:
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.21
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.14.0
       '@types/yargs':
         specifier: ^17.0.10
         version: 17.0.33

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2081,6 +2081,9 @@ importers:
       '@types/jest':
         specifier: 'catalog:'
         version: 29.5.14
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.14.0
       '@types/react':
         specifier: 'catalog:'
         version: 19.1.0


### PR DESCRIPTION
## Summary

Explicitly defining node types across packages

## Rationale

I was personally running into issues with my system not referring back to the monorepo-defined node types version, so we thought it was a good idea to explicitly define versioning.

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code
