### PR TITLE
fix(entropy-explorer): handle gas limit exceeded errors

### DIFF
--- a/apps/entropy-explorer/src/requests.ts
+++ b/apps/entropy-explorer/src/requests.ts
@@ -86,7 +86,7 @@ export const getRequests = async ({
                     return request.state.callback_failed
                       ? Request.CallbackErrored({
                           ...completedCommon,
-                          returnValue: request.state.callback_return_value,
+                          reason: request.state.callback_return_value,
                         })
                       : Request.Complete({
                           ...completedCommon,
@@ -244,7 +244,7 @@ type CompletedArgs = BaseArgs & {
   callbackTxHash: `0x${string}`;
 };
 type CallbackErrorArgs = CompletedArgs & {
-  returnValue: string;
+  reason: string;
 };
 
 const Request = {


### PR DESCRIPTION
## Summary

Handle gas limit exceeded errors in entropy explorer

## Rationale

Before:

<img width="1127" height="467" alt="screenshot-2025-10-29-115325" src="https://github.com/user-attachments/assets/5edf7237-478e-4070-bfe3-188f05e0bb63" />


After:

<img width="1043" height="424" alt="screenshot-2025-10-29-115610" src="https://github.com/user-attachments/assets/f92a9a8f-4ac4-41cf-b331-5c28162be76e" />



## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code