### PR TITLE
chore(lazer/publisher-sdk): Add Rejections for Market Closed and Unauthorized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5728,7 +5728,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-publisher-sdk"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "fs-err",

--- a/lazer/publisher_sdk/proto/transaction_envelope.proto
+++ b/lazer/publisher_sdk/proto/transaction_envelope.proto
@@ -66,5 +66,5 @@ enum RejectReason {
     MissingFields = 4;
     InactiveFeedId = 5;
     MarketClosed = 6;
-    Unpermissioned = 7;
+    Unauthorized = 7;
 }

--- a/lazer/publisher_sdk/proto/transaction_envelope.proto
+++ b/lazer/publisher_sdk/proto/transaction_envelope.proto
@@ -65,4 +65,6 @@ enum RejectReason {
     InvalidFeedId = 3;
     MissingFields = 4;
     InactiveFeedId = 5;
+    MarketClosed = 6;
+    Unpermissioned = 7;
 }

--- a/lazer/publisher_sdk/rust/Cargo.toml
+++ b/lazer/publisher_sdk/rust/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/pyth-network/pyth-crosschain"
 
 [dependencies]
-pyth-lazer-protocol = { version = "0.10.1", path = "../../sdk/rust/protocol" }
+pyth-lazer-protocol = { version = "0.10.2", path = "../../sdk/rust/protocol" }
 anyhow = "1.0.98"
 protobuf = "3.7.2"
 serde_json = "1.0.140"

--- a/lazer/publisher_sdk/rust/Cargo.toml
+++ b/lazer/publisher_sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-publisher-sdk"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Pyth Lazer Publisher SDK types."
 license = "Apache-2.0"

--- a/lazer/sdk/rust/client/Cargo.toml
+++ b/lazer/sdk/rust/client/Cargo.toml
@@ -6,7 +6,7 @@ description = "A Rust client for Pyth Lazer"
 license = "Apache-2.0"
 
 [dependencies]
-pyth-lazer-protocol = { path = "../protocol", version = "0.10.1" }
+pyth-lazer-protocol = { path = "../protocol", version = "0.10.2" }
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = { version = "0.20", features = ["native-tls"] }
 futures-util = "0.3"


### PR DESCRIPTION
## Summary
Adds reject reasons for if the market is closed for the feed, and if the publisher is not permissioned for that feed. 

## Rationale
We still want to process and store these, but not produce aggregates on them. 

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
