### PR TITLE
chore(fortuna): improve fee withdrawal logs, dont error log on pkey unique constraint violation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3058,7 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "fortuna"
-version = "8.2.0"
+version = "8.2.1"
 dependencies = [
  "anyhow",
  "axum 0.6.20",

--- a/apps/fortuna/Cargo.toml
+++ b/apps/fortuna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortuna"
-version = "8.2.0"
+version = "8.2.1"
 edition = "2021"
 
 [lib]

--- a/apps/fortuna/src/history.rs
+++ b/apps/fortuna/src/history.rs
@@ -357,7 +357,18 @@ impl History {
             }
         };
         if let Err(e) = result {
-            tracing::error!("Failed to update request status: {}", e);
+            match e.as_database_error() {
+                Some(db_error) if db_error.is_unique_violation() => {
+                    tracing::info!(
+                        "Failed to insert request, request already exists: Chain ID: {}, Sequence: {}",
+                        network_id,
+                        sequence
+                    );
+                }
+                _ => {
+                    tracing::error!("Failed to update request status: {}", e);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Tune the logs on Fortuna:
- Add more logs for fee withdrawals to make tracing easier
- Downgrade pkey unique violation logs since this is expected behavior, we are using the unique constraint to prevent one instance from overwriting a request row that another created.

## Rationale

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
