### PR TITLE
chore: fix sui doc comment

### DIFF
--- a/target_chains/sui/contracts/sources/price.move
+++ b/target_chains/sui/contracts/sources/price.move
@@ -6,9 +6,9 @@ module pyth::price {
     /// The confidence interval roughly corresponds to the standard error of a normal distribution.
     /// Both the price and confidence are stored in a fixed-point numeric representation,
     /// `x * (10^expo)`, where `expo` is the exponent.
-    //
+    ///
     /// Please refer to the documentation at https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices for how
-    /// to how this price safely.
+    /// to use this price safely.
     struct Price has copy, drop, store {
         price: I64,
         /// Confidence interval around the price


### PR DESCRIPTION
## Summary

fixing a compiler warning because the doc comment is interrupted by the // 

## Rationale

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
