### PR TITLE
docs: add BNB Chain addresses to Pyth Pro contract addresses

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/contract-addresses.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/contract-addresses.mdx
@@ -36,6 +36,7 @@ This page lists the contract addresses for Pyth Pro (formerly known as Pyth Laze
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Arbitrum   | <CopyAddress address="0xACeA761c27A909d4D3895128EBe6370FDE2dF481" url="https://arbiscan.io/address/0xACeA761c27A909d4D3895128EBe6370FDE2dF481" />             |
 | Base       | <CopyAddress address="0xACeA761c27A909d4D3895128EBe6370FDE2dF481" url="https://basescan.org/address/0xACeA761c27A909d4D3895128EBe6370FDE2dF481" />            |
+| BNB Chain  | <CopyAddress address="0xACeA761c27A909d4D3895128EBe6370FDE2dF481" url="https://bscscan.com/address/0xACeA761c27A909d4D3895128EBe6370FDE2dF481" />             |
 | Ethereal   | <CopyAddress address="0xACeA761c27A909d4D3895128EBe6370FDE2dF481" url="https://explorer.ethereal.trade/address/0xACeA761c27A909d4D3895128EBe6370FDE2dF481" /> |
 | MegaETH    | <CopyAddress address="0xACeA761c27A909d4D3895128EBe6370FDE2dF481" url="https://www.megaexplorer.xyz/address/0xACeA761c27A909d4D3895128EBe6370FDE2dF481" />    |
 | Polygon    | <CopyAddress address="0xACeA761c27A909d4D3895128EBe6370FDE2dF481" url="https://polygonscan.com/address/0xACeA761c27A909d4D3895128EBe6370FDE2dF481" />         |
@@ -48,6 +49,7 @@ This page lists the contract addresses for Pyth Pro (formerly known as Pyth Laze
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Arbitrum Sepolia    | <CopyAddress address="0xACeA761c27A909d4D3895128EBe6370FDE2dF481" url="https://sepolia.arbiscan.io/address/0xACeA761c27A909d4D3895128EBe6370FDE2dF481" />                       |
 | Base Sepolia        | <CopyAddress address="0xACeA761c27A909d4D3895128EBe6370FDE2dF481" url="https://sepolia.basescan.org/address/0xACeA761c27A909d4D3895128EBe6370FDE2dF481" />                      |
+| BNB Testnet         | <CopyAddress address="0xACeA761c27A909d4D3895128EBe6370FDE2dF481" url="https://testnet.bscscan.com/address/0xACeA761c27A909d4D3895128EBe6370FDE2dF481" />                       |
 | Ethereal Testnet V2 | <CopyAddress address="0x4D4772F06c595F69FB57039599a180536FDE8245" url="https://explorer-ethereal-testnet-0.t.conduit.xyz/address/0x4D4772F06c595F69FB57039599a180536FDE8245" /> |
 | Ethereum Sepolia    | <CopyAddress address="0xACeA761c27A909d4D3895128EBe6370FDE2dF481" url="https://sepolia.etherscan.io/address/0xACeA761c27A909d4D3895128EBe6370FDE2dF481" />                      |
 | Optimism Sepolia    | <CopyAddress address="0xACeA761c27A909d4D3895128EBe6370FDE2dF481" url="https://sepolia-optimism.etherscan.io/address/0xACeA761c27A909d4D3895128EBe6370FDE2dF481" />             |


### PR DESCRIPTION
Adds BNB Chain mainnet and testnet contract addresses to the Pyth Pro (Lazer) contract addresses documentation.

**Changes:**
- Added BNB Chain (mainnet): `0xACeA761c27A909d4D3895128EBe6370FDE2dF481` → [bscscan](https://bscscan.com/address/0xACeA761c27A909d4D3895128EBe6370FDE2dF481)
- Added BNB Testnet: `0xACeA761c27A909d4D3895128EBe6370FDE2dF481` → [testnet.bscscan](https://testnet.bscscan.com/address/0xACeA761c27A909d4D3895128EBe6370FDE2dF481)

Both addresses use the same contract address as other EVM deployments.