### PR TITLE
Remove 1ms fixed rate from lazer fixed rate channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-client"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "alloy-primitives 0.8.25",
  "anyhow",
@@ -5682,7 +5682,7 @@ dependencies = [
  "futures-util",
  "hex",
  "libsecp256k1 0.7.2",
- "pyth-lazer-protocol 0.10.2",
+ "pyth-lazer-protocol 0.12.0",
  "serde",
  "serde_json",
  "tokio",
@@ -5715,7 +5715,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-protocol"
-version = "0.10.2"
+version = "0.12.0"
 dependencies = [
  "alloy-primitives 0.8.25",
  "anyhow",
@@ -5753,13 +5753,13 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-publisher-sdk"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "fs-err",
  "protobuf",
  "protobuf-codegen",
- "pyth-lazer-protocol 0.10.2",
+ "pyth-lazer-protocol 0.12.0",
  "serde_json",
 ]
 

--- a/lazer/publisher_sdk/proto/governance_instruction.proto
+++ b/lazer/publisher_sdk/proto/governance_instruction.proto
@@ -235,7 +235,7 @@ message AddFeed {
     // [required]
     optional uint32 min_publishers = 103;
     // [required]
-    optional google.protobuf.Duration min_rate = 104;
+    optional Channel min_channel = 104;
     // [required]
     optional google.protobuf.Duration expiry_time = 105;
     // [required]
@@ -282,7 +282,7 @@ message UpdateFeedProperties {
     // [optional]
     optional uint32 min_publishers = 103;
     // [optional]
-    optional google.protobuf.Duration min_rate = 104;
+    optional Channel min_channel = 104;
     // [optional]
     optional google.protobuf.Duration expiry_time = 105;
     // [optional]

--- a/lazer/publisher_sdk/proto/state.proto
+++ b/lazer/publisher_sdk/proto/state.proto
@@ -3,10 +3,19 @@ package pyth_lazer;
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/empty.proto";
 
 import "dynamic_value.proto";
 
+
 // All optional fields should always be set unless documented otherwise.
+
+message Channel {
+    oneof kind {
+        google.protobuf.Duration rate = 1;
+        google.protobuf.Empty real_time = 2;
+    }
+}
 
 // State of a Pyth Lazer shard.
 //
@@ -92,9 +101,9 @@ message Feed {
     optional sint32 exponent = 102;
     // [required] Minimal number of publisher prices required to produce an aggregate.
     optional uint32 min_publishers = 103;
-    // [required] Minimal rate of aggregation performed by the aggregator for this feed.
+    // [required] Minimal channel of aggregation performed by the aggregator for this feed.
     // Cannot be lower than the shard's top level `State.min_rate`.
-    optional google.protobuf.Duration min_rate = 104;
+    optional Channel min_channel = 104;
     // [required] Time after which the publisher update is discarded.
     optional google.protobuf.Duration expiry_time = 105;
     // [required] Market schedule in Pythnet format.

--- a/lazer/publisher_sdk/rust/Cargo.toml
+++ b/lazer/publisher_sdk/rust/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "pyth-lazer-publisher-sdk"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Pyth Lazer Publisher SDK types."
 license = "Apache-2.0"
 repository = "https://github.com/pyth-network/pyth-crosschain"
 
 [dependencies]
-pyth-lazer-protocol = { version = "0.10.2", path = "../../sdk/rust/protocol" }
+pyth-lazer-protocol = { version = "0.12.0", path = "../../sdk/rust/protocol" }
 anyhow = "1.0.98"
 protobuf = "3.7.2"
 serde_json = "1.0.140"

--- a/lazer/publisher_sdk/rust/src/lib.rs
+++ b/lazer/publisher_sdk/rust/src/lib.rs
@@ -114,3 +114,36 @@ impl From<state::FeedKind> for FeedKind {
         }
     }
 }
+
+impl TryFrom<state::Channel> for pyth_lazer_protocol::router::Channel {
+    type Error = anyhow::Error;
+
+    fn try_from(value: state::Channel) -> Result<Self, Self::Error> {
+        Ok(match value.kind {
+            Some(kind) => match kind {
+                state::channel::Kind::Rate(rate) => {
+                    pyth_lazer_protocol::router::Channel::FixedRate(rate.try_into()?)
+                }
+                state::channel::Kind::RealTime(_) => pyth_lazer_protocol::router::Channel::RealTime,
+            },
+            None => pyth_lazer_protocol::router::Channel::FixedRate(
+                pyth_lazer_protocol::router::FixedRate::MIN,
+            ),
+        })
+    }
+}
+
+impl From<pyth_lazer_protocol::router::Channel> for state::Channel {
+    fn from(value: pyth_lazer_protocol::router::Channel) -> Self {
+        let mut result = state::Channel::new();
+        match value {
+            pyth_lazer_protocol::router::Channel::FixedRate(rate) => {
+                result.set_rate(rate.into());
+            }
+            pyth_lazer_protocol::router::Channel::RealTime => {
+                result.set_real_time(::protobuf::well_known_types::empty::Empty::new());
+            }
+        };
+        result
+    }
+}

--- a/lazer/sdk/rust/client/Cargo.toml
+++ b/lazer/sdk/rust/client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "pyth-lazer-client"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2021"
 description = "A Rust client for Pyth Lazer"
 license = "Apache-2.0"
 
 [dependencies]
-pyth-lazer-protocol = { path = "../protocol", version = "0.10.2" }
+pyth-lazer-protocol = { path = "../protocol", version = "0.12.0" }
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = { version = "0.20", features = ["native-tls"] }
 futures-util = "0.3"

--- a/lazer/sdk/rust/protocol/Cargo.toml
+++ b/lazer/sdk/rust/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-protocol"
-version = "0.10.2"
+version = "0.12.0"
 edition = "2021"
 description = "Pyth Lazer SDK - protocol types."
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Remove 1 ms Fixed-Rate Channel and Add Real-Time Channel Support

## Rationale

Previously, the Pyth Lazer used 1ms fixed-rate channels, pushing updates every millisecond regardless of whether the price changed. This created unnecessarily high load, as actual price changes often occur less frequently and at variable intervals.
With this change, the fixed 1 ms updates are replaced by a real-time, event-driven channel:
   - If the price changes, an update is sent immediately.
   - If there’s no change, an update is sent at a maximum interval of 50 ms.
This approach significantly reduces load while ensuring prices are still updated promptly and reliably.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [X] Manually tested the code