### PR TITLE
fix(entropy-explorer): fix infinite spinner

### DIFF
--- a/apps/entropy-explorer/next-env.d.ts
+++ b/apps/entropy-explorer/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/entropy-explorer/package.json
+++ b/apps/entropy-explorer/package.json
@@ -12,7 +12,7 @@
     "fix:lint:eslint": "eslint --fix .",
     "fix:lint:stylelint": "stylelint --fix 'src/**/*.scss'",
     "pull:env": "[ $CI ] || VERCEL_ORG_ID=team_BKQrg3JJFLxZyTqpuYtIY0rj VERCEL_PROJECT_ID=prj_34F8THr7mZ3eAOQoCLdo8xWj9fdT vercel env pull",
-    "start:dev": "next dev --port 3006 --turbopack",
+    "start:dev": "next dev --port 3006",
     "start:prod": "next start --port 3006",
     "test:format": "prettier --check .",
     "test:lint:eslint": "eslint . --max-warnings 0",

--- a/apps/entropy-explorer/src/components/Home/search-controls.tsx
+++ b/apps/entropy-explorer/src/components/Home/search-controls.tsx
@@ -53,7 +53,7 @@ const useSearchBar = () => {
 };
 
 export const Paginator = (props: ComponentProps<typeof ResolvedPaginator>) => (
-  <Suspense fallback={<Paginator {...props} />}>
+  <Suspense>
     <ResolvedPaginator {...props} />
   </Suspense>
 );

--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
             pkgs.cli
             pkgs.git
             pkgs.libusb1
+            pkgs.udev
             pkgs.nodejs
             pkgs.pkg-config
             pkgs.pnpm


### PR DESCRIPTION
The `Paginator` suspense boundary was incorrectly referring to the `<Paginator>` component in the fallback case, which was a circular reference and caused the stack to blow up, caused the browser loading spinner to go on indefinitely, and is causing a bunch of errors in the Vercel logs.  This commit fixes that issue.