### PR TITLE
feat(pyth-lazer-agent) Publish the agent to crates.io

### DIFF
--- a/.github/workflows/publish-rust-lazer-agent.yml
+++ b/.github/workflows/publish-rust-lazer-agent.yml
@@ -1,0 +1,18 @@
+name: Publish Rust package pyth-lazer-agent to crates.io
+
+on:
+  push:
+    tags:
+      - pyth-lazer-agent-v*
+jobs:
+  publish-pyth-lazer-protocol:
+    name: Publish Rust package pyth-lazer-agent to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        working-directory: "apps/pyth-lazer-agent"

--- a/apps/pyth-lazer-agent/Cargo.toml
+++ b/apps/pyth-lazer-agent/Cargo.toml
@@ -2,6 +2,9 @@
 name = "pyth-lazer-agent"
 version = "0.3.2"
 edition = "2024"
+description = "Pyth Lazer Agent"
+license = "Apache-2.0"
+repository = "https://github.com/pyth-network/pyth-crosschain"
 
 [dependencies]
 pyth-lazer-publisher-sdk = "0.1.7"


### PR DESCRIPTION
## Summary
Add a gh workflow to publish the `pyth-lazer-agent` to crates.io and update Cargo.toml

## Rationale
Simplifies the deployment of the agent

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
