### PR TITLE
fix(transfer-balance-entropy-chains): round transfer amount to avoid conv errors

### DIFF
--- a/contract_manager/scripts/transfer_balance_entropy_chains.ts
+++ b/contract_manager/scripts/transfer_balance_entropy_chains.ts
@@ -160,6 +160,9 @@ async function transferOnChain(
       transferAmountEth = (balanceEth - gasCostEth) * transferRatio!;
     }
 
+    // Round to 10 decimal places to avoid Web3 conversion errors
+    transferAmountEth = Math.round(transferAmountEth * 1e10) / 1e10;
+
     // Validate transfer amount
     if (transferAmountEth <= 0) {
       console.log(


### PR DESCRIPTION
## Summary

Sometimes when using `--ratio`, the amount to transfer can be a number with many decimals. `web3.utils.toWei` errors on these numbers with `'[ethjs-unit] while converting number 0.0016499420763857226 to wei, too many decimal places' `

## Rationale

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
