### PR TITLE
fix: Exclude feeds for which there are product accounts but no price account

### DIFF
--- a/apps/insights/src/services/pyth/get-feeds.ts
+++ b/apps/insights/src/services/pyth/get-feeds.ts
@@ -6,11 +6,13 @@ import { priceFeedsSchema } from "../../schemas/pyth/price-feeds-schema";
 const _getFeeds = async (cluster: Cluster) => {
   const unfilteredData = await getPythMetadata(cluster);
   const filtered = unfilteredData.symbols
-    .filter(
-      (symbol) =>
-        unfilteredData.productFromSymbol.get(symbol)?.display_symbol !==
-        undefined,
-    )
+    .filter((symbol) => {
+      const product = unfilteredData.productFromSymbol.get(symbol);
+      const hasDisplaySymbol = product?.display_symbol !== undefined;
+      const hasPriceAccount = product?.price_account !== undefined;
+
+      return hasDisplaySymbol && hasPriceAccount;
+    })
     .map((symbol) => ({
       symbol,
       product: unfilteredData.productFromSymbol.get(symbol),


### PR DESCRIPTION
## Summary

While uncommon, there are indeed cases where we create a product account and then fail to create price account. In such cases the `price_account` field (plus a few others) will be `undefined`, which breaks the `zod` schema.

Typically we'd remove these products manually, but we might as well just filter them out.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code
