### PR TITLE
chore: Fix install forge dependency script

### DIFF
--- a/target_chains/ethereum/contracts/package.json
+++ b/target_chains/ethereum/contracts/package.json
@@ -23,7 +23,7 @@
     "migrate": "truffle migrate",
     "receiver-submit-guardian-sets": "truffle exec scripts/receiverSubmitGuardianSetUpgrades.js",
     "verify": "truffle run verify $npm_config_module@$npm_config_contract_address --network $npm_config_network",
-    "install-forge-deps": "forge install foundry-rs/forge-std@v1.7.6 --no-git --no-commit",
+    "install-forge-deps": "forge install foundry-rs/forge-std@v1.7.6 --no-git",
     "coverage": "./coverage.sh",
     "test:format": "prettier --check .",
     "fix:format": "prettier --write ."


### PR DESCRIPTION
## Summary
While running `npm run install-forge-deps` get error saying `unexpected argument`.
<img width="626" height="228" alt="Screenshot 2025-08-16 at 12 08 01 AM" src="https://github.com/user-attachments/assets/d9025718-b383-4051-9f87-ea42a8258866" />


## Rationale
Unable to run `npm run install-forge-deps`

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
