### PR TITLE
feat(stylus): added crate for types shared across Wormhole and Pyth

### DIFF
--- a/target_chains/stylus/Cargo.lock
+++ b/target_chains/stylus/Cargo.lock
@@ -3612,6 +3612,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyth-types"
+version = "0.1.0"
+dependencies = [
+ "stylus-sdk 0.6.0",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/target_chains/stylus/Cargo.toml
+++ b/target_chains/stylus/Cargo.toml
@@ -1,8 +1,8 @@
 [workspace]
 members = [
     "contracts/wormhole",
-    "contracts/pyth-receiver"
-]
+    "contracts/pyth-receiver",
+    "contracts/pyth-types"]
 resolver = "2"
 
 [workspace.package]

--- a/target_chains/stylus/contracts/pyth-types/Cargo.toml
+++ b/target_chains/stylus/contracts/pyth-types/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "pyth-types"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+
+[dependencies]
+stylus-sdk = { workspace = true, default-features = false }

--- a/target_chains/stylus/contracts/pyth-types/src/lib.rs
+++ b/target_chains/stylus/contracts/pyth-types/src/lib.rs
@@ -1,0 +1,30 @@
+use stylus_sdk::{
+    alloy_primitives::{Address, FixedBytes},
+};
+
+#[derive(Clone, PartialEq, Default)]
+pub struct GuardianSet {
+    pub keys: Vec<Address>,
+    pub expiration_time: u32,
+}
+
+#[derive(Clone)]
+pub struct GuardianSignature {
+    pub guardian_index: u8,
+    pub signature: FixedBytes<65>,
+}
+
+#[derive(Clone)]
+pub struct VerifiedVM {
+    pub version: u8,
+    pub guardian_set_index: u32,
+    pub signatures: Vec<GuardianSignature>,
+    pub timestamp: u32,
+    pub nonce: u32,
+    pub emitter_chain_id: u16,
+    pub emitter_address: FixedBytes<32>,
+    pub sequence: u64,
+    pub consistency_level: u8,
+    pub payload: Vec<u8>,
+    pub hash: FixedBytes<32>,
+}


### PR DESCRIPTION
## Summary

Added a new crate that defines types for structs shared between Wormhole and Pyth stylus contracts

## Rationale

Allows for more flexible refactoring of structs in the future.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

The crate currently builds. I will test it further when integrating it into their respective libraries.
