### PR TITLE
chore: support anchor 0.32.1 in pyth-solana-receiver-sdk

### DIFF
--- a/target_chains/solana/pyth_solana_receiver_sdk/Cargo.lock
+++ b/target_chains/solana/pyth_solana_receiver_sdk/Cargo.lock
@@ -1017,7 +1017,7 @@ dependencies = [
  "anchor-lang",
  "hex",
  "pythnet-sdk",
- "solana-program",
+ "solana-borsh",
 ]
 
 [[package]]

--- a/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
+++ b/target_chains/solana/pyth_solana_receiver_sdk/Cargo.toml
@@ -20,4 +20,4 @@ pythnet-sdk = { path = "../../../pythnet/pythnet_sdk", version = "2.3.1", featur
 ] }
 
 [dev-dependencies]
-solana-program = "2.3.0"
+solana-borsh = "2.2.1" # Needed for borsh0_10 compatibility

--- a/target_chains/solana/pyth_solana_receiver_sdk/src/price_update.rs
+++ b/target_chains/solana/pyth_solana_receiver_sdk/src/price_update.rs
@@ -325,14 +325,14 @@ pub mod tests {
         },
         anchor_lang::prelude::*,
         pythnet_sdk::messages::PriceFeedMessage,
-        solana_program::borsh0_10,
+        solana_borsh::v0_10,
     };
 
     #[test]
     fn check_size() {
         // borsh0_10 is deprecated, v1::get_packed_len should be used in the future
         #[allow(deprecated)]
-        let len = PriceUpdateV2::DISCRIMINATOR.len() + borsh0_10::get_packed_len::<PriceUpdateV2>();
+        let len = PriceUpdateV2::DISCRIMINATOR.len() + v0_10::get_packed_len::<PriceUpdateV2>();
         assert_eq!(len, PriceUpdateV2::LEN);
     }
 


### PR DESCRIPTION
## Summary
- update anchor-lang dependency to 0.32.1
- add solana-program dev dependency for the updated tests
- adjust tests to import borsh helpers from solana

## Testing
- cargo test -p pyth-solana-receiver-sdk
