### PR TITLE
chore(entropy): Add hardhat config for abstract and adjust hardhat Solidity version

### DIFF
--- a/target_chains/ethereum/contracts/hardhat.config.ts
+++ b/target_chains/ethereum/contracts/hardhat.config.ts
@@ -60,6 +60,13 @@ module.exports = {
       verifyURL:
         "https://api-explorer-verify.testnet.abs.xyz/contract_verification",
     },
+    abstract: {
+      url: "https://api.mainnet.abs.xyz",
+      ethNetwork: "mainnet",
+      zksync: true,
+      verifyURL:
+        "https://api-explorer-verify.mainnet.abs.xyz/contract_verification",
+    },
     mathMainnet: {
       url: "https://redacted.master.dev/",
       ethNetwork: "mainnet",
@@ -112,7 +119,7 @@ module.exports = {
     ],
   },
   solidity: {
-    version: "0.8.29",
+    version: "0.8.20",
     evmVersion: "paris",
     settings: {
       optimizer: {


### PR DESCRIPTION
## Summary

Add configuration for abstract to hardhat and lower solidity version to something supported by Hardhat. Hardhat doesn't build the contracts with 0.8.29 and i backed up until I found one that works.

## Rationale

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
