### PR TITLE
chore(fortuna) Add server tag in OpenAPI

### DIFF
--- a/apps/fortuna/src/command/run.rs
+++ b/apps/fortuna/src/command/run.rs
@@ -51,6 +51,10 @@ pub async fn run_api(
     ),
     tags(
     (name = "fortuna", description = "Random number service for the Pyth Entropy protocol")
+    ),
+    servers(
+        (url = "https://fortuna.dourolabs.app", description = "Default Provider for mainnet chains"),
+        (url = "https://fortuna-staging.dourolabs.app", description = "Default Provider for testnet chains")
     )
     )]
     struct ApiDoc;


### PR DESCRIPTION
## Summary

We need this to generate api reference from open api schema

https://arc.net/l/quote/qinpvjym

## Rationale

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
