### PR TITLE
feat(fortuna): track balance of fee manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3071,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "fortuna"
-version = "8.2.5"
+version = "8.2.6"
 dependencies = [
  "anyhow",
  "axum 0.6.20",

--- a/apps/fortuna/Cargo.toml
+++ b/apps/fortuna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortuna"
-version = "8.2.5"
+version = "8.2.6"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
## Summary

Update the tracking thread to also track the balance of the fee manager wallet. This will help us set up accurate balance monitoring & alerting, since the keepers and the fee mgr should all be somewhat equally funded. Currently we only track the keeper balances.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code
  - Tested locally 
