### PR TITLE
chore(pyth-lazer-publisher-sdk) Bump to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5736,19 +5736,14 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-publisher-sdk"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
- "derive_more 2.0.1",
  "fs-err",
- "hex",
- "humantime",
  "protobuf",
  "protobuf-codegen",
  "pyth-lazer-protocol 0.10.0",
- "serde",
  "serde_json",
- "tracing",
 ]
 
 [[package]]

--- a/lazer/publisher_sdk/rust/Cargo.toml
+++ b/lazer/publisher_sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-publisher-sdk"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Pyth Lazer Publisher SDK types."
 license = "Apache-2.0"
@@ -10,12 +10,7 @@ repository = "https://github.com/pyth-network/pyth-crosschain"
 pyth-lazer-protocol = { version = "0.10.0", path = "../../sdk/rust/protocol" }
 anyhow = "1.0.98"
 protobuf = "3.7.2"
-humantime = "2.2.0"
-tracing = "0.1.41"
-serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-derive_more = { version = "2.0.1", features = ["from"] }
-hex = "0.4.3"
 
 [build-dependencies]
 fs-err = "3.1.0"


### PR DESCRIPTION
Previous version depended on `pyth-lazer-protocol:v0.9.1` - we need a release of `pyth-lazer-publisher-sdk` with that version. Also clean up deps. 