### PR TITLE
fix(apps/pyth-lazer-agent): determine correct update type in /v2/publisher endpoint handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-agent"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "backoff",

--- a/apps/pyth-lazer-agent/Cargo.toml
+++ b/apps/pyth-lazer-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-agent"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 description = "Pyth Lazer Agent"
 license = "Apache-2.0"

--- a/apps/pyth-lazer-agent/src/publisher_handle.rs
+++ b/apps/pyth-lazer-agent/src/publisher_handle.rs
@@ -124,11 +124,21 @@ async fn try_handle_publisher(
                     Ok((data, _)) => FeedUpdate {
                         feed_id: Some(data.price_feed_id.0),
                         source_timestamp: MessageField::some(data.source_timestamp_us.into()),
-                        update: Some(Update::FundingRateUpdate(FundingRateUpdate {
-                            price: data.price.map(|p| p.mantissa_i64()),
-                            rate: data.funding_rate.map(|r| r.mantissa()),
-                            ..FundingRateUpdate::default()
-                        })),
+                        update: if data.funding_rate.is_some() {
+                            Some(Update::FundingRateUpdate(FundingRateUpdate {
+                                price: data.price.map(|p| p.mantissa_i64()),
+                                rate: data.funding_rate.map(|r| r.mantissa()),
+                                funding_rate_interval: MessageField::none(),
+                                special_fields: Default::default(),
+                            }))
+                        } else {
+                            Some(Update::PriceUpdate(PriceUpdate {
+                                price: data.price.map(|p| p.mantissa_i64()),
+                                best_bid_price: data.best_bid_price.map(|p| p.mantissa_i64()),
+                                best_ask_price: data.best_ask_price.map(|p| p.mantissa_i64()),
+                                special_fields: Default::default(),
+                            }))
+                        },
                         special_fields: Default::default(),
                     },
                     Err(err) => {


### PR DESCRIPTION
## Summary

* Detect update kind (price update or funding rate update)
* Send correct update kind in the transaction

## Rationale

Assuming all updates are funding rate updates is incorrect. This was causing issues with https://github.com/pyth-network/pyth-lazer/pull/865.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

Not tested.