### PR TITLE
refactor(component-library): set default page sizes

### DIFF
--- a/apps/insights/src/components/PriceComponentsCard/index.tsx
+++ b/apps/insights/src/components/PriceComponentsCard/index.tsx
@@ -448,7 +448,6 @@ export const PriceComponentsCardContents = <
             onPageChange={props.onPageChange}
             pageSize={props.pageSize}
             onPageSizeChange={props.onPageSizeChange}
-            pageSizeOptions={[10, 20, 30, 40, 50]}
             mkPageLink={props.mkPageLink}
           />
         ),

--- a/apps/insights/src/components/PriceFeeds/price-feeds-card.tsx
+++ b/apps/insights/src/components/PriceFeeds/price-feeds-card.tsx
@@ -288,7 +288,6 @@ const PriceFeedsCardContents = ({ id, ...props }: PriceFeedsCardContents) => (
           onPageChange={props.onPageChange}
           pageSize={props.pageSize}
           onPageSizeChange={props.onPageSizeChange}
-          pageSizeOptions={[10, 20, 30, 40, 50]}
           mkPageLink={props.mkPageLink}
         />
       ),

--- a/apps/insights/src/components/Publishers/publishers-card.tsx
+++ b/apps/insights/src/components/Publishers/publishers-card.tsx
@@ -290,7 +290,6 @@ const PublishersCardContents = ({
           onPageChange={props.onPageChange}
           pageSize={props.pageSize}
           onPageSizeChange={props.onPageSizeChange}
-          pageSizeOptions={[10, 20, 30, 40, 50]}
           mkPageLink={props.mkPageLink}
         />
       ),

--- a/packages/component-library/src/Paginator/index.tsx
+++ b/packages/component-library/src/Paginator/index.tsx
@@ -19,19 +19,21 @@ type Props = {
   onPageChange: (newPage: number) => void;
   isPageTransitioning?: boolean | undefined;
   pageSize: number;
-  pageSizeOptions: number[];
+  pageSizeOptions?: number[];
   onPageSizeChange: (newPageSize: number) => void;
   isPageSizeTransitioning?: boolean | undefined;
   mkPageLink?: ((page: number) => string) | undefined;
   className?: string | undefined;
 };
 
+const DEFAULT_PAGE_SIZE_OPTIONS = [10, 20, 30, 40, 50];
+
 export const Paginator = ({
   numPages,
   currentPage,
   isPageTransitioning,
   pageSize,
-  pageSizeOptions,
+  pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
   onPageChange,
   onPageSizeChange,
   isPageSizeTransitioning,


### PR DESCRIPTION
## Summary

Seems we're always setting the same value for the pagination sizes so I figured we should make that as a default.

## Rationale

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
