### PR TITLE
fix(hip-3-pusher): prometheus address fix

### DIFF
--- a/apps/hip-3-pusher/pyproject.toml
+++ b/apps/hip-3-pusher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hip-3-pusher"
-version = "0.1.2"
+version = "0.1.3"
 description = "Hyperliquid HIP-3 market oracle pusher"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/apps/hip-3-pusher/src/metrics.py
+++ b/apps/hip-3-pusher/src/metrics.py
@@ -10,7 +10,7 @@ class Metrics:
     def __init__(self, config):
         # Adapted from opentelemetry-exporter-prometheus example code.
         # Start Prometheus client
-        start_http_server(port=config["prometheus_port"], addr="localhost")
+        start_http_server(port=config["prometheus_port"])
         # Exporter to export metrics to Prometheus
         reader = PrometheusMetricReader()
         # Meter is responsible for creating and recording metrics

--- a/apps/hip-3-pusher/uv.lock
+++ b/apps/hip-3-pusher/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "hip-3-pusher"
-version = "0.1.2"
+version = "0.1.3"
 source = { virtual = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
## Summary
The prometheus listen address should have been left at the default of 0.0.0.0, not localhost.

## Rationale
Getting metrics working.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
