### PR TITLE
fix(pyth-lazer-agent) Respond to Ping messages from the relayer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5633,7 +5633,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-agent"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "backoff",

--- a/apps/pyth-lazer-agent/Cargo.toml
+++ b/apps/pyth-lazer-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-agent"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "Pyth Lazer Agent"
 license = "Apache-2.0"

--- a/apps/pyth-lazer-agent/src/relayer_session.rs
+++ b/apps/pyth-lazer-agent/src/relayer_session.rs
@@ -145,6 +145,10 @@ impl RelayerSessionTask {
                 // Handle messages from the relayers, such as errors if we send a bad update
                 msg = relayer_ws_receiver.next() => {
                     match msg {
+                        Some(Ok(TungsteniteMessage::Ping(payload))) => {
+                            tracing::debug!("Received a Ping from relayer {}", self.url);
+                            relayer_ws_session.ws_sender.send(TungsteniteMessage::Pong(payload)).await?
+                        }
                         Some(Ok(msg)) => {
                             tracing::debug!("Received a message from relayer: {msg:?}");
                         }


### PR DESCRIPTION
## Summary
Send `Pong` responses to `Ping` messages from the relayers.

## Rationale
We should respond to `Ping`s.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
