### PR TITLE
fix(hyperliquid-recorder): explicitly type empty L2 arrays to avoid async insert NULL error

### DIFF
--- a/apps/hyperliquid-recorder/src/clickhouse.rs
+++ b/apps/hyperliquid-recorder/src/clickhouse.rs
@@ -209,6 +209,9 @@ fn snapshot_to_values(snapshot: &L2Snapshot) -> String {
 }
 
 fn levels_to_ch_array(levels: &[crate::models::L2Level]) -> String {
+    if levels.is_empty() {
+        return "CAST([] AS Array(Tuple(Decimal64(12), Decimal64(12), UInt32)))".to_string();
+    }
     let tuples = levels
         .iter()
         .map(|level| {


### PR DESCRIPTION
## Summary
- Fixes a `CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN` (code 349) error in production when inserting L2 snapshots with empty bids or asks arrays via ClickHouse async inserts.
- A bare `[]` literal is inferred as `Array(Nothing)` by ClickHouse. When the async insert engine batches rows together, it wraps the untyped empty array in a nullable coercion (`if(isNull(...))`) that fails against the non-Nullable `bids`/`asks` columns.
- Adds an explicit `CAST([] AS Array(Tuple(Decimal64(12), Decimal64(12), UInt32)))` for empty arrays so the type is unambiguous.

## Test plan
- [ ] Deploy to staging and verify L2 inserts succeed for markets with empty order book sides
- [ ] Confirm no more `CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN` errors in prod logs

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
