### PR TITLE
chore(entropy v2): requestv2 comment fix

### DIFF
--- a/target_chains/ethereum/entropy_sdk/solidity/IEntropyV2.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/IEntropyV2.sol
@@ -12,9 +12,7 @@ interface IEntropyV2 is EntropyEventsV2 {
     /// The `entropyCallback` method on that interface will receive a callback with the returned sequence number and
     /// the generated random number.
     ///
-    /// `entropyCallback` will be run with the `gasLimit` provided to this function.
-    /// The `gasLimit` will be rounded up to a multiple of 10k (e.g., 19000 -> 20000), and furthermore is lower bounded
-    /// by the provider's configured default limit.
+    /// `entropyCallback` will be run with the provider's configured default gas limit.
     ///
     /// This method will revert unless the caller provides a sufficient fee (at least `getFeeV2()`) as msg.value.
     /// Note that the fee can change over time. Callers of this method should explicitly compute `getFeeV2()`


### PR DESCRIPTION
## Summary

`requestv2()` has a [comment](https://github.com/pyth-network/pyth-crosschain/blob/5d8d4f2cffdd0aae62214bc9387bfcd913dc3990/target_chains/ethereum/entropy_sdk/solidity/IEntropyV2.sol#L15) which needs to be rectified as this function does not take any input parameter of gasLimit.

<!-- Briefly describe the changes -->

## Rationale
The comment is confusing as there is no `gasLimit` provided.

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
