### PR TITLE
fix(component-library): fix table header sort buttons not appearing

### DIFF
--- a/packages/component-library/src/Table/index.module.scss
+++ b/packages/component-library/src/Table/index.module.scss
@@ -136,6 +136,10 @@
           right: theme.spacing(2);
           top: theme.spacing(2);
 
+          svg {
+            width: 1em;
+          }
+
           .ascending,
           .descending {
             opacity: 0.25;


### PR DESCRIPTION
## Summary

I noticed that at some point something broke and the sort buttons in the column headers in tables weren't showing up.  This commit fixes that.

Before:
<img width="2022" height="72" alt="screenshot-2025-10-29-081946" src="https://github.com/user-attachments/assets/28035c2d-7ed7-4064-b7b0-0f91ccc12f3b" />


After:
<img width="2035" height="75" alt="screenshot-2025-10-29-081902" src="https://github.com/user-attachments/assets/556449a6-0901-4bf7-88a3-71a776d4f639" />


## Rationale

If it ain't broke, don't fix it.  But it's broke.  So I fixed it.


## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code