### PR TITLE
feat(entropy-tester): add retries

### DIFF
--- a/apps/entropy-tester/package.json
+++ b/apps/entropy-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/entropy-tester",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Utility to test entropy provider callbacks",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

Add retries to the entropy-tester script

## Rationale

We use entropy-tester as a synthetic test for Entropy. If the script fails, it's a good signal that something is wrong. However, this can be a bit noisy, as currently a single failed callback raises an alarm, even though it is likely due to a transient chain issue we can't do anything about.

Adding retries to the tester allows us to reduce this noise by only alerting if we fail to receive multiple callbacks in a row. After this change, a critical alert will be fired if 3 callbacks fail back to back, giving us better confidence that something is actually wrong.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code
  - Tested locally with prod config