### PR TITLE
feat: rounded property to toggle

### DIFF
--- a/packages/component-library/src/SingleToggleGroup/index.module.scss
+++ b/packages/component-library/src/SingleToggleGroup/index.module.scss
@@ -20,7 +20,13 @@
       transition-duration: 100ms;
       transition-timing-function: linear;
     }
-
+    &[data-rounded] {
+      border-radius: theme.border-radius("full");
+      .bubble {
+        border-radius: theme.border-radius("full");
+      }
+    }
+    
     &[data-selected] {
       color: theme.color("button", "solid", "foreground");
       pointer-events: none;
@@ -37,6 +43,7 @@
             "hover"
           );
         }
+
 
         &[data-pressed] .bubble {
           background-color: theme.color(

--- a/packages/component-library/src/SingleToggleGroup/index.stories.tsx
+++ b/packages/component-library/src/SingleToggleGroup/index.stories.tsx
@@ -5,6 +5,12 @@ import { SingleToggleGroup as SingleToggleGroupComponent } from "./index.jsx";
 const meta = {
   component: SingleToggleGroupComponent,
   argTypes: {
+    rounded: {
+      control: "boolean",
+      table: {
+        category: "Appearance",
+      },
+    },
     items: {
       table: {
         disable: true,
@@ -21,6 +27,7 @@ export default meta;
 
 export const SingleToggleGroup = {
   args: {
+    rounded: false,
     items: [
       { id: "foo", children: "Foo" },
       { id: "bar", children: "Bar" },

--- a/packages/component-library/src/SingleToggleGroup/index.tsx
+++ b/packages/component-library/src/SingleToggleGroup/index.tsx
@@ -14,7 +14,9 @@ type OwnProps = {
   selectedKey?: Key | undefined;
   onSelectionChange?: (newValue: Key) => void;
   items: ComponentProps<typeof ToggleButton>[];
+  rounded?: boolean | undefined;
 };
+
 type Props = Omit<
   ComponentProps<typeof ToggleButtonGroup>,
   keyof OwnProps | "selectionMode" | "selectedKeys"
@@ -26,6 +28,7 @@ export const SingleToggleGroup = ({
   onSelectionChange,
   className,
   items,
+  rounded = false,
   ...props
 }: Props) => {
   const id = useId();
@@ -63,6 +66,7 @@ export const SingleToggleGroup = ({
           )}
           data-size="sm"
           data-variant="ghost"
+          data-rounded={rounded ? true : undefined}
           {...toggleButton}
         >
           {(args) => (


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/b460fde1-bc1f-4b7c-a331-e06df9488a64

## Rationale

Added a rounded option for the toggle that will be used for the chart timeframe buttons.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
