### PR TITLE
feat(lazer): add allowed feeds per publisher, aggregated prices and feature flags to state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5761,7 +5761,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-publisher-sdk"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "fs-err",

--- a/lazer/publisher_sdk/proto/governance_instruction.proto
+++ b/lazer/publisher_sdk/proto/governance_instruction.proto
@@ -176,6 +176,8 @@ message AddPublisher {
     repeated bytes public_keys = 3;
     // [required] If true, the publisher is active, i.e. it's allowed to publish updates.
     optional bool is_active = 4;
+    // IDs of the feeds for which the publisher's price will be included in the aggregate.
+    repeated uint32 allowed_feed_ids = 5;
 }
 
 message UpdatePublisher {

--- a/lazer/publisher_sdk/proto/governance_instruction.proto
+++ b/lazer/publisher_sdk/proto/governance_instruction.proto
@@ -93,6 +93,8 @@ message GovernanceInstructionItem {
         AddFeed add_feed = 111;
         UpdateFeed update_feed = 112;
         RemoveFeed remove_feed = 113;
+        AddFeatureFlag add_feature_flag = 114;
+        RemoveFeatureFlag remove_feature_flag = 115;
     }
 }
 
@@ -187,6 +189,9 @@ message UpdatePublisher {
         RemovePublisherPublicKeys remove_publisher_public_keys = 103;
         SetPublisherPublicKeys set_publisher_public_keys = 104;
         SetPublisherActive set_publisher_active = 105;
+        AddPublisherAllowedFeedIds add_publisher_allowed_feed_ids = 106;
+        RemovePublisherAllowedFeedIds remove_publisher_allowed_feed_ids = 107;
+        SetPublisherAllowedFeedIds set_publisher_allowed_feed_ids = 108;
     }
 }
 
@@ -215,6 +220,24 @@ message RemovePublisherPublicKeys {
 // Remove all existing public keys and add new keys (if specified).
 message SetPublisherPublicKeys {
     repeated bytes public_keys = 1;
+}
+
+// Allow publisher to publish for the specified feeds.
+message AddPublisherAllowedFeedIds {
+    // Must not be empty.
+    repeated bytes allowed_feed_ids_to_add = 1;
+}
+
+// Disallow publisher to publish for the specified feeds.
+message RemovePublisherAllowedFeedIds {
+    // Must not be empty.
+    repeated bytes allowed_feed_ids_to_remove = 1;
+}
+
+// Allow publisher to publish for only the specified feeds.
+// Remove all previous allowances.
+message SetPublisherAllowedFeedIds {
+    repeated bytes allowed_feed_ids = 1;
 }
 
 message SetPublisherActive {
@@ -325,4 +348,16 @@ message DisableFeedInShard {
     // the feed will be disabled immediately when this
     // governance instruction is processed.
     optional google.protobuf.Timestamp disable_in_shard_timestamp = 1;
+}
+
+// Add a new feature flag.
+message AddFeatureFlag {
+    // [required] Feature flag to add.
+    optional string feature_flag = 1;
+}
+
+// Remove a feature flag.
+message RemoveFeatureFlag {
+    // [required] Feature flag to remove.
+    optional string feature_flag = 1;
 }

--- a/lazer/publisher_sdk/proto/state.proto
+++ b/lazer/publisher_sdk/proto/state.proto
@@ -46,6 +46,8 @@ message State {
     repeated Publisher publishers = 8;
     // List of governance sources.
     repeated GovernanceSourceState governance_sources = 9;
+    // Currently active feature flags. Feature flags influence the aggregator's behavior.
+    repeated string feature_flags = 10;
 }
 
 // An item of the state describing a publisher.
@@ -58,6 +60,8 @@ message Publisher {
     repeated bytes public_keys = 3;
     // [required] If true, the publisher is active, i.e. it's allowed to publish updates.
     optional bool is_active = 4;
+    // IDs of the feeds for which the publisher's price will be included in the aggregate.
+    repeated uint32 allowed_feed_ids = 5;
 }
 
 enum FeedState {
@@ -112,6 +116,8 @@ message Feed {
     optional FeedState state = 107;
     // [required] Feed kind.
     optional FeedKind kind = 108;
+    // [required] Current aggregated data of the feed.
+    optional FeedDataFields aggregated_data = 109;
 
 
     // [required] Feed status in the current shard. Disabled feeds will not be visible in
@@ -158,16 +164,21 @@ message FeedData {
     optional google.protobuf.Timestamp source_timestamp = 1;
     // [required] Timestamp of the publisher.
     optional google.protobuf.Timestamp publisher_timestamp = 2;
+    // [required] Values of the data fields.
+    optional FeedDataFields fields = 3;
+}
+
+message FeedDataFields {
     // [optional] Best executable price. Can be absent if no data is available. Never present for funding rate feeds.
-    optional int64 price = 3;
+    optional int64 price = 1;
     // [optional] Best bid price. Can be absent if no data is available. Never present for funding rate feeds.
-    optional int64 best_bid_price = 4;
+    optional int64 best_bid_price = 2;
     // [optional] Best ask price. Can be absent if no data is available. Never present for funding rate feeds.
-    optional int64 best_ask_price = 5;
+    optional int64 best_ask_price = 3;
     // [optional] Funding rate. Can be absent if no data is available. Can only be present for funding rate feeds.
-    optional int64 funding_rate = 6;
+    optional int64 funding_rate = 4;
     // [optional] Funding rate interval. Can be absent if no data is available. Can only be present for funding rate feeds.
-    optional google.protobuf.Duration funding_rate_interval = 7;
+    optional google.protobuf.Duration funding_rate_interval = 5;
 }
 
 // State associated with a governance source.
@@ -206,6 +217,8 @@ message Permissions {
         // including operations added in the future.
         UPDATE_FEED = 112;
         REMOVE_FEED = 113;
+        ADD_FEATURE_FLAG = 114;
+        REMOVE_FEATURE_FLAG = 115;
     }
 
     enum UpdateGovernanceSourceAction {
@@ -222,6 +235,9 @@ message Permissions {
         REMOVE_PUBLISHER_PUBLIC_KEYS = 103;
         SET_PUBLISHER_PUBLIC_KEYS = 104;
         SET_PUBLISHER_ACTIVE = 105;
+        ADD_PUBLISHER_ALLOWED_FEED_IDS = 106;
+        REMOVE_PUBLISHER_ALLOWED_FEED_IDS = 107;
+        SET_PUBLISHER_ALLOWED_FEED_IDS = 108;
     }
 
     enum UpdateFeedAction {

--- a/lazer/publisher_sdk/rust/Cargo.toml
+++ b/lazer/publisher_sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-publisher-sdk"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Pyth Lazer Publisher SDK types."
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

* Add allowed feed IDs to publisher state data.
* Add feature flags to state. They can be used in the future to alter the aggregator's behavior while keeping it deterministic.
* Add aggregated data to feed state.
* Add governance actions for new fields (except aggregated data).

## Rationale

Implementing state and governance.

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
