### PR TITLE
feat(lazer/sui): better parsing and error handling

### DIFF
--- a/lazer/contracts/sui/sources/channel.move
+++ b/lazer/contracts/sui/sources/channel.move
@@ -1,5 +1,8 @@
 module pyth_lazer::channel;
 
+// Error codes for channel parsing
+const EInvalidChannel: u64 = 1;
+
 public enum Channel has copy, drop {
     Invalid,
     RealTime,
@@ -25,6 +28,21 @@ public fun new_fixed_rate_50ms(): Channel {
 /// Create a new FixedRate200ms channel
 public fun new_fixed_rate_200ms(): Channel {
     Channel::FixedRate200ms
+}
+
+/// Parse channel from a channel value byte
+public fun from_u8(channel_value: u8): Channel {
+    if (channel_value == 0) {
+        new_invalid()
+    } else if (channel_value == 1) {
+        new_real_time()
+    } else if (channel_value == 2) {
+        new_fixed_rate_50ms()
+    } else if (channel_value == 3) {
+        new_fixed_rate_200ms()
+    } else {
+        abort EInvalidChannel
+    }
 }
 
 /// Check if the channel is Invalid

--- a/lazer/contracts/sui/sources/channel.move
+++ b/lazer/contracts/sui/sources/channel.move
@@ -4,15 +4,9 @@ module pyth_lazer::channel;
 const EInvalidChannel: u64 = 1;
 
 public enum Channel has copy, drop {
-    Invalid,
     RealTime,
     FixedRate50ms,
     FixedRate200ms,
-}
-
-/// Create a new Invalid channel
-public fun new_invalid(): Channel {
-    Channel::Invalid
 }
 
 /// Create a new RealTime channel
@@ -32,9 +26,7 @@ public fun new_fixed_rate_200ms(): Channel {
 
 /// Parse channel from a channel value byte
 public fun from_u8(channel_value: u8): Channel {
-    if (channel_value == 0) {
-        new_invalid()
-    } else if (channel_value == 1) {
+    if (channel_value == 1) {
         new_real_time()
     } else if (channel_value == 2) {
         new_fixed_rate_50ms()
@@ -42,14 +34,6 @@ public fun from_u8(channel_value: u8): Channel {
         new_fixed_rate_200ms()
     } else {
         abort EInvalidChannel
-    }
-}
-
-/// Check if the channel is Invalid
-public fun is_invalid(channel: &Channel): bool {
-    match (channel) {
-        Channel::Invalid => true,
-        _ => false,
     }
 }
 

--- a/lazer/contracts/sui/sources/pyth_lazer.move
+++ b/lazer/contracts/sui/sources/pyth_lazer.move
@@ -96,13 +96,11 @@ public fun parse_and_verify_le_ecdsa_update(s: &State, clock: &Clock, update: ve
         sig_i = sig_i + 1;
     };
 
-    // Parse payload length
+    // Parse expected payload length and get remaining bytes as payload
     let payload_len = cursor.peel_u16();
-
-    // Get remaining bytes as payload
     let payload = cursor.into_remainder_bytes();
 
-    // Validate payload length
+    // Validate expectedpayload length
     assert!((payload_len as u64) == payload.length(), EInvalidPayloadLength);
 
     // Parse payload
@@ -113,6 +111,5 @@ public fun parse_and_verify_le_ecdsa_update(s: &State, clock: &Clock, update: ve
     // Verify the signature against trusted signers
     verify_le_ecdsa_message(s, clock, &signature, &payload);
 
-    // Parse the actual update data using the update module
     update::parse_from_cursor(payload_cursor)
 }

--- a/lazer/contracts/sui/sources/pyth_lazer.move
+++ b/lazer/contracts/sui/sources/pyth_lazer.move
@@ -1,10 +1,6 @@
 module pyth_lazer::pyth_lazer;
 
-use pyth_lazer::channel;
-use pyth_lazer::feed::{Self, Feed};
 use pyth_lazer::state::{Self, State};
-use pyth_lazer::i64::{Self};
-use pyth_lazer::i16::{Self};
 use pyth_lazer::update::{Self, Update};
 use sui::bcs;
 use sui::clock::Clock;
@@ -15,12 +11,10 @@ const UPDATE_MESSAGE_MAGIC: u32 = 1296547300;
 const PAYLOAD_MAGIC: u32 = 2479346549;
 
 // Error codes
-const EInvalidUpdate: u64 = 1;
 const ESignerNotTrusted: u64 = 2;
 const ESignerExpired: u64 = 3;
-
-// TODO:
-// error handling
+const EInvalidMagic: u64 = 4;
+const EInvalidPayloadLength: u64 = 6;
 
 /// The `PYTH_LAZER` resource serves as the one-time witness.
 /// It has the `drop` ability, allowing it to be consumed immediately after use.
@@ -83,161 +77,42 @@ public(package) fun verify_le_ecdsa_message(
 /// * `update` - The LeEcdsa formatted Lazer update
 ///
 /// # Errors
-/// * `EInvalidUpdate` - Failed to parse the update according to the protocol definition
+/// * `EInvalidMagic` - Invalid magic number in update or payload
+/// * `EInvalidPayloadLength` - Payload length doesn't match actual data
 /// * `ESignerNotTrusted` - The recovered public key is not in the trusted signers list
+/// * `ESignerExpired` - The signer's certificate has expired
 public fun parse_and_verify_le_ecdsa_update(s: &State, clock: &Clock, update: vector<u8>): Update {
     let mut cursor = bcs::new(update);
 
-    // TODO: introduce helper functions to check data len before peeling. allows us to return more
-    // granular error messages.
-
+    // Parse and validate message magic
     let magic = cursor.peel_u32();
-    assert!(magic == UPDATE_MESSAGE_MAGIC, 0);
+    assert!(magic == UPDATE_MESSAGE_MAGIC, EInvalidMagic);
 
+    // Parse signature
     let mut signature = vector::empty<u8>();
-
     let mut sig_i = 0;
     while (sig_i < SECP256K1_SIG_LEN) {
         signature.push_back(cursor.peel_u8());
         sig_i = sig_i + 1;
     };
 
+    // Parse payload length
     let payload_len = cursor.peel_u16();
 
+    // Get remaining bytes as payload
     let payload = cursor.into_remainder_bytes();
 
-    assert!((payload_len as u64) == payload.length(), 0);
+    // Validate payload length
+    assert!((payload_len as u64) == payload.length(), EInvalidPayloadLength);
 
-    let mut cursor = bcs::new(payload);
-    let payload_magic = cursor.peel_u32();
-    assert!(payload_magic == PAYLOAD_MAGIC, 0);
-
-    let timestamp = cursor.peel_u64();
+    // Parse payload
+    let mut payload_cursor = bcs::new(payload);
+    let payload_magic = payload_cursor.peel_u32();
+    assert!(payload_magic == PAYLOAD_MAGIC, EInvalidMagic);
 
     // Verify the signature against trusted signers
     verify_le_ecdsa_message(s, clock, &signature, &payload);
 
-    let channel_value = cursor.peel_u8();
-    let channel = if (channel_value == 0) {
-        channel::new_invalid()
-    } else if (channel_value == 1) {
-        channel::new_real_time()
-    } else if (channel_value == 2) {
-        channel::new_fixed_rate_50ms()
-    } else if (channel_value == 3) {
-        channel::new_fixed_rate_200ms()
-    } else {
-        channel::new_invalid() // Default to Invalid for unknown values
-    };
-
-    let mut feeds = vector::empty<Feed>();
-    let mut feed_i = 0;
-
-    let feed_count = cursor.peel_u8();
-
-    while (feed_i < feed_count) {
-        let feed_id = cursor.peel_u32();
-        let mut feed = feed::new(
-            feed_id,
-            option::none(),
-            option::none(),
-            option::none(),
-            option::none(),
-            option::none(),
-            option::none(),
-            option::none(),
-            option::none(),
-            option::none(),
-        );
-
-        let properties_count = cursor.peel_u8();
-        let mut properties_i = 0;
-
-        while (properties_i < properties_count) {
-            let property_id = cursor.peel_u8();
-
-            if (property_id == 0) {
-                let price = cursor.peel_u64();
-                if (price != 0) {
-                    feed.set_price(option::some(option::some(i64::from_u64(price))));
-                } else {
-                    feed.set_price(option::some(option::none()));
-                }
-            } else if (property_id == 1) {
-                let best_bid_price = cursor.peel_u64();
-                if (best_bid_price != 0) {
-                    feed.set_best_bid_price(
-                        option::some(option::some(i64::from_u64(best_bid_price))),
-                    );
-                } else {
-                    feed.set_best_bid_price(option::some(option::none()));
-                }
-            } else if (property_id == 2) {
-                let best_ask_price = cursor.peel_u64();
-                if (best_ask_price != 0) {
-                    feed.set_best_ask_price(
-                        option::some(option::some(i64::from_u64(best_ask_price))),
-                    );
-                } else {
-                    feed.set_best_ask_price(option::some(option::none()));
-                }
-            } else if (property_id == 3) {
-                let publisher_count = cursor.peel_u16();
-                feed.set_publisher_count(option::some(publisher_count));
-            } else if (property_id == 4) {
-                let exponent = cursor.peel_u16();
-                feed.set_exponent(option::some(i16::from_u16(exponent)));
-            } else if (property_id == 5) {
-                let confidence = cursor.peel_u64();
-                if (confidence != 0) {
-                    feed.set_confidence(option::some(option::some(i64::from_u64(confidence))));
-                } else {
-                    feed.set_confidence(option::some(option::none()));
-                }
-            } else if (property_id == 6) {
-                let exists = cursor.peel_u8();
-                if (exists == 1) {
-                    let funding_rate = cursor.peel_u64();
-                    feed.set_funding_rate(option::some(option::some(i64::from_u64(funding_rate))));
-                } else {
-                    feed.set_funding_rate(option::some(option::none()));
-                }
-            } else if (property_id == 7) {
-                let exists = cursor.peel_u8();
-
-                if (exists == 1) {
-                    let funding_timestamp = cursor.peel_u64();
-                    feed.set_funding_timestamp(option::some(option::some(funding_timestamp)));
-                } else {
-                    feed.set_funding_timestamp(option::some(option::none()));
-                }
-            } else if (property_id == 8) {
-                let exists = cursor.peel_u8();
-
-                if (exists == 1) {
-                    let funding_rate_interval = cursor.peel_u64();
-                    feed.set_funding_rate_interval(
-                        option::some(option::some(funding_rate_interval)),
-                    );
-                } else {
-                    feed.set_funding_rate_interval(option::some(option::none()));
-                }
-            } else {
-                // When we have an unknown property, we do not know its length, and therefore
-                // we cannot ignore it and parse the next properties.
-                abort EInvalidUpdate // FIXME: return more granular error messages
-            };
-
-            properties_i = properties_i + 1;
-        };
-
-        vector::push_back(&mut feeds, feed);
-
-        feed_i = feed_i + 1;
-    };
-
-    let remaining_bytes = cursor.into_remainder_bytes();
-    assert!(remaining_bytes.length() == 0, 0);
-
-    update::new(timestamp, channel, feeds)
+    // Parse the actual update data using the update module
+    update::parse_from_cursor(payload_cursor)
 }

--- a/lazer/contracts/sui/sources/update.move
+++ b/lazer/contracts/sui/sources/update.move
@@ -1,7 +1,11 @@
 module pyth_lazer::update;
 
-use pyth_lazer::channel::Channel;
-use pyth_lazer::feed::Feed;
+use pyth_lazer::channel::{Self, Channel};
+use pyth_lazer::feed::{Self, Feed};
+use sui::bcs;
+
+// Error codes for update parsing
+const EInvalidPayload: u64 = 3;
 
 public struct Update has copy, drop {
     timestamp: u64,
@@ -9,11 +13,7 @@ public struct Update has copy, drop {
     feeds: vector<Feed>,
 }
 
-public(package) fun new(
-    timestamp: u64,
-    channel: Channel,
-    feeds: vector<Feed>
-): Update {
+public(package) fun new(timestamp: u64, channel: Channel, feeds: vector<Feed>): Update {
     Update { timestamp, channel, feeds }
 }
 
@@ -30,4 +30,32 @@ public fun channel(update: &Update): Channel {
 /// Get a reference to the feeds vector of the update
 public fun feeds(update: &Update): vector<Feed> {
     update.feeds
+}
+
+/// Parse the update from a BCS cursor containing the payload data
+/// This assumes the payload magic has already been validated and consumed
+public(package) fun parse_from_cursor(mut cursor: bcs::BCS): Update {
+    // Parse timestamp
+    let timestamp = cursor.peel_u64();
+    
+    // Parse channel
+    let channel_value = cursor.peel_u8();
+    let channel = channel::from_u8(channel_value);
+    
+    // Parse feeds
+    let feed_count = cursor.peel_u8();
+    let mut feeds = vector::empty<Feed>();
+    let mut feed_i = 0;
+    
+    while (feed_i < feed_count) {
+        let feed = feed::parse_from_cursor(&mut cursor);
+        vector::push_back(&mut feeds, feed);
+        feed_i = feed_i + 1;
+    };
+    
+    // Verify no remaining bytes
+    let remaining_bytes = cursor.into_remainder_bytes();
+    assert!(remaining_bytes.length() == 0, EInvalidPayload);
+    
+    Update { timestamp, channel, feeds }
 }


### PR DESCRIPTION
## Summary
- Better parsing and error handling.
- Split up the monolithic parsing code. Now each layer of the payload (e.g. `update`, `feed`, `channel`) is responsible for its own deserialization logic.

## Rationale
- This lets us return granular error messages and gracefully handle bad payloads.

## How has this been tested?

- [x] Current tests cover my changes
  - Existing parse test didn't regress
- [x] Added new tests
  - Added negative tests to check that granular error handling works
- [ ] Manually tested the code