### PR TITLE
fix: fixed nuqs usage by doing a pass-through export from a new package and clamping package to ESM

### DIFF
--- a/apps/developer-hub/package.json
+++ b/apps/developer-hub/package.json
@@ -35,7 +35,7 @@
     "katex": "catalog:",
     "next": "catalog:",
     "next-themes": "catalog:",
-    "nuqs": "catalog:",
+    "@pythnetwork/react-hooks": "workspace:",
     "react": "catalog:",
     "react-aria": "catalog:",
     "react-dom": "catalog:",

--- a/apps/developer-hub/src/components/Root/index.tsx
+++ b/apps/developer-hub/src/components/Root/index.tsx
@@ -1,6 +1,6 @@
 import { RootProviders } from "@pythnetwork/component-library/AppShell";
+import { NuqsAdapter } from "@pythnetwork/react-hooks/nuqs-adapters-next";
 import { RootProvider as FumadocsRootProvider } from "fumadocs-ui/provider";
-import { NuqsAdapter } from "nuqs/adapters/next/app";
 import type { ReactNode } from "react";
 
 import "./global.css";

--- a/apps/entropy-explorer/package.json
+++ b/apps/entropy-explorer/package.json
@@ -24,7 +24,7 @@
     "@pythnetwork/component-library": "workspace:*",
     "clsx": "catalog:",
     "next": "catalog:",
-    "nuqs": "catalog:",
+    "@pythnetwork/react-hooks": "workspace:",
     "react": "catalog:",
     "react-aria": "catalog:",
     "react-dom": "catalog:",

--- a/apps/entropy-explorer/src/components/Root/index.tsx
+++ b/apps/entropy-explorer/src/components/Root/index.tsx
@@ -1,5 +1,5 @@
 import { AppShell } from "@pythnetwork/component-library/AppShell";
