### PR TITLE
docs: add Optimism push feeds configuration

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/optimism-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/optimism-mainnet.json
@@ -1,0 +1,39 @@
+{
+  "feeds": [
+    {
+      "alias": "SETHFI/ETHFI.RR",
+      "id": "6d5216dab65051b9242a6ec458ea917e6a8f2cd122eebc25d8ab00dbe703612a",
+      "time_difference": 3600,
+      "price_deviation": 1,
+      "confidence_ratio": 100
+    },
+    {
+      "alias": "ETHFI/USD",
+      "id": "b27578a9654246cb0a2950842b92330e9ace141c52b63829cc72d5c45a5a595a",
+      "time_difference": 3600,
+      "price_deviation": 1,
+      "confidence_ratio": 100
+    },
+    {
+      "alias": "BEHYPE/HYPE.RR",
+      "id": "0f150eddafc98344c37f6ebe90fe303c12136436baf242f3c5ab412dbf91312c",
+      "time_difference": 3600,
+      "price_deviation": 1,
+      "confidence_ratio": 100
+    },
+    {
+      "alias": "HYPE/USD",
+      "id": "4279e31cc369bbcc2faf022b382b080e32a8e689ff20fbc530d2a603eb6cd98b",
+      "time_difference": 3600,
+      "price_deviation": 1,
+      "confidence_ratio": 100
+    },
+    {
+      "alias": "EURC/USD",
+      "id": "76fa85158bf14ede77087fe3ae472f66213f6ea2f5b411cb2de472794990fa5c",
+      "time_difference": 3600,
+      "price_deviation": 1,
+      "confidence_ratio": 100
+    }
+  ]
+}

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/evm.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/evm.mdx
@@ -15,6 +15,7 @@ import ethereumMainnet from "./data/evm/ethereum-mainnet.json";
 import hyperevmMainnet from "./data/evm/hyperevm-mainnet.json";
 import lineaMainnet from "./data/evm/linea-mainnet.json";
 import monadMainnet from "./data/evm/monad-mainnet.json";
+import optimismMainnet from "./data/evm/optimism-mainnet.json";
 import soneiumMainnet from "./data/evm/soneium-mainnet.json";
 import sonicMainnet from "./data/evm/sonic-mainnet.json";
 
@@ -29,6 +30,7 @@ The following EVM chains have push feeds:
 - [HyperEVM Mainnet](#hyperevm-mainnet)
 - [Linea Mainnet](#linea-mainnet)
 - [Monad Mainnet](#monad-mainnet)
+- [Optimism Mainnet](#optimism-mainnet)
 - [Soneium Mainnet](#soneium-mainnet)
 - [Sonic Mainnet](#sonic-mainnet)
 
@@ -90,6 +92,13 @@ The following EVM chains have push feeds:
 ## Monad Mainnet
 
 <SponsoredFeedsTable feeds={monadMainnet.feeds} networkName="Monad mainnet" />
+
+## Optimism Mainnet
+
+<SponsoredFeedsTable
+  feeds={optimismMainnet.feeds}
+  networkName="Optimism mainnet"
+/>
 
 ## Soneium Mainnet
 


### PR DESCRIPTION
## Summary

Adds push feed configuration for Optimism mainnet with the following price feeds:

| Alias | Price Feed ID |
|-------|--------------|
| SETHFI/ETHFI.RR | `6d5216dab65051b9242a6ec458ea917e6a8f2cd122eebc25d8ab00dbe703612a` |
| ETHFI/USD | `b27578a9654246cb0a2950842b92330e9ace141c52b63829cc72d5c45a5a595a` |
| BEHYPE/HYPE.RR | `0f150eddafc98344c37f6ebe90fe303c12136436baf242f3c5ab412dbf91312c` |
| HYPE/USD | `4279e31cc369bbcc2faf022b382b080e32a8e689ff20fbc530d2a603eb6cd98b` |
| EURC/USD | `76fa85158bf14ede77087fe3ae472f66213f6ea2f5b411cb2de472794990fa5c` |

All feeds configured with:
- `time_difference`: 3600
- `price_deviation`: 1  
- `confidence_ratio`: 100