### PR TITLE
feat(pyth-lazer-agent): liveness and readiness endpoints

### DIFF
--- a/apps/pyth-lazer-agent/Cargo.lock
+++ b/apps/pyth-lazer-agent/Cargo.lock
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-agent"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "backoff",

--- a/apps/pyth-lazer-agent/Cargo.toml
+++ b/apps/pyth-lazer-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-agent"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [dependencies]

--- a/apps/pyth-lazer-agent/src/lazer_publisher.rs
+++ b/apps/pyth-lazer-agent/src/lazer_publisher.rs
@@ -14,6 +14,8 @@ use pyth_lazer_publisher_sdk::transaction::{
 };
 use solana_keypair::read_keypair_file;
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use tokio::sync::broadcast;
 use tokio::{
     select,
@@ -25,6 +27,7 @@ use tracing::error;
 #[derive(Clone)]
 pub struct LazerPublisher {
     sender: Sender<FeedUpdate>,
+    pub(crate) is_ready: Arc<AtomicBool>,
 }
 
 impl LazerPublisher {
@@ -66,11 +69,13 @@ impl LazerPublisher {
             };
 
         let (relayer_sender, _) = broadcast::channel(CHANNEL_CAPACITY);
+        let is_ready = Arc::new(AtomicBool::new(false));
         for url in config.relayer_urls.iter() {
             let mut task = RelayerSessionTask {
                 url: url.clone(),
                 token: authorization_token.clone(),
                 receiver: relayer_sender.subscribe(),
+                is_ready: is_ready.clone(),
             };
             tokio::spawn(async move { task.run().await });
         }
@@ -84,7 +89,10 @@ impl LazerPublisher {
             signing_key,
         };
         tokio::spawn(async move { task.run().await });
-        Self { sender }
+        Self {
+            sender,
+            is_ready: Arc::new(AtomicBool::new(false)),
+        }
     }
 
     pub async fn push_feed_update(&self, feed_update: FeedUpdate) -> Result<()> {


### PR DESCRIPTION
## Summary

Add /live and /ready to lazer agent.

## Rationale

k8s deploys for internal publishers

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
