### PR TITLE
enhancements(API reference): Indicate deprecated func clearly in the menu

### DIFF
--- a/apps/api-reference/src/apis/evm/get-price-unsafe.ts
+++ b/apps/api-reference/src/apis/evm/get-price-unsafe.ts
@@ -10,7 +10,7 @@ export const getPriceUnsafe = readApi<"id">({
 
   **This function may return a price from arbitrarily far in the past.** It is the
   caller's responsibility to check the returned \`publishTime\` to ensure that the
-  update is recent enough for their use case. If you need the latest price, update the price using [\`updatePriceFeeds()\`](updatePriceFeeds) and then call [\`getPrice()\`](getPrice).
+  update is recent enough for their use case. If you need the latest price, update the price using [\`updatePriceFeeds()\`](updatePriceFeeds) and then call [\`getPriceNoOlderThan()\`](getPriceNoOlderThan).
 
   The price object contains the following fields:
   1. \`price\`: The latest price of the price feed.

--- a/apps/api-reference/src/apis/evm/parse-price-feed-updates.tsx
+++ b/apps/api-reference/src/apis/evm/parse-price-feed-updates.tsx
@@ -24,7 +24,7 @@ export const parsePriceFeedUpdates = writeApi<
 
   Use this function if you want to use a Pyth price for a fixed time and not the most
   recent price; otherwise, consider using [updatePriceFeeds](update-price-feeds)
-  followed by [getPrice](get-price) or one of its variants.
+  followed by [getPriceNoOlderThan](get-price-no-older-than) or one of its variants.
 
   Unlike [updatePriceFeeds](updatePriceFeeds), calling this function will **not** update the on-chain price.
 

--- a/apps/api-reference/src/components/Sidebar/index.tsx
+++ b/apps/api-reference/src/components/Sidebar/index.tsx
@@ -23,9 +23,9 @@ const CHAIN_TO_NAME = {
 const MENU = Object.fromEntries(
   Object.entries(apis).map(([chain, methods]) => [
     chain,
-    Object.entries(methods).map(([name]) => ({
-      name,
-      href: `/price-feeds/${chain}/${name}`,
+    Object.entries(methods).map(([methodKey, methodValue]) => ({
+      name: (methodValue as { name: string }).name,
+      href: `/price-feeds/${chain}/${methodKey}`,
     })),
   ]),
 );


### PR DESCRIPTION
## Summary

The menu does not show if the method is deprecated, indicating it clearly so users allows at a glance. This will enhance the developer experience.
<!-- Briefly describe the changes -->

## Rationale

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code
<img width="261" height="561" alt="image" src="https://github.com/user-attachments/assets/d9179ddc-499a-4b9b-8770-117956bf7fdc" />


<!-- Describe the steps you've taken to verify the changes -->
