### PR TITLE
fix(argus) Fix compilation issues related to EscalationPolicy

### DIFF
--- a/apps/argus/src/config.rs
+++ b/apps/argus/src/config.rs
@@ -159,10 +159,6 @@ impl Default for EscalationPolicyConfig {
 impl EscalationPolicyConfig {
     pub fn to_policy(&self) -> EscalationPolicy {
         EscalationPolicy {
-            gas_limit_tolerance_pct: self.gas_limit_tolerance_pct,
-            initial_gas_multiplier_pct: self.initial_gas_multiplier_pct,
-            gas_multiplier_pct: self.gas_multiplier_pct,
-            gas_multiplier_cap_pct: self.gas_multiplier_cap_pct,
             fee_multiplier_pct: self.fee_multiplier_pct,
             fee_multiplier_cap_pct: self.fee_multiplier_cap_pct,
         }


### PR DESCRIPTION
## Summary
Remove the fields argus config that no longer exist in  EscalationPolicy

## Rationale
The fields were removed in #2691 causing compilation errors in argus:
```
error[E0560]: struct `EscalationPolicy` has no field named `gas_limit_tolerance_pct`
   --> apps/argus/src/config.rs:162:13
    |
162 |             gas_limit_tolerance_pct: self.gas_limit_tolerance_pct,
    |             ^^^^^^^^^^^^^^^^^^^^^^^ `EscalationPolicy` does not have this field
    |
    = note: all struct fields are already assigned

error[E0560]: struct `EscalationPolicy` has no field named `initial_gas_multiplier_pct`
   --> apps/argus/src/config.rs:163:13
    |
163 |             initial_gas_multiplier_pct: self.initial_gas_multiplier_pct,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ `EscalationPolicy` does not have this field
    |
    = note: all struct fields are already assigned

error[E0560]: struct `EscalationPolicy` has no field named `gas_multiplier_pct`
   --> apps/argus/src/config.rs:164:13
    |
164 |             gas_multiplier_pct: self.gas_multiplier_pct,
    |             ^^^^^^^^^^^^^^^^^^ `EscalationPolicy` does not have this field
    |
    = note: all struct fields are already assigned

error[E0560]: struct `EscalationPolicy` has no field named `gas_multiplier_cap_pct`
   --> apps/argus/src/config.rs:165:13
    |
165 |             gas_multiplier_cap_pct: self.gas_multiplier_cap_pct,
    |             ^^^^^^^^^^^^^^^^^^^^^^ `EscalationPolicy` does not have this field
    |
    = note: all struct fields are already assigned
```

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->