### PR TITLE
fix(pyth-solana-receiver-sdk): remove lint reason

### DIFF
--- a/target_chains/solana/pyth_solana_receiver_sdk/Cargo.lock
+++ b/target_chains/solana/pyth_solana_receiver_sdk/Cargo.lock
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-solana-receiver-sdk"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anchor-lang",
  "hex",

--- a/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
+++ b/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-solana-receiver-sdk"
-version = "1.0.0"
+version = "1.0.1"
 description = "SDK for the Pyth Solana Receiver program"
 authors = ["Pyth Data Association"]
 repository = "https://github.com/pyth-network/pyth-crosschain"

--- a/target_chains/solana/pyth_solana_receiver_sdk/src/price_update.rs
+++ b/target_chains/solana/pyth_solana_receiver_sdk/src/price_update.rs
@@ -329,10 +329,8 @@ pub mod tests {
 
     #[test]
     fn check_size() {
-        #[allow(
-            deprecated,
-            reason = "borsh0_10 is deprecated, v1::get_packed_len should be used in the future"
-        )]
+        // borsh0_10 is deprecated, v1::get_packed_len should be used in the future
+        #[allow(deprecated)]
         let len = PriceUpdateV2::DISCRIMINATOR.len() + borsh0_10::get_packed_len::<PriceUpdateV2>();
         assert_eq!(len, PriceUpdateV2::LEN);
     }


### PR DESCRIPTION
## Summary
lint reasons are experimental in older rust versions, causing the SDK to fail to build. removed the `reason` at the request of a couple users.
https://dev-forum.pyth.network/t/pyth-solana-receiver-sdk-v1-0-0-fails-with-borsh0-10-is-deprecated/401

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code