### PR TITLE
fix(pyth-lazer-agent) Allow the relayer endpoint path in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5611,7 +5611,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-agent"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "backoff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5611,7 +5611,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-agent"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "backoff",

--- a/apps/pyth-lazer-agent/Cargo.toml
+++ b/apps/pyth-lazer-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-agent"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/apps/pyth-lazer-agent/Cargo.toml
+++ b/apps/pyth-lazer-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-agent"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 
 [dependencies]

--- a/apps/pyth-lazer-agent/src/relayer_session.rs
+++ b/apps/pyth-lazer-agent/src/relayer_session.rs
@@ -22,10 +22,7 @@ use url::Url;
 type RelayerWsSender = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, TungsteniteMessage>;
 type RelayerWsReceiver = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 
-async fn connect_to_relayer(
-    url: Url,
-    token: &str,
-) -> Result<(RelayerWsSender, RelayerWsReceiver)> {
+async fn connect_to_relayer(url: Url, token: &str) -> Result<(RelayerWsSender, RelayerWsReceiver)> {
     tracing::info!("connecting to the relayer at {}", url);
     let mut req = url.clone().into_client_request()?;
     let headers = req.headers_mut();

--- a/apps/pyth-lazer-agent/src/relayer_session.rs
+++ b/apps/pyth-lazer-agent/src/relayer_session.rs
@@ -23,11 +23,10 @@ type RelayerWsSender = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Tun
 type RelayerWsReceiver = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 
 async fn connect_to_relayer(
-    mut url: Url,
+    url: Url,
     token: &str,
 ) -> Result<(RelayerWsSender, RelayerWsReceiver)> {
     tracing::info!("connecting to the relayer at {}", url);
-    url.set_path("/v1/transaction");
     let mut req = url.clone().into_client_request()?;
     let headers = req.headers_mut();
     headers.insert(


### PR DESCRIPTION
## Summary
Allow the full URL (including path) to be specified for the relayers. Also bump to 0.1.5 for release

## Rationale
The path structure differs and prod and staging so we can't simply hardcode it as `/v1/transactions` 

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
