### PR TITLE
fix(xc_admin): rethrow caught error instead of empty Error

### DIFF
--- a/governance/xc_admin/packages/crank_executor/src/index.ts
+++ b/governance/xc_admin/packages/crank_executor/src/index.ts
@@ -60,6 +60,6 @@ async function run() {
     await run();
   } catch (err) {
     console.error(err);
-    throw new Error();
+    throw err;
   }
 })();

--- a/governance/xc_admin/packages/crank_pythnet_relayer/src/index.ts
+++ b/governance/xc_admin/packages/crank_pythnet_relayer/src/index.ts
@@ -228,6 +228,6 @@ async function run() {
     await run();
   } catch (err) {
     console.error(err);
-    throw new Error();
+    throw err;
   }
 })();


### PR DESCRIPTION
## Summary

The change replaces throw new Error(); with throw err; in the top-level catch of both crank scripts.

## Rationale

  - `throw new Error()` creates a brand-new Error with no message and a stack trace that points at line 63 (or 231) which is at the re-throw itself, not at where the failure actually happened.                                                                                                  
  - The original error is discarded. `console.error(err)` prints it to stderr first, but Node's eventual "uncaught exception" report shows the thrown error which is the empty one.     
  - Result in practice: an operator looking at why a crank process died sees a useless empty-message stack ending at `throw new Error()` instead of the real RPC timeout / auth failure / malformed VAA / whatever triggered it.                                                                
  - `throw err;` preserves the original error message, stack, and any properties like cause. Node reports the real failure in its crash output, so root-causing a production incident is one less instead of a forensic dig.   

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code