### PR TITLE
Fix: fixed typos to improve readability and code standards

### DIFF
--- a/doc/code-guidelines.md
+++ b/doc/code-guidelines.md
@@ -76,7 +76,7 @@
       ```tsx
       function handleEvent(e) {
           // Many inlined state tracking vars. Not much better than globals.
-          var latstPythNetupdateTime = DateTime.now();
+          var latestPythNetUpdateTime = DateTime.now();
           var clientsWaiting         = {};
           var ...
 
@@ -110,7 +110,7 @@
       // main.ts
       const { db } = require('db');
       function() {
-          initDb(); // Databaes not passed, implies global use.
+          initDb(); // Database not passed, implies global use.
       }
 
       ```

--- a/doc/rust-code-guidelines.md
+++ b/doc/rust-code-guidelines.md
@@ -60,7 +60,7 @@ The recommendations on this page should help with dealing with these lints.
 
 Refer also to [Clippy lints documentation](https://rust-lang.github.io/rust-clippy/master/index.html) for more information about the lints.
 
-If the lint is a false positive, put `#[allow(lint_name, reason = "...")]` on the relevant line or block and and specify the reason why the code is correct.
+If the lint is a false positive, put `#[allow(lint_name, reason = "...")]` on the relevant line or block and specify the reason why the code is correct.
 
 Many of the lints (e.g. most of the panic-related lints) can be allowed globally for tests and other non-production code.
 


### PR DESCRIPTION
## Summary

- Fixed typo in word "latest" and camel case type in variable latstPythNetupdateTime → latestPythNetUpdateTime
- fixed typo in word "Databaes" → "Database"
- removed the extra word "and"

## Rationale

- Corrected typos and variable naming errors to improve readability and code standards.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
