### PR TITLE
fix(hermes): Update Hermes API Response to No Context

### DIFF
--- a/apps/hermes/server/src/api/rest.rs
+++ b/apps/hermes/server/src/api/rest.rs
@@ -49,10 +49,10 @@ impl IntoResponse for RestError {
     fn into_response(self) -> Response {
         match self {
             RestError::BenchmarkPriceNotUnique => {
-                (StatusCode::NOT_FOUND, "Benchmark price is not unique").into_response()
+                (StatusCode::NO_CONTENT, "Benchmark price is not unique").into_response()
             }
             RestError::UpdateDataNotFound => {
-                (StatusCode::NOT_FOUND, "Update data not found").into_response()
+                (StatusCode::NO_CONTENT, "Update data not found").into_response()
             }
             RestError::CcipUpdateDataNotFound => {
                 // Return "Bad Gateway" error because CCIP expects a 5xx error if it needs to retry
@@ -75,7 +75,7 @@ impl IntoResponse for RestError {
                     .join(", ");
 
                 (
-                    StatusCode::NOT_FOUND,
+                    StatusCode::NO_CONTENT,
                     format!("Price ids not found: {missing_ids}"),
                 )
                     .into_response()


### PR DESCRIPTION
## Summary
Changed Hermes to return Status Code 204 when request params lead to certain resources not being found, causing the request to fail. 

## Rationale
Hermes previously was returning 404, which can indicate the API itself does not exist, which is misleading. 

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
