### PR TITLE
fix(contract_manager) Don't log private key when running contract_manager

### DIFF
--- a/contract_manager/scripts/deploy_evm_executor_contracts.ts
+++ b/contract_manager/scripts/deploy_evm_executor_contracts.ts
@@ -120,8 +120,12 @@ export async function main() {
     CACHE_FILE,
   );
 
+  const maskedDeploymentConfig = {
+    ...deploymentConfig,
+    privateKey: deploymentConfig.privateKey ? `<REDACTED>` : undefined,
+  };
   console.log(
-    `Deployment config: ${JSON.stringify(deploymentConfig, null, 2)}\n`,
+    `Deployment config: ${JSON.stringify(maskedDeploymentConfig, null, 2)}\n`,
   );
 
   console.log(`Deploying executor contracts on ${chain.getId()}...`);


### PR DESCRIPTION
## Summary
We are currently printing out the plaintext private key to logs. Let's stop.

## Rationale
We shouldn't be printing out the plaintext private key to logs.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
