### PR TITLE
chore(ci): fix starknet build

### DIFF
--- a/.github/workflows/ci-starknet-contract.yml
+++ b/.github/workflows/ci-starknet-contract.yml
@@ -27,7 +27,8 @@ jobs:
         run: curl https://get.starkli.sh | sh && . ~/.config/.starkli/env && starkliup -v $(awk '/starkli/{print $2}' .tool-versions)
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install Devnet
-        run: cargo install starknet-devnet --version $(awk '/starknet-devnet/{print $2}' .tool-versions)
+        # it doesn't build with more recent Rust versions
+        run: cargo +1.85.0 install starknet-devnet --version $(awk '/starknet-devnet/{print $2}' .tool-versions)
       - name: Check formatting
         run: scarb fmt --check
       - name: Run tests


### PR DESCRIPTION
## Summary

Pin Rust version for building starknet-devnet because it somehow fails to build on newer Rust.

## Rationale

Fix CI

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
