### PR TITLE
fix: rename instruction

### DIFF
--- a/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/idl/integrity-pool.json
+++ b/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/idl/integrity-pool.json
@@ -83,7 +83,7 @@
           "type": "u64"
         }
       ],
-      "name": "update_y"
+      "name": "updateY"
     }
   ],
   "name": "integrity-pool",


### PR DESCRIPTION
## Rationale

The version of anchor that we are using expects the instruction name to be in camel case.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