-import { NuqsAdapter } from "nuqs/adapters/next/app";
+import { NuqsAdapter } from "@pythnetwork/react-hooks/nuqs-adapters-next";
 import type { ReactNode } from "react";
 
 import {

--- a/apps/insights/package.json
+++ b/apps/insights/package.json
@@ -40,7 +40,7 @@
     "motion": "catalog:",
     "next": "catalog:",
     "next-themes": "catalog:",
-    "nuqs": "catalog:",
+    "@pythnetwork/react-hooks": "workspace:",
     "react": "catalog:",
     "react-aria": "catalog:",
     "react-dom": "catalog:",

--- a/apps/insights/src/components/PriceComponentDrawer/index.tsx
+++ b/apps/insights/src/components/PriceComponentDrawer/index.tsx
@@ -12,10 +12,10 @@ import type { Button as UnstyledButton } from "@pythnetwork/component-library/un
 import { StateType, useData } from "@pythnetwork/component-library/useData";
 import { useDrawer } from "@pythnetwork/component-library/useDrawer";
 import { useLogger } from "@pythnetwork/component-library/useLogger";
+import { parseAsString, useQueryState } from "@pythnetwork/react-hooks/nuqs";
 import { useMountEffect } from "@react-hookz/web";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
-import { parseAsString, useQueryState } from "nuqs";
 import type { ReactNode } from "react";
 import {
   Suspense,

--- a/apps/insights/src/components/PriceComponentsCard/index.tsx
+++ b/apps/insights/src/components/PriceComponentsCard/index.tsx
@@ -17,8 +17,12 @@ import type {
 import { Table } from "@pythnetwork/component-library/Table";
 import { useLogger } from "@pythnetwork/component-library/useLogger";
 import { useQueryParamFilterPagination } from "@pythnetwork/component-library/useQueryParamsPagination";
+import {
+  useQueryState,
+  parseAsStringEnum,
+  parseAsBoolean,
+} from "@pythnetwork/react-hooks/nuqs";
 import clsx from "clsx";
-import { useQueryState, parseAsStringEnum, parseAsBoolean } from "nuqs";
 import type { ReactNode } from "react";
 import { Fragment, Suspense, useMemo, useCallback } from "react";
 import { useFilter, useCollator } from "react-aria";

--- a/apps/insights/src/components/PriceFeed/Chart/use-chart-toolbar.tsx
+++ b/apps/insights/src/components/PriceFeed/Chart/use-chart-toolbar.tsx
@@ -1,4 +1,7 @@
-import { parseAsStringLiteral, useQueryState } from "nuqs";
+import {
+  parseAsStringLiteral,
+  useQueryState,
+} from "@pythnetwork/react-hooks/nuqs";
 
 export const RESOLUTIONS = ["1s", "1m", "5m", "1H", "1D"] as const;
 export type Resolution = (typeof RESOLUTIONS)[number];

--- a/apps/insights/src/components/PriceFeed/publishers-card.tsx
+++ b/apps/insights/src/components/PriceFeed/publishers-card.tsx
@@ -2,7 +2,7 @@
 
 import { Switch } from "@pythnetwork/component-library/Switch";
 import { useLogger } from "@pythnetwork/component-library/useLogger";
-import { useQueryState, parseAsBoolean } from "nuqs";
+import { useQueryState, parseAsBoolean } from "@pythnetwork/react-hooks/nuqs";
 import { Suspense, useCallback, useMemo } from "react";
 
 import { Cluster } from "../../services/pyth";

--- a/apps/insights/src/components/PriceFeeds/asset-class-table.tsx
+++ b/apps/insights/src/components/PriceFeeds/asset-class-table.tsx
@@ -4,13 +4,13 @@ import { Badge } from "@pythnetwork/component-library/Badge";
 import { Table } from "@pythnetwork/component-library/Table";
 import { useDrawer } from "@pythnetwork/component-library/useDrawer";
 import { useLogger } from "@pythnetwork/component-library/useLogger";
-import { usePathname } from "next/navigation";
 import {
   parseAsString,
   parseAsInteger,
   useQueryStates,
   createSerializer,
-} from "nuqs";
+} from "@pythnetwork/react-hooks/nuqs";
+import { usePathname } from "next/navigation";
 import { useMemo } from "react";
 import { useCollator } from "react-aria";
 

--- a/apps/insights/src/components/PriceFeeds/price-feeds-card.tsx
+++ b/apps/insights/src/components/PriceFeeds/price-feeds-card.tsx
@@ -16,8 +16,8 @@ import type {
 import { Table } from "@pythnetwork/component-library/Table";
 import { useLogger } from "@pythnetwork/component-library/useLogger";
 import { useQueryParamFilterPagination } from "@pythnetwork/component-library/useQueryParamsPagination";
+import { parseAsString, useQueryState } from "@pythnetwork/react-hooks/nuqs";
 import { matchSorter } from "match-sorter";
-import { parseAsString, useQueryState } from "nuqs";
 import type { ReactNode } from "react";
 import { Suspense, useCallback, useMemo } from "react";
 import { useCollator } from "react-aria";

--- a/apps/insights/src/components/Publishers/publishers-card.tsx
+++ b/apps/insights/src/components/Publishers/publishers-card.tsx
@@ -17,8 +17,11 @@ import type {
 import { Table } from "@pythnetwork/component-library/Table";
 import { useLogger } from "@pythnetwork/component-library/useLogger";
 import { useQueryParamFilterPagination } from "@pythnetwork/component-library/useQueryParamsPagination";
+import {
+  useQueryState,
+  parseAsStringEnum,
+} from "@pythnetwork/react-hooks/nuqs";
 import clsx from "clsx";
-import { useQueryState, parseAsStringEnum } from "nuqs";
 import type { ReactNode } from "react";
 import { Suspense, useMemo, useCallback } from "react";
 import { useFilter, useCollator } from "react-aria";

--- a/apps/insights/src/components/Root/index.tsx
+++ b/apps/insights/src/components/Root/index.tsx
@@ -1,6 +1,6 @@
 import { AppShell } from "@pythnetwork/component-library/AppShell";
 import { lookup as lookupPublisher } from "@pythnetwork/known-publishers";
-import { NuqsAdapter } from "nuqs/adapters/next/app";
+import { NuqsAdapter } from "@pythnetwork/react-hooks/nuqs-adapters-next";
 import type { ReactNode } from "react";
 
 import { SearchButton as SearchButtonImpl } from "./search-button";

--- a/governance/xc_admin/packages/xc_admin_frontend/components/tabs/Proposals/Proposals.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/tabs/Proposals/Proposals.tsx
@@ -3,10 +3,13 @@
 /* eslint-disable @typescript-eslint/no-deprecated */
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import { Menu, Transition } from '@headlessui/react'
+import {
+  useQueryState,
+  parseAsStringLiteral,
+} from '@pythnetwork/react-hooks/nuqs'
 import { useWallet } from '@solana/wallet-adapter-react'
 import type { TransactionAccount } from '@sqds/mesh/lib/types'
 import { useRouter } from 'next/router'
-import { useQueryState, parseAsStringLiteral } from 'nuqs'
 import { useContext, useEffect, useState, useMemo, Fragment } from 'react'
 
 import { Proposal } from './Proposal'

--- a/governance/xc_admin/packages/xc_admin_frontend/package.json
+++ b/governance/xc_admin/packages/xc_admin_frontend/package.json
@@ -38,7 +38,7 @@
     "message_buffer": "workspace:^",
     "next": "catalog:",
     "next-seo": "^5.15.0",
-    "nuqs": "catalog:",
+    "@pythnetwork/react-hooks": "workspace:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-hot-toast": "^2.4.0",

--- a/governance/xc_admin/packages/xc_admin_frontend/pages/_app.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/pages/_app.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable n/no-process-env */
+import { NuqsAdapter } from '@pythnetwork/react-hooks/nuqs-adapters-next'
 import { WalletAdapterNetwork } from '@solana/wallet-adapter-base'
 import {
   ConnectionProvider,
@@ -18,7 +19,6 @@ import { clusterApiUrl } from '@solana/web3.js'
 import type { AppProps } from 'next/app'
 import Head from 'next/head'
 import { DefaultSeo } from 'next-seo'
-import { NuqsAdapter } from 'nuqs/adapters/next/pages'
 import { useMemo } from 'react'
 import { Toaster } from 'react-hot-toast'
 

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -338,7 +338,7 @@
     "modern-normalize": "catalog:",
     "motion": "catalog:",
     "next-themes": "catalog:",
-    "nuqs": "catalog:",
+    "@pythnetwork/react-hooks": "workspace:",
     "pino": "catalog:",
     "react-aria": "catalog:",
     "react-aria-components": "catalog:",

--- a/packages/component-library/src/useQueryParamsPagination/index.ts
+++ b/packages/component-library/src/useQueryParamsPagination/index.ts
@@ -1,13 +1,13 @@
 "use client";
 
-import { usePathname } from "next/navigation";
 import {
   parseAsString,
   parseAsInteger,
   parseAsBoolean,
   useQueryStates,
   createSerializer,
-} from "nuqs";
+} from "@pythnetwork/react-hooks/nuqs";
+import { usePathname } from "next/navigation";
 import { useCallback, useMemo } from "react";
 
 import type { SortDescriptor } from "../unstyled/Table";

--- a/packages/react-hooks/.gitignore
+++ b/packages/react-hooks/.gitignore
@@ -1,0 +1,22 @@
+# Coverage directory used by tools like istanbul
+coverage
+
+# Dependency directories
+node_modules/
+
+# Optional npm cache directory
+.npm
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# dotenv environment variables file
+.env
+
+# Build directory
+dist/
+
+tsconfig.tsbuildinfo

--- a/packages/react-hooks/.prettierignore
+++ b/packages/react-hooks/.prettierignore
@@ -1,0 +1,12 @@
+.vscode/
+coverage/
+dist/
+doc/
+doc*/
+node_modules/
+dist/
+lib/
+build/
+node_modules/
+package.json
+tsconfig*.json

--- a/packages/react-hooks/eslint.config.js
+++ b/packages/react-hooks/eslint.config.js
@@ -1,0 +1,1 @@
+export { base as default } from "@cprussin/eslint-config";

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -1,0 +1,47 @@
+{
+  "private": true,
+  "name": "@pythnetwork/react-hooks",
+  "description": "collection of utility hooks used across react applications powering parts of the pyth network",
+  "version": "0.0.0",
+  "scripts": {
+    "build": "ts-duality --clean --noCjs",
+    "clean": "rm -rf ./dist",
+    "fix:format": "prettier --write .",
+    "fix:lint": "eslint --fix . --max-warnings 0",
+    "test:lint": "eslint . --max-warnings 0",
+    "test:format": "prettier --check .",
+    "test:types": "tsc"
+  },
+  "devDependencies": {
+    "@cprussin/eslint-config": "catalog:",
+    "@cprussin/tsconfig": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "eslint": "catalog:"
+  },
+  "dependencies": {
+    "nuqs": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "type": "module",
+  "exports": {
+    "./nuqs-adapters-next": {
+      "types": "./dist/nuqs-adapters-next.d.ts",
+      "default": "./dist/nuqs-adapters-next.mjs"
+    },
+    "./nuqs-server": {
+      "types": "./dist/nuqs-server.d.ts",
+      "default": "./dist/nuqs-server.mjs"
+    },
+    "./nuqs-testing": {
+      "types": "./dist/nuqs-testing.d.ts",
+      "default": "./dist/nuqs-testing.mjs"
+    },
+    "./nuqs": {
+      "types": "./dist/nuqs.d.ts",
+      "default": "./dist/nuqs.mjs"
+    },
+    "./package.json": "./package.json"
+  }
+}

--- a/packages/react-hooks/src/nuqs-adapters-next.ts
+++ b/packages/react-hooks/src/nuqs-adapters-next.ts
@@ -1,0 +1,1 @@
+export * from "nuqs/adapters/next";

--- a/packages/react-hooks/src/nuqs-server.ts
+++ b/packages/react-hooks/src/nuqs-server.ts
@@ -1,0 +1,1 @@
+export * from "nuqs/server";

--- a/packages/react-hooks/src/nuqs-testing.ts
+++ b/packages/react-hooks/src/nuqs-testing.ts
@@ -1,0 +1,1 @@
+export * from "nuqs/testing";

--- a/packages/react-hooks/src/nuqs.ts
+++ b/packages/react-hooks/src/nuqs.ts
@@ -1,0 +1,9 @@
+// this file exists as a way to export a single, unified instance of
+// the nuqs library, to prevent the following error:
+// https://nuqs.dev/NUQS-404
+// solutions have been discussed here about using nuqs in a monorepo:
+// https://github.com/47ng/nuqs/issues/798
+// NOTE: this helps prevent mixed ESM and CJS usages of the hooks and context providers,
+// which is likely what causes the issue in bundler environments that support both
+// and aren't strictly opinionated about CJS vs ESM
+export * from "nuqs";

--- a/packages/react-hooks/tsconfig.build.json
+++ b/packages/react-hooks/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": false,
+    "noEmit": false
+  }
+}

--- a/packages/react-hooks/tsconfig.json
+++ b/packages/react-hooks/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@cprussin/tsconfig/base.json",
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^7.27.1
       version: 7.27.1
     '@better-builds/ts-duality':
-      specifier: '>=0.1.0'
-      version: 0.1.0
+      specifier: ^0.1.2
+      version: 0.1.2
     '@bonfida/spl-name-service':
       specifier: ^3.0.10
       version: 3.0.10
@@ -354,7 +354,7 @@ importers:
     devDependencies:
       '@better-builds/ts-duality':
         specifier: 'catalog:'
-        version: 0.1.0(typescript@5.9.3)
+        version: 0.1.2(typescript@5.9.3)
       '@cprussin/prettier-config':
         specifier: 'catalog:'
         version: 2.2.2(prettier@3.5.3)
@@ -521,6 +521,9 @@ importers:
       '@pythnetwork/entropy-sdk-solidity':
         specifier: workspace:*
         version: link:../../target_chains/ethereum/entropy_sdk/solidity
+      '@pythnetwork/react-hooks':
+        specifier: 'workspace:'
+        version: link:../../packages/react-hooks
       '@react-hookz/web':
         specifier: 'catalog:'
         version: 25.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -551,9 +554,6 @@ importers:
       next-themes:
         specifier: 'catalog:'
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      nuqs:
-        specifier: 'catalog:'
-        version: 2.4.1(next@15.5.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.86.1))(react@19.1.0)
       react:
         specifier: 'catalog:'
         version: 19.1.0
@@ -663,15 +663,15 @@ importers:
       '@pythnetwork/component-library':
         specifier: workspace:*
         version: link:../../packages/component-library
+      '@pythnetwork/react-hooks':
+        specifier: 'workspace:'
+        version: link:../../packages/react-hooks
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
       next:
         specifier: 'catalog:'
         version: 15.5.0(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.86.1)
-      nuqs:
-        specifier: 'catalog:'
-        version: 2.4.1(next@15.5.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.86.1))(react@19.1.0)
       react:
         specifier: 'catalog:'
         version: 19.1.0
@@ -870,6 +870,9 @@ importers:
       '@pythnetwork/known-publishers':
         specifier: workspace:*
         version: link:../../packages/known-publishers
+      '@pythnetwork/react-hooks':
+        specifier: 'workspace:'
+        version: link:../../packages/react-hooks
       '@react-hookz/web':
         specifier: 'catalog:'
         version: 25.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -912,9 +915,6 @@ importers:
       next-themes:
         specifier: 'catalog:'
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      nuqs:
-        specifier: 'catalog:'
-        version: 2.4.1(next@15.5.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.86.1))(react@19.1.0)
       react:
         specifier: 'catalog:'
         version: 19.1.0
