### PR TITLE
chore(bug): updatePriceFeedsIfNecessary typo fix

### DIFF
--- a/apps/api-reference/src/apis/evm/update-price-feeds-if-necessary.tsx
+++ b/apps/api-reference/src/apis/evm/update-price-feeds-if-necessary.tsx
@@ -38,7 +38,7 @@ export const updatePriceFeedsIfNecessary = writeApi<
   ### Error Response
 
   The above method can return the following error response:
-  - \`NoFreshUpdate\`: The provided update is not fresh enough to apply. It means the provided \`publishTime\` is not equal to corresponding corresponding price id in \`updateData\`.
+  - \`NoFreshUpdate\`: The provided update is not fresh enough to apply. It means the provided \`publishTime\` is not equal to corresponding price id in \`updateData\`.
   - \`InvalidUpdateData\`: The provided update data is invalid or incorrectly signed.
   - \`InsufficientFee\`: The fee provided is less than the required fee. Try calling [getUpdateFee](getUpdateFee) to get the required fee.
   `,


### PR DESCRIPTION
## Summary
There's a typo in https://api-reference.pyth.network/price-feeds/evm/updatePriceFeedsIfNecessary under `Error Response`
<!-- Briefly describe the changes -->

## Rationale

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
