### PR TITLE
feat: Use benchmarks API for historical data

### DIFF
--- a/apps/insights/src/components/PriceFeed/Chart/chart.tsx
+++ b/apps/insights/src/components/PriceFeed/Chart/chart.tsx
@@ -184,15 +184,7 @@ const useChartElem = (symbol: string, feedId: string) => {
             return;
           }
 
-          const benchmarkData = benchmarksApiResponseSchema.parse(jsonData);
-
-          // Transform OHLC data to our format using close prices
-          const data = benchmarkData.t.map((timestamp, i) => ({
-            time: timestamp as UTCTimestamp,
-            price: benchmarkData.c[i], // Use close price
-            confidence: 0, // No confidence data from benchmarks API
-            status: PriceStatus.Trading,
-          }));
+          const data = benchmarksApiResponseSchema.parse(jsonData);
 
           // Get the current historical price data
           // Note that .data() returns (WhitespaceData | LineData)[], hence the type cast.
@@ -408,15 +400,24 @@ type ChartRefContents = {
   price: ISeriesApi<"Line">;
 };
 
-const benchmarksApiResponseSchema = z.object({
-  s: z.string(), // status
-  t: z.array(z.number()), // timestamp
-  o: z.array(z.number()), // open
-  h: z.array(z.number()), // high
-  l: z.array(z.number()), // low
-  c: z.array(z.number()), // close
-  v: z.array(z.number()), // volume
-});
+const benchmarksApiResponseSchema = z
+  .object({
+    s: z.string(),
+    t: z.array(z.number()),
+    o: z.array(z.number()),
+    h: z.array(z.number()),
+    l: z.array(z.number()),
+    c: z.array(z.number()),
+    v: z.array(z.number()),
+  })
+  .transform((data) =>
+    data.t.map((timestamp, i) => ({
+      time: timestamp as UTCTimestamp,
+      price: data.c[i], // Use close price for now
+      confidence: 0, // No confidence data from benchmarks API
+      status: PriceStatus.Trading,
+    })),
+  );
 const priceFormat = {
   type: "price",
   precision: 5,


### PR DESCRIPTION
## Summary

With this PR we now consume historical price data from the Benchmarks API instead of using our own hand-rolled Clickhouse query.

One downside is that we don't have confidence intervals in the Benchmarks API...

## Rationale

Our clients' users have complained that they're seeing inconsistent data in insights hub vs. the data on our clients' pages. With this change we now make sure that the data our clients are consuming is the same one we're using on insights hub, meaning there shouldn't be any inconsistencies.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code
