### PR TITLE
fix: adjust initial rewards

### DIFF
--- a/apps/staking/src/components/Header/stats.tsx
+++ b/apps/staking/src/components/Header/stats.tsx
@@ -12,7 +12,7 @@ import { Tokens } from "../Tokens";
 const ONE_SECOND_IN_MS = 1000;
 const ONE_MINUTE_IN_MS = 60 * ONE_SECOND_IN_MS;
 const REFRESH_INTERVAL = 1 * ONE_MINUTE_IN_MS;
-const INITIAL_REWARD_POOL_SIZE = 60_000_000_000_000n;
+const INITIAL_REWARD_POOL_SIZE = 100_000_010_000_000n;
 
 export const Stats = ({ className, ...props }: HTMLProps<HTMLDivElement>) => {
   const { connection } = useConnection();


### PR DESCRIPTION
## Summary

We hardcode the total amount if rewards transferred by PDA to OIS.

## Rationale

New rewards were sent to OIS, making the old number inaccurate.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
