### PR TITLE
fix(fortuna): set last_updated_at correctly, use ms precision

### DIFF
--- a/apps/fortuna/src/keeper/process_event.rs
+++ b/apps/fortuna/src/keeper/process_event.rs
@@ -181,6 +181,7 @@ pub async fn process_event_with_backoff(
         .get_or_create(&account_label)
         .inc();
 
+    status.last_updated_at = chrono::Utc::now();
     match success {
         Ok(result) => {
             status.state = RequestEntryState::Completed {


### PR DESCRIPTION
## Summary

- Update timestamp precision to milliseconds
- Set `last_updated_at` after we get back the tx receipt (or lack thereof)
  - I would've liked to add an assertion for this but this business logic doesn't have tests 

## Rationale

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->