@@ -1714,6 +1714,9 @@ importers:
       '@pythnetwork/client':
         specifier: 'catalog:'
         version: 2.22.1(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@pythnetwork/react-hooks':
+        specifier: 'workspace:'
+        version: link:../../../../packages/react-hooks
       '@pythnetwork/solana-utils':
         specifier: workspace:^
         version: link:../../../../target_chains/solana/sdk/js/solana_utils
@@ -1768,9 +1771,6 @@ importers:
       next-seo:
         specifier: ^5.15.0
         version: 5.15.0(next@15.5.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.86.1))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      nuqs:
-        specifier: 'catalog:'
-        version: 2.4.1(next@15.5.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.86.1))(react@19.1.0)
       react:
         specifier: 'catalog:'
         version: 19.1.0
@@ -1995,6 +1995,9 @@ importers:
       '@next/third-parties':
         specifier: 'catalog:'
         version: 15.3.2(next@15.5.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.86.1))(react@19.1.0)
+      '@pythnetwork/react-hooks':
+        specifier: 'workspace:'
+        version: link:../react-hooks
       '@react-hookz/web':
         specifier: 'catalog:'
         version: 25.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2019,9 +2022,6 @@ importers:
       next-themes:
         specifier: 'catalog:'
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      nuqs:
-        specifier: 'catalog:'
-        version: 2.4.1(next@15.5.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.86.1))(react@19.1.0)
       pino:
         specifier: 'catalog:'
         version: 9.6.0
