### PR TITLE
chore(pyth-lazer-agent) Update README.md and config sample

### DIFF
--- a/apps/pyth-lazer-agent/README.md
+++ b/apps/pyth-lazer-agent/README.md
@@ -44,7 +44,7 @@ The agent takes a single `--config` CLI option, pointing at
 `config/config.toml` by default. Configuration is currently minimal:
 
 ```toml
-relayer_urls = ["wss://relayer.pyth-lazer-staging.dourolabs.app/v1/transaction", "wss://relayer-1.pyth-lazer-staging.dourolabs.app/v1/transaction"]
+relayer_urls = ["wss://relayer-0.pyth-lazer.dourolabs.app/v1/transaction", "wss://relayer-1.pyth-lazer.dourolabs.app/v1/transaction"]
 publish_keypair_path = "/path/to/keypair.json"
 authorization_token = "your_token"
 listen_address = "0.0.0.0:8910"

--- a/apps/pyth-lazer-agent/config/config.toml
+++ b/apps/pyth-lazer-agent/config/config.toml
@@ -1,5 +1,6 @@
-relayer_urls = ["wss://relayer.pyth-lazer-staging.dourolabs.app/v1/transaction", "wss://relayer-1.pyth-lazer-staging.dourolabs.app/v1/transaction"]
+relayer_urls = ["wss://relayer-0.pyth-lazer.dourolabs.app/v1/transaction", "wss://relayer-1.pyth-lazer.dourolabs.app/v1/transaction"]
 publish_keypair_path = "/path/to/solana/id.json"
 listen_address = "0.0.0.0:8910"
 publish_interval_duration = "25ms"
-authorization_token="token1"
+authorization_token = "token1"
+enable_update_deduplication = true


### PR DESCRIPTION
## Summary
Remove references to the staging environment and use prod instead

## Rationale
Moving producers to prod env

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
