### PR TITLE
Replace self-hosted bounty program with Immunefi Bug Bounty in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Bug Bounty Program
 
-Pyth operates a [bug bounty program](https://immunefi.com/bug-bounty/pythnetwork/information/) on Immunefi to financially incentivize independent researchers (with up to $250,000 USDC) for finding and responsibly disclosing security issues.
+Pyth operates a [bug bounty program](https://pyth.network/bounty) on Immunefi to financially incentivize independent researchers (with up to $250,000 USDC) for finding and responsibly disclosing security issues.
 
 - **Scopes**
   Please see the [Immunefi scope list](https://immunefi.com/bug-bounty/pythnetwork/scope/#top) for an up-to-date list of the included scopes


### PR DESCRIPTION
I noticed that the `SECURITY.md` still references the previous self-hosted bounty program. Replaced it with the Immunefi bounty program.