### PR TITLE
docs(price-feeds/pro): expand understanding-price-data

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/payload-reference.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/payload-reference.mdx
@@ -30,7 +30,7 @@ A Pyth Pro payload is a real-time data update containing financial market inform
 | `exponent`            | `i16`    | All         | Decimal exponent: `actual_price = mantissa × 10^exponent`.               |
 | `marketSession`       | `string` | All         | Session: `regular`, `preMarket`, `postMarket`, `overNight`, `closed`.    |
 | `price`               | `i64`    | Spot        | Aggregate market price (mantissa). Use with `exponent` for actual price. |
-| `confidence`          | `i64`    | Spot        | Price uncertainty; higher = more disagreement. (Experimental)            |
+| `confidence`          | `i64`    | Spot        | Price uncertainty across publishers; higher = more disagreement.         |
 | `bestBidPrice`        | `i64`    | Spot        | Tightest non-overlapping bid across publishers. (Experimental)           |
 | `bestAskPrice`        | `i64`    | Spot        | Tightest non-overlapping ask across publishers. (Experimental)           |
 | `emaPrice`            | `i64`    | Spot        | Exponential moving average of the price.                                 |
@@ -42,11 +42,9 @@ A Pyth Pro payload is a real-time data update containing financial market inform
 **Scope:** _All_ = every feed type; _Spot_ = spot price feeds; _Derivatives_ = funding rate feeds.
 
 <Callout type="warning" title="Experimental">
-  The `confidence`, `bestBidPrice`, and `bestAskPrice` fields are **experimental**.
-  These fields are not yet covered by automated data quality assurance, so their
-  accuracy and reliability may vary. The current quality and uptime focus is on
-  the aggregated `price` field. Use experimental fields with caution in
-  production systems.
+  The `bestBidPrice` and `bestAskPrice` fields are **experimental**. These
+  fields are not yet covered by automated data quality assurance, so their
+  accuracy and reliability may vary. Use with caution in production systems.
 </Callout>
 
 <Callout type="info">
@@ -161,14 +159,14 @@ Based on the protocol specification, here are the technical details for each pro
       name: "confidence",
       type: "optional i64",
       description:
-        "**Experimental:** Confidence interval representing price uncertainty, calculated from all publisher prices, bids, and asks combined. Represented as mantissa. This field is not yet covered by automated data quality assurance.",
+        "Confidence interval representing the uncertainty of publisher-reported prices, calculated from all publisher prices, bids, and asks combined. Represented as mantissa.",
       availability: "Only included if requested in subscription properties",
       algorithm: "Refer to price aggregation for the current algorithm",
       algorithmLink: "/price-feeds/core/how-pyth-works/price-aggregation",
       invariants: ["Positive when present"],
       usage:
         "Risk management and price quality assessment. A high confidence value means high uncertainty (publishers disagree more).",
