### PR TITLE
Make relayer_session module public

### DIFF
--- a/apps/pyth-lazer-agent/src/main.rs
+++ b/apps/pyth-lazer-agent/src/main.rs
@@ -12,7 +12,7 @@ mod http_server;
 mod jrpc_handle;
 mod lazer_publisher;
 mod publisher_handle;
-mod relayer_session;
+pub mod relayer_session;
 mod websocket_utils;
 
 #[derive(Parser, Deserialize)]


### PR DESCRIPTION
## Summary

This makes `RelayerSessionTask` usable directly as a Rust crate dependency.

## Rationale

It makes it possible to run publishing in-process, as opposed to via JSON-RPC WebSocket interface.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
