### PR TITLE
fix(insights-hub): fixed price feed description and price getting pushed off screen on mobile devices

### DIFF
--- a/packages/component-library/src/EntityList/index.module.scss
+++ b/packages/component-library/src/EntityList/index.module.scss
@@ -52,9 +52,10 @@
 
     .itemHeader,
     .itemDetailsItem {
+      align-items: center;
       display: flex;
       flex-flow: row nowrap;
-      align-items: center;
+      gap: theme.spacing(2); // give items a little breathing room if text is long
       justify-content: space-between;
     }
 

--- a/packages/component-library/src/SymbolPairTag/index.module.scss
+++ b/packages/component-library/src/SymbolPairTag/index.module.scss
@@ -50,10 +50,21 @@
 
     .description {
       color: theme.color("muted");
-      overflow: hidden;
-      text-overflow: ellipsis;
-
+      // this helps prevent long feed descriptions from looking gross
+      // and overflowing off the page, pushing the curren values off the page,
+      // too
+      overflow: initial;
+      text-overflow: initial;
+      white-space: normal;
+      
       @include theme.text("xs", "medium");
+      
+      // reset the above on large devices, to match when the price feeds grid switches over
+      @include theme.breakpoint("2xl") {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: unset;
+      }
     }
   }
 


### PR DESCRIPTION
# Resolves [this Slack thread](https://dourolabs.slack.com/archives/C02G1P1KUG6/p1761539901762809)

## Summary

Adjusted some CSS properties to max `white-space` responsive when the price feed grid changes to its mobile layout, and added some `gap` as breathing room when text runs long.

## Rationale

see comments, above ☝️ 

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [X] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
## Screenshots

### Mobile before

<img width="454" height="723" alt="mobile-before" src="https://github.com/user-attachments/assets/5d9fd877-9fd0-4f37-ad47-4a5f678d2d80" />

### Mobile after

<img width="504" height="764" alt="mobile-after" src="https://github.com/user-attachments/assets/dc6dd70b-b388-4cbb-9725-feca4ade1180" />

## Videos

### Responsive resizing

https://github.com/user-attachments/assets/b290e3df-b620-4470-a4eb-2460c64f2759



