### PR TITLE
chore: remove deprecated BlastAPI endpoints

### DIFF
--- a/contract_manager/store/chains/EvmChains.json
+++ b/contract_manager/store/chains/EvmChains.json
@@ -2,7 +2,7 @@
   {
     "id": "linea_goerli",
     "mainnet": false,
-    "rpcUrl": "https://linea-goerli.blastapi.io/$ENV_BLAST_API_KEY",
+    "rpcUrl": "https://rpc.goerli.linea.build",
     "networkId": 59140,
     "type": "EvmChain"
   },
@@ -102,7 +102,7 @@
   {
     "id": "fantom_testnet",
     "mainnet": false,
-    "rpcUrl": "https://fantom-testnet.blastapi.io/$ENV_BLAST_API_KEY",
+    "rpcUrl": "https://fantom.api.onfinality.io/public",
     "networkId": 4002,
     "type": "EvmChain"
   },
@@ -123,7 +123,7 @@
   {
     "id": "mumbai",
     "mainnet": false,
-    "rpcUrl": "https://polygon-testnet.blastapi.io/$ENV_BLAST_API_KEY",
+    "rpcUrl": "https://polygon-mumbai.api.onfinality.io/public",
     "networkId": 80001,
     "type": "EvmChain"
   },
@@ -401,7 +401,7 @@
   {
     "id": "sepolia",
     "mainnet": false,
-    "rpcUrl": "https://eth-sepolia.public.blastapi.io",
+    "rpcUrl": "https://sepolia.drpc.org",
     "networkId": 11155111,
     "type": "EvmChain"
   },

--- a/contract_manager/store/chains/StarknetChains.json
+++ b/contract_manager/store/chains/StarknetChains.json
@@ -3,14 +3,14 @@
     "id": "starknet_sepolia",
     "wormholeChainName": "starknet_sepolia",
     "mainnet": false,
-    "rpcUrl": "https://starknet-sepolia.public.blastapi.io/",
+    "rpcUrl": "https://starknet-sepolia.drpc.org",
     "type": "StarknetChain"
   },
   {
     "id": "starknet_mainnet",
     "wormholeChainName": "starknet",
     "mainnet": true,
-    "rpcUrl": "https://starknet-mainnet.public.blastapi.io/",
+    "rpcUrl": "https://starknet.drpc.org",
     "type": "StarknetChain"
   }
 ]

--- a/lazer/contracts/evm/README.md
+++ b/lazer/contracts/evm/README.md
@@ -35,7 +35,7 @@ forge snapshot
 Anvil does not come with CreateX by default. It can be deployed or an RPC which has the contract can be forked. The below command forks an RPC with a functional CreateX contract.
 
 ```shell
-anvil --fork-url "https://eth-sepolia.public.blastapi.io"
+anvil --fork-url "https://sepolia.drpc.org"
 ```
 
 ### Deploy

--- a/target_chains/starknet/contracts/deploy/deploy.sh
+++ b/target_chains/starknet/contracts/deploy/deploy.sh
@@ -29,7 +29,7 @@ if [ "${PYTH_DEPLOY_MODE}" == "devnet" ]; then
     # there is no second fee token pre-deployed in devnet
     fee_token_address2=0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
 elif [ "${PYTH_DEPLOY_MODE}" == "sepolia" ]; then
-    export STARKNET_RPC=https://starknet-sepolia.public.blastapi.io/rpc/v0_6
+    export STARKNET_RPC=https://starknet-sepolia.drpc.org/rpc/v0_6
 
     chain_id=50075 # starknet_sepolia
 
@@ -39,7 +39,7 @@ elif [ "${PYTH_DEPLOY_MODE}" == "sepolia" ]; then
     # ETH
     fee_token_address2=0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
 elif [ "${PYTH_DEPLOY_MODE}" == "mainnet" ]; then
-    export STARKNET_RPC=https://starknet-mainnet.public.blastapi.io/rpc/v0_6
+    export STARKNET_RPC=https://starknet.drpc.org/rpc/v0_6
 
     chain_id=60051 # starknet_mainnet
 

--- a/target_chains/starknet/sdk/js/README.md
+++ b/target_chains/starknet/sdk/js/README.md
@@ -52,7 +52,7 @@ import {
 
 // Create a provider for interacting with Starknet RPC.
 const provider = new RpcProvider({
-  nodeUrl: "https://starknet-sepolia.public.blastapi.io/rpc/v0_6",
+  nodeUrl: "https://starknet-sepolia.drpc.org/rpc/v0_6",
 });
 
 // Create a `Contract` instance to interact with a fee token contract on Starknet


### PR DESCRIPTION
## Summary

BlastAPI has been acquired by Alchemy and their RPCs will go out of service by end of Oct.