-      note: "A high confidence value means high uncertainty (publishers disagree more). See [Understanding Price Data](/price-feeds/pro/understanding-price-data) for how confidence differs from best bid/ask and when to use each metric.",
+      note: "Confidence reflects publisher disagreement, which may or may not track market volatility. See [Understanding Price Data](/price-feeds/pro/understanding-price-data) for the algorithm, how it differs from best bid/ask, and when to use each metric.",
     },
     {
       name: "emaPrice",

--- a/apps/developer-hub/content/docs/price-feeds/pro/payload-reference.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/payload-reference.mdx
@@ -238,7 +238,7 @@ freshness and origin of the price.
 
 ### Market Depth Properties
 
-Best bid and best ask represent the tightest **non-overlapping** top-of-book across publishers — the highest publisher bid and the lowest publisher ask selected such that `bestBidPrice < bestAskPrice`, with crossing quotes excluded. For a detailed comparison with confidence intervals, see [Understanding Price Data](/price-feeds/pro/understanding-price-data).
+Best bid and best ask represent the tightest **non-overlapping spread** across publishers — the highest publisher bid and the lowest publisher ask selected such that `bestBidPrice < bestAskPrice`, with crossing quotes excluded. For a detailed comparison with confidence intervals, see [Understanding Price Data](/price-feeds/pro/understanding-price-data).
 
 <Callout type="warning" title="Experimental">
   The `bestBidPrice` and `bestAskPrice` fields are **experimental**. These fields
@@ -252,7 +252,7 @@ Best bid and best ask represent the tightest **non-overlapping** top-of-book acr
       name: "bestBidPrice",
       type: "optional non-zero i64",
       description:
-        "Highest publisher bid that does not cross any publisher ask (tightest non-overlapping top-of-book bid), represented as mantissa.",
+        "Highest publisher bid that does not cross any publisher ask; together with `bestAskPrice`, forms the tightest non-overlapping spread across publishers. Represented as mantissa.",
       availability: "Only included if requested in subscription properties",
       algorithm: "Refer to price aggregation for the current algorithm",
       algorithmLink: "/price-feeds/core/how-pyth-works/price-aggregation",
@@ -266,7 +266,7 @@ Best bid and best ask represent the tightest **non-overlapping** top-of-book acr
       name: "bestAskPrice",
       type: "optional non-zero i64",
       description:
-        "Lowest publisher ask that does not cross any publisher bid (tightest non-overlapping top-of-book ask), represented as mantissa.",
+        "Lowest publisher ask that does not cross any publisher bid; together with `bestBidPrice`, forms the tightest non-overlapping spread across publishers. Represented as mantissa.",
       availability: "Only included if requested in subscription properties",
       algorithm: "Refer to price aggregation for the current algorithm",
       algorithmLink: "/price-feeds/core/how-pyth-works/price-aggregation",

--- a/apps/developer-hub/content/docs/price-feeds/pro/payload-reference.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/payload-reference.mdx
@@ -31,8 +31,8 @@ A Pyth Pro payload is a real-time data update containing financial market inform
 | `marketSession`       | `string` | All         | Session: `regular`, `preMarket`, `postMarket`, `overNight`, `closed`.    |
 | `price`               | `i64`    | Spot        | Aggregate market price (mantissa). Use with `exponent` for actual price. |
 | `confidence`          | `i64`    | Spot        | Price uncertainty; higher = more disagreement. (Experimental)            |
-| `bestBidPrice`        | `i64`    | Spot        | Highest bid across publishers. (Experimental)                            |
-| `bestAskPrice`        | `i64`    | Spot        | Lowest ask across publishers. (Experimental)                             |
+| `bestBidPrice`        | `i64`    | Spot        | Tightest non-overlapping bid across publishers. (Experimental)           |
+| `bestAskPrice`        | `i64`    | Spot        | Tightest non-overlapping ask across publishers. (Experimental)           |
 | `emaPrice`            | `i64`    | Spot        | Exponential moving average of the price.                                 |
 | `emaConfidence`       | `i64`    | Spot        | Exponential moving average of the confidence.                            |
 | `fundingRate`         | `i64`    | Derivatives | Funding rate (perpetual futures).                                        |
@@ -240,7 +240,7 @@ freshness and origin of the price.
 
 ### Market Depth Properties
 
-Best bid and best ask represent the tightest prices across publishers. For a detailed comparison with confidence intervals, see [Understanding Price Data](/price-feeds/pro/understanding-price-data).
+Best bid and best ask represent the tightest **non-overlapping** top-of-book across publishers — the highest publisher bid and the lowest publisher ask selected such that `bestBidPrice < bestAskPrice`, with crossing quotes excluded. For a detailed comparison with confidence intervals, see [Understanding Price Data](/price-feeds/pro/understanding-price-data).
 
 <Callout type="warning" title="Experimental">
   The `bestBidPrice` and `bestAskPrice` fields are **experimental**. These fields
@@ -254,21 +254,29 @@ Best bid and best ask represent the tightest prices across publishers. For a det
       name: "bestBidPrice",
       type: "optional non-zero i64",
       description:
-        "Highest bid price across all contributing publishers, represented as mantissa.",
+        "Highest publisher bid that does not cross any publisher ask (tightest non-overlapping top-of-book bid), represented as mantissa.",
       availability: "Only included if requested in subscription properties",
       algorithm: "Refer to price aggregation for the current algorithm",
       algorithmLink: "/price-feeds/core/how-pyth-works/price-aggregation",
-      invariants: ["Non-zero when present", "Typically ≤ current price"],
+      invariants: [
+        "Non-zero when present",
+        "Strictly less than bestAskPrice when both are present",
+        "Typically ≤ current price",
+      ],
     },
     {
       name: "bestAskPrice",
       type: "optional non-zero i64",
       description:
-        "Lowest ask price across all contributing publishers, represented as mantissa.",
+        "Lowest publisher ask that does not cross any publisher bid (tightest non-overlapping top-of-book ask), represented as mantissa.",
       availability: "Only included if requested in subscription properties",
       algorithm: "Refer to price aggregation for the current algorithm",
       algorithmLink: "/price-feeds/core/how-pyth-works/price-aggregation",
-      invariants: ["Non-zero when present", "Typically ≥ current price"],
+      invariants: [
+        "Non-zero when present",
+        "Strictly greater than bestBidPrice when both are present",
+        "Typically ≥ current price",
+      ],
     },
   ]}
 />

