### PR TITLE
chore(bug): remove MTR token pyth ID 

### DIFF
--- a/contract_manager/store/tokens/Tokens.json
+++ b/contract_manager/store/tokens/Tokens.json
@@ -199,7 +199,6 @@
   },
   {
     "id": "MTR",
-    "pythId": "8cdc9b2118d2ce55a299f8f1d700d0127cf4036d1aa666a8cd51dcab4254284f",
     "decimals": 18,
     "type": "token"
   },

--- a/contract_manager/store/tokens/Tokens.json
+++ b/contract_manager/store/tokens/Tokens.json
@@ -198,11 +198,6 @@
     "type": "token"
   },
   {
-    "id": "MTR",
-    "decimals": 18,
-    "type": "token"
-  },
-  {
     "id": "RON",
     "pythId": "97cfe19da9153ef7d647b011c5e355142280ddb16004378573e6494e499879f3",
     "decimals": 18,


### PR DESCRIPTION
## Summary

Running `pnpm exec ts-node scripts/fetch_fees.ts` from contract-manager returns 404 error abruptly.

Removed the MTR token pyth ID that was causing the issue, making the script run.

<!-- Briefly describe the changes -->

## Rationale

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
