### PR TITLE
fix(stylus) - fixed order of fee calculation

### DIFF
--- a/target_chains/stylus/contracts/pyth-receiver/src/integration_tests.rs
+++ b/target_chains/stylus/contracts/pyth-receiver/src/integration_tests.rs
@@ -8,6 +8,7 @@ mod test {
     use motsu::prelude::*;
     use pythnet_sdk::wire::v1::{AccumulatorUpdateData, Proof};
     use std::time::Duration;
+    use stylus_sdk::types::AddressVM;
     use wormhole_contract::WormholeContract;
 
     const PYTHNET_CHAIN_ID: u16 = 26;
@@ -106,7 +107,11 @@ mod test {
         let result = pyth_contract
             .sender_and_value(alice, update_fee)
             .update_price_feeds(update_data);
+
         assert!(result.is_ok());
+
+        assert_eq!(alice.balance(), U256::ZERO);
+        assert_eq!(pyth_contract.balance(), update_fee);
 
         let price_result = pyth_contract
             .sender(alice)
@@ -157,10 +162,16 @@ mod test {
             .update_price_feeds(update_data1);
         assert!(result1.is_ok());
 
+        assert_eq!(alice.balance(), update_fee2);
+        assert_eq!(pyth_contract.balance(), update_fee1);
+
         let result2 = pyth_contract
             .sender_and_value(alice, update_fee2)
             .update_price_feeds(update_data2);
         assert!(result2.is_ok());
+
+        assert_eq!(alice.balance(), U256::ZERO);
+        assert_eq!(pyth_contract.balance(), update_fee1 + update_fee2);
 
         let price_result = pyth_contract
             .sender(alice)
@@ -231,6 +242,9 @@ mod test {
             .update_price_feeds(update_data);
         assert!(result.is_ok());
 
+        assert_eq!(alice.balance(), U256::ZERO);
+        assert_eq!(pyth_contract.balance(), update_fee);
+
         let price_result = pyth_contract
             .sender(alice)
             .get_price_no_older_than(btc_usd_feed_id(), u64::MAX);
@@ -256,6 +270,9 @@ mod test {
             .sender_and_value(alice, update_fee)
             .update_price_feeds(update_data);
         assert!(result.is_ok());
+
+        assert_eq!(alice.balance(), U256::ZERO);
+        assert_eq!(pyth_contract.balance(), update_fee);
 
         let price_result = pyth_contract
             .sender(alice)
@@ -285,6 +302,9 @@ mod test {
             .sender_and_value(alice, update_fee)
             .update_price_feeds(update_data);
         assert!(result.is_ok());
+
+        assert_eq!(alice.balance(), U256::ZERO);
+        assert_eq!(pyth_contract.balance(), update_fee);
 
         let first_price_result = pyth_contract
             .sender(alice)
@@ -327,6 +347,9 @@ mod test {
             .update_price_feeds(update_data);
         assert!(result.is_ok());
 
+        assert_eq!(alice.balance(), U256::ZERO);
+        assert_eq!(pyth_contract.balance(), update_fee);
+
         assert!(pyth_contract
             .sender(alice)
             .price_feed_exists(ban_usd_feed_id()));
@@ -368,6 +391,9 @@ mod test {
             .sender_and_value(alice, update_fee)
             .update_price_feeds(update_data);
 
+        assert_eq!(alice.balance(), U256::ZERO);
+        assert_eq!(pyth_contract.balance(), update_fee);
+
         assert!(result.is_ok());
 
         let price_result = pyth_contract
@@ -394,6 +420,9 @@ mod test {
         let result = pyth_contract
             .sender_and_value(alice, update_fee)
             .update_price_feeds(update_data);
+
+        assert_eq!(alice.balance(), U256::ZERO);
+        assert_eq!(pyth_contract.balance(), update_fee);
 
         assert!(result.is_ok());
 

--- a/target_chains/stylus/contracts/pyth-receiver/src/lib.rs
+++ b/target_chains/stylus/contracts/pyth-receiver/src/lib.rs
@@ -213,16 +213,16 @@ impl PythReceiver {
         &mut self,
         update_data: Vec<Vec<u8>>,
     ) -> Result<(), PythReceiverError> {
-        for data in &update_data {
-            self.update_price_feeds_internal(data.clone(), 0, 0, false)?;
-        }
-
-        let total_fee = self.get_update_fee(update_data)?;
+        let total_fee = self.get_update_fee(update_data.clone())?;
 
         let value = self.vm().msg_value();
 
         if value < total_fee {
             return Err(PythReceiverError::InsufficientFee);
+        }
+
+        for data in &update_data {
+            self.update_price_feeds_internal(data.clone(), 0, 0, false)?;
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

UpdatePriceFeeds now collects fees from the user before actually going through the update script.

## Rationale

Need to make sure that we validate fee before doing the work so that people can't use the service without paying tax.

## How has this been tested?

- [x] Current tests cover my changes
- [x] Added new tests
- [x] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
