### PR TITLE
feat(lazer-protocol): bump version to 0.15.2 and upgrade path dependents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5674,8 +5674,8 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "protobuf",
- "pyth-lazer-protocol 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pyth-lazer-publisher-sdk 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pyth-lazer-protocol 0.15.1",
+ "pyth-lazer-publisher-sdk 0.12.1",
  "reqwest 0.12.23",
  "serde",
  "serde_json",
@@ -5693,7 +5693,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-client"
-version = "8.1.0"
+version = "8.1.1"
 dependencies = [
  "alloy-primitives 0.8.25",
  "anyhow",
@@ -5711,7 +5711,7 @@ dependencies = [
  "hex",
  "humantime-serde",
  "libsecp256k1 0.7.2",
- "pyth-lazer-protocol 0.15.1",
+ "pyth-lazer-protocol 0.15.2",
  "reqwest 0.12.23",
  "serde",
  "serde_json",
@@ -5721,32 +5721,6 @@ dependencies = [
  "tracing-subscriber",
  "ttl_cache",
  "url",
-]
-
-[[package]]
-name = "pyth-lazer-protocol"
-version = "0.15.1"
-dependencies = [
- "alloy-primitives 0.8.25",
- "anyhow",
- "assert_float_eq",
- "bincode 1.3.3",
- "bs58",
- "byteorder",
- "chrono",
- "derive_more 1.0.0",
- "ed25519-dalek 2.1.1",
- "hex",
- "humantime",
- "humantime-serde",
- "itertools 0.13.0",
- "libsecp256k1 0.7.2",
- "mry",
- "protobuf",
- "rust_decimal",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -5771,15 +5745,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "pyth-lazer-publisher-sdk"
-version = "0.12.1"
+name = "pyth-lazer-protocol"
+version = "0.15.2"
 dependencies = [
+ "alloy-primitives 0.8.25",
  "anyhow",
- "fs-err",
+ "assert_float_eq",
+ "bincode 1.3.3",
+ "bs58",
+ "byteorder",
+ "chrono",
+ "derive_more 1.0.0",
+ "ed25519-dalek 2.1.1",
+ "hex",
+ "humantime",
+ "humantime-serde",
+ "itertools 0.13.0",
+ "libsecp256k1 0.7.2",
+ "mry",
  "protobuf",
- "protobuf-codegen",
- "pyth-lazer-protocol 0.15.1",
+ "rust_decimal",
+ "serde",
  "serde_json",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -5792,7 +5780,19 @@ dependencies = [
  "fs-err",
  "protobuf",
  "protobuf-codegen",
- "pyth-lazer-protocol 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pyth-lazer-protocol 0.15.1",
+ "serde_json",
+]
+
+[[package]]
+name = "pyth-lazer-publisher-sdk"
+version = "0.12.2"
+dependencies = [
+ "anyhow",
+ "fs-err",
+ "protobuf",
+ "protobuf-codegen",
+ "pyth-lazer-protocol 0.15.2",
  "serde_json",
 ]
 

--- a/lazer/contracts/solana/programs/pyth-lazer-solana-contract/Cargo.toml
+++ b/lazer/contracts/solana/programs/pyth-lazer-solana-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-solana-contract"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Pyth Lazer Solana contract and SDK."
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]
-pyth-lazer-protocol = { path = "../../../../sdk/rust/protocol", version = "0.15.0" }
+pyth-lazer-protocol = { path = "../../../../sdk/rust/protocol", version = "0.15.2" }
 
 anchor-lang = "0.31.1"
 bytemuck = { version = "1.20.0", features = ["derive"] }

--- a/lazer/publisher_sdk/rust/Cargo.toml
+++ b/lazer/publisher_sdk/rust/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "pyth-lazer-publisher-sdk"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 description = "Pyth Lazer Publisher SDK types."
 license = "Apache-2.0"
 repository = "https://github.com/pyth-network/pyth-crosschain"
 
 [dependencies]
-pyth-lazer-protocol = { version = "0.15.1", path = "../../sdk/rust/protocol" }
+pyth-lazer-protocol = { version = "0.15.2", path = "../../sdk/rust/protocol" }
 anyhow = "1.0.98"
 protobuf = "3.7.2"
 serde_json = "1.0.140"

--- a/lazer/sdk/rust/client/Cargo.toml
+++ b/lazer/sdk/rust/client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "pyth-lazer-client"
-version = "8.1.0"
+version = "8.1.1"
 edition = "2021"
 description = "A Rust client for Pyth Lazer"
 license = "Apache-2.0"
 
 [dependencies]
-pyth-lazer-protocol = { path = "../protocol", version = "0.15.0" }
+pyth-lazer-protocol = { path = "../protocol", version = "0.15.2" }
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = { version = "0.20", features = ["native-tls"] }
 futures-util = "0.3"

--- a/lazer/sdk/rust/protocol/Cargo.toml
+++ b/lazer/sdk/rust/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-protocol"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 description = "Pyth Lazer SDK - protocol types."
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Missed bumping the protocol version in #3065 

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code
