### PR TITLE
chore: fix pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,59 +34,59 @@ repos:
       - id: cargo-fmt-remote-executor
         name: Cargo format for remote executor
         language: "rust"
-        entry: cargo +1.73.0 fmt --manifest-path ./governance/remote_executor/Cargo.toml --all
+        entry: cd governance/remote_executor && cargo fmt
         pass_filenames: false
         files: governance/remote_executor
       - id: cargo-clippy-remote-executor
         name: Cargo clippy for remote executor
         language: "rust"
-        entry: cargo +1.73.0 clippy --manifest-path ./governance/remote_executor/Cargo.toml --tests -- --deny warnings
+        entry: cd governance/remote_executor && cargo clippy --all-targets -- --deny warnings
         pass_filenames: false
         files: governance/remote_executor
       # Hooks for cosmwasm contract
       - id: cargo-fmt-cosmwasm
         name: Cargo format for cosmwasm contract
         language: "rust"
-        entry: cargo +1.82.0 fmt --manifest-path ./target_chains/cosmwasm/Cargo.toml --all
+        entry: cd target_chains/cosmwasm && cargo fmt
         pass_filenames: false
         files: target_chains/cosmwasm
       - id: cargo-clippy-cosmwasm
         name: Cargo clippy for cosmwasm contract
         language: "rust"
-        entry: cargo +1.82.0 clippy --manifest-path ./target_chains/cosmwasm/Cargo.toml --tests -- --deny warnings
+        entry: cd target_chains/cosmwasm && cargo clippy --all-targets -- --deny warnings
         pass_filenames: false
         files: target_chains/cosmwasm
       # Hooks for Hermes
       - id: cargo-fmt-hermes
         name: Cargo format for Hermes
         language: "rust"
-        entry: cargo +1.82.0 fmt --manifest-path ./apps/hermes/server/Cargo.toml --all
+        entry: cd apps/hermes/server && cargo fmt
         pass_filenames: false
         files: apps/hermes
       - id: cargo-clippy-hermes
         name: Cargo clippy for Hermes
         language: "rust"
-        entry: cargo +1.82.0 clippy --manifest-path ./apps/hermes/server/Cargo.toml --tests -- --deny warnings
+        entry: cd apps/hermes/server && cargo clippy --all-targets -- --deny warnings
         pass_filenames: false
         files: apps/hermes
       # Hooks for Quorum
       - id: cargo-fmt-quorum
         name: Cargo format for Quorum
         language: "rust"
-        entry: cargo +1.87.0 fmt --manifest-path ./apps/quorum/Cargo.toml --all
+        entry: cargo fmt -p quorum
         pass_filenames: false
         files: apps/quorum
       - id: cargo-clippy-quorum
         name: Cargo clippy for Quorum
         language: "rust"
-        entry: cargo +1.87.0 clippy --manifest-path ./apps/quorum/Cargo.toml --tests -- --deny warnings
+        entry: cargo clippy -p quorum --all-targets -- --deny warnings
         pass_filenames: false
         files: apps/quorum
       # Hooks for Fortuna
       - id: cargo-fmt-fortuna
         name: Cargo format for Fortuna
         language: "rust"
-        entry: cargo +1.82.0 fmt --manifest-path ./apps/fortuna/Cargo.toml --all
+        entry: cargo fmt -p fortuna
         pass_filenames: false
         files: apps/fortuna
       - id: cargo-sqlx-fortuna
@@ -98,71 +98,71 @@ repos:
       - id: cargo-clippy-fortuna
         name: Cargo clippy for Fortuna
         language: "rust"
-        entry: cargo +1.82.0 clippy --manifest-path ./apps/fortuna/Cargo.toml --tests -- --deny warnings
+        entry: cargo clippy -p fortuna --all-targets -- --deny warnings
         pass_filenames: false
         files: apps/fortuna
       # Hooks for message buffer contract
       - id: cargo-fmt-message-buffer
         name: Cargo format for message buffer contract
         language: "rust"
-        entry: cargo +1.66.1 fmt --manifest-path ./pythnet/message_buffer/Cargo.toml --all
+        entry: cd pythnet/message_buffer && cargo fmt
         pass_filenames: false
         files: pythnet/message_buffer
       - id: cargo-clippy-message-buffer
         name: Cargo clippy for message buffer contract
         language: "rust"
