### PR TITLE
feat(component-library): Add disclaimer

### DIFF
--- a/packages/component-library/src/Footer/index.module.scss
+++ b/packages/component-library/src/Footer/index.module.scss
@@ -101,7 +101,7 @@
       .trademarkDisclaimerHeader {
         @include theme.text("sm", "medium");
 
-        margin-bottom: theme.spacing(2);
+        margin: theme.spacing(2) 0;
       }
 
       .trademarkDisclaimerBody {

--- a/packages/component-library/src/Footer/index.tsx
+++ b/packages/component-library/src/Footer/index.tsx
@@ -35,6 +35,20 @@ export const Footer = ({ className, ...props }: ComponentProps<"footer">) => (
     </div>
     <div className={styles.trademarkDisclaimer}>
       <div className={styles.trademarkDisclaimerContent}>
+        <h3 className={styles.trademarkDisclaimerHeader}>DISCLAIMER</h3>
+        <p className={styles.trademarkDisclaimerBody}>
+          Pyth Price Feeds are provided on an &quot;AS IS,&quot; &quot;WITH ALL
+          FAULTS,&quot; and &quot;AS AVAILABLE&quot; basis, without any
+          warranties or representations of any kind. Please read the following
+          important disclaimer before using them.{" "}
+          <Link
+            href="https://www.pyth.network/legal/disclaimer-for-pyth-network-price-feeds"
+            target="_blank"
+          >
+            Read disclaimer
+          </Link>
+          .
+        </p>
         <h3 className={styles.trademarkDisclaimerHeader}>
           TRADEMARK DISCLAIMER
         </h3>


### PR DESCRIPTION
## Summary

In this PR we add another disclaimer right above the current "TRADEMARK DISCLAIMER" in the component library footer.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code