### PR TITLE
feat: make price formatting feed-exponent aware

### DIFF
--- a/apps/insights/src/components/PriceFeed/Chart/chart.tsx
+++ b/apps/insights/src/components/PriceFeed/Chart/chart.tsx
@@ -69,7 +69,6 @@ const useChartElem = (symbol: string, feedId: string) => {
   const chartContainerRef = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<ChartRefContents | undefined>(undefined);
   const isBackfilling = useRef(false);
-  const priceFormatter = usePriceFormatter();
   const abortControllerRef = useRef<AbortController | undefined>(undefined);
   // Lightweight charts has [a
   // bug](https://github.com/tradingview/lightweight-charts/issues/1649) where
@@ -79,6 +78,9 @@ const useChartElem = (symbol: string, feedId: string) => {
   const whitespaceData = useRef<Set<WhitespaceData>>(new Set());
 
   const { current: livePriceData } = useLivePriceData(Cluster.Pythnet, feedId);
+  const priceFormatter = usePriceFormatter(livePriceData?.exponent, {
+    subscriptZeros: false,
+  });
 
   const didResetVisibleRange = useRef(false);
   const didLoadInitialData = useRef(false);
@@ -369,6 +371,17 @@ const useChartElem = (symbol: string, feedId: string) => {
       resolution,
     });
   }, [quickSelectWindow, resolution, fetchHistoricalData]);
+
+  // Update the chart's price formatter when the exponent becomes available
+  useEffect(() => {
+    if (chartRef.current && livePriceData?.exponent !== undefined) {
+      chartRef.current.chart.applyOptions({
+        localization: {
+          priceFormatter: priceFormatter.format,
+        },
+      });
+    }
+  }, [livePriceData?.exponent, priceFormatter]);
 
   return { chartRef, chartContainerRef };
 };

--- a/apps/insights/src/hooks/use-live-price-data.tsx
+++ b/apps/insights/src/hooks/use-live-price-data.tsx
@@ -72,6 +72,7 @@ export const useLivePriceComponent = (
     prev: prev?.priceComponents.find((component) =>
       component.publisher.equals(publisherKey),
     ),
+    exponent: current?.exponent,
   };
 };
 

--- a/apps/insights/src/hooks/use-price-formatter.ts
+++ b/apps/insights/src/hooks/use-price-formatter.ts
@@ -1,17 +1,45 @@
 import { useCallback, useMemo } from "react";
 import { useNumberFormatter } from "react-aria";
 
-export const usePriceFormatter = () => {
+export const usePriceFormatter = (
+  exponent?: number,
+  { subscriptZeros = true }: { subscriptZeros?: boolean } = {},
+) => {
+  // Calculate the number of decimal places based on the exponent
+  // The exponent represents the power of 10, so -8 means 8 decimal places
+  const decimals = exponent === undefined ? undefined : Math.abs(exponent);
+
   const bigNumberFormatter = useNumberFormatter({ maximumFractionDigits: 2 });
   const smallNumberFormatter = useNumberFormatter({
     maximumSignificantDigits: 6,
   });
+  const exponentBasedFormatter = useNumberFormatter({
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+
   const format = useCallback(
-    (n: number) =>
-      n >= 1000
-        ? bigNumberFormatter.format(n)
-        : formatToSubscriptNumber(smallNumberFormatter.format(n)),
-    [bigNumberFormatter, smallNumberFormatter],
+    (n: number) => {
+      // If we have an exponent, use exponent-based formatting
+      if (decimals !== undefined) {
+        const formatted = exponentBasedFormatter.format(n);
+        return subscriptZeros ? formatToSubscriptNumber(formatted) : formatted;
+      }
+      // Otherwise, fall back to the old behavior
+      if (n >= 1000) {
+        const formatted = bigNumberFormatter.format(n);
+        return subscriptZeros ? formatToSubscriptNumber(formatted) : formatted;
+      }
+      const formatted = smallNumberFormatter.format(n);
+      return subscriptZeros ? formatToSubscriptNumber(formatted) : formatted;
+    },
+    [
+      bigNumberFormatter,
+      smallNumberFormatter,
+      exponentBasedFormatter,
+      decimals,
+      subscriptZeros,
+    ],
   );
   return useMemo(() => ({ format }), [format]);
 };


### PR DESCRIPTION
## Summary

In this PR we make use of the feed's `exponent` in all places where we display its price or confidence intervals. 

## Rationale

While slightly less visually pleasing, this change should prevent users from seeing any inconsistencies as a result of rounding.


## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code