### PR TITLE
ondo-recorder: per-symbol chain configuration

### DIFF
--- a/apps/ondo-recorder/README.md
+++ b/apps/ondo-recorder/README.md
@@ -47,7 +47,7 @@ See [config.sample.yml](config.sample.yml) for all options.
 
 ## Rate limits
 
-Ondo's API rate limit sits somewhere around **~100 req/sec**. The recorder's total request rate is `sum(sizes_per_token) * 2 (buy+sell) / poll_interval_seconds` — keep this under the limit or you will see 429 Too Many Requests responses. The default config (9 tokens × 4 sizes × 2 sides / 1s = 72 req/sec) is well under.
+Ondo's API rate limit sits somewhere around **~100 req/sec**. The recorder's total request rate is `sum(sizes_per_token) * 2 (buy+sell) / poll_interval_seconds` — keep this under the limit or you will see 429 Too Many Requests responses. The default config (9 symbols × 3 chains × 1 size × 2 sides / 1s = 54 req/sec) is well under.
 
 ## Schema management
 

--- a/apps/ondo-recorder/config.sample.yml
+++ b/apps/ondo-recorder/config.sample.yml
@@ -1,31 +1,96 @@
 ondo:
   api_url: "https://api.gm.ondo.finance/v1/attestations/soft"
   api_key: "replace-me" # overriden by env var ONDO_RECORDER__ONDO__API_KEY
-  chain_id: "ethereum-1"
   duration: "short"
 
 # Ondo's API rate limit sits somewhere around ~100 req/sec. Total rate =
 # sum(len(sizes) for each token) * 2 (buy+sell) / poll_interval_seconds.
 # Keep the overall rate under this or you will see 429 Too Many Requests.
+#
+# Each token is scoped to a specific chain. Supported chains: ethereum-1,
+# bsc-56, solana-900. The same symbol may appear on multiple chains.
 tokens:
   - symbol: "NVDAon"
-    sizes: [1, 10, 50, 100]
+    chain_id: "ethereum-1"
+    sizes: [1]
+  - symbol: "NVDAon"
+    chain_id: "bsc-56"
+    sizes: [1]
+  - symbol: "NVDAon"
+    chain_id: "solana-900"
+    sizes: [1]
   - symbol: "TSLAon"
-    sizes: [1, 10, 50, 100]
+    chain_id: "ethereum-1"
+    sizes: [1]
+  - symbol: "TSLAon"
+    chain_id: "bsc-56"
+    sizes: [1]
+  - symbol: "TSLAon"
+    chain_id: "solana-900"
+    sizes: [1]
   - symbol: "GOOGLon"
-    sizes: [1, 10, 50, 100]
+    chain_id: "ethereum-1"
+    sizes: [1]
+  - symbol: "GOOGLon"
+    chain_id: "bsc-56"
+    sizes: [1]
+  - symbol: "GOOGLon"
+    chain_id: "solana-900"
+    sizes: [1]
   - symbol: "MSFTon"
-    sizes: [1, 10, 50, 100]
+    chain_id: "ethereum-1"
+    sizes: [1]
+  - symbol: "MSFTon"
+    chain_id: "bsc-56"
+    sizes: [1]
+  - symbol: "MSFTon"
+    chain_id: "solana-900"
+    sizes: [1]
   - symbol: "HOODon"
-    sizes: [1, 10, 50, 100]
+    chain_id: "ethereum-1"
+    sizes: [1]
+  - symbol: "HOODon"
+    chain_id: "bsc-56"
+    sizes: [1]
+  - symbol: "HOODon"
+    chain_id: "solana-900"
+    sizes: [1]
   - symbol: "AAPLon"
-    sizes: [1, 10, 50, 100]
+    chain_id: "ethereum-1"
+    sizes: [1]
+  - symbol: "AAPLon"
+    chain_id: "bsc-56"
+    sizes: [1]
+  - symbol: "AAPLon"
+    chain_id: "solana-900"
+    sizes: [1]
   - symbol: "COINon"
-    sizes: [1, 10, 50, 100]
+    chain_id: "ethereum-1"
+    sizes: [1]
+  - symbol: "COINon"
+    chain_id: "bsc-56"
+    sizes: [1]
+  - symbol: "COINon"
+    chain_id: "solana-900"
+    sizes: [1]
   - symbol: "CRCLon"
-    sizes: [1, 10, 50, 100]
+    chain_id: "ethereum-1"
+    sizes: [1]
+  - symbol: "CRCLon"
+    chain_id: "bsc-56"
+    sizes: [1]
+  - symbol: "CRCLon"
+    chain_id: "solana-900"
+    sizes: [1]
   - symbol: "MSTRon"
-    sizes: [1, 10, 50, 100]
+    chain_id: "ethereum-1"
+    sizes: [1]
+  - symbol: "MSTRon"
+    chain_id: "bsc-56"
+    sizes: [1]
+  - symbol: "MSTRon"
+    chain_id: "solana-900"
+    sizes: [1]
 
 clickhouse:
   url: "http://clickhouse-local:8123"

