### PR TITLE
feat: add push_updates method to jrpc lazer protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5711,7 +5711,7 @@ dependencies = [
  "hex",
  "humantime-serde",
  "libsecp256k1 0.7.2",
- "pyth-lazer-protocol 0.15.0",
+ "pyth-lazer-protocol 0.15.1",
  "reqwest 0.12.23",
  "serde",
  "serde_json",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-protocol"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "alloy-primitives 0.8.25",
  "anyhow",
@@ -5786,13 +5786,13 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-publisher-sdk"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "fs-err",
  "protobuf",
  "protobuf-codegen",
- "pyth-lazer-protocol 0.15.0",
+ "pyth-lazer-protocol 0.15.1",
  "serde_json",
 ]
 

--- a/lazer/publisher_sdk/rust/Cargo.toml
+++ b/lazer/publisher_sdk/rust/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "pyth-lazer-publisher-sdk"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 description = "Pyth Lazer Publisher SDK types."
 license = "Apache-2.0"
 repository = "https://github.com/pyth-network/pyth-crosschain"
 
 [dependencies]
-pyth-lazer-protocol = { version = "0.15.0", path = "../../sdk/rust/protocol" }
+pyth-lazer-protocol = { version = "0.15.1", path = "../../sdk/rust/protocol" }
 anyhow = "1.0.98"
 protobuf = "3.7.2"
 serde_json = "1.0.140"

--- a/lazer/sdk/rust/protocol/Cargo.toml
+++ b/lazer/sdk/rust/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-protocol"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 description = "Pyth Lazer SDK - protocol types."
 license = "Apache-2.0"

--- a/lazer/sdk/rust/protocol/src/jrpc.rs
+++ b/lazer/sdk/rust/protocol/src/jrpc.rs
@@ -19,6 +19,7 @@ pub struct PythLazerAgentJrpcV1 {
 #[serde(rename_all = "snake_case")]
 pub enum JrpcCall {
     PushUpdate(FeedUpdateParams),
+    PushUpdates(Vec<FeedUpdateParams>),
     GetMetadata(GetMetadataParams),
 }
 


### PR DESCRIPTION
## Summary

This PR adds a new method to the jrpc protocol used in lazer agent.

## Rationale

This should allow agent to handle higher loads

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

manually tested
