### PR TITLE
fix(entropy): Only mark callbacks as failed if enough gas was provided, regardless of revert code

### DIFF
--- a/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
+++ b/target_chains/ethereum/contracts/contracts/entropy/Entropy.sol
@@ -619,13 +619,12 @@ abstract contract Entropy is IEntropy, EntropyState {
                 );
                 clearRequest(provider, sequenceNumber);
             } else if (
-                ret.length > 0 ||
                 (startingGas * 31) / 32 >
                 uint256(req.gasLimit10k) * TEN_THOUSAND
             ) {
                 // The callback reverted for some reason.
-                // If ret.length > 0, then we know the callback manually triggered a revert, so it's safe to mark it as failed.
-                // If ret.length == 0, then the callback might have run out of gas (though there are other ways to trigger a revert with ret.length == 0).
+                // We don't use ret to condition the behavior here (out-of-gas or other revert), as we have found that some user contracts
+                // catch out-of-gas errors and revert with a different error.
                 // In this case, ensure that the callback was provided with sufficient gas. Technically, 63/64ths of the startingGas is forwarded,
                 // but we're using 31/32 to introduce a margin of safety.
                 emit CallbackFailed(

--- a/target_chains/ethereum/contracts/test/Entropy.t.sol
+++ b/target_chains/ethereum/contracts/test/Entropy.t.sol
@@ -1113,6 +1113,16 @@ contract EntropyTest is Test, EntropyTestUtils, EntropyEvents, EntropyEventsV2 {
             userRandomNumber
         );
 
+        // If the callback reverts, the Entropy reveal also reverts unless
+        // provided enough gas to pass on.
+        vm.expectRevert();
+        random.revealWithCallback{gas: defaultGasLimit - 1000}(
+            provider1,
+            assignedSequenceNumber,
+            userRandomNumber,
+            provider1Proofs[assignedSequenceNumber]
+        );
+
         // On the first attempt, the transaction should succeed and emit CallbackFailed event.
         bytes memory revertReason = abi.encodeWithSelector(
             0x08c379a0,


### PR DESCRIPTION
## Summary

This PR removes the check that allows us to mark callbacks as failed (even if enough gas wasn't provided) if they revert with a non-empty return code.

## Rationale

When we wrote this initally, we thought that all out-of-gas reverts from calling contracts would bubble up and be caught by the `ret.length == 0` condition. However, we have found that some contracts catch out-of-gas reverts and then revert with a different error code. This means we can end up calling these callbacks without enough gas. 

Simple fix here is to require enough gas to be provided regardless of the revert code.

## How has this been tested?

- [ ] Current tests cover my changes
- [x] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
