### PR TITLE
Add real time update timestamp to lazer state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5674,7 +5674,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "protobuf",
- "pyth-lazer-protocol 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pyth-lazer-protocol 0.18.1",
  "pyth-lazer-publisher-sdk 0.16.1",
  "reqwest 0.12.23",
  "serde",
@@ -5693,7 +5693,7 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-client"
-version = "8.4.1"
+version = "8.5.0"
 dependencies = [
  "alloy-primitives 0.8.25",
  "anyhow",
@@ -5711,7 +5711,7 @@ dependencies = [
  "hex",
  "humantime-serde",
  "libsecp256k1 0.7.2",
- "pyth-lazer-protocol 0.18.1",
+ "pyth-lazer-protocol 0.19.0",
  "reqwest 0.12.23",
  "serde",
  "serde_json",
@@ -5721,32 +5721,6 @@ dependencies = [
  "tracing-subscriber",
  "ttl_cache",
  "url",
-]
-
-[[package]]
-name = "pyth-lazer-protocol"
-version = "0.18.1"
-dependencies = [
- "alloy-primitives 0.8.25",
- "anyhow",
- "assert_float_eq",
- "bincode 1.3.3",
- "bs58",
- "byteorder",
- "chrono",
- "derive_more 1.0.0",
- "ed25519-dalek 2.1.1",
- "hex",
- "humantime",
- "humantime-serde",
- "itertools 0.13.0",
- "libsecp256k1 0.7.2",
- "mry",
- "protobuf",
- "rust_decimal",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -5771,6 +5745,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyth-lazer-protocol"
+version = "0.19.0"
+dependencies = [
+ "alloy-primitives 0.8.25",
+ "anyhow",
+ "assert_float_eq",
+ "bincode 1.3.3",
+ "bs58",
+ "byteorder",
+ "chrono",
+ "derive_more 1.0.0",
+ "ed25519-dalek 2.1.1",
+ "hex",
+ "humantime",
+ "humantime-serde",
+ "itertools 0.13.0",
+ "libsecp256k1 0.7.2",
+ "mry",
+ "protobuf",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "pyth-lazer-publisher-sdk"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5780,19 +5780,19 @@ dependencies = [
  "fs-err",
  "protobuf",
  "protobuf-codegen",
- "pyth-lazer-protocol 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pyth-lazer-protocol 0.18.1",
  "serde_json",
 ]
 
 [[package]]
 name = "pyth-lazer-publisher-sdk"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "fs-err",
  "protobuf",
  "protobuf-codegen",
- "pyth-lazer-protocol 0.18.1",
+ "pyth-lazer-protocol 0.19.0",
  "serde_json",
 ]
 

--- a/lazer/publisher_sdk/proto/state.proto
+++ b/lazer/publisher_sdk/proto/state.proto
@@ -48,6 +48,8 @@ message State {
     repeated GovernanceSourceState governance_sources = 9;
     // Currently active feature flags. Feature flags influence the aggregator's behavior.
     repeated string feature_flags = 10;
+    // [required] Timestamp of the last real-time update processed by the shard.
+    optional google.protobuf.Timestamp last_real_time_update_timestamp = 11;
 }
 
 // An item of the state describing a publisher.

--- a/lazer/publisher_sdk/rust/Cargo.toml
+++ b/lazer/publisher_sdk/rust/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "pyth-lazer-publisher-sdk"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Pyth Lazer Publisher SDK types."
 license = "Apache-2.0"
 repository = "https://github.com/pyth-network/pyth-crosschain"
 
 [dependencies]
-pyth-lazer-protocol = { version = "0.18.1", path = "../../sdk/rust/protocol" }
+pyth-lazer-protocol = { version = "0.19.0", path = "../../sdk/rust/protocol" }
 anyhow = "1.0.98"
 protobuf = "3.7.2"
 serde_json = "1.0.140"

--- a/lazer/sdk/rust/client/Cargo.toml
+++ b/lazer/sdk/rust/client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "pyth-lazer-client"
-version = "8.4.1"
+version = "8.5.0"
 edition = "2021"
 description = "A Rust client for Pyth Lazer"
 license = "Apache-2.0"
 
 [dependencies]
-pyth-lazer-protocol = { path = "../protocol", version = "0.18.1" }
+pyth-lazer-protocol = { path = "../protocol", version = "0.19.0" }
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = { version = "0.20", features = ["native-tls"] }
 futures-util = "0.3"

--- a/lazer/sdk/rust/protocol/Cargo.toml
+++ b/lazer/sdk/rust/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyth-lazer-protocol"
-version = "0.18.1"
+version = "0.19.0"
 edition = "2021"
 description = "Pyth Lazer SDK - protocol types."
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

This PR adds the last real time timestamp to lazer state

## Rationale

We need to know when was the last update in the real time channel to make sure updates are being consistent on all machines.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code
