### PR TITLE
Reduce lazer rust client memory usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5693,7 +5693,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-client"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "alloy-primitives 0.8.25",
  "anyhow",

--- a/lazer/sdk/rust/client/Cargo.toml
+++ b/lazer/sdk/rust/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-client"
-version = "8.0.0"
+version = "8.0.1"
 edition = "2021"
 description = "A Rust client for Pyth Lazer"
 license = "Apache-2.0"

--- a/lazer/sdk/rust/client/src/stream_client.rs
+++ b/lazer/sdk/rust/client/src/stream_client.rs
@@ -183,7 +183,7 @@ impl PythLazerStreamClient {
                 if seen_updates.contains_key(&cache_key) {
                     continue;
                 }
-                seen_updates.insert(cache_key, response.clone(), DEDUP_TTL);
+                seen_updates.insert(cache_key, true, DEDUP_TTL);
 
                 match sender.try_send(response) {
                     Ok(_) => (),


### PR DESCRIPTION
## Summary

This PR aims to reduce lazer rust client memory usage

## Rationale

While we run the router stress test on lazer side, the high memory usage will lead to OOM Killed error in k8s pods. This will reduce the memory usage and fix the issue.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code