-        entry: cargo +1.66.1 clippy --manifest-path ./pythnet/message_buffer/Cargo.toml --tests -- --deny warnings
+        entry: cd pythnet/message_buffer && cargo clippy --all-targets -- --deny warnings
         pass_filenames: false
         files: pythnet/message_buffer
       # Hooks for pythnet_sdk
       - id: cargo-fmt-pythnet-sdk
         name: Cargo format for pythnet SDK
         language: "rust"
-        entry: cargo +1.82.0 fmt --manifest-path ./pythnet/pythnet_sdk/Cargo.toml --all
+        entry: cargo fmt -p pythnet-sdk
         pass_filenames: false
         files: pythnet/pythnet_sdk
       - id: cargo-clippy-pythnet-sdk
         name: Cargo clippy for pythnet SDK
         language: "rust"
-        entry: cargo +1.82.0 clippy --manifest-path ./pythnet/pythnet_sdk/Cargo.toml --tests -- --deny warnings
+        entry: cargo clippy -p pythnet-sdk --all-targets -- --deny warnings
         pass_filenames: false
         files: pythnet/pythnet_sdk
       # Hooks for solana receiver contract
       - id: cargo-fmt-pyth-solana-receiver
         name: Cargo format for solana target chain contract
         language: "rust"
-        entry: cargo +1.73.0 fmt --manifest-path ./target_chains/solana/Cargo.toml --all
+        entry: cd target_chains/solana && cargo fmt
         pass_filenames: false
         files: target_chains/solana
       - id: cargo-clippy-pyth-solana-receiver
         name: Cargo clippy for solana target chain contract
         language: "rust"
-        entry: cargo +1.73.0 clippy --manifest-path ./target_chains/solana/Cargo.toml --tests -- --deny warnings
+        entry: cd target_chains/solana/ && cargo clippy --all-targets -- --deny warnings
         pass_filenames: false
         files: target_chains/solana
-      # For Lazer
+      # Hooks for Lazer
       - id: cargo-fmt-lazer
         name: Cargo format for Lazer
         language: "rust"
-        entry: cargo +1.82.0 fmt --manifest-path ./lazer/Cargo.toml --all
+        entry: cargo fmt -p pyth-lazer-protocol -p pyth-lazer-client -p pyth-lazer-publisher-sdk
         pass_filenames: false
         files: lazer
       - id: cargo-clippy-lazer
         name: Cargo clippy for Lazer
         language: "rust"
-        entry: cargo +1.82.0 clippy --manifest-path ./lazer/Cargo.toml --all-targets -- --deny warnings
+        entry: cargo clippy -p pyth-lazer-protocol -p pyth-lazer-client -p pyth-lazer-publisher-sdk --all-targets -- --deny warnings
         pass_filenames: false
         files: lazer
       - id: cargo-fmt-stylus-sdk
         name: Cargo format for Stylus SDK
         language: "rust"
-        entry: cargo +1.82.0 fmt --manifest-path ./target_chains/ethereum/sdk/stylus/Cargo.toml --all
+        entry: cd target_chains/ethereum/sdk/stylus && cargo fmt
         pass_filenames: false
         files: target_chains/ethereum/sdk/stylus
       - id: cargo-clippy-stylus-sdk
         name: Cargo clippy for Stylus SDK
         language: "rust"
-        entry: cargo +1.82.0 clippy --manifest-path ./target_chains/ethereum/sdk/stylus/Cargo.toml  --all-targets -- --deny warnings
+        entry: cd target_chains/ethereum/sdk/stylus && cargo clippy --all-targets -- --deny warnings
         pass_filenames: false
         files: target_chains/ethereum/sdk/stylus
       - id: fmt-aptos-lazer
@@ -174,6 +174,6 @@ repos:
       - id: lint-aptos-lazer
         name: Lint Aptos Lazer contracts
         language: system
-        entry: aptos move lint --package-dir lazer/contracts/aptos --check-test-code --dev
+        entry: aptos move lint --package-dir lazer/contracts/aptos --dev
         pass_filenames: false
         files: lazer/contracts/aptos


### PR DESCRIPTION
## Summary

Update rust related command in pre-commit-config. Remove hardcoded Rust versions so that pre-commit uses versions from rust-toolchain files.

## Rationale

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
