### PR TITLE
fix(fortuna): Fix bug in get_request_v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3071,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "fortuna"
-version = "8.2.3"
+version = "8.2.4"
 dependencies = [
  "anyhow",
  "axum 0.6.20",

--- a/apps/fortuna/Cargo.toml
+++ b/apps/fortuna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortuna"
-version = "8.2.3"
+version = "8.2.4"
 edition = "2021"
 
 [lib]

--- a/apps/fortuna/src/chain/ethereum.rs
+++ b/apps/fortuna/src/chain/ethereum.rs
@@ -274,13 +274,17 @@ impl<T: JsonRpcClient + 'static> EntropyReader for PythRandom<Provider<T>> {
             .get_request_v2(provider_address, sequence_number)
             .call()
             .await?;
-        Ok(Some(reader::Request {
-            provider: request.provider,
-            sequence_number: request.sequence_number,
-            block_number: request.block_number,
-            use_blockhash: request.use_blockhash,
-            callback_status: reader::RequestCallbackStatus::try_from(request.callback_status)?,
-        }))
+        if request.sequence_number == 0 {
+            Ok(None)
+        } else {
+            Ok(Some(reader::Request {
+                provider: request.provider,
+                sequence_number: request.sequence_number,
+                block_number: request.block_number,
+                use_blockhash: request.use_blockhash,
+                callback_status: reader::RequestCallbackStatus::try_from(request.callback_status)?,
+            }))
+        }
     }
 
     async fn get_block_number(&self, confirmed_block_status: BlockStatus) -> Result<BlockNumber> {


### PR DESCRIPTION
## Summary

I introduced a bug in this method in the PR when I upgraded fortuna to handle the v2 contract. This bug is breaking the stats on callback errors.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