@@ -2161,7 +2161,7 @@ importers:
     devDependencies:
       '@better-builds/ts-duality':
         specifier: 'catalog:'
-        version: 0.1.0(typescript@5.9.3)
+        version: 0.1.2(typescript@5.9.3)
       '@cprussin/eslint-config':
         specifier: 'catalog:'
         version: 4.0.2(@testing-library/dom@10.4.0)(@typescript-eslint/eslint-plugin@8.29.0(@typescript-eslint/parser@8.29.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.9.3))(eslint@9.23.0(jiti@2.4.2))(typescript@5.9.3))(@typescript-eslint/parser@8.29.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.9.3))(eslint@9.23.0(jiti@2.4.2))(jest@29.7.0(@types/node@22.14.0)(ts-node@10.9.2(@swc/core@1.15.0)(@types/node@22.14.0)(typescript@5.9.3)))(ts-node@10.9.2(@swc/core@1.15.0)(@types/node@22.14.0)(typescript@5.9.3))(turbo@2.5.8)(typescript@5.9.3)
@@ -2207,6 +2207,34 @@ importers:
       react:
         specifier: 'catalog:'
         version: 19.1.0
+
+  packages/react-hooks:
+    dependencies:
+      nuqs:
+        specifier: 'catalog:'
+        version: 2.4.1(next@15.5.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.86.1))(react@19.1.0)
+      react:
+        specifier: 'catalog:'
+        version: 19.1.0
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.1.0(react@19.1.0)
+    devDependencies:
+      '@cprussin/eslint-config':
+        specifier: 'catalog:'
+        version: 4.0.2(@testing-library/dom@10.4.0)(@typescript-eslint/eslint-plugin@8.29.0(@typescript-eslint/parser@8.29.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.9.3))(eslint@9.23.0(jiti@2.4.2))(typescript@5.9.3))(@typescript-eslint/parser@8.29.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.9.3))(eslint@9.23.0(jiti@2.4.2))(jest@29.7.0(@types/node@22.14.0)(ts-node@10.9.2(@swc/core@1.15.0)(@types/node@22.14.0)(typescript@5.9.3)))(ts-node@10.9.2(@swc/core@1.15.0)(@types/node@22.14.0)(typescript@5.9.3))(turbo@2.5.8)(typescript@5.9.3)
+      '@cprussin/tsconfig':
+        specifier: 'catalog:'
+        version: 3.1.2(typescript@5.9.3)
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.1.0
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.1.1(@types/react@19.1.0)
+      eslint:
+        specifier: 'catalog:'
+        version: 9.23.0(jiti@2.4.2)
 
   price_service/client/js:
     dependencies:
