### PR TITLE
chore(README): use correct node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Fortuna is an off-chain service which can be used by [Entropy](https://pyth.netw
 
 Please install the following tools in order to work in this repository:
 
-- [NVM](https://github.com/nvm-sh/nvm?tab=readme-ov-file#installing-and-updating) to manage your node version, then run `nvm use 20` to ensure you are using node version 20.
+- [NVM](https://github.com/nvm-sh/nvm?tab=readme-ov-file#installing-and-updating) to manage your node version, then run `nvm use 22` to ensure you are using node version 22.
 - [Foundry](https://book.getfoundry.sh/getting-started/installation) in order to use `forge` for Ethereum contract development
 - [Solana CLI](https://solana.com/docs/intro/installation) for working with Solana programs.
   - After installing, please run `solana keygen new` to generate a local private key.


### PR DESCRIPTION
## Summary

With node version 20, gets error saying Node version is incompatible as `package.json` excepts node version 22. 

<!-- Briefly describe the changes -->
<img width="677" height="146" alt="Screenshot 2025-08-16 at 12 04 34 AM" src="https://github.com/user-attachments/assets/900ef538-2cbf-4c3c-9883-993bb7d36226" />

## Rationale
Cannot install dependencies with the node version specified in the README file.

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
