### PR TITLE
fix(contract_manager): rethrow unhandled rejections, fix p-cancelable typo

### DIFF
--- a/contract_manager/scripts/sync_wormhole_guardian_set.ts
+++ b/contract_manager/scripts/sync_wormhole_guardian_set.ts
@@ -12,7 +12,7 @@ const GUARDIAN_INDEX_TIMEOUT_MS = 10_000;
 const SYNC_GUARDIAN_SETS_TIMEOUT_MS = 3 * 60 * 1000;
 
 /** Suppress got/p-cancelable race when our timeout fires before the request settles. */
-function isPancelableRaceError(err: unknown): boolean {
+function isPCancelableRaceError(err: unknown): boolean {
   return (
     err instanceof Error &&
     err.message.includes("onCancel") &&
@@ -21,10 +21,11 @@ function isPancelableRaceError(err: unknown): boolean {
 }
 
 process.on("unhandledRejection", (reason: unknown) => {
-  if (isPancelableRaceError(reason)) return;
+  if (isPCancelableRaceError(reason)) return;
+  throw reason;
 });
 process.on("uncaughtException", (err: Error) => {
-  if (isPancelableRaceError(err)) return;
+  if (isPCancelableRaceError(err)) return;
   throw err;
 });
 


### PR DESCRIPTION
## Summary

 Two small fixes in sync_wormhole_guardian_set.ts:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           

- The unhandledRejection handler only filters out the p-cancelable race error and falls through with no re-throw, silently swallowing every other rejection. The sister uncaughtException handler re-throws non-matching errors; mirror that behavior so unexpected failures crash loudly.
- Rename isPancelableRaceError → isPCancelableRaceError (the underlying library is https://github.com/sindresorhus/p-cancelable).

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
