### PR TITLE
feat(entropy-tester): accept custom endpoint

### DIFF
--- a/apps/entropy-tester/config.sample.json
+++ b/apps/entropy-tester/config.sample.json
@@ -9,6 +9,7 @@
   },
   {
     "chain-id": "blast",
-    "interval": "10m"
+    "interval": "10m",
+    "endpoint": "https://rpc.blast.io"
   }
 ]

--- a/apps/entropy-tester/config.sample.json
+++ b/apps/entropy-tester/config.sample.json
@@ -10,6 +10,6 @@
   {
     "chain-id": "blast",
     "interval": "10m",
-    "endpoint": "https://rpc.blast.io"
+    "rpc-endpoint": "https://rpc.blast.io"
   }
 ]

--- a/apps/entropy-tester/package.json
+++ b/apps/entropy-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/entropy-tester",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Utility to test entropy provider callbacks",
   "private": true,
   "type": "module",

--- a/apps/entropy-tester/src/index.ts
+++ b/apps/entropy-tester/src/index.ts
@@ -45,7 +45,7 @@ async function loadConfig(configPath: string): Promise<LoadedConfig[]> {
     z.strictObject({
       "chain-id": z.string(),
       interval: z.string(),
-      endpoint: z.string().optional(),
+      "rpc-endpoint": z.string().optional(),
     }),
   );
   const configContent = (await import(configPath, {
@@ -68,13 +68,13 @@ async function loadConfig(configPath: string): Promise<LoadedConfig[]> {
         `Multiple contracts found for chain ${config["chain-id"]}, check contract manager store.`,
       );
     }
-    if (config.endpoint) {
+    if (config["rpc-endpoint"]) {
       const evmChain = firstContract.chain;
       firstContract.chain = new EvmChain(
         evmChain.getId(),
         evmChain.isMainnet(),
         evmChain.getNativeToken(),
-        config.endpoint,
+        config["rpc-endpoint"],
         evmChain.networkId,
       );
     }

--- a/contract_manager/src/core/chains.ts
+++ b/contract_manager/src/core/chains.ts
@@ -429,8 +429,8 @@ export class EvmChain extends Chain {
     id: string,
     mainnet: boolean,
     nativeToken: TokenId | undefined,
-    private rpcUrl: string,
-    private networkId: number,
+    public rpcUrl: string,
+    public networkId: number,
   ) {
     // On EVM networks we use the chain id as the wormhole chain name
     super(id, mainnet, id, nativeToken);


### PR DESCRIPTION
## Summary

Use a custom endpoint for making requests

## Rationale

I was hoping that the load is small enough such that public rpcs would be sustainable. But that was not the case.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code