--- a/apps/developer-hub/content/docs/price-feeds/pro/understanding-price-data.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/understanding-price-data.mdx
@@ -28,22 +28,12 @@ Consumers can detect this case by comparing `feedUpdateTimestamp` against the up
 
 ## Confidence Interval
 
-**Confidence reflects the uncertainty of the prices reported among publishers.** **This may or may not reflect the uncertainty (volatility) of the underlying market price.**
+**Confidence reflects the measurement uncertainty of the prices reported among publishers.** **This may or may not reflect the uncertainty (volatility) of the underlying market price.** A high confidence value means publishers are deviating from the aggregate more than usual — whether because market conditions are volatile, publishers hold varying views on the current price, or there is less agreement across data sources. A low confidence value means publishers are in closer agreement about the price.
 
-When the number of contributing publishers is low, non-optimal behavior from a single publisher — for example, being slow to update or serving stale data — can move confidence in ways unrelated to market volatility. We recommend:
+Because confidence captures publisher disagreement rather than market volatility directly, a low publisher count can distort it: non-optimal behavior from a single publisher — for example, being slow to update or serving stale data — can move confidence in ways unrelated to the market. We recommend:
 
 - Using `publisherCount` to filter out updates with too few contributors for your use case.
 - Using `emaConfidence` rather than raw `confidence` to smooth out short-term noise.
