### PR TITLE
fix(price-pusher/solana): Swallow exceptions in jito onBundleResult

### DIFF
--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/price-pusher",
-  "version": "10.1.0",
+  "version": "10.2.0",
   "description": "Pyth Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/apps/price_pusher/src/solana/command.ts
+++ b/apps/price_pusher/src/solana/command.ts
@@ -198,8 +198,8 @@ export default {
     // Fetch the account lookup table if provided
     const lookupTableAccount = addressLookupTableAccount
       ? await connection
-          .getAddressLookupTable(new PublicKey(addressLookupTableAccount))
-          .then((result) => result.value ?? undefined)
+        .getAddressLookupTable(new PublicKey(addressLookupTableAccount))
+        .then((result) => result.value ?? undefined)
       : undefined;
 
     let solanaPricePusher;
@@ -274,10 +274,14 @@ export default {
 };
 
 export const onBundleResult = (c: SearcherClient, logger: Logger) => {
-  c.onBundleResult(
-    () => undefined,
-    (err) => {
-      logger.error(err, "Error in bundle result");
-    },
-  );
+  try {
+    c.onBundleResult(
+      () => undefined,
+      (err) => {
+        logger.error(err, "Error in bundle result");
+      },
+    );
+  } catch (error) {
+    logger.error(error, "Exception in bundle result");
+  }
 };


### PR DESCRIPTION
## Summary

Swallow exceptions in [SearcherClient.onBundleResult](https://github.com/jito-labs/jito-ts/blob/89e40b04c0a842b09d98d76c1c282856c0895656/src/sdk/block-engine/searcher.ts#L262). Not all errors are propagated via the `err` callback, some are simply thrown. These uncaught exceptions will crash the app, so we swallow and log them instead.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code
  - Manually tested that early errors such as bad auth no longer crash the app 