@@ -4261,8 +4289,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@better-builds/ts-duality@0.1.0':
-    resolution: {integrity: sha512-y89T3c2Ino20sbQervVjWd/cIJ78StSRPl7vTwhMdjyOdAecOh3SJMsrQKUqkP9IjWi7Uedwagoj5mSQcao+gA==}
+  '@better-builds/ts-duality@0.1.2':
+    resolution: {integrity: sha512-YFj6lFMjIyBtoBKDtuIxrZwJvrqdVy0hFODa/9Y5yXZjsjY4PDpDLfIeFrNNg8zZS3SzZ56GuP3RovXA9yXa0Q==}
     engines: {bun: '>=1.3.0', node: '>=22.14.0'}
     hasBin: true
     peerDependencies:
@@ -24208,7 +24236,7 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@better-builds/ts-duality@0.1.0(typescript@5.9.3)':
+  '@better-builds/ts-duality@0.1.2(typescript@5.9.3)':
     dependencies:
       '@swc/core': 1.15.0
       chalk: 5.6.2
@@ -45989,13 +46017,6 @@ snapshots:
     dependencies:
       bn.js: 4.11.6
       strip-hex-prefix: 1.0.0
-
-  nuqs@2.4.1(next@15.5.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.86.1))(react@19.1.0):
-    dependencies:
-      mitt: 3.0.1
-      react: 19.1.0
-    optionalDependencies:
-      next: 15.5.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.86.1)
 
   nuqs@2.4.1(next@15.5.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.86.1))(react@19.1.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,7 +51,7 @@ catalog:
   "@amplitude/analytics-browser": ^2.13.0
   "@amplitude/plugin-autocapture-browser": ^1.0.0
   "@axe-core/react": ^4.10.1
-  "@better-builds/ts-duality": ">=0.1.0"
+  "@better-builds/ts-duality": ^0.1.2
   "ag-grid-community": ^34.2.0
   "ag-grid-react": ^34.2.0
   "@babel/cli": ^7.27.2


### PR DESCRIPTION
# Resolves issue from this [Slack thread](https://dourolabs.slack.com/archives/C08790XNKFC/p1762431911890909)

## Summary

Created a `@pythnetworks/react-hooks` package that currently just re-exports `nuqs`, but can be used as a place to put shared hooks in the future. Also upgrade ts-duality to the latest version, which no longer formats the built files that are rendered into `dist/` (which was not valuable, anyways)

### Rationale

Per discourse [here](https://github.com/47ng/nuqs/issues/798), using `nuqs` in a monorepo with packages and bundlers that support mixed exports between CJS and ESM, some codepaths can import the CJS variant, whereas others import the ESM variant, which causes runtime issues since the contexts are different.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [X] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->

Loaded the Pyth Insights price feeds page, clicked around and ensured that nothing blew up at runtime.

## Screenshots

### Before

<img width="1987" height="1695" alt="CleanShot 2025-11-06 at 14 23 24" src="https://github.com/user-attachments/assets/eff80cde-936d-40ee-bd7b-d36b79d5d7e2" />

### After

<img width="1987" height="1695" alt="CleanShot 2025-11-06 at 14 27 06" src="https://github.com/user-attachments/assets/45757889-3839-4b2f-836b-82eaadedf8c6" />

