### PR TITLE
feat(fortuna): allow filtering callback failing logs

### DIFF
--- a/apps/fortuna/Cargo.toml
+++ b/apps/fortuna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortuna"
-version = "9.0.0"
+version = "9.1.0"
 edition = "2021"
 
 [lib]

--- a/apps/fortuna/src/api.rs
+++ b/apps/fortuna/src/api.rs
@@ -39,21 +39,12 @@ mod revelation;
 pub type ChainId = String;
 pub type NetworkId = u64;
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, utoipa::ToSchema, sqlx::Type)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 pub enum StateTag {
     Pending,
-    Completed,
     Failed,
-}
-
-impl std::fmt::Display for StateTag {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            StateTag::Pending => write!(f, "Pending"),
-            StateTag::Completed => write!(f, "Completed"),
-            StateTag::Failed => write!(f, "Failed"),
-        }
-    }
+    Completed,
+    CallbackErrored,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]


### PR DESCRIPTION
## Summary

Adds support for filtering logs based on callback failed / callback succeeded state to Fortuna.

## Rationale

Entropy explorer

## How has this been tested?

- [x] Current tests cover my changes
- [x] Added new tests
- [x] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
