### PR TITLE
fix(lazer): solana program test

### DIFF
--- a/lazer/contracts/solana/programs/pyth-lazer-solana-contract/tests/test1.rs
+++ b/lazer/contracts/solana/programs/pyth-lazer-solana-contract/tests/test1.rs
@@ -20,7 +20,7 @@ fn program_test() -> ProgramTest {
         env::set_var(
             "SBF_OUT_DIR",
             format!(
-                "{}/../../../../target/sbf-solana-solana/release",
+                "{}/../../../../target/sbpf-solana-solana/release",
                 env::var("CARGO_MANIFEST_DIR").unwrap()
             ),
         );


### PR DESCRIPTION
The new Solana CLI, fetched with `sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"`, places the compiled program in a new directory.