### PR TITLE
docs: add Pyth Terminal page to developer hub

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/meta.json
+++ b/apps/developer-hub/content/docs/price-feeds/pro/meta.json
@@ -1,6 +1,7 @@
 {
   "pages": [
     "getting-started",
+    "pyth-terminal",
     "---How-To Guides---",
     "acquire-access-token",
     "subscribe-to-prices",

--- a/apps/developer-hub/content/docs/price-feeds/pro/pyth-terminal.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/pyth-terminal.mdx
@@ -1,0 +1,55 @@
+---
+title: Pyth Terminal
+description: Explore Pyth price feeds, get a free API key, and trial Pyth Pro from your browser
+slug: /price-feeds/pro/pyth-terminal
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+[Pyth Terminal](https://pythdata.app) is a self-serve web application where you can explore Pyth's full catalog of price feeds, view historical chart data, and get a free Pyth Pro API trial key — all without needing to contact sales. Whether you're evaluating Pyth for a new integration or browsing available data, Terminal is the fastest way to get started.
+
+## What You Can Do
+
+- **Explore Feeds** — Browse and filter 500+ price feeds across crypto, US equities, FX, commodities, and more
+- **View Historical Charts** — Inspect OHLC candlestick data with trading schedule overlays
+- **Get a Free API Trial** — Generate a Pyth Pro access token instantly, no credit card required
+- **Access Benchmark Data** — View benchmark pricing for US equities and FX
+- **Manage Your Subscription** — Upgrade your plan, add payment, and manage billing online
+
+## Tutorials
+
+### Getting Started with Pyth Terminal
+
+Walk through the core features: searching feeds, filtering by asset class, viewing price charts, and generating your API key.
+
+<div style={{ position: "relative", paddingBottom: "calc(57.6023% + 41px)", height: "0px", width: "100%" }}>
+  <iframe
+    src="https://demo.arcade.software/Dff79k3g1AoTzaoL7Nrp?embed&embed_mobile=inline&embed_desktop=inline&show_copy_link=true"
+    title="Pyth Terminal User Guide"
+    frameBorder="0"
+    loading="lazy"
+    allowFullScreen
+    allow="clipboard-write"
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", colorScheme: "light" }}
+  />
+</div>
+
+### Pyth Pro x Polymarket
+
+See how Polymarket uses Pyth Pro data through Terminal, including RWA feeds and subscription setup.
+
+<div style={{ position: "relative", paddingBottom: "calc(79.4221% + 41px)", height: "0px", width: "100%" }}>
+  <iframe
+    src="https://demo.arcade.software/RpQ2htd1SvLjJBwCf9yz?embed&embed_mobile=inline&embed_desktop=inline&show_copy_link=true"
+    title="Pyth Pro x Polymarket"
+    frameBorder="0"
+    loading="lazy"
+    allowFullScreen
+    allow="clipboard-write"
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", colorScheme: "light" }}
+  />
+</div>
+
+<Callout type="info">
+  Ready to try it yourself? Visit [Pyth Terminal](https://pythdata.app) to start exploring price feeds and get your free API key.
+</Callout>


### PR DESCRIPTION
## Summary
- Adds a new "Pyth Terminal" page under Price Feeds > Pro in the developer hub
- Introduces Pyth Terminal (pythdata.app) with feature highlights and two interactive Arcade tutorial embeds
- Page appears in sidebar right after "Getting Started"

## Changes
- **New file:** `apps/developer-hub/content/docs/price-feeds/pro/pyth-terminal.mdx`
- **Edit:** `apps/developer-hub/content/docs/price-feeds/pro/meta.json` — added `pyth-terminal` to nav

## Test plan
- [ ] Verify page renders at `/price-feeds/pro/pyth-terminal`
- [ ] Verify sidebar placement (after Getting Started, before How-To Guides)
- [ ] Verify both Arcade embeds load and are interactive
- [ ] Verify CTA link to pythdata.app works
- [ ] Check mobile responsiveness of Arcade iframes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
