### PR TITLE
fix(insights): when feeds aren't trading, show last valid price

### DIFF
--- a/apps/insights/src/components/PriceFeedChangePercent/index.tsx
+++ b/apps/insights/src/components/PriceFeedChangePercent/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { PriceStatus } from "@pythnetwork/client";
 import { StateType, useData } from "@pythnetwork/component-library/useData";
 import type { ComponentProps } from "react";
 import { createContext, use } from "react";
@@ -109,15 +110,19 @@ const PriceFeedChangePercentLoaded = ({
 }: PriceFeedChangePercentLoadedProps) => {
   const { current } = useLivePriceData(Cluster.Pythnet, feedKey);
 
-  return current === undefined ? (
-    <ChangePercent className={className} isLoading />
-  ) : (
-    <ChangePercent
-      className={className}
-      currentValue={current.aggregate.price}
-      previousValue={priorPrice}
-    />
-  );
+  if (current === undefined) {
+    return <ChangePercent className={className} isLoading />;
+  } else if (current.status === PriceStatus.Trading) {
+    return (
+      <ChangePercent
+        className={className}
+        currentValue={current.aggregate.price}
+        previousValue={priorPrice}
+      />
+    );
+  } else {
+    return "-";
+  }
 };
 
 class YesterdaysPricesNotInitializedError extends Error {


### PR DESCRIPTION
## Summary

When feeds are not currently trading, we would previously still show the price point published to pythnet.  However this is misleading in IH since it looks like the feed is still live and updating.  With this PR, we now only show ticking prices when feeds are trading -- when they aren't we instead fall back to `previousPrice` / `previousTimestamp`.

We also enter whitespace data into the chart for points where the feed is not trading -- to be honest there are probably more intuitive ways to account for this in the chart (e.g. maybe we should just skip these points and default the chart to show a window including the last published point or something), but this is a reasonable stopgap that correctly displays what we saw in pythnet, while removing confusion around stale data looking like it's still being published.  cc @fhqvst , this is something to think of in future iterations of the chart.

## Rationale

Resolves some confusing behavior of IH

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
