### PR TITLE
chore(pyth-sdk-solidity): ignore some more extraneous files

### DIFF
--- a/target_chains/ethereum/sdk/solidity/.npmignore
+++ b/target_chains/ethereum/sdk/solidity/.npmignore
@@ -1,4 +1,6 @@
 .gitignore
 .prettierignore
+build/
+.turbo/
 prettier.config.js
 turbo.json


### PR DESCRIPTION
## Summary

Missed some extraneous files that were accidentally included in the NPM package

## Rationale

helps keep the npm install size down

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [X] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
ran `npm pack` and verified the tarball
