### PR TITLE
fix(dev-hub): redact user API key from playground code snippets

### DIFF
--- a/apps/developer-hub/src/components/Playground/CodeGenerators/cli.ts
+++ b/apps/developer-hub/src/components/Playground/CodeGenerators/cli.ts
@@ -4,8 +4,6 @@ import type { PlaygroundConfig } from "../types";
  * Generates CLI code using wscat for WebSocket connections
  */
 export function generateCliCode(config: PlaygroundConfig): string {
-  // If accessToken is empty, use demo token placeholder
-  const token = config.accessToken.trim() || "DEMO_TOKEN";
   const priceFeedIds =
     config.priceFeedIds.length > 0 ? config.priceFeedIds : [1, 2];
   const properties =
@@ -30,10 +28,12 @@ export function generateCliCode(config: PlaygroundConfig): string {
   return `# Install wscat if not already installed
 npm install -g wscat
 
+# Export your API key so it never ends up in shell history or version control
+export LAZER_TOKEN="your-api-key-here"
+
 # Connect to Pyth Lazer WebSocket with authentication
-# Replace YOUR_ACCESS_TOKEN with your actual token
 wscat -c "wss://pyth-lazer-0.dourolabs.app/v1/stream" \\
-  -H "Authorization: Bearer ${token}"
+  -H "Authorization: Bearer $LAZER_TOKEN"
 
 # Once connected, send this subscription message:
 ${payloadStr}
@@ -42,7 +42,7 @@ ${payloadStr}
 
 # Alternative: Using curl for one-shot requests (HTTP API)
 curl -X POST "https://pyth-lazer-0.dourolabs.app/v1/latest_price" \\
-  -H "Authorization: Bearer ${token}" \\
+  -H "Authorization: Bearer $LAZER_TOKEN" \\
   -H "Content-Type: application/json" \\
   -d '${JSON.stringify({ formats, parsed: config.parsed, priceFeedIds, properties })}'
 

--- a/apps/developer-hub/src/components/Playground/CodeGenerators/go.ts
+++ b/apps/developer-hub/src/components/Playground/CodeGenerators/go.ts
@@ -4,8 +4,6 @@ import type { PlaygroundConfig } from "../types";
  * Generates Go code using gorilla/websocket for WebSocket connections
  */
 export function generateGoCode(config: PlaygroundConfig): string {
-  // If accessToken is empty, use demo token placeholder
-  const token = config.accessToken.trim() || "DEMO_TOKEN";
   const priceFeedIds =
     config.priceFeedIds.length > 0 ? config.priceFeedIds : [1, 2];
   const properties =
@@ -82,7 +80,11 @@ func main() {
 		"wss://pyth-lazer-2.dourolabs.app/v1/stream",
 	}
 
-	token := "${token}"
+	// Read your API key from the environment (never hard-code it)
+	token := os.Getenv("LAZER_TOKEN")
+	if token == "" {
+		log.Fatal("Set LAZER_TOKEN in your environment")
+	}
 
 	// Set up interrupt handler
 	interrupt := make(chan os.Signal, 1)

--- a/apps/developer-hub/src/components/Playground/CodeGenerators/python.ts
+++ b/apps/developer-hub/src/components/Playground/CodeGenerators/python.ts
@@ -4,8 +4,6 @@ import type { PlaygroundConfig } from "../types";
  * Generates Python code using websockets library
  */
 export function generatePythonCode(config: PlaygroundConfig): string {
-  // If accessToken is empty, use demo token placeholder
-  const token = config.accessToken.trim() || "DEMO_TOKEN";
   const priceFeedIds =
     config.priceFeedIds.length > 0 ? config.priceFeedIds : [1, 2];
   const properties =
@@ -32,6 +30,7 @@ Usage:
 
 import asyncio
 import json
+import os
 import signal
 from typing import Any
 
@@ -42,8 +41,8 @@ except ImportError:
     exit(1)
 
 
-# Configuration
-TOKEN = "${token}"
+# Read your API key from the environment (never hard-code it)
+TOKEN = os.environ["LAZER_TOKEN"]
 ENDPOINTS = [
     "wss://pyth-lazer-0.dourolabs.app/v1/stream",
     "wss://pyth-lazer-1.dourolabs.app/v1/stream",

--- a/apps/developer-hub/src/components/Playground/CodeGenerators/typescript.ts
+++ b/apps/developer-hub/src/components/Playground/CodeGenerators/typescript.ts
@@ -4,8 +4,6 @@ import type { PlaygroundConfig } from "../types";
  * Generates TypeScript code using the pyth-lazer-sdk package
  */
 export function generateTypeScriptCode(config: PlaygroundConfig): string {
-  // If accessToken is empty, use demo token placeholder
-  const token = config.accessToken.trim() || "DEMO_TOKEN";
   const priceFeedIds =
     config.priceFeedIds.length > 0 ? config.priceFeedIds : [1, 2];
   const properties =
@@ -19,9 +17,13 @@ export function generateTypeScriptCode(config: PlaygroundConfig): string {
 
   return `import { PythLazerClient } from "@pythnetwork/pyth-lazer-sdk";
 
+// Read your API key from the environment (never hard-code it)
+const token = process.env.LAZER_TOKEN;
+if (!token) throw new Error("Set LAZER_TOKEN in your environment");
+
 // Create the Pyth Lazer client with WebSocket pool configuration
 const client = await PythLazerClient.create({
-  token: "${token}",
+  token,
   webSocketPoolConfig: {
     urls: [
       "wss://pyth-lazer-0.dourolabs.app/v1/stream",


### PR DESCRIPTION
## Summary

- The code snippets shown in the playground's Monaco editor interpolated `config.accessToken` verbatim. Users who pasted their real key into the `type="password"` input would still leak it on video calls and screenshares, since the editor renders plaintext.
- Rewrote all four generators (TypeScript, Python, Go, CLI) so the snippet reads the key from a `LAZER_TOKEN` env var — matching the convention the rest of the monorepo uses. The generated code is now also a better template: pasting it into a real project Just Works once the env var is set.
- Run button is unaffected — it authenticates through `/api/playground/stream` using React state, not the rendered snippet.

## Test plan

- [ ] Load `/playground`, paste a recognizable fake key (e.g. `sk_live_SECRETKEY_xyz`).
- [ ] Switch through all four tabs (TypeScript, CLI, Go, Python) — none of them should contain the key. Each should reference `LAZER_TOKEN`.
- [ ] Clear the input and press Run — stream still connects and messages arrive.
- [ ] Copy / Download a snippet — downloaded file references `LAZER_TOKEN`, no raw key inside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
