### PR TITLE
Add Monad mainnet and testnet Lazer contracts

### DIFF
--- a/contract_manager/src/store/contracts/EvmLazerContracts.json
+++ b/contract_manager/src/store/contracts/EvmLazerContracts.json
@@ -86,6 +86,16 @@
   },
   {
     "address": "0xACeA761c27A909d4D3895128EBe6370FDE2dF481",
+    "chain": "monad",
+    "type": "EvmLazerContract"
+  },
+  {
+    "address": "0xACeA761c27A909d4D3895128EBe6370FDE2dF481",
+    "chain": "monad_testnet",
+    "type": "EvmLazerContract"
+  },
+  {
+    "address": "0xACeA761c27A909d4D3895128EBe6370FDE2dF481",
     "chain": "polygon",
     "type": "EvmLazerContract"
   },


### PR DESCRIPTION
Adds the Pyth Lazer contract address for Monad mainnet and testnet.

Contract Address: `0xACeA761c27A909d4D3895128EBe6370FDE2dF481`

Both chains already exist in `EvmChains.json` and have other Pyth contracts deployed (Core, Entropy, etc.). This PR adds the Lazer contract registrations.