### PR TITLE
fix(contract_manager): include filename in JSON parse errors

### DIFF
--- a/contract_manager/src/node/utils/store.ts
+++ b/contract_manager/src/node/utils/store.ts
@@ -56,6 +56,17 @@ import {
 } from "../../core/contracts/starknet";
 import { Token } from "../../core/token";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseJsonFile(jsonFile: string): any {
+  try {
+    return JSON.parse(readFileSync(jsonFile, "utf8"));
+  } catch (err) {
+    throw new Error(
+      `Failed to parse ${jsonFile}: ${(err as Error).message}`,
+    );
+  }
+}
+
 export class Store {
   public chains: Record<string, Chain> = { global: new GlobalChain() };
   public contracts: Record<string, PriceFeedContract> = {};
@@ -114,7 +125,7 @@ export class Store {
     };
 
     for (const jsonFile of this.getJsonFiles(`${this.path}/chains/`)) {
-      const parsedArray = JSON.parse(readFileSync(jsonFile, "utf8"));
+      const parsedArray = parseJsonFile(jsonFile);
       for (const parsed of parsedArray) {
         if (allChainClasses[parsed.type] === undefined) {
           throw new Error(
@@ -202,7 +213,7 @@ export class Store {
       [SuiLazerContract.type]: SuiLazerContract,
     };
     this.getJsonFiles(`${this.path}/contracts/`).forEach((jsonFile) => {
-      const parsedArray = JSON.parse(readFileSync(jsonFile, "utf8"));
+      const parsedArray = parseJsonFile(jsonFile);
       for (const parsed of parsedArray) {
         if (allContractClasses[parsed.type] === undefined) return;
         if (!this.chains[parsed.chain])
@@ -242,7 +253,7 @@ export class Store {
 
   loadAllTokens() {
     this.getJsonFiles(`${this.path}/tokens/`).forEach((jsonFile) => {
-      const parsedArray = JSON.parse(readFileSync(jsonFile, "utf8"));
+      const parsedArray = parseJsonFile(jsonFile);
       for (const parsed of parsedArray) {
         if (parsed.type !== Token.type) return;
 
@@ -256,7 +267,7 @@ export class Store {
 
   loadAllVaults() {
     this.getJsonFiles(`${this.path}/vaults/`).forEach((jsonFile) => {
-      const parsedArray = JSON.parse(readFileSync(jsonFile, "utf8"));
+      const parsedArray = parseJsonFile(jsonFile);
       for (const parsed of parsedArray) {
         if (parsed.type !== Vault.type) return;
 


### PR DESCRIPTION
## Summary

`contract_manager` loads `chain/contract/token/vault` configs via four `JSON.parse(readFileSync(...))` calls. A syntax error in any config file crashes the CLI with a bare SyntaxError and no filename, making it painful to track down typos when editing configs. This wraps the calls in a  small parseJsonFile helper that re-throws with the offending filename prepended.

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

