### PR TITLE
chore(entropy): redirect to IEntropyv2 for more gas usage

### DIFF
--- a/target_chains/ethereum/entropy_sdk/solidity/IEntropy.sol
+++ b/target_chains/ethereum/entropy_sdk/solidity/IEntropy.sol
@@ -52,7 +52,8 @@ interface IEntropy is EntropyEvents, EntropyEventsV2, IEntropyV2 {
     // The address calling this function should be a contract that inherits from the IEntropyConsumer interface.
     // The `entropyCallback` method on that interface will receive a callback with the generated random number.
     // `entropyCallback` will be run with the provider's default gas limit (see `getProviderInfo(provider).defaultGasLimit`).
-    // If your callback needs additional gas, please use `requestv2` of `IEntropyV2` interface.
+    // If your callback needs additional gas, please use the function `requestv2` from `IEntropyV2` interface 
+    // with gasLimit as the input parameter.
     //
     // This method will revert unless the caller provides a sufficient fee (at least `getFee(provider)`) as msg.value.
     // Note that excess value is *not* refunded to the caller.


### PR DESCRIPTION
## Summary

In requestWithCallback [comment](https://github.com/pyth-network/pyth-crosschain/blob/5d8d4f2cffdd0aae62214bc9387bfcd913dc3990/target_chains/ethereum/entropy_sdk/solidity/IEntropy.sol#L55), there's a mention of `requestWithCallbackAndGasLimit` in case more gas is required.

Updating the comment so it points to the Entropyv2 interface request method.

<!-- Briefly describe the changes -->

## Rationale

`requestWithCallbackAndGasLimit` does not exist, redirect the user to use the version 2 in case they want to set their custom gas limit

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