-
-### What High Confidence Means
-
-A **high confidence value** indicates **high measurement uncertainty** — publishers are deviating from the aggregate more than usual. This could happen when:
-
-- Market conditions are volatile.
-- Publishers have varying views on the current price.
-- There is less agreement among data sources.
-
-A **low confidence value** indicates **low uncertainty** — publishers are in closer agreement about the price.
 
 ### How Confidence Is Calculated
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/understanding-price-data.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/understanding-price-data.mdx
@@ -123,3 +123,16 @@ For a deeper explanation of the algorithm and its motivation, see [EMA Price Agg
   alone. Consumers doing session-specific analysis should keep this in
   mind — the EMA is a rolling 1-hour average, not a per-session average.
 </Callout>
+
+## Circuit Breakers
+
+The aggregator applies **circuit breakers** to reject publisher updates that are clearly out of line with the expected price. When a circuit breaker trips, the offending publisher update is excluded from the aggregation window rather than being counted toward the median. This protects the aggregate from stale, mis-scaled, or otherwise anomalous inputs during known sensitive periods.
+
+### Split / Reverse-Split Corporate Actions (US Equities)
+
+When a US equity undergoes a **stock split** or **reverse split**:
+
+- The previous **`overNight` session is closed** on the execution date — there is no overnight aggregation spanning the corporate action boundary.
+- The split or reverse split is **applied at the start of the next `preMarket` session**. From that point forward, all aggregate prices reflect the adjusted share count.
+
+Publishers ingesting prices from upstream venues may not immediately pick up the corporate action and could briefly continue to publish **non-adjusted (pre-split) prices** after it takes effect. To keep these stale prices out of the aggregate, the aggregator rejects publisher updates whose price deviates beyond a **threshold from the adjusted last price** (for example, ~10%) for a **protection window after the action is applied** (for example, ~10 minutes into the new `preMarket` session). Once the window ends, aggregation returns to normal behavior.

--- a/apps/developer-hub/content/docs/price-feeds/pro/understanding-price-data.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/understanding-price-data.mdx
@@ -22,7 +22,9 @@ All three values are **optional** — a publisher may submit any subset of them 
 
 The aggregate `price` is the **median of all publisher prices** when at least `min_pub` publishers have contributed a price in the current aggregation window.
 
-If fewer than `min_pub` publishers have contributed a price, **no new aggregate is produced**: the `price` value remains the same as the previous update, and `feedUpdateTimestamp` does **not** advance. Consumers can detect this case by comparing `feedUpdateTimestamp` against the update's `timestampUs` — if they differ, the price is carried forward from a prior update rather than freshly generated. See [Payload Reference](/price-feeds/pro/payload-reference) for details on these fields.
+If fewer than `min_pub` publishers have contributed a price, **no new aggregate is produced**. In this case **none of the price properties update** — `price`, `confidence`, `bestBidPrice`, `bestAskPrice`, `emaPrice`, `emaConfidence`, and `feedUpdateTimestamp` are all carried forward from the previous update. The only property that still updates is `marketSession`, which reflects the current trading session regardless of whether a fresh aggregate was produced.
+
+Consumers can detect this case by comparing `feedUpdateTimestamp` against the update's `timestampUs` — if they differ, the price data is carried forward from a prior update rather than freshly generated. See [Payload Reference](/price-feeds/pro/payload-reference) for details on these fields.
 
 ## Confidence Interval
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/understanding-price-data.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/understanding-price-data.mdx
@@ -8,6 +8,22 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 This page explains the key metrics in Pyth Pro price feeds and what they represent. Understanding these concepts is essential for properly interpreting price data and building robust applications. For technical field specifications and API details, see [Payload Reference](/price-feeds/pro/payload-reference).
 
+## Publisher Contributions
+
+Each publisher contributes up to **three prices** in every update:
+
+- **Best bid price**: the highest price at which the publisher is willing to buy.
+- **Price**: the publisher's view of the mid/market price.
+- **Best ask price**: the lowest price at which the publisher is willing to sell.
+
+All three values are **optional** — a publisher may submit any subset of them in a given update depending on what its data sources provide. The aggregate metrics (`price`, `confidence`, `bestBidPrice`, `bestAskPrice`) are derived from whichever values publishers have contributed.
+
+## Price
+
+The aggregate `price` is the **median of all publisher prices** when at least `min_pub` publishers have contributed a price in the current aggregation window.
+
+If fewer than `min_pub` publishers have contributed a price, **no new aggregate is produced**: the `price` value remains the same as the previous update, and `feedUpdateTimestamp` does **not** advance. Consumers can detect this case by comparing `feedUpdateTimestamp` against the update's `timestampUs` — if they differ, the price is carried forward from a prior update rather than freshly generated. See [Payload Reference](/price-feeds/pro/payload-reference) for details on these fields.
+
 ## Confidence Interval
 
 <Callout type="warning" title="Experimental">
@@ -52,12 +68,12 @@ This approach ensures the confidence interval reflects the full range of what pu
   See [Payload Reference](/price-feeds/pro/payload-reference) for details.
 </Callout>
 
-Best Bid and Best Ask represent the **tightest bid and ask prices** across all contributing publishers.
+Best Bid and Best Ask represent the **tightest non-overlapping bid and ask** across all contributing publishers. The aggregation selects the highest bid and lowest ask such that `bestBidPrice < bestAskPrice` — publisher quotes that would cross the book are excluded so the resulting top-of-book is always well-formed.
 
-| Field          | Description                                              |
-| -------------- | -------------------------------------------------------- |
-| `bestBidPrice` | The highest bid price across all contributing publishers |
-| `bestAskPrice` | The lowest ask price across all contributing publishers  |
+| Field          | Description                                                                    |
+| -------------- | ------------------------------------------------------------------------------ |
+| `bestBidPrice` | The highest bid price across publishers that does not cross any publisher ask  |
+| `bestAskPrice` | The lowest ask price across publishers that does not cross any publisher bid   |
 
 ### How Best Bid/Ask Differ from Confidence
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/understanding-price-data.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/understanding-price-data.mdx
@@ -103,3 +103,23 @@ Best bid and ask are useful for:
   market uncertainty. Use both confidence intervals and best bid/ask data
   together for a more complete picture of market conditions.
 </Callout>
+
+## EMA Price and EMA Confidence
+
+`emaPrice` and `emaConfidence` are **exponentially-weighted moving averages** of the aggregate `price` and `confidence`, with an averaging window of approximately **1 hour**.
+
+In an EMA, the most recent samples receive the most weight and older samples decay exponentially. For a 1-hour window, samples roughly 1 hour in the past contribute about 50% of the weighting, samples 2 hours back contribute ~25%, 3 hours back contribute ~12.5%, and so on. This produces a smoothed view of the price that is resilient to short-term noise while still tracking sustained moves.
+
+The averaging is also **inverse-confidence weighted**: samples with a tight confidence interval contribute more weight than samples with a wide confidence. This dampens the influence of outlier aggregates published with high uncertainty, so transient publisher disagreement does not pull the EMA around.
+
+For a deeper explanation of the algorithm and its motivation, see [EMA Price Aggregation](/price-feeds/core/how-pyth-works/ema-price-aggregation).
+
+<Callout type="warning" title="EMA does not reset on market session boundaries">
+  `emaPrice` and `emaConfidence` continue averaging across session
+  transitions (for example, from `regular` to `postMarket` to `overNight`,
+  or back to `regular`). The EMA observed early in a new session still
+  carries contributions from the prior session's aggregates, so it may
+  reflect overnight or pre-market activity rather than the current session
+  alone. Consumers doing session-specific analysis should keep this in
+  mind — the EMA is a rolling 1-hour average, not a per-session average.
+</Callout>

--- a/apps/developer-hub/content/docs/price-feeds/pro/understanding-price-data.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/understanding-price-data.mdx
@@ -28,40 +28,42 @@ Consumers can detect this case by comparing `feedUpdateTimestamp` against the up
 
 ## Confidence Interval
 
-<Callout type="warning" title="Experimental">
-  This field is **experimental** and not yet covered by automated data quality assurance.
-  See [Payload Reference](/price-feeds/pro/payload-reference) for details.
-</Callout>
+**Confidence reflects the uncertainty of the prices reported among publishers.** This may or may not reflect the uncertainty (volatility) of the underlying market price.
 
-The confidence interval measures **the spread of price observations across publishers**. It measures how much individual publishers deviate from the aggregate price.
+When the number of contributing publishers is low, non-optimal behavior from a single publisher — for example, being slow to update or serving stale data — can move confidence in ways unrelated to market volatility. We recommend:
 
-<Callout type="warning">
-  **Important Distinction**: The confidence interval does NOT represent price
-  dislocation between trading venues. It reflects publisher uncertainty, which
-  does not always equal the market uncertainty.
-</Callout>
+- Using `publisherCount` to filter out updates with too few contributors for your use case.
+- Using `emaConfidence` rather than raw `confidence` to smooth out short-term noise.
 
 ### What High Confidence Means
 
-A **high confidence value** indicates **high uncertainty** - publishers are deviating from the aggregate more than usual. This could happen when:
+A **high confidence value** indicates **high uncertainty** — publishers are deviating from the aggregate more than usual. This could happen when:
 
 - Market conditions are volatile.
 - Publishers have varying views on the current price.
 - There is less agreement among data sources.
 
-A **low confidence value** indicates **low uncertainty** - publishers are in closer agreement about the price.
+A **low confidence value** indicates **low uncertainty** — publishers are in closer agreement about the price.
 
 ### How Confidence Is Calculated
 
-The confidence interval is computed using the interquartile range of publisher data. Importantly, the calculation combines **all prices, bids, and asks** from publishers — not just mid-prices.
+Confidence is the **maximum distance** from the aggregate `price` to the 25th and 75th percentiles of the combined publisher dataset:
 
-1. **Combine All Data**: The system pools all publisher prices, bids, and asks into a single dataset.
-2. **Calculate Percentiles**: The 25th percentile (price25) and 75th percentile (price75) are computed from this combined dataset.
-3. **Left Confidence**: Calculated as `median_price - price25`.
-4. **Right Confidence**: Calculated as `price75 - median_price`.
-5. **Final Confidence**: The larger of left confidence and right confidence is used as the reported confidence value.
+1. **Pool all publisher quotes**: For each publisher, collect their `price`, `bestBid`, and `bestAsk` into a single combined dataset across all publishers (missing fields are imputed first — see below).
+2. **Compute percentiles**: Calculate the 25th percentile (`p25`) and 75th percentile (`p75`) of the combined dataset.
+3. **Take the maximum distance**: `confidence = max(price − p25, p75 − price)`, where `price` is the aggregate price.
 
-This approach ensures the confidence interval reflects the full range of what publishers are reporting, including their view of market depth.
+This approach uses the interquartile range of all publisher quotes, so the confidence reflects both price disagreement and publishers' view of market depth.
+
+#### Imputing Missing Fields
+
+Publishers may submit any subset of `price`, `bestBid`, and `bestAsk` (see [Publisher Contributions](#publisher-contributions)). Before a publisher's quotes are added to the pool, missing fields are imputed from what they did provide:
+
+- **Only one field provided**: the other two are set equal to it.
+- **`price` missing, both `bestBid` and `bestAsk` provided**: `price` is set to the average of `bestBid` and `bestAsk`.
+- **`price` provided, `bestBid` or `bestAsk` missing**: the missing bid/ask is set equal to `price`.
+
+This ensures every publisher contributes three values to the confidence calculation regardless of which fields they submitted.
 
 ## Best Bid and Best Ask
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/understanding-price-data.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/understanding-price-data.mdx
@@ -16,7 +16,7 @@ Each publisher contributes up to **three prices** in every update:
 - **Price**: the publisher's view of the mid/market price.
 - **Best ask price**: the lowest price at which the publisher is willing to sell.
 
-All three values are **optional** — a publisher may submit any subset of them in a given update depending on what its data sources provide. The aggregate metrics (`price`, `confidence`, `bestBidPrice`, `bestAskPrice`) are derived from whichever values publishers have contributed.
+All three values are **optional** — a publisher may submit any subset of them in a given update depending on what its data sources provide. An update that contains none of the three is rejected and does not contribute to the aggregate. The aggregate metrics (`price`, `confidence`, `bestBidPrice`, `bestAskPrice`) are derived from whichever values publishers have contributed.
 
 ## Price
 
@@ -37,7 +37,7 @@ When the number of contributing publishers is low, non-optimal behavior from a s
 
 ### What High Confidence Means
 
-A **high confidence value** indicates **high uncertainty** — publishers are deviating from the aggregate more than usual. This could happen when:
+A **high confidence value** indicates **high measurement uncertainty** — publishers are deviating from the aggregate more than usual. This could happen when:
 
 - Market conditions are volatile.
 - Publishers have varying views on the current price.
@@ -49,7 +49,7 @@ A **low confidence value** indicates **low uncertainty** — publishers are in c
 
 Confidence is the **maximum distance** from the aggregate `price` to the 25th and 75th percentiles of the combined publisher dataset:
 
-1. **Pool all publisher quotes**: For each publisher, collect their `price`, `bestBid`, and `bestAsk` into a single combined dataset across all publishers (missing fields are imputed first — see below).
+1. **Pool all publisher quotes**: For each publisher, collect their `price`, `bestBidPrice`, and `bestAskPrice` into a single combined dataset across all publishers (missing fields are imputed first — see below).
 2. **Compute percentiles**: Calculate the 25th percentile (`p25`) and 75th percentile (`p75`) of the combined dataset.
 3. **Take the maximum distance**: `confidence = max(price − p25, p75 − price)`, where `price` is the aggregate price.
 
@@ -57,11 +57,11 @@ This approach uses the interquartile range of all publisher quotes, so the confi
 
 #### Imputing Missing Fields
 
-Publishers may submit any subset of `price`, `bestBid`, and `bestAsk` (see [Publisher Contributions](#publisher-contributions)). Before a publisher's quotes are added to the pool, missing fields are imputed from what they did provide:
+Publishers may submit any subset of `price`, `bestBidPrice`, and `bestAskPrice` (see [Publisher Contributions](#publisher-contributions)). Before a publisher's quotes are added to the pool, missing fields are imputed from what they did provide:
 
 - **Only one field provided**: the other two are set equal to it.
-- **`price` missing, both `bestBid` and `bestAsk` provided**: `price` is set to the average of `bestBid` and `bestAsk`.
-- **`price` provided, `bestBid` or `bestAsk` missing**: the missing bid/ask is set equal to `price`.
+- **`price` missing, both `bestBidPrice` and `bestAskPrice` provided**: `price` is set to the average of `bestBidPrice` and `bestAskPrice`.
+- **`price` provided, `bestBidPrice` or `bestAskPrice` missing**: the missing bid/ask is set equal to `price`.
 
 This ensures every publisher contributes three values to the confidence calculation regardless of which fields they submitted.
 
@@ -72,7 +72,7 @@ This ensures every publisher contributes three values to the confidence calculat
   See [Payload Reference](/price-feeds/pro/payload-reference) for details.
 </Callout>
 
-Best Bid and Best Ask represent the **tightest non-overlapping bid and ask** across all contributing publishers. The aggregation selects the highest bid and lowest ask such that `bestBidPrice < bestAskPrice` — publisher quotes that would cross the book are excluded so the resulting top-of-book is always well-formed.
+Best Bid and Best Ask represent the **tightest non-overlapping bid and ask** across all contributing publishers. The aggregation selects the highest bid and lowest ask such that `bestBidPrice < bestAskPrice` — publisher quotes that would cross are excluded so the resulting spread is always well-formed.
 
 | Field          | Description                                                                    |
 | -------------- | ------------------------------------------------------------------------------ |
@@ -133,6 +133,6 @@ The aggregator applies **circuit breakers** to reject publisher updates that are
 When a US equity undergoes a **stock split** or **reverse split**:
 
 - The previous **`overNight` session is closed** on the execution date — there is no overnight aggregation spanning the corporate action boundary.
-- The split or reverse split is **applied at the start of the next `preMarket` session**. From that point forward, all aggregate prices reflect the adjusted share count.
+- The split or reverse split is **applied at the start of the next `preMarket` session** for feeds enabled for 24/5 trading, and at the start of the next `regular` session for feeds enabled only for the regular session. From that point forward, all aggregate prices reflect the adjusted share count.
 
 Publishers ingesting prices from upstream venues may not immediately pick up the corporate action and could briefly continue to publish **non-adjusted (pre-split) prices** after it takes effect. To keep these stale prices out of the aggregate, the aggregator rejects publisher updates whose price deviates beyond a **threshold from the adjusted last price** (for example, ~10%) for a **protection window after the action is applied** (for example, ~10 minutes into the new `preMarket` session). Once the window ends, aggregation returns to normal behavior.

--- a/apps/developer-hub/content/docs/price-feeds/pro/understanding-price-data.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/understanding-price-data.mdx
@@ -22,13 +22,13 @@ All three values are **optional** — a publisher may submit any subset of them 
 
 The aggregate `price` is the **median of all publisher prices** when at least `min_pub` publishers have contributed a price in the current aggregation window.
 
-If fewer than `min_pub` publishers have contributed a price, **no new aggregate is produced**. In this case **none of the price properties update** — `price`, `confidence`, `bestBidPrice`, `bestAskPrice`, `emaPrice`, `emaConfidence`, and `feedUpdateTimestamp` are all carried forward from the previous update. The only property that still updates is `marketSession`, which reflects the current trading session regardless of whether a fresh aggregate was produced.
+If fewer than `min_pub` publishers have contributed a price, **no new aggregate is produced**. In this case **none of the price properties update** — `price`, `confidence`, `bestBidPrice`, `bestAskPrice`, `emaPrice`, `emaConfidence`, `publisherCount`, and `feedUpdateTimestamp` are all carried forward from the previous update. The only property that still updates is `marketSession`, which reflects the current trading session regardless of whether a fresh aggregate was produced.
 
 Consumers can detect this case by comparing `feedUpdateTimestamp` against the update's `timestampUs` — if they differ, the price data is carried forward from a prior update rather than freshly generated. See [Payload Reference](/price-feeds/pro/payload-reference) for details on these fields.
 
 ## Confidence Interval
 
-**Confidence reflects the uncertainty of the prices reported among publishers.** This may or may not reflect the uncertainty (volatility) of the underlying market price.
+**Confidence reflects the uncertainty of the prices reported among publishers.** **This may or may not reflect the uncertainty (volatility) of the underlying market price.**
 
 When the number of contributing publishers is low, non-optimal behavior from a single publisher — for example, being slow to update or serving stale data — can move confidence in ways unrelated to market volatility. We recommend:
 


### PR DESCRIPTION
## Summary

Expanding the Pyth Pro "Understanding Price Data" page. More changes to follow in this branch.

- Added a **Publisher Contributions** section documenting that each publisher contributes up to three optional prices per update (best bid, price, best ask).
- Added a **Price** section explaining that the aggregate is the median of publisher prices when at least `min_pub` have contributed, and that `feedUpdateTimestamp` does not advance when no new aggregate is produced.
- Updated **Best Bid and Best Ask** to clarify the result is the tightest **non-overlapping** top-of-book.

## Test plan

- [ ] Preview the rendered docs page and verify formatting (tables, callouts, links)
- [ ] Confirm the behavior described for `min_pub` / carry-forward matches implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
