### PR TITLE
fix(hyperliquid-recorder): don't ensure schema

### DIFF
--- a/apps/hyperliquid-recorder/src/main.rs
+++ b/apps/hyperliquid-recorder/src/main.rs
@@ -29,7 +29,6 @@ async fn run() -> Result<()> {
     let config = AppConfig::from_sources(cli.config.as_deref())?;
 
     let writer_client = create_client_with_retry(config.clone(), 30).await?;
-    writer_client.ensure_schema(config.retention_days).await?;
     let ping_client = create_client_with_retry(config.clone(), 30).await?;
 
     let metrics = Arc::new(RecorderMetrics::new()?);


### PR DESCRIPTION
## Summary

In prod the user doesn't have DDL access

## Rationale

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
