### PR TITLE
cardano.mdx: add warning about price update validity checking

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/cardano.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/cardano.mdx
@@ -20,6 +20,10 @@ Integrating with Pyth Pro in Cardano smart contracts as a consumer is a three-st
 2. **Subscribe** to Pyth Pro websocket to receive signed price updates.
 3. **Include** those updates in a Cardano transaction by doing a zero withdrawal from the Pyth withdraw script.
 
+<Callout type="warning">
+  Purpose of the Pyth withdraw script is to verify signature validity of a provided price update payload. It does not enforce freshness of the update, nor does it disallow verifying the same update multiple times. If your contract puts constraints on a validity window of an update, make sure to enforce this directly in your contract implementation, e.g. by checking `timestamp_us` field.
+</Callout>
+
 <Steps>
 <Step>
 ### Use the Aiken library in your on-chain code


### PR DESCRIPTION
## Summary

Adds warning to Cardano docs:

> Purpose of the Pyth withdraw script is to verify signature validity of a provided price update payload. It does not enforce freshness of the update, nor does it disallow verifying the same update multiple times. If your contract puts constraints on a validity window of an update, make sure to enforce this directly in your contract implementation, e.g. by checking `timestamp_us` field.

## Rationale

Not enforcing timestamps in Cardano contract is a design decision, but we want users to be mindful about that.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