--- a/apps/ondo-recorder/migrations/001-init.sql
+++ b/apps/ondo-recorder/migrations/001-init.sql
@@ -14,5 +14,5 @@ CREATE TABLE IF NOT EXISTS pyth_analytics.ondo_quotes
 )
 ENGINE = ReplacingMergeTree(ingested_at)
 PARTITION BY toYYYYMM(polled_at)
-ORDER BY (symbol, side, token_amount, polled_at)
+ORDER BY (symbol, side, token_amount, polled_at, chain_id)
 TTL toDateTime(polled_at) + INTERVAL 90 DAY DELETE;

--- a/apps/ondo-recorder/migrations/002-add-chain-to-order-by.sql
+++ b/apps/ondo-recorder/migrations/002-add-chain-to-order-by.sql
@@ -1,0 +1,32 @@
+-- Add chain_id to the sorting key so that ReplacingMergeTree does not
+-- silently deduplicate rows for the same symbol across different chains
+-- during background merges.
+--
+-- ClickHouse does not allow adding an existing column to ORDER BY via
+-- ALTER, so we recreate the table and backfill the data.
+
+CREATE TABLE IF NOT EXISTS pyth_analytics.ondo_quotes_v2
+(
+    symbol       LowCardinality(String),
+    ticker       LowCardinality(String),
+    chain_id     LowCardinality(String),
+    side         LowCardinality(String),
+    token_amount Decimal128(18),
+    price        Decimal128(18),
+    asset_address String,
+    polled_at    DateTime64(3),
+    ingested_at  DateTime64(3) DEFAULT now64(3)
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toYYYYMM(polled_at)
+ORDER BY (symbol, side, token_amount, polled_at, chain_id)
+TTL toDateTime(polled_at) + INTERVAL 90 DAY DELETE;
+
+INSERT INTO pyth_analytics.ondo_quotes_v2
+    (symbol, ticker, chain_id, side, token_amount, price, asset_address, polled_at, ingested_at)
+SELECT symbol, ticker, chain_id, side, token_amount, price, asset_address, polled_at, ingested_at
+FROM pyth_analytics.ondo_quotes;
+
+DROP TABLE pyth_analytics.ondo_quotes;
+
+RENAME TABLE pyth_analytics.ondo_quotes_v2 TO pyth_analytics.ondo_quotes;

--- a/apps/ondo-recorder/src/config.rs
+++ b/apps/ondo-recorder/src/config.rs
@@ -28,6 +28,7 @@ pub struct ClickHouseTarget {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TokenConfig {
     pub symbol: String,
+    pub chain_id: String,
     pub sizes: Vec<u32>,
 }
 
@@ -35,7 +36,6 @@ pub struct TokenConfig {
 pub struct AppConfig {
     pub api_url: String,
     pub api_key: String,
-    pub chain_id: String,
     pub duration: String,
     pub tokens: Vec<TokenConfig>,
     pub clickhouse: ClickHouseTarget,
@@ -54,13 +54,13 @@ pub struct AppConfig {
 struct OndoConfig {
     api_url: Option<String>,
     api_key: Option<String>,
-    chain_id: Option<String>,
     duration: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 struct TokenInput {
     symbol: String,
+    chain_id: String,
     #[serde(default = "default_sizes")]
     sizes: Vec<u32>,
 }
@@ -103,10 +103,6 @@ impl AppConfig {
             .filter(|s| !s.trim().is_empty())
             .unwrap_or_else(|| default_api_url().to_string());
         let api_key = required_string(ondo.api_key, "ONDO_RECORDER__ONDO__API_KEY")?;
-        let chain_id = ondo
-            .chain_id
-            .filter(|s| !s.trim().is_empty())
-            .unwrap_or_else(|| "ethereum-1".to_string());
         let duration = ondo
             .duration
             .filter(|s| !s.trim().is_empty())
@@ -118,7 +114,6 @@ impl AppConfig {
         Ok(AppConfig {
             api_url,
             api_key,
-            chain_id,
             duration,
             tokens,
             clickhouse,
@@ -170,10 +165,19 @@ fn parse_tokens(tokens_input: Vec<TokenInput>) -> Result<Vec<TokenConfig>, Confi
         ));
     }
     let mut tokens = Vec::with_capacity(tokens_input.len());
+    let mut seen = std::collections::HashSet::with_capacity(tokens_input.len());
     for token in tokens_input {
         validate_token(&token)?;
+        let key = (token.symbol.clone(), token.chain_id.clone());
+        if !seen.insert(key) {
+            return Err(ConfigError::Invalid(format!(
+                "duplicate token entry for symbol '{}' on chain '{}'",
+                token.symbol, token.chain_id
+            )));
+        }
         tokens.push(TokenConfig {
             symbol: token.symbol,
+            chain_id: token.chain_id,
             sizes: token.sizes,
         });
     }
@@ -185,6 +189,12 @@ fn validate_token(token: &TokenInput) -> Result<(), ConfigError> {
         return Err(ConfigError::Invalid(
             "token symbol cannot be empty".to_string(),
         ));
+    }
+    if token.chain_id.trim().is_empty() {
+        return Err(ConfigError::Invalid(format!(
+            "token '{}' has empty chain_id",
+            token.symbol
+        )));
     }
     if token.sizes.is_empty() {
         return Err(ConfigError::Invalid(format!(
@@ -243,6 +253,7 @@ fn default_sizes() -> Vec<u32> {
 fn default_tokens() -> Vec<TokenInput> {
     vec![TokenInput {
         symbol: "AAPLon".to_string(),
+        chain_id: "ethereum-1".to_string(),
         sizes: default_sizes(),
     }]
 }

--- a/apps/ondo-recorder/src/health.rs
+++ b/apps/ondo-recorder/src/health.rs
@@ -11,16 +11,31 @@ use tokio::task::JoinHandle;
 
 use crate::metrics::RecorderMetrics;
 
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+pub struct Market {
+    pub symbol: String,
+    pub chain_id: String,
+}
+
+impl Market {
+    pub fn new(symbol: impl Into<String>, chain_id: impl Into<String>) -> Self {
+        Self {
+            symbol: symbol.into(),
+            chain_id: chain_id.into(),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct HealthState {
-    expected_symbols: Vec<String>,
+    expected_markets: Vec<Market>,
     stale_seconds: u64,
     inner: Arc<Mutex<HealthInner>>,
 }
 
 #[derive(Default)]
 struct HealthInner {
-    token_last_poll: HashMap<String, f64>,
+    market_last_poll: HashMap<Market, f64>,
     clickhouse_ok: bool,
 }
 
@@ -28,23 +43,23 @@ struct HealthInner {
 struct ReadyResponse {
     ready: bool,
     clickhouse_ok: bool,
-    stale_tokens: Vec<String>,
+    stale_markets: Vec<Market>,
 }
 
 impl HealthState {
-    pub fn new(expected_symbols: Vec<String>, stale_seconds: u64) -> Self {
+    pub fn new(expected_markets: Vec<Market>, stale_seconds: u64) -> Self {
         Self {
-            expected_symbols,
+            expected_markets,
             stale_seconds,
             inner: Arc::new(Mutex::new(HealthInner::default())),
         }
     }
 
-    pub fn set_market_seen(&self, symbol: &str) {
+    pub fn set_market_seen(&self, symbol: &str, chain_id: &str) {
         let mut inner = self.inner.lock().expect("health mutex poisoned");
         inner
-            .token_last_poll
-            .insert(symbol.to_string(), unix_seconds_now());
+            .market_last_poll
+            .insert(Market::new(symbol, chain_id), unix_seconds_now());
     }
 
     pub fn set_clickhouse_ok(&self, healthy: bool) {
@@ -59,13 +74,13 @@ impl HealthState {
     fn to_ready_response(&self) -> ReadyResponse {
         let inner = self.inner.lock().expect("health mutex poisoned");
         let now = unix_seconds_now();
-        let stale_tokens = self
-            .expected_symbols
+        let stale_markets = self
+            .expected_markets
             .iter()
-            .filter(|symbol| {
+            .filter(|market| {
                 inner
-                    .token_last_poll
-                    .get(*symbol)
+                    .market_last_poll
+                    .get(*market)
                     .map(|seen| now - *seen > self.stale_seconds as f64)
                     .unwrap_or(true)
             })
@@ -73,9 +88,9 @@ impl HealthState {
             .collect::<Vec<_>>();
 
         ReadyResponse {
-            ready: inner.clickhouse_ok && stale_tokens.is_empty(),
+            ready: inner.clickhouse_ok && stale_markets.is_empty(),
             clickhouse_ok: inner.clickhouse_ok,
-            stale_tokens,
+            stale_markets,
         }
     }
 }

--- a/apps/ondo-recorder/src/main.rs
+++ b/apps/ondo-recorder/src/main.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use ondo_recorder::{
     clickhouse::ClickHouseClient,
     config::AppConfig,
-    health::{start_http_servers, HealthState},
+    health::{start_http_servers, HealthState, Market},
     metrics::RecorderMetrics,
     recorder::{RecorderRuntime, WriterRuntimeConfig},
 };
@@ -32,7 +32,11 @@ async fn run() -> Result<()> {
 
     let metrics = Arc::new(RecorderMetrics::new()?);
     let health = HealthState::new(
-        config.tokens.iter().map(|t| t.symbol.clone()).collect(),
+        config
+            .tokens
+            .iter()
+            .map(|t| Market::new(t.symbol.clone(), t.chain_id.clone()))
+            .collect(),
         config.ready_stale_seconds,
     );
     let (health_server, metrics_server) = start_http_servers(
@@ -45,7 +49,6 @@ async fn run() -> Result<()> {
     let mut runtime = RecorderRuntime::new(
         config.api_url,
         config.api_key,
-        config.chain_id,
         config.duration,
         config.tokens,
         Duration::from_secs_f64(config.poll_interval_seconds),

--- a/apps/ondo-recorder/src/metrics.rs
+++ b/apps/ondo-recorder/src/metrics.rs
@@ -34,7 +34,7 @@ impl RecorderMetrics {
                 "ondo_recorder_poll_requests_total",
                 "Total API poll requests",
             ),
-            &["symbol", "side", "size", "status"],
+            &["symbol", "chain", "side", "size", "status"],
         )?;
         let poll_latency_seconds = Histogram::with_opts(
             HistogramOpts::new(
@@ -44,18 +44,15 @@ impl RecorderMetrics {
             .buckets(vec![0.01, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0]),
         )?;
         let poll_errors = CounterVec::new(
-            Opts::new(
-                "ondo_recorder_poll_errors_total",
-                "Total API poll errors",
-            ),
-            &["symbol", "error_type"],
+            Opts::new("ondo_recorder_poll_errors_total", "Total API poll errors"),
+            &["symbol", "chain", "error_type"],
         )?;
         let token_last_poll_unix_seconds = GaugeVec::new(
             Opts::new(
                 "ondo_recorder_token_last_poll_unix_seconds",
                 "Unix timestamp of last successful poll per token",
             ),
-            &["symbol"],
+            &["symbol", "chain"],
         )?;
         let queue_depth = Gauge::with_opts(Opts::new(
             "ondo_recorder_queue_depth",
@@ -70,7 +67,7 @@ impl RecorderMetrics {
                 "ondo_recorder_queue_drops_total",
                 "Total dropped quotes due to queue saturation",
             ),
-            &["symbol"],
+            &["symbol", "chain"],
         )?;
         let insert_attempts = CounterVec::new(
             Opts::new(
@@ -133,13 +130,14 @@ impl RecorderMetrics {
         self.poll_requests
             .with_label_values(&[
                 &quote.symbol,
+                &quote.chain_id,
                 &quote.side,
                 &quote.token_amount.normalize().to_string(),
                 "success",
             ])
             .inc();
         self.token_last_poll_unix_seconds
-            .with_label_values(&[&quote.symbol])
+            .with_label_values(&[&quote.symbol, &quote.chain_id])
             .set(unix_seconds_now());
     }
 

--- a/apps/ondo-recorder/src/models.rs
+++ b/apps/ondo-recorder/src/models.rs
@@ -71,15 +71,6 @@ impl OndoQuote {
             polled_at,
         })
     }
-
-    pub fn dedupe_key(&self) -> (String, String, String, i64) {
-        (
-            self.symbol.clone(),
-            self.side.clone(),
-            self.token_amount.normalize().to_string(),
-            self.polled_at.timestamp_millis(),
-        )
-    }
 }
 
 fn parse_decimal(value: &str, field: &str) -> Result<Decimal> {

--- a/apps/ondo-recorder/src/poller.rs
+++ b/apps/ondo-recorder/src/poller.rs
@@ -19,7 +19,6 @@ pub async fn run_poller_for_token(
     http_client: reqwest::Client,
     api_url: String,
     api_key: String,
-    chain_id: String,
     duration: String,
     token: TokenConfig,
     poll_interval: Duration,
@@ -36,7 +35,7 @@ pub async fn run_poller_for_token(
     let mut interval_rows: u64 = 0;
     let mut last_log = Instant::now();
 
-    tracing::info!(symbol = %token.symbol, "starting poller");
+    tracing::info!(symbol = %token.symbol, chain_id = %token.chain_id, "starting poller");
 
     while !stop_token.is_cancelled() {
         interval.tick().await;
@@ -51,7 +50,7 @@ pub async fn run_poller_for_token(
         for &size in &token.sizes {
             for side in &sides {
                 let request = OndoApiRequest {
-                    chain_id: chain_id.clone(),
+                    chain_id: token.chain_id.clone(),
                     symbol: token.symbol.clone(),
                     side: side.to_string(),
                     token_amount: size.to_string(),
@@ -74,7 +73,12 @@ pub async fn run_poller_for_token(
         for result in results {
             match result {
                 Ok((response, req_side, req_chain_id)) => {
-                    match OndoQuote::from_api_response(response, &req_side, &req_chain_id, polled_at) {
+                    match OndoQuote::from_api_response(
+                        response,
+                        &req_side,
+                        &req_chain_id,
+                        polled_at,
+                    ) {
                         Ok(quote) => {
                             metrics.record_quote(&quote);
                             if sender
@@ -84,7 +88,7 @@ pub async fn run_poller_for_token(
                             {
                                 metrics
                                     .queue_drops
-                                    .with_label_values(&[&token.symbol])
+                                    .with_label_values(&[&token.symbol, &token.chain_id])
                                     .inc();
                             } else {
                                 total_rows += 1;
@@ -95,10 +99,11 @@ pub async fn run_poller_for_token(
                         Err(err) => {
                             metrics
                                 .poll_errors
-                                .with_label_values(&[&token.symbol, "parse"])
+                                .with_label_values(&[&token.symbol, &token.chain_id, "parse"])
                                 .inc();
                             tracing::warn!(
                                 symbol = %token.symbol,
+                                chain_id = %token.chain_id,
                                 error = ?err,
                                 "failed to parse API response"
                             );
@@ -108,14 +113,15 @@ pub async fn run_poller_for_token(
                 Err((symbol, side, size, err)) => {
                     metrics
                         .poll_requests
-                        .with_label_values(&[&symbol, &side, &size, "error"])
+                        .with_label_values(&[&symbol, &token.chain_id, &side, &size, "error"])
                         .inc();
                     metrics
                         .poll_errors
-                        .with_label_values(&[&symbol, "http"])
+                        .with_label_values(&[&symbol, &token.chain_id, "http"])
                         .inc();
                     tracing::warn!(
                         symbol = %symbol,
+                        chain_id = %token.chain_id,
                         side = %side,
                         size = %size,
                         error = ?err,
@@ -126,12 +132,13 @@ pub async fn run_poller_for_token(
         }
 
         if cycle_success {
-            health.set_market_seen(&token.symbol);
+            health.set_market_seen(&token.symbol, &token.chain_id);
         }
 
         if last_log.elapsed() >= Duration::from_secs(5) {
             tracing::info!(
                 symbol = %token.symbol,
+                chain_id = %token.chain_id,
                 interval_rows = interval_rows,
                 total_rows = total_rows,
                 rows_per_second = interval_rows as f64 / last_log.elapsed().as_secs_f64().max(1e-9),
@@ -142,7 +149,12 @@ pub async fn run_poller_for_token(
         }
     }
 
-    tracing::info!(symbol = %token.symbol, total_rows = total_rows, "poller stopped");
+    tracing::info!(
+        symbol = %token.symbol,
+        chain_id = %token.chain_id,
+        total_rows = total_rows,
+        "poller stopped"
+    );
 }
 
 /// Returns (response, request_side, request_chain_id) on success,

--- a/apps/ondo-recorder/src/recorder.rs
+++ b/apps/ondo-recorder/src/recorder.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use tokio::{
     sync::mpsc,
@@ -8,12 +8,8 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 
 use crate::{
-    clickhouse::ClickHouseClient,
-    config::TokenConfig,
-    health::HealthState,
-    metrics::RecorderMetrics,
-    models::OndoQuote,
-    poller::run_poller_for_token,
+    clickhouse::ClickHouseClient, config::TokenConfig, health::HealthState,
+    metrics::RecorderMetrics, models::OndoQuote, poller::run_poller_for_token,
 };
 
 #[derive(Clone, Debug)]
@@ -26,7 +22,6 @@ pub struct WriterRuntimeConfig {
 pub struct RecorderRuntime {
     api_url: String,
     api_key: String,
-    chain_id: String,
     duration: String,
     tokens: Vec<TokenConfig>,
     poll_interval: Duration,
@@ -44,7 +39,6 @@ impl RecorderRuntime {
     pub fn new(
         api_url: String,
         api_key: String,
-        chain_id: String,
         duration: String,
         tokens: Vec<TokenConfig>,
         poll_interval: Duration,
@@ -57,7 +51,6 @@ impl RecorderRuntime {
         Self {
             api_url,
             api_key,
-            chain_id,
             duration,
             tokens,
             poll_interval,
@@ -81,7 +74,6 @@ impl RecorderRuntime {
                 http_client.clone(),
                 self.api_url.clone(),
                 self.api_key.clone(),
-                self.chain_id.clone(),
                 self.duration.clone(),
                 token,
                 self.poll_interval,
@@ -116,7 +108,7 @@ impl RecorderRuntime {
         let insert_async = self.insert_async;
 
         let handle = tokio::spawn(async move {
-            let mut dedupe: HashMap<(String, String, String, i64), OndoQuote> = HashMap::new();
+            let mut buffer: Vec<OndoQuote> = Vec::with_capacity(batch_max_rows);
             let mut last_flush = Instant::now();
 
             loop {
@@ -129,7 +121,7 @@ impl RecorderRuntime {
                     .await
                 {
                     Ok(Some(quote)) => {
-                        dedupe.insert(quote.dedupe_key(), quote);
+                        buffer.push(quote);
                         let size = receiver.len();
                         metrics.queue_depth.set(size as f64);
                         metrics
@@ -140,32 +132,19 @@ impl RecorderRuntime {
                     Err(_) => {}
                 }
 
-                let should_flush = dedupe.len() >= batch_max_rows
-                    || (!dedupe.is_empty()
+                let should_flush = buffer.len() >= batch_max_rows
+                    || (!buffer.is_empty()
                         && last_flush.elapsed().as_secs_f64() >= batch_flush_seconds);
                 if should_flush {
-                    flush_with_retry(
-                        &writer,
-                        &metrics,
-                        dedupe.values().cloned().collect::<Vec<_>>(),
-                        stop_token.clone(),
-                        insert_async,
-                    )
-                    .await;
-                    dedupe.clear();
+                    let batch = std::mem::take(&mut buffer);
+                    flush_with_retry(&writer, &metrics, batch, stop_token.clone(), insert_async)
+                        .await;
                     last_flush = Instant::now();
                 }
             }
 
-            if !dedupe.is_empty() {
-                flush_with_retry(
-                    &writer,
-                    &metrics,
-                    dedupe.values().cloned().collect::<Vec<_>>(),
-                    stop_token,
-                    insert_async,
-                )
-                .await;
+            if !buffer.is_empty() {
+                flush_with_retry(&writer, &metrics, buffer, stop_token, insert_async).await;
             }
         });
         self.handles.push(handle);

--- a/apps/ondo-recorder/tests/test_config.rs
+++ b/apps/ondo-recorder/tests/test_config.rs
@@ -14,7 +14,6 @@ fn test_config_parses_yaml_file() {
     clear_env_vars([
         "ONDO_RECORDER__ONDO__API_URL",
         "ONDO_RECORDER__ONDO__API_KEY",
-        "ONDO_RECORDER__ONDO__CHAIN_ID",
         "ONDO_RECORDER__ONDO__DURATION",
         "ONDO_RECORDER__CLICKHOUSE__URL",
         "ONDO_RECORDER__CLICKHOUSE__USER",
@@ -30,12 +29,13 @@ fn test_config_parses_yaml_file() {
 ondo:
   api_url: "https://api.gm.ondo.finance/v1/attestations/soft"
   api_key: "test-key"
-  chain_id: "ethereum-1"
   duration: "short"
 tokens:
   - symbol: "AAPLon"
+    chain_id: "ethereum-1"
     sizes: [1, 10, 50, 100]
   - symbol: "NVDAon"
+    chain_id: "bsc-56"
     sizes: [1, 10]
 clickhouse:
   url: "http://127.0.0.1:8123"
@@ -50,15 +50,113 @@ health_port: 8083
     let config = AppConfig::from_sources(Some(&config_file)).expect("yaml config should parse");
     assert_eq!(config.tokens.len(), 2);
     assert_eq!(config.tokens[0].symbol, "AAPLon");
+    assert_eq!(config.tokens[0].chain_id, "ethereum-1");
     assert_eq!(config.tokens[0].sizes, vec![1, 10, 50, 100]);
     assert_eq!(config.tokens[1].symbol, "NVDAon");
+    assert_eq!(config.tokens[1].chain_id, "bsc-56");
     assert_eq!(config.tokens[1].sizes, vec![1, 10]);
     assert_eq!(config.api_key, "test-key");
-    assert_eq!(config.chain_id, "ethereum-1");
     assert_eq!(config.metrics_port, 9093);
     assert_eq!(config.health_port, 8083);
     assert_eq!(config.clickhouse.host, "127.0.0.1");
     assert_eq!(config.clickhouse.table, "ondo_quotes");
+
+    let _ = fs::remove_file(config_file);
+}
+
+#[test]
+fn test_same_symbol_on_multiple_chains() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    clear_env_vars([
+        "ONDO_RECORDER__ONDO__API_KEY",
+        "ONDO_RECORDER__CLICKHOUSE__URL",
+    ]);
+
+    let config_file = temp_yaml_path("ondo-config-multichain");
+    let yaml = r#"
+ondo:
+  api_key: "test-key"
+tokens:
+  - symbol: "NVDAon"
+    chain_id: "ethereum-1"
+    sizes: [1]
+  - symbol: "NVDAon"
+    chain_id: "bsc-56"
+    sizes: [1]
+  - symbol: "NVDAon"
+    chain_id: "solana-900"
+    sizes: [1]
+clickhouse:
+  url: "http://127.0.0.1:8123"
+"#;
+    fs::write(&config_file, yaml).expect("write yaml config");
+    let config =
+        AppConfig::from_sources(Some(&config_file)).expect("multichain config should parse");
+    assert_eq!(config.tokens.len(), 3);
+    let chains: Vec<&str> = config.tokens.iter().map(|t| t.chain_id.as_str()).collect();
+    assert_eq!(chains, vec!["ethereum-1", "bsc-56", "solana-900"]);
+    for token in &config.tokens {
+        assert_eq!(token.symbol, "NVDAon");
+    }
+
+    let _ = fs::remove_file(config_file);
+}
+
+#[test]
+fn test_duplicate_symbol_chain_pair_fails() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    clear_env_vars([
+        "ONDO_RECORDER__ONDO__API_KEY",
+        "ONDO_RECORDER__CLICKHOUSE__URL",
+    ]);
+
+    let config_file = temp_yaml_path("ondo-config-dup");
+    let yaml = r#"
+ondo:
+  api_key: "test-key"
+tokens:
+  - symbol: "NVDAon"
+    chain_id: "ethereum-1"
+    sizes: [1]
+  - symbol: "NVDAon"
+    chain_id: "ethereum-1"
+    sizes: [10]
+clickhouse:
+  url: "http://127.0.0.1:8123"
+"#;
+    fs::write(&config_file, yaml).expect("write yaml config");
+    let result = AppConfig::from_sources(Some(&config_file));
+    assert!(result.is_err(), "duplicate (symbol, chain_id) should fail");
+    let message = result.err().map(|err| err.to_string()).unwrap_or_default();
+    assert!(
+        message.contains("duplicate token entry"),
+        "unexpected error: {message}"
+    );
+
+    let _ = fs::remove_file(config_file);
+}
+
+#[test]
+fn test_missing_chain_id_fails() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    clear_env_vars([
+        "ONDO_RECORDER__ONDO__API_KEY",
+        "ONDO_RECORDER__CLICKHOUSE__URL",
+    ]);
+
+    let config_file = temp_yaml_path("ondo-config-no-chain");
+    let yaml = r#"
+ondo:
+  api_key: "test-key"
+tokens:
+  - symbol: "NVDAon"
+    sizes: [1]
+clickhouse:
+  url: "http://127.0.0.1:8123"
+"#;
+    fs::write(&config_file, yaml).expect("write yaml config");
+    let result = AppConfig::from_sources(Some(&config_file));
+    assert!(result.is_err(), "missing chain_id should fail");
 
     let _ = fs::remove_file(config_file);
 }
@@ -69,7 +167,6 @@ fn test_env_overrides_yaml_values() {
     clear_env_vars([
         "ONDO_RECORDER__ONDO__API_URL",
         "ONDO_RECORDER__ONDO__API_KEY",
-        "ONDO_RECORDER__ONDO__CHAIN_ID",
         "ONDO_RECORDER__ONDO__DURATION",
         "ONDO_RECORDER__CLICKHOUSE__URL",
         "ONDO_RECORDER__CLICKHOUSE__USER",
@@ -84,10 +181,10 @@ fn test_env_overrides_yaml_values() {
 ondo:
   api_url: "https://api.gm.ondo.finance/v1/attestations/soft"
   api_key: "yaml-key"
-  chain_id: "ethereum-1"
   duration: "short"
 tokens:
   - symbol: "AAPLon"
+    chain_id: "ethereum-1"
     sizes: [1, 10]
 clickhouse:
   url: "http://127.0.0.1:8123"
@@ -124,6 +221,7 @@ ondo:
   api_key: "test-key"
 tokens:
   - symbol: ""
+    chain_id: "ethereum-1"
     sizes: [1, 10]
 clickhouse:
   url: "http://127.0.0.1:8123"

--- a/apps/ondo-recorder/tests/test_health.rs
+++ b/apps/ondo-recorder/tests/test_health.rs
@@ -1,25 +1,50 @@
 use std::time::Duration;
 
-use ondo_recorder::health::HealthState;
+use ondo_recorder::health::{HealthState, Market};
 
 #[test]
-fn test_health_requires_clickhouse_and_token_freshness() {
-    let state = HealthState::new(vec!["AAPLon".to_string(), "NVDAon".to_string()], 30);
+fn test_health_requires_clickhouse_and_market_freshness() {
+    let state = HealthState::new(
+        vec![
+            Market::new("AAPLon", "ethereum-1"),
+            Market::new("NVDAon", "ethereum-1"),
+        ],
+        30,
+    );
     assert!(!state.is_ready());
 
     state.set_clickhouse_ok(true);
     assert!(!state.is_ready());
 
-    state.set_market_seen("AAPLon");
-    state.set_market_seen("NVDAon");
+    state.set_market_seen("AAPLon", "ethereum-1");
+    state.set_market_seen("NVDAon", "ethereum-1");
     assert!(state.is_ready());
 }
 
 #[test]
-fn test_health_becomes_unready_when_token_stale() {
-    let state = HealthState::new(vec!["AAPLon".to_string()], 0);
+fn test_health_tracks_same_symbol_across_chains_independently() {
+    let state = HealthState::new(
+        vec![
+            Market::new("AAPLon", "ethereum-1"),
+            Market::new("AAPLon", "bsc-56"),
+        ],
+        30,
+    );
     state.set_clickhouse_ok(true);
-    state.set_market_seen("AAPLon");
+    state.set_market_seen("AAPLon", "ethereum-1");
+    assert!(
+        !state.is_ready(),
+        "one chain still missing a poll should keep state unready"
+    );
+    state.set_market_seen("AAPLon", "bsc-56");
+    assert!(state.is_ready());
+}
+
+#[test]
+fn test_health_becomes_unready_when_market_stale() {
+    let state = HealthState::new(vec![Market::new("AAPLon", "ethereum-1")], 0);
+    state.set_clickhouse_ok(true);
+    state.set_market_seen("AAPLon", "ethereum-1");
     std::thread::sleep(Duration::from_millis(10));
     assert!(!state.is_ready());
 }

--- a/apps/ondo-recorder/tests/test_models.rs
+++ b/apps/ondo-recorder/tests/test_models.rs
@@ -15,35 +15,14 @@ fn test_quote_from_api_response_normalizes_wei() {
         price: "230500000000000000000".to_string(),       // $230.50 in wei
     };
     let polled_at = chrono::Utc.with_ymd_and_hms(2026, 4, 13, 12, 0, 0).unwrap();
-    let quote =
-        OndoQuote::from_api_response(response, "buy", "ethereum-1", polled_at).expect("should parse");
+    let quote = OndoQuote::from_api_response(response, "buy", "ethereum-1", polled_at)
+        .expect("should parse");
     assert_eq!(quote.symbol, "AAPLon");
     assert_eq!(quote.ticker, "AAPL");
     assert_eq!(quote.side, "buy");
     assert_eq!(quote.chain_id, "ethereum-1");
     assert_eq!(quote.token_amount.to_string(), "10");
     assert_eq!(quote.price.to_string(), "230.50");
-}
-
-#[test]
-fn test_quote_dedupe_key() {
-    let response = OndoApiResponse {
-        chain_id: "1".to_string(),
-        symbol: "AAPLon".to_string(),
-        ticker: "AAPL".to_string(),
-        asset_address: "0x1234".to_string(),
-        side: "0".to_string(),
-        token_amount: "10000000000000000000".to_string(),
-        price: "230500000000000000000".to_string(),
-    };
-    let polled_at = chrono::Utc.with_ymd_and_hms(2026, 4, 13, 12, 0, 0).unwrap();
-    let quote =
-        OndoQuote::from_api_response(response, "buy", "ethereum-1", polled_at).expect("should parse");
-    let key = quote.dedupe_key();
-    assert_eq!(key.0, "AAPLon");
-    assert_eq!(key.1, "buy");
-    assert_eq!(key.2, "10");
-    assert_eq!(key.3, polled_at.timestamp_millis());
 }
 
 #[test]
@@ -54,12 +33,12 @@ fn test_quote_normalizes_fractional_prices() {
         ticker: "HOOD".to_string(),
         asset_address: "0xabcd".to_string(),
         side: "1".to_string(),
-        token_amount: "1000000000000000000".to_string(),   // 1 token
-        price: "67896035000000000000".to_string(),          // $67.896035
+        token_amount: "1000000000000000000".to_string(), // 1 token
+        price: "67896035000000000000".to_string(),       // $67.896035
     };
     let polled_at = chrono::Utc::now();
-    let quote =
-        OndoQuote::from_api_response(response, "sell", "ethereum-1", polled_at).expect("should parse");
+    let quote = OndoQuote::from_api_response(response, "sell", "ethereum-1", polled_at)
+        .expect("should parse");
     assert_eq!(quote.side, "sell");
     assert_eq!(quote.token_amount.to_string(), "1");
     assert_eq!(quote.price.to_string(), "67.896035");
@@ -80,5 +59,8 @@ fn test_invalid_decimal_in_response() {
     let result = OndoQuote::from_api_response(response, "buy", "ethereum-1", polled_at);
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
-    assert!(err.contains("tokenAmount"), "error should mention field: {err}");
+    assert!(
+        err.contains("tokenAmount"),
+        "error should mention field: {err}"
+    );
 }


### PR DESCRIPTION
## Summary

- Move `chain_id` from a global config field to a required per-token field, allowing the same symbol to be polled across multiple chains (`ethereum-1`, `bsc-56`, `solana-900`)
- Add `chain` label to all per-symbol Prometheus metrics so series stay distinct across chains
- Switch health readiness tracking from symbol-only to `(symbol, chain_id)` market pairs
- Remove the writer dedupe `HashMap` in favor of a plain `Vec` buffer
- This is a **breaking config change** — every token entry must now declare `chain_id`; the global `ondo.chain_id` field is removed

## Test plan

- [x] `cargo fmt`, `cargo clippy`, `cargo test` all pass (12 tests including 4 new ones)
- [x] Local e2e: docker-compose stack with 9 symbols x 3 chains confirmed writing distinct rows per chain to ClickHouse
- [x] `/ready` returns new `stale_markets` shape with `{symbol, chain_id}` objects
- [x] `/metrics` shows separate `chain` label on `poll_requests_total`, `poll_errors_total`, etc.
- [x] Old config shape (global `ondo.chain_id`, tokens without `chain_id`) fails parsing with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
