### PR TITLE
feat: add lazer hermes evm deployment

### DIFF
--- a/contract_manager/scripts/common.ts
+++ b/contract_manager/scripts/common.ts
@@ -17,17 +17,18 @@ import Web3 from "web3";
 import type { Contract } from "web3-eth-contract";
 import type { InferredOptionType } from "yargs";
 
-import type { PrivateKey } from "../src/core/base";
+import type { DeploymentType, PrivateKey } from "../src/core/base";
 import { getDefaultDeploymentConfig } from "../src/core/base";
 import { EvmChain } from "../src/core/chains";
+import type { EvmEntropyContract } from "../src/core/contracts";
 import {
-  EvmEntropyContract,
   EvmExecutorContract,
   EvmWormholeContract,
 } from "../src/core/contracts";
 import { DefaultStore } from "../src/node/utils/store";
 
 export type BaseDeployConfig = {
+  type: DeploymentType;
   gasMultiplier: number;
   gasPriceMultiplier: number;
   jsonOutputDir: string;
@@ -47,7 +48,7 @@ export async function deployIfNotCached(
   cacheKey?: string,
 ): Promise<string> {
   const runIfNotCached = makeCacheFunction(cacheFile);
-  const key = cacheKey ?? `${chain.getId()}-${artifactName}`;
+  const key = cacheKey ?? `${chain.getId()}-${artifactName}-${config.type}`;
   return runIfNotCached(key, async () => {
     const artifact = JSON.parse(
       readFileSync(
@@ -106,77 +107,77 @@ export function getWeb3Contract(
 }
 
 export const COMMON_DEPLOY_OPTIONS = {
-  "std-output-dir": {
-    type: "string",
-    demandOption: true,
-    desc: "Path to the Foundry output directory (typically 'out/' directory, contains Contract.sol/Contract.json structure)",
-  },
-  "private-key": {
-    type: "string",
-    demandOption: true,
-    desc: "Private key to sign the transactions with",
-  },
   chain: {
-    type: "array",
-    string: true,
     demandOption: true,
     desc: "Chains to upload the contract on. Must be one of the chains available in the store",
+    string: true,
+    type: "array",
   },
   "deployment-type": {
-    type: "string",
-    demandOption: false,
     default: "stable",
-    desc: "Deployment type to use. Can be 'stable' or 'beta'",
+    demandOption: false,
+    desc: "Deployment type to use. Can be 'stable', 'beta', 'lazer-staging', or 'lazer-prod'",
+    type: "string",
   },
   "gas-multiplier": {
-    type: "number",
-    demandOption: false,
     // Proxy (ERC1967) contract gas estimate is insufficient in many networks and thus we use 2 by default to make it work.
     default: 2,
+    demandOption: false,
     desc: "Gas multiplier to use for the deployment. This is useful when gas estimates are not accurate",
+    type: "number",
   },
   "gas-price-multiplier": {
-    type: "number",
-    demandOption: false,
     default: 1,
+    demandOption: false,
     desc: "Gas price multiplier to use for the deployment. This is useful when gas price estimates are not accurate",
+    type: "number",
+  },
+  "private-key": {
+    demandOption: true,
+    desc: "Private key to sign the transactions with",
+    type: "string",
   },
   "save-contract": {
-    type: "boolean",
-    demandOption: false,
     default: true,
+    demandOption: false,
     desc: "Save the contract to the store",
+    type: "boolean",
+  },
+  "std-output-dir": {
+    demandOption: true,
+    desc: "Path to the Foundry output directory (typically 'out/' directory, contains Contract.sol/Contract.json structure)",
+    type: "string",
   },
 } as const;
 export const CHAIN_SELECTION_OPTIONS = {
-  testnet: {
-    type: "boolean",
-    default: false,
-    desc: "Upgrade testnet contracts instead of mainnet",
-  },
   "all-chains": {
-    type: "boolean",
     default: false,
     desc: "Upgrade the contract on all chains. Use with --testnet flag to upgrade all testnet contracts",
+    type: "boolean",
   },
   chain: {
-    type: "array",
-    string: true,
     desc: "Chains to upgrade the contract on",
+    string: true,
+    type: "array",
+  },
+  testnet: {
+    default: false,
+    desc: "Upgrade testnet contracts instead of mainnet",
+    type: "boolean",
   },
 } as const;
 export const COMMON_UPGRADE_OPTIONS = {
   ...CHAIN_SELECTION_OPTIONS,
-  "private-key": COMMON_DEPLOY_OPTIONS["private-key"],
   "ops-key-path": {
-    type: "string",
     demandOption: true,
     desc: "Path to the private key of the proposer to use for the operations multisig governance proposal",
-  },
-  "std-output": {
     type: "string",
+  },
+  "private-key": COMMON_DEPLOY_OPTIONS["private-key"],
+  "std-output": {
     demandOption: false,
     desc: "Path to the standard JSON output of the pyth contract (build artifact)",
+    type: "string",
   },
 } as const;
 
@@ -249,17 +250,20 @@ export function findEntropyContract(chain: EvmChain): EvmEntropyContract {
 }
 
 /**
- * Finds the wormhole contract for a given EVM chain.
+ * Finds the wormhole contract for a given EVM chain and guardian set source.
  * @param {EvmChain} chain The EVM chain to find the wormhole contract for.
- * @returns If found, the wormhole contract for the given EVM chain. Else, undefined
+ * @param {"wormhole" | "lazer"} guardianSetSource The guardian set source to filter by.
+ * @returns If found, the wormhole contract for the given EVM chain and source. Else, undefined
  */
 export function findWormholeContract(
   chain: EvmChain,
+  guardianSetSource: "wormhole" | "lazer",
 ): EvmWormholeContract | undefined {
   for (const contract of Object.values(DefaultStore.wormhole_contracts)) {
     if (
       contract instanceof EvmWormholeContract &&
-      contract.getChain().getId() === chain.getId()
+      contract.getChain().getId() === chain.getId() &&
+      contract.guardianSetSource === guardianSetSource
     ) {
       return contract;
     }
@@ -291,7 +295,7 @@ export function findExecutorContract(
 
 export type DeployWormholeReceiverContractsConfig = {
   saveContract: boolean;
-  type: "stable" | "beta";
+  type: DeploymentType;
 } & BaseDeployConfig;
 /**
  * Deploys the wormhole receiver contract for a given EVM chain.
@@ -305,6 +309,8 @@ export async function deployWormholeContract(
   config: DeployWormholeReceiverContractsConfig,
   cacheFile: string,
 ): Promise<EvmWormholeContract> {
+  const { wormholeConfig } = getDefaultDeploymentConfig(config.type);
+
   const receiverSetupAddr = await deployIfNotCached(
     cacheFile,
     chain,
@@ -317,7 +323,9 @@ export async function deployWormholeContract(
     cacheFile,
     chain,
     config,
-    "ReceiverImplementation",
+    wormholeConfig.guardianSetSource === "lazer"
+      ? "ReceiverImplementationHalf"
+      : "ReceiverImplementation",
     [],
   );
 
@@ -327,8 +335,6 @@ export async function deployWormholeContract(
     "ReceiverSetup",
     receiverSetupAddr,
   );
-
-  const { wormholeConfig } = getDefaultDeploymentConfig(config.type);
 
   const initData = setupContract.methods
     .setup(
@@ -348,7 +354,11 @@ export async function deployWormholeContract(
     [receiverSetupAddr, initData],
   );
 
-  const wormholeContract = new EvmWormholeContract(chain, wormholeReceiverAddr);
+  const wormholeContract = new EvmWormholeContract(
+    chain,
+    wormholeReceiverAddr,
+    wormholeConfig.guardianSetSource,
+  );
 
   if (config.type === "stable") {
     console.log(`Syncing mainnet guardian sets for ${chain.getId()}...`);
@@ -379,8 +389,9 @@ export async function getOrDeployWormholeContract(
   config: DeployWormholeReceiverContractsConfig,
   cacheFile: string,
 ): Promise<EvmWormholeContract> {
+  const { wormholeConfig } = getDefaultDeploymentConfig(config.type);
   return (
-    findWormholeContract(chain) ??
+    findWormholeContract(chain, wormholeConfig.guardianSetSource) ??
     (await deployWormholeContract(chain, config, cacheFile))
   );
 }
@@ -435,10 +446,10 @@ export async function topupAccountsIfNecessary(
 
       const tx = await web3.eth.sendTransaction({
         from: signer.address,
-        to: accountAddress,
         gas: estimatedGas * deploymentConfig.gasMultiplier,
         gasPrice: gasPrice.toString(),
         nonce: nonce,
+        to: accountAddress,
         value: web3.utils.toWei(`${minBalance}`, "ether"),
         // // Uncomment this if your tx are getting stuck in the mempool. Or if you get this error:
         // // "An existing transaction had higher priority"

--- a/contract_manager/scripts/common.ts
+++ b/contract_manager/scripts/common.ts
@@ -338,7 +338,7 @@ export async function deployWormholeContract(
     cacheFile,
     chain,
     config,
-    wormholeConfig.guardianSetSource === "lazer"
+    wormholeConfig.quorum === "half"
       ? "ReceiverImplementationHalf"
       : "ReceiverImplementation",
     [],

--- a/contract_manager/scripts/common.ts
+++ b/contract_manager/scripts/common.ts
@@ -250,21 +250,36 @@ export function findEntropyContract(chain: EvmChain): EvmEntropyContract {
 }
 
 /**
- * Finds the wormhole contract for a given EVM chain and guardian set source.
- * @param {EvmChain} chain The EVM chain to find the wormhole contract for.
- * @param {"wormhole" | "lazer"} guardianSetSource The guardian set source to filter by.
- * @returns If found, the wormhole contract for the given EVM chain and source. Else, undefined
+ * Finds the wormhole contract for a given EVM chain that's compatible with
+ * the requested deployment type.
+ *
+ * Canonical Wormhole receivers (stable/beta) are shared across those two
+ * deployment types — they have the same guardian set. Pre-existing entries
+ * in the JSON store have no `deploymentType` label (they predate this
+ * field) and are presumed canonical, so a `stable` or `beta` lookup matches
+ * any stable / beta / unlabeled entry on the chain.
+ *
+ * Lazer receivers are NOT shared: lazer-staging and lazer-prod each carry
+ * their own guardian set, so the lookup is strict.
  */
 export function findWormholeContract(
   chain: EvmChain,
-  guardianSetSource: "wormhole" | "lazer",
+  deploymentType: DeploymentType,
 ): EvmWormholeContract | undefined {
+  const isCanonicalWormhole =
+    deploymentType === "stable" || deploymentType === "beta";
   for (const contract of Object.values(DefaultStore.wormhole_contracts)) {
-    if (
-      contract instanceof EvmWormholeContract &&
-      contract.getChain().getId() === chain.getId() &&
-      contract.guardianSetSource === guardianSetSource
-    ) {
+    if (!(contract instanceof EvmWormholeContract)) continue;
+    if (contract.getChain().getId() !== chain.getId()) continue;
+    if (isCanonicalWormhole) {
+      if (
+        contract.deploymentType === undefined ||
+        contract.deploymentType === "stable" ||
+        contract.deploymentType === "beta"
+      ) {
+        return contract;
+      }
+    } else if (contract.deploymentType === deploymentType) {
       return contract;
     }
   }
@@ -357,7 +372,7 @@ export async function deployWormholeContract(
   const wormholeContract = new EvmWormholeContract(
     chain,
     wormholeReceiverAddr,
-    wormholeConfig.guardianSetSource,
+    config.type,
   );
 
   if (config.type === "stable") {
@@ -389,9 +404,8 @@ export async function getOrDeployWormholeContract(
   config: DeployWormholeReceiverContractsConfig,
   cacheFile: string,
 ): Promise<EvmWormholeContract> {
-  const { wormholeConfig } = getDefaultDeploymentConfig(config.type);
   return (
-    findWormholeContract(chain, wormholeConfig.guardianSetSource) ??
+    findWormholeContract(chain, config.type) ??
     (await deployWormholeContract(chain, config, cacheFile))
   );
 }

--- a/contract_manager/scripts/common.ts
+++ b/contract_manager/scripts/common.ts
@@ -250,18 +250,12 @@ export function findEntropyContract(chain: EvmChain): EvmEntropyContract {
 }
 
 /**
- * Finds the wormhole contract for a given EVM chain that's compatible with
- * the requested deployment type.
- *
- * Canonical Wormhole receivers (stable/beta) are shared across those two
- * deployment types — they have the same guardian set. Pre-existing entries
- * in the JSON store have no `deploymentType` label (they predate this
- * field) and are presumed canonical, so a `stable` or `beta` lookup matches
- * any stable / beta / unlabeled entry on the chain.
- *
- * Lazer receivers are NOT shared: lazer-staging and lazer-prod each carry
- * their own guardian set, so the lookup is strict.
- */
+ * Finds the wormhole contract for a given EVM chain.
+ * @param {EvmChain} chain The EVM chain to find the wormhole contract for.
+ * @param {DeploymentType} deploymentType The deployment type to find the wormhole contract for.
+ * If deploymentType is "stable" or "beta", it will also find wormhole contracts with no deployment to preserve backwards compatibility.
+ * @returns If found, the wormhole contract for the given EVM chain. Else, undefined
+*/
 export function findWormholeContract(
   chain: EvmChain,
   deploymentType: DeploymentType,
@@ -271,15 +265,10 @@ export function findWormholeContract(
   for (const contract of Object.values(DefaultStore.wormhole_contracts)) {
     if (!(contract instanceof EvmWormholeContract)) continue;
     if (contract.getChain().getId() !== chain.getId()) continue;
-    if (isCanonicalWormhole) {
-      if (
-        contract.deploymentType === undefined ||
-        contract.deploymentType === "stable" ||
-        contract.deploymentType === "beta"
-      ) {
-        return contract;
-      }
-    } else if (contract.deploymentType === deploymentType) {
+    if (
+      contract.deploymentType === deploymentType || 
+      (isCanonicalWormhole && !contract.deploymentType))
+    {
       return contract;
     }
   }

--- a/contract_manager/scripts/deploy_evm_pricefeed_contracts.ts
+++ b/contract_manager/scripts/deploy_evm_pricefeed_contracts.ts
@@ -13,14 +13,6 @@
 import { HermesClient } from "@pythnetwork/hermes-client";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-
-import type { BaseDeployConfig } from "./common";
-import {
-  COMMON_DEPLOY_OPTIONS,
-  deployIfNotCached,
-  getWeb3Contract,
-  getOrDeployWormholeContract,
-} from "./common";
 import type { DeploymentType } from "../src/core/base";
 import {
   getDefaultDeploymentConfig,
@@ -30,6 +22,13 @@ import {
 import { EvmChain } from "../src/core/chains";
 import { EvmPriceFeedContract } from "../src/core/contracts";
 import { DefaultStore } from "../src/node/utils/store";
+import type { BaseDeployConfig } from "./common";
+import {
+  COMMON_DEPLOY_OPTIONS,
+  deployIfNotCached,
+  getOrDeployWormholeContract,
+  getWeb3Contract,
+} from "./common";
 
 type DeploymentConfig = {
   type: DeploymentType;
@@ -47,32 +46,32 @@ const parser = yargs(hideBin(process.argv))
   )
   .options({
     ...COMMON_DEPLOY_OPTIONS,
-    "valid-time-period-seconds": {
-      type: "number",
-      demandOption: false,
-      default: 60,
-      desc: "Valid time period in seconds for the price feed staleness",
-    },
-    "single-update-fee-in-wei": {
-      type: "number",
-      demandOption: false,
-      default: 1,
-      desc: "Single update fee in wei for the price feed",
-    },
-    "single-update-fee-in-usd": {
-      type: "number",
-      demandOption: false,
-      desc: "Single update fee in USD for the price feed. (This overrides the single-update-fee-in-wei option) ",
-    },
-    "native-token-price-feed-id": {
-      type: "string",
-      demandOption: false,
-      desc: "Pyth Price Feed ID to fetch the current price of the native token (This will be used to calculate the single-update-fee-in-usd)",
-    },
     "native-token-decimals": {
-      type: "number",
       demandOption: false,
       desc: "Number of decimals of the native token",
+      type: "number",
+    },
+    "native-token-price-feed-id": {
+      demandOption: false,
+      desc: "Pyth Price Feed ID to fetch the current price of the native token (This will be used to calculate the single-update-fee-in-usd)",
+      type: "string",
+    },
+    "single-update-fee-in-usd": {
+      demandOption: false,
+      desc: "Single update fee in USD for the price feed. (This overrides the single-update-fee-in-wei option) ",
+      type: "number",
+    },
+    "single-update-fee-in-wei": {
+      default: 1,
+      demandOption: false,
+      desc: "Single update fee in wei for the price feed",
+      type: "number",
+    },
+    "valid-time-period-seconds": {
+      default: 60,
+      demandOption: false,
+      desc: "Valid time period in seconds for the price feed staleness",
+      type: "number",
     },
   });
 
@@ -158,14 +157,14 @@ async function main() {
   }
 
   const deploymentConfig: DeploymentConfig = {
-    type: toDeploymentType(argv.deploymentType),
-    validTimePeriodSeconds: argv.validTimePeriodSeconds,
-    singleUpdateFeeInWei: singleUpdateFeeInWei,
     gasMultiplier: argv.gasMultiplier,
     gasPriceMultiplier: argv.gasPriceMultiplier,
-    privateKey: toPrivateKey(argv.privateKey),
     jsonOutputDir: argv.stdOutputDir,
+    privateKey: toPrivateKey(argv.privateKey),
     saveContract: argv.saveContract,
+    singleUpdateFeeInWei: singleUpdateFeeInWei,
+    type: toDeploymentType(argv.deploymentType),
+    validTimePeriodSeconds: argv.validTimePeriodSeconds,
   };
 
   const maskedDeploymentConfig = {
@@ -197,7 +196,11 @@ async function main() {
 
     if (deploymentConfig.saveContract) {
       console.log("Saving the contract in the store...");
-      const contract = new EvmPriceFeedContract(chain, priceFeedAddr);
+      const contract = new EvmPriceFeedContract(
+        chain,
+        priceFeedAddr,
+        deploymentConfig.type,
+      );
       DefaultStore.contracts[contract.getId()] = contract;
       DefaultStore.saveAllContracts();
     }

--- a/contract_manager/scripts/sync_wormhole_guardian_set.ts
+++ b/contract_manager/scripts/sync_wormhole_guardian_set.ts
@@ -7,6 +7,7 @@ import type { PrivateKey } from "../src/core/base";
 import { toPrivateKey } from "../src/core/base";
 import type { WormholeContract } from "../src/core/contracts/wormhole";
 import { DefaultStore } from "../src/node/utils/store";
+import { EvmWormholeContract } from "../src/core/contracts";
 
 const GUARDIAN_INDEX_TIMEOUT_MS = 10_000;
 const SYNC_GUARDIAN_SETS_TIMEOUT_MS = 3 * 60 * 1000;
@@ -147,9 +148,16 @@ async function main() {
   const chains = argv.chain;
   const targetIndex = argv.targetIndex;
 
-  const contracts = Object.values(DefaultStore.wormhole_contracts).filter(
+  const contracts = Object.values(DefaultStore.wormhole_contracts)
+  // Filter chains
+  .filter(
     (contract) => !chains || chains.includes(contract.getChain().getId()),
-  );
+  )
+  // Filter out lazer wormhole contracts
+  .filter((contract) => (
+    !(contract instanceof EvmWormholeContract) || 
+    (contract.deploymentType !== "lazer-staging" && contract.deploymentType !== "lazer-prod")
+  ));
 
   const results = await Promise.all(
     contracts.map((contract) =>

--- a/contract_manager/scripts/sync_wormhole_guardian_set.ts
+++ b/contract_manager/scripts/sync_wormhole_guardian_set.ts
@@ -156,7 +156,9 @@ async function main() {
   // Filter out lazer wormhole contracts
   .filter((contract) => (
     !(contract instanceof EvmWormholeContract) || 
-    (contract.deploymentType !== "lazer-staging" && contract.deploymentType !== "lazer-prod")
+    contract.deploymentType === undefined ||
+    contract.deploymentType === "stable" ||
+    contract.deploymentType === "beta"
   ));
 
   const results = await Promise.all(

--- a/contract_manager/src/core/base.ts
+++ b/contract_manager/src/core/base.ts
@@ -9,7 +9,7 @@ export type TxResult = {
   info: unknown; // chain specific info
 };
 
-export type DeploymentType = "stable" | "beta";
+export type DeploymentType = "stable" | "beta" | "lazer-staging" | "lazer-prod";
 export type PrivateKey = string & { __type: "PrivateKey" };
 
 function checkIsPrivateKey(key: string): asserts key is PrivateKey {
@@ -23,7 +23,13 @@ export function toPrivateKey(key: string): PrivateKey {
 }
 
 export function toDeploymentType(type: string): DeploymentType {
-  if (type === "stable" || type === "beta") return type;
+  if (
+    type === "stable" ||
+    type === "beta" ||
+    type === "lazer-staging" ||
+    type === "lazer-prod"
+  )
+    return type;
   throw new Error(`Invalid deployment type ${type}`);
 }
 
@@ -133,36 +139,40 @@ export function getDefaultDeploymentConfig(deploymentType: DeploymentType): {
     governanceChainId: number;
     governanceContract: string; // 32 byte address in 64 char hex format
     initialGuardianSet: string[]; // 20 byte addresses in 40 char hex format
+    // Source of the guardian set this receiver follows. Drives the quorum
+    // threshold (wormhole = 2/3+1, lazer = 1/2+1)
+    guardianSetSource: "wormhole" | "lazer";
   };
 } {
   if (deploymentType === "stable")
     return {
       dataSources: [
         {
-          emitterChain: 1,
           emitterAddress:
             "6bb14509a612f01fbbc4cffeebd4bbfb492a86df717ebe92eb6df432a3f00a25",
+          emitterChain: 1,
         },
         {
-          emitterChain: 26,
           emitterAddress:
             "f8cd23c2ab91237730770bbea08d61005cdda0984348f3f6eecb559638c0bba0",
+          emitterChain: 26,
         },
         {
-          emitterChain: 26,
           emitterAddress:
             "e101faedac5851e32b9b23b5f9411a8c2bac4aae3ed4dd7b811dd1a72ea4aa71",
+          emitterChain: 26,
         },
       ],
       governanceDataSource: {
-        emitterChain: 1,
         emitterAddress:
           "5635979a221c34931e32620b9293a463065555ea71fe97cd6237ade875b12e9e",
+        emitterChain: 1,
       },
       wormholeConfig: {
         governanceChainId: 1,
         governanceContract:
           "0000000000000000000000000000000000000000000000000000000000000004",
+        guardianSetSource: "wormhole",
         initialGuardianSet: ["58cc3ae5c097b213ce3c81979e1b9f9570746aa5"],
       },
     };
@@ -170,31 +180,86 @@ export function getDefaultDeploymentConfig(deploymentType: DeploymentType): {
     return {
       dataSources: [
         {
-          emitterChain: 1,
           emitterAddress:
             "f346195ac02f37d60d4db8ffa6ef74cb1be3550047543a4a9ee9acf4d78697b0",
+          emitterChain: 1,
         },
         {
-          emitterChain: 26,
           emitterAddress:
             "a27839d641b07743c0cb5f68c51f8cd31d2c0762bec00dc6fcd25433ef1ab5b6",
+          emitterChain: 26,
         },
         {
-          emitterChain: 26,
           emitterAddress:
             "e101faedac5851e32b9b23b5f9411a8c2bac4aae3ed4dd7b811dd1a72ea4aa71",
+          emitterChain: 26,
         },
       ],
       governanceDataSource: {
-        emitterChain: 1,
         emitterAddress:
           "63278d271099bfd491951b3e648f08b1c71631e4a53674ad43e8f9f98068c385",
+        emitterChain: 1,
       },
       wormholeConfig: {
         governanceChainId: 1,
         governanceContract:
           "0000000000000000000000000000000000000000000000000000000000000004",
+        guardianSetSource: "wormhole",
         initialGuardianSet: ["13947bd48b18e53fdaeee77f3473391ac727c638"],
+      },
+    };
+  else if (deploymentType === "lazer-staging")
+    return {
+      dataSources: [
+        {
+          emitterAddress:
+            "507974686e6574507974686e6574507974686e6574507974686e657450797468",
+          emitterChain: 26,
+        },
+      ],
+      governanceDataSource: {
+        emitterAddress:
+          "0000000000000000000000000000000000000000000000000000000000000004",
+        emitterChain: 1,
+      },
+      wormholeConfig: {
+        governanceChainId: 1,
+        governanceContract:
+          "0000000000000000000000000000000000000000000000000000000000000004",
+        guardianSetSource: "lazer",
+        initialGuardianSet: [
+          "dcd37a16f42a7ddd377046c3d607e7227c1ef459",
+          "1098b22a55202594341052605228e3d896132f6a",
+          "ff3b3ab7e07314359bd2469c2b1591478e398124",
+        ],
+      },
+    };
+  else if (deploymentType === "lazer-prod")
+    return {
+      dataSources: [
+        {
+          emitterAddress:
+            "507974686e6574507974686e6574507974686e6574507974686e657450797468",
+          emitterChain: 26,
+        },
+      ],
+      governanceDataSource: {
+        emitterAddress:
+          "0000000000000000000000000000000000000000000000000000000000000004",
+        emitterChain: 1,
+      },
+      wormholeConfig: {
+        governanceChainId: 1,
+        governanceContract:
+          "0000000000000000000000000000000000000000000000000000000000000004",
+        guardianSetSource: "lazer",
+        initialGuardianSet: [
+          "41534bb176e461a3fb30479400f210549ecce638",
+          "6502987b62f21cab7eb5ccd8f0173084b60d5b41",
+          "44a3e8f6a382412cf6bb90a3f8106e68977476c9",
+          "d9d7d4529577864352c9a6539a48238fcd447052",
+          "1663a5a822336ece48559b1dfb1e93a017a7dac3",
+        ],
       },
     };
   else throw new Error(`Invalid deployment type ${deploymentType}`);

--- a/contract_manager/src/core/base.ts
+++ b/contract_manager/src/core/base.ts
@@ -9,6 +9,7 @@ export type TxResult = {
   info: unknown; // chain specific info
 };
 
+// "stable" and "beta" are for pythnet and "lazer-staging" and "lazer-prod" are for lazer deployments
 export type DeploymentType = "stable" | "beta" | "lazer-staging" | "lazer-prod";
 export type PrivateKey = string & { __type: "PrivateKey" };
 

--- a/contract_manager/src/core/base.ts
+++ b/contract_manager/src/core/base.ts
@@ -139,9 +139,8 @@ export function getDefaultDeploymentConfig(deploymentType: DeploymentType): {
     governanceChainId: number;
     governanceContract: string; // 32 byte address in 64 char hex format
     initialGuardianSet: string[]; // 20 byte addresses in 40 char hex format
-    // Source of the guardian set this receiver follows. Drives the quorum
-    // threshold (wormhole = 2/3+1, lazer = 1/2+1)
-    guardianSetSource: "wormhole" | "lazer";
+    // The quorum threshold (pythnet = 2/3+1, lazer = 1/2+1)
+    quorum: "two-third" | "half";
   };
 } {
   if (deploymentType === "stable")
@@ -172,7 +171,7 @@ export function getDefaultDeploymentConfig(deploymentType: DeploymentType): {
         governanceChainId: 1,
         governanceContract:
           "0000000000000000000000000000000000000000000000000000000000000004",
-        guardianSetSource: "wormhole",
+        quorum: "two-third",
         initialGuardianSet: ["58cc3ae5c097b213ce3c81979e1b9f9570746aa5"],
       },
     };
@@ -204,7 +203,7 @@ export function getDefaultDeploymentConfig(deploymentType: DeploymentType): {
         governanceChainId: 1,
         governanceContract:
           "0000000000000000000000000000000000000000000000000000000000000004",
-        guardianSetSource: "wormhole",
+        quorum: "two-third",
         initialGuardianSet: ["13947bd48b18e53fdaeee77f3473391ac727c638"],
       },
     };
@@ -226,7 +225,7 @@ export function getDefaultDeploymentConfig(deploymentType: DeploymentType): {
         governanceChainId: 1,
         governanceContract:
           "0000000000000000000000000000000000000000000000000000000000000004",
-        guardianSetSource: "lazer",
+        quorum: "half",
         initialGuardianSet: [
           "dcd37a16f42a7ddd377046c3d607e7227c1ef459",
           "1098b22a55202594341052605228e3d896132f6a",
@@ -252,7 +251,7 @@ export function getDefaultDeploymentConfig(deploymentType: DeploymentType): {
         governanceChainId: 1,
         governanceContract:
           "0000000000000000000000000000000000000000000000000000000000000004",
-        guardianSetSource: "lazer",
+        quorum: "half",
         initialGuardianSet: [
           "41534bb176e461a3fb30479400f210549ecce638",
           "6502987b62f21cab7eb5ccd8f0173084b60d5b41",

--- a/contract_manager/src/core/base.ts
+++ b/contract_manager/src/core/base.ts
@@ -218,7 +218,7 @@ export function getDefaultDeploymentConfig(deploymentType: DeploymentType): {
       ],
       governanceDataSource: {
         emitterAddress:
-          "0000000000000000000000000000000000000000000000000000000000000004",
+          "63278d271099bfd491951b3e648f08b1c71631e4a53674ad43e8f9f98068c385",
         emitterChain: 1,
       },
       wormholeConfig: {
@@ -244,7 +244,7 @@ export function getDefaultDeploymentConfig(deploymentType: DeploymentType): {
       ],
       governanceDataSource: {
         emitterAddress:
-          "0000000000000000000000000000000000000000000000000000000000000004",
+          "5635979a221c34931e32620b9293a463065555ea71fe97cd6237ade875b12e9e",
         emitterChain: 1,
       },
       wormholeConfig: {

--- a/contract_manager/src/core/contracts/evm.ts
+++ b/contract_manager/src/core/contracts/evm.ts
@@ -74,7 +74,7 @@ export class EvmWormholeContract extends WormholeContract {
     parsed: {
       type: string;
       address: string;
-      guardianSetSource?: "wormhole" | "lazer";
+      deploymentType?: DeploymentType;
     },
   ): EvmWormholeContract {
     if (parsed.type !== EvmWormholeContract.type)
@@ -84,14 +84,14 @@ export class EvmWormholeContract extends WormholeContract {
     return new EvmWormholeContract(
       chain,
       parsed.address,
-      parsed.guardianSetSource ?? "wormhole",
+      parsed.deploymentType,
     );
   }
 
   constructor(
     public chain: EvmChain,
     public address: string,
-    public guardianSetSource: "wormhole" | "lazer" = "wormhole",
+    public deploymentType?: DeploymentType,
   ) {
     super();
   }
@@ -142,8 +142,12 @@ export class EvmWormholeContract extends WormholeContract {
     return {
       address: this.address,
       chain: this.chain.getId(),
-      guardianSetSource: this.guardianSetSource,
       type: EvmWormholeContract.type,
+      // Only emit deploymentType for entries that have it set; pre-existing
+      // unlabeled entries round-trip unchanged.
+      ...(this.deploymentType !== undefined && {
+        deploymentType: this.deploymentType,
+      }),
     };
   }
 }

--- a/contract_manager/src/core/contracts/evm.ts
+++ b/contract_manager/src/core/contracts/evm.ts
@@ -13,7 +13,7 @@ import type { DataSource } from "@pythnetwork/xc-admin-common";
 import Web3 from "web3";
 import type { Contract } from "web3-eth-contract";
 
-import type { PrivateKey } from "../base";
+import type { DeploymentType, PrivateKey } from "../base";
 import { PriceFeedContract, Storable } from "../base";
 import type { Chain } from "../chains";
 import { EvmChain } from "../chains";
@@ -71,18 +71,27 @@ export class EvmWormholeContract extends WormholeContract {
 
   static fromJson(
     chain: Chain,
-    parsed: { type: string; address: string },
+    parsed: {
+      type: string;
+      address: string;
+      guardianSetSource?: "wormhole" | "lazer";
+    },
   ): EvmWormholeContract {
     if (parsed.type !== EvmWormholeContract.type)
       throw new Error("Invalid type");
     if (!(chain instanceof EvmChain))
       throw new Error(`Wrong chain type ${chain}`);
-    return new EvmWormholeContract(chain, parsed.address);
+    return new EvmWormholeContract(
+      chain,
+      parsed.address,
+      parsed.guardianSetSource ?? "wormhole",
+    );
   }
 
   constructor(
     public chain: EvmChain,
     public address: string,
+    public guardianSetSource: "wormhole" | "lazer" = "wormhole",
   ) {
     super();
   }
@@ -133,6 +142,7 @@ export class EvmWormholeContract extends WormholeContract {
     return {
       address: this.address,
       chain: this.chain.getId(),
+      guardianSetSource: this.guardianSetSource,
       type: EvmWormholeContract.type,
     };
   }
@@ -543,19 +553,28 @@ export class EvmPriceFeedContract extends PriceFeedContract {
   constructor(
     public chain: EvmChain,
     public address: string,
+    public deploymentType?: DeploymentType,
   ) {
     super();
   }
 
   static fromJson(
     chain: Chain,
-    parsed: { type: string; address: string },
+    parsed: {
+      type: string;
+      address: string;
+      deploymentType?: DeploymentType;
+    },
   ): EvmPriceFeedContract {
     if (parsed.type !== EvmPriceFeedContract.type)
       throw new Error("Invalid type");
     if (!(chain instanceof EvmChain))
       throw new Error(`Wrong chain type ${chain}`);
-    return new EvmPriceFeedContract(chain, parsed.address);
+    return new EvmPriceFeedContract(
+      chain,
+      parsed.address,
+      parsed.deploymentType,
+    );
   }
 
   getId(): string {
@@ -748,6 +767,11 @@ export class EvmPriceFeedContract extends PriceFeedContract {
       address: this.address,
       chain: this.chain.getId(),
       type: EvmPriceFeedContract.type,
+      // Only emit deploymentType for entries that have it set; existing JSON
+      // entries without this field are left untouched on save.
+      ...(this.deploymentType !== undefined && {
+        deploymentType: this.deploymentType,
+      }),
     };
   }
 }

--- a/contract_manager/src/store/contracts/EvmPriceFeedContracts.json
+++ b/contract_manager/src/store/contracts/EvmPriceFeedContracts.json
@@ -948,5 +948,17 @@
     "address": "0xe9d69CdD6Fe41e7B621B4A688C5D1a68cB5c8ADc",
     "chain": "fluent",
     "type": "EvmPriceFeedContract"
+  },
+  {
+    "address": "0xc643e55EE8944F3017F4CB8C82aa3DB1AA2d8941",
+    "chain": "sepolia",
+    "deploymentType": "lazer-staging",
+    "type": "EvmPriceFeedContract"
+  },
+  {
+    "address": "0xa78951b6bADC9F4740f6f456E9144705D5C5E4B2",
+    "chain": "ethereum",
+    "deploymentType": "lazer-prod",
+    "type": "EvmPriceFeedContract"
   }
 ]

--- a/contract_manager/src/store/contracts/EvmWormholeContracts.json
+++ b/contract_manager/src/store/contracts/EvmWormholeContracts.json
@@ -2,1165 +2,973 @@
   {
     "address": "0x35a58BeeE77a2Ad547FcDed7e8CB1c6e19746b13",
     "chain": "polygon",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41955476936DdA8d0fA98b8d1778172F7E4fCcA1",
     "chain": "aurora",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x35a58BeeE77a2Ad547FcDed7e8CB1c6e19746b13",
     "chain": "fantom",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x87047526937246727E4869C5f76A347160e08672",
     "chain": "optimism",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xEbe57e8045F2F230872523bbff7374986E45C486",
     "chain": "arbitrum",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x26DD80569a8B23768A1d80869Ed7339e07595E85",
     "chain": "gnosis",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41955476936DdA8d0fA98b8d1778172F7E4fCcA1",
     "chain": "polygon_zkevm",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xDd24F84d36BF92C65F92307595335bdFab5Bbd21",
     "chain": "conflux_espace",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41955476936DdA8d0fA98b8d1778172F7E4fCcA1",
     "chain": "bsc",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x0708325268dF9F66270F1401206434524814508b",
     "chain": "kava",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41955476936DdA8d0fA98b8d1778172F7E4fCcA1",
     "chain": "avalanche",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xf0a1b566B55e0A0CB5BeF52Eb2a57142617Bee67",
     "chain": "canto",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x0708325268dF9F66270F1401206434524814508b",
     "chain": "linea",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xCd76c50c3210C5AaA9c39D53A4f95BFd8b1a3a19",
     "chain": "neon",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xf0a1b566B55e0A0CB5BeF52Eb2a57142617Bee67",
     "chain": "mantle",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xfA133831D350A2A5997d6db182B6Ca9e8ad4191B",
     "chain": "meter",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41955476936DdA8d0fA98b8d1778172F7E4fCcA1",
     "chain": "kcc",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xEbe57e8045F2F230872523bbff7374986E45C486",
     "chain": "eos",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41955476936DdA8d0fA98b8d1778172F7E4fCcA1",
     "chain": "celo",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xEbe57e8045F2F230872523bbff7374986E45C486",
     "chain": "wemix",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x87047526937246727E4869C5f76A347160e08672",
     "chain": "base",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x53cD6960888cA09361506678adfE267b4CE81A08",
     "chain": "zksync",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "horizen_eon",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "shimmer",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x26DD80569a8B23768A1d80869Ed7339e07595E85",
     "chain": "boba",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "manta",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "scroll",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "chiliz",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "coredao",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "viction",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xfA25E653b44586dBbe27eE9d252192F0e4956683",
     "chain": "arbitrum_sepolia",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x5744Cbf430D99456a0A8771208b674F27f8EF0Fb",
     "chain": "fuji",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c",
     "chain": "canto_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x2880aB155794e7179c9eE2e38200202908C17B43",
     "chain": "aurora_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x87047526937246727E4869C5f76A347160e08672",
     "chain": "chiado",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xD458261E832415CFd3BAE5E416FdF3230ce6F134",
     "chain": "kava_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xEbe57e8045F2F230872523bbff7374986E45C486",
     "chain": "conflux_espace_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x2880aB155794e7179c9eE2e38200202908C17B43",
     "chain": "celo_alfajores_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xe9d69CdD6Fe41e7B621B4A688C5D1a68cB5c8ADc",
     "chain": "bsc_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x2880aB155794e7179c9eE2e38200202908C17B43",
     "chain": "kcc_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8D254a21b3C86D32F7179855531CE99164721933",
     "chain": "eos_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x257c3B61102442C1c3286Efbd24242322d002920",
     "chain": "meter_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x98046Bd286715D3B0BC227Dd7a956b83D8978603",
     "chain": "shimmer_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320",
     "chain": "scroll_sepolia",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x98046Bd286715D3B0BC227Dd7a956b83D8978603",
     "chain": "boba_goerli",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x98046Bd286715D3B0BC227Dd7a956b83D8978603",
     "chain": "manta_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x98046Bd286715D3B0BC227Dd7a956b83D8978603",
     "chain": "chiliz_spicy",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x98046Bd286715D3B0BC227Dd7a956b83D8978603",
     "chain": "coredao_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E",
     "chain": "cronos_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c",
     "chain": "wemix_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x2880aB155794e7179c9eE2e38200202908C17B43",
     "chain": "evmos_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8D254a21b3C86D32F7179855531CE99164721933",
     "chain": "zetachain_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509",
     "chain": "neon_devnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8D254a21b3C86D32F7179855531CE99164721933",
     "chain": "optimism_sepolia",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "mode",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "mode_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "bttc_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "bttc",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xc10F5BE78E464BB0E1f534D66E5A6ecaB150aEFa",
     "chain": "zksync_sepolia",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "base_sepolia",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "movement_evm_devnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "zkfair_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "blast_s2_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "zkfair",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "filecoin_calibration",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "filecoin",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "zetachain",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x5f3c61944CEb01B3eAef861251Fb1E0f14b848fb",
     "chain": "lightlink_pegasus_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "dela_deperp_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "lightlink_phoenix",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "injective_inevm_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "injective_inevm",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "hedera_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "hedera",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "blast",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "astar_zkevm",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "merlin_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x66E9cBa5529824a03B5Bc9931d9c63637101D0F7",
     "chain": "mantle_sepolia",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "merlin",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "manta_sepolia",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "polygon_blackberry",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "arbitrum_blueberry",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "optimism_celestia_raspberry",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x87047526937246727E4869C5f76A347160e08672",
     "chain": "polynomial_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x87047526937246727E4869C5f76A347160e08672",
     "chain": "parallel_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "parallel",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "linea_sepolia",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "morph_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41955476936DdA8d0fA98b8d1778172F7E4fCcA1",
     "chain": "cronos",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41955476936DdA8d0fA98b8d1778172F7E4fCcA1",
     "chain": "ronin",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320",
     "chain": "saigon",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E",
     "chain": "ethereum",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x876A4e56A51386aBb1a5ab5d62f77E814372f0C7",
     "chain": "mumbai",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xe9d69CdD6Fe41e7B621B4A688C5D1a68cB5c8ADc",
     "chain": "fantom_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c",
     "chain": "sepolia",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xfA25E653b44586dBbe27eE9d252192F0e4956683",
     "chain": "linea_goerli",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "taiko_hekla",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E",
     "chain": "olive_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "orange_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "polygon_amoy",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "taiko_mainnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "sei_evm_mainnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x66E9cBa5529824a03B5Bc9931d9c63637101D0F7",
     "chain": "dela_mithreum_deperp_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "opbnb",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "gravity",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E",
     "chain": "opbnb_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "etherlink_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "polynomial",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "etherlink",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "sei_evm_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "kaia_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "kaia",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "morph_holesky_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "b3_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "kinto",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "reya_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "b3_mainnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xc10F5BE78E464BB0E1f534D66E5A6ecaB150aEFa",
     "chain": "cronos_zkevm_mainnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x470d1c91b1b1d9295815A2357FB0D20E7350ab71",
     "chain": "cronos_zkevm_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "movement_evm_devnet_imola",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "flow_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "idex_xchain_mainnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "apechain_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "soneium_minato_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "apechain_mainnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "flow_mainnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xB1DB1498902F08E16E11F1a423ec9CCB9537E1D6",
     "chain": "abstract_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "sanko",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "sanko_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "unichain_sepolia",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "kakarot_sepolia",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "skate",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "skate_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "morph",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "kraken_ink_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "ethena_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "superseed_mainnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "superseed_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "hemi_mainnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x35a58BeeE77a2Ad547FcDed7e8CB1c6e19746b13",
     "chain": "tabi_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "hyperevm_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "unichain",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x056f829183Ec806A78c26C98961678c24faB71af",
     "chain": "abstract",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "eventum_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "sonic_blaze_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "fantom_sonic_mainnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "eventum_mainnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "soneium",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "kraken_ink_mainnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "coredao_testnet_v2",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "berachain_mainnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c",
     "chain": "story",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "bittensor_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x66E9cBa5529824a03B5Bc9931d9c63637101D0F7",
     "chain": "hyperevm",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "bittensor_mainnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "story_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "berachain_bepolia",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "megaeth_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x66E9cBa5529824a03B5Bc9931d9c63637101D0F7",
     "chain": "worldchain",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509",
     "chain": "swellchain",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320",
     "chain": "swellchain_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "worldchain_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "mezo_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "hemi_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "converge_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "mezo",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509",
     "chain": "injective_evm_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E",
     "chain": "ethereal_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "camp_network",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "ethereal_devnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x66E9cBa5529824a03B5Bc9931d9c63637101D0F7",
     "chain": "ethereal_testnet_v2",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "fluent_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "monad",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "zero_gravity",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "giwa_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x35a58BeeE77a2Ad547FcDed7e8CB1c6e19746b13",
     "chain": "ethereal",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "plasma",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "sonic_evm_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x2880aB155794e7179c9eE2e38200202908C17B43",
     "chain": "injective_evm",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "etherlink_new_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "hoodi",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "taiko_hoodi",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "morph_hoodi",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "orange",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "celo_sepolia_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "monad_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "arc_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41955476936DdA8d0fA98b8d1778172F7E4fCcA1",
     "chain": "tempo_testnet",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "tempo",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "megaeth",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x87047526937246727E4869C5f76A347160e08672",
     "chain": "iota",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "fluent",
-    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x636915338a2f5Ff0F332636be44fc124a9842A74",
     "chain": "sepolia",
-    "guardianSetSource": "lazer",
-    "type": "EvmWormholeContract"
+    "type": "EvmWormholeContract",
+    "deploymentType": "lazer-staging"
   },
   {
     "address": "0x237b7aFF1Af5d9F311f830234792d429355A58F3",
     "chain": "ethereum",
-    "guardianSetSource": "lazer",
-    "type": "EvmWormholeContract"
+    "type": "EvmWormholeContract",
+    "deploymentType": "lazer-prod"
   }
 ]

--- a/contract_manager/src/store/contracts/EvmWormholeContracts.json
+++ b/contract_manager/src/store/contracts/EvmWormholeContracts.json
@@ -2,961 +2,1165 @@
   {
     "address": "0x35a58BeeE77a2Ad547FcDed7e8CB1c6e19746b13",
     "chain": "polygon",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41955476936DdA8d0fA98b8d1778172F7E4fCcA1",
     "chain": "aurora",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x35a58BeeE77a2Ad547FcDed7e8CB1c6e19746b13",
     "chain": "fantom",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x87047526937246727E4869C5f76A347160e08672",
     "chain": "optimism",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xEbe57e8045F2F230872523bbff7374986E45C486",
     "chain": "arbitrum",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x26DD80569a8B23768A1d80869Ed7339e07595E85",
     "chain": "gnosis",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41955476936DdA8d0fA98b8d1778172F7E4fCcA1",
     "chain": "polygon_zkevm",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xDd24F84d36BF92C65F92307595335bdFab5Bbd21",
     "chain": "conflux_espace",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41955476936DdA8d0fA98b8d1778172F7E4fCcA1",
     "chain": "bsc",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x0708325268dF9F66270F1401206434524814508b",
     "chain": "kava",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41955476936DdA8d0fA98b8d1778172F7E4fCcA1",
     "chain": "avalanche",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xf0a1b566B55e0A0CB5BeF52Eb2a57142617Bee67",
     "chain": "canto",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x0708325268dF9F66270F1401206434524814508b",
     "chain": "linea",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xCd76c50c3210C5AaA9c39D53A4f95BFd8b1a3a19",
     "chain": "neon",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xf0a1b566B55e0A0CB5BeF52Eb2a57142617Bee67",
     "chain": "mantle",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xfA133831D350A2A5997d6db182B6Ca9e8ad4191B",
     "chain": "meter",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41955476936DdA8d0fA98b8d1778172F7E4fCcA1",
     "chain": "kcc",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xEbe57e8045F2F230872523bbff7374986E45C486",
     "chain": "eos",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41955476936DdA8d0fA98b8d1778172F7E4fCcA1",
     "chain": "celo",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xEbe57e8045F2F230872523bbff7374986E45C486",
     "chain": "wemix",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x87047526937246727E4869C5f76A347160e08672",
     "chain": "base",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x53cD6960888cA09361506678adfE267b4CE81A08",
     "chain": "zksync",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "horizen_eon",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "shimmer",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x26DD80569a8B23768A1d80869Ed7339e07595E85",
     "chain": "boba",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "manta",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "scroll",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "chiliz",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "coredao",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "viction",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xfA25E653b44586dBbe27eE9d252192F0e4956683",
     "chain": "arbitrum_sepolia",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x5744Cbf430D99456a0A8771208b674F27f8EF0Fb",
     "chain": "fuji",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c",
     "chain": "canto_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x2880aB155794e7179c9eE2e38200202908C17B43",
     "chain": "aurora_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x87047526937246727E4869C5f76A347160e08672",
     "chain": "chiado",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xD458261E832415CFd3BAE5E416FdF3230ce6F134",
     "chain": "kava_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xEbe57e8045F2F230872523bbff7374986E45C486",
     "chain": "conflux_espace_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x2880aB155794e7179c9eE2e38200202908C17B43",
     "chain": "celo_alfajores_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xe9d69CdD6Fe41e7B621B4A688C5D1a68cB5c8ADc",
     "chain": "bsc_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x2880aB155794e7179c9eE2e38200202908C17B43",
     "chain": "kcc_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8D254a21b3C86D32F7179855531CE99164721933",
     "chain": "eos_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x257c3B61102442C1c3286Efbd24242322d002920",
     "chain": "meter_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x98046Bd286715D3B0BC227Dd7a956b83D8978603",
     "chain": "shimmer_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320",
     "chain": "scroll_sepolia",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x98046Bd286715D3B0BC227Dd7a956b83D8978603",
     "chain": "boba_goerli",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x98046Bd286715D3B0BC227Dd7a956b83D8978603",
     "chain": "manta_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x98046Bd286715D3B0BC227Dd7a956b83D8978603",
     "chain": "chiliz_spicy",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x98046Bd286715D3B0BC227Dd7a956b83D8978603",
     "chain": "coredao_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E",
     "chain": "cronos_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c",
     "chain": "wemix_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x2880aB155794e7179c9eE2e38200202908C17B43",
     "chain": "evmos_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8D254a21b3C86D32F7179855531CE99164721933",
     "chain": "zetachain_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509",
     "chain": "neon_devnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8D254a21b3C86D32F7179855531CE99164721933",
     "chain": "optimism_sepolia",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "mode",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "mode_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "bttc_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "bttc",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xc10F5BE78E464BB0E1f534D66E5A6ecaB150aEFa",
     "chain": "zksync_sepolia",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "base_sepolia",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "movement_evm_devnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "zkfair_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "blast_s2_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "zkfair",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "filecoin_calibration",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "filecoin",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "zetachain",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x5f3c61944CEb01B3eAef861251Fb1E0f14b848fb",
     "chain": "lightlink_pegasus_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "dela_deperp_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "lightlink_phoenix",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "injective_inevm_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "injective_inevm",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "hedera_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "hedera",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "blast",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "astar_zkevm",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "merlin_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x66E9cBa5529824a03B5Bc9931d9c63637101D0F7",
     "chain": "mantle_sepolia",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "merlin",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "manta_sepolia",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "polygon_blackberry",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "arbitrum_blueberry",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "optimism_celestia_raspberry",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x87047526937246727E4869C5f76A347160e08672",
     "chain": "polynomial_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x87047526937246727E4869C5f76A347160e08672",
     "chain": "parallel_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "parallel",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "linea_sepolia",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "morph_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41955476936DdA8d0fA98b8d1778172F7E4fCcA1",
     "chain": "cronos",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41955476936DdA8d0fA98b8d1778172F7E4fCcA1",
     "chain": "ronin",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320",
     "chain": "saigon",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E",
     "chain": "ethereum",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x876A4e56A51386aBb1a5ab5d62f77E814372f0C7",
     "chain": "mumbai",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xe9d69CdD6Fe41e7B621B4A688C5D1a68cB5c8ADc",
     "chain": "fantom_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c",
     "chain": "sepolia",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xfA25E653b44586dBbe27eE9d252192F0e4956683",
     "chain": "linea_goerli",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "taiko_hekla",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E",
     "chain": "olive_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "orange_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "polygon_amoy",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "taiko_mainnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "sei_evm_mainnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x66E9cBa5529824a03B5Bc9931d9c63637101D0F7",
     "chain": "dela_mithreum_deperp_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "opbnb",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "gravity",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E",
     "chain": "opbnb_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "etherlink_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "polynomial",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "etherlink",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "sei_evm_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "kaia_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "kaia",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "morph_holesky_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "b3_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "kinto",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "reya_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "b3_mainnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xc10F5BE78E464BB0E1f534D66E5A6ecaB150aEFa",
     "chain": "cronos_zkevm_mainnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x470d1c91b1b1d9295815A2357FB0D20E7350ab71",
     "chain": "cronos_zkevm_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "movement_evm_devnet_imola",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "flow_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "idex_xchain_mainnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "apechain_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "soneium_minato_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "apechain_mainnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "flow_mainnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xB1DB1498902F08E16E11F1a423ec9CCB9537E1D6",
     "chain": "abstract_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "sanko",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "sanko_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "unichain_sepolia",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "kakarot_sepolia",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "skate",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "skate_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "morph",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "kraken_ink_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "ethena_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "superseed_mainnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "superseed_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "hemi_mainnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x35a58BeeE77a2Ad547FcDed7e8CB1c6e19746b13",
     "chain": "tabi_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "hyperevm_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "unichain",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x056f829183Ec806A78c26C98961678c24faB71af",
     "chain": "abstract",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "eventum_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "sonic_blaze_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "fantom_sonic_mainnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "eventum_mainnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "soneium",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "kraken_ink_mainnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "coredao_testnet_v2",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "berachain_mainnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c",
     "chain": "story",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "bittensor_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x66E9cBa5529824a03B5Bc9931d9c63637101D0F7",
     "chain": "hyperevm",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "bittensor_mainnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "story_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "berachain_bepolia",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "megaeth_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x66E9cBa5529824a03B5Bc9931d9c63637101D0F7",
     "chain": "worldchain",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509",
     "chain": "swellchain",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320",
     "chain": "swellchain_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "worldchain_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "mezo_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "hemi_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "converge_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "mezo",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509",
     "chain": "injective_evm_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E",
     "chain": "ethereal_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "camp_network",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "ethereal_devnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x66E9cBa5529824a03B5Bc9931d9c63637101D0F7",
     "chain": "ethereal_testnet_v2",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "fluent_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "monad",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "zero_gravity",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "giwa_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x35a58BeeE77a2Ad547FcDed7e8CB1c6e19746b13",
     "chain": "ethereal",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "plasma",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "sonic_evm_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x2880aB155794e7179c9eE2e38200202908C17B43",
     "chain": "injective_evm",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "etherlink_new_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
     "chain": "hoodi",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "taiko_hoodi",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "morph_hoodi",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "orange",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "celo_sepolia_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "monad_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "arc_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x41955476936DdA8d0fA98b8d1778172F7E4fCcA1",
     "chain": "tempo_testnet",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "tempo",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "megaeth",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0x87047526937246727E4869C5f76A347160e08672",
     "chain": "iota",
+    "guardianSetSource": "wormhole",
     "type": "EvmWormholeContract"
   },
   {
     "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
     "chain": "fluent",
+    "guardianSetSource": "wormhole",
+    "type": "EvmWormholeContract"
+  },
+  {
+    "address": "0x636915338a2f5Ff0F332636be44fc124a9842A74",
+    "chain": "sepolia",
+    "guardianSetSource": "lazer",
+    "type": "EvmWormholeContract"
+  },
+  {
+    "address": "0x237b7aFF1Af5d9F311f830234792d429355A58F3",
+    "chain": "ethereum",
+    "guardianSetSource": "lazer",
     "type": "EvmWormholeContract"
   }
 ]

--- a/target_chains/ethereum/contracts/contracts/wormhole-receiver/ReceiverImplementationHalf.sol
+++ b/target_chains/ethereum/contracts/contracts/wormhole-receiver/ReceiverImplementationHalf.sol
@@ -1,0 +1,18 @@
+// contracts/ImplementationHalf.sol
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+pragma experimental ABIEncoderV2;
+
+import "./ReceiverImplementation.sol";
+
+/// @dev Variant of `ReceiverImplementation` that requires only a 1/2 + 1
+/// majority of guardian signatures to verify a VAA, instead of the default
+/// 2/3 + 1.
+contract ReceiverImplementationHalf is ReceiverImplementation {
+    function quorumThreshold(
+        uint numGuardians
+    ) internal pure override returns (uint) {
+        return numGuardians / 2 + 1;
+    }
+}

--- a/target_chains/ethereum/contracts/contracts/wormhole-receiver/ReceiverMessages.sol
+++ b/target_chains/ethereum/contracts/contracts/wormhole-receiver/ReceiverMessages.sol
@@ -15,6 +15,17 @@ error SignatureIndexesNotAscending();
 contract ReceiverMessages is ReceiverGetters {
     using BytesLib for bytes;
 
+    /// @dev Returns the minimum number of guardian signatures required to reach
+    /// quorum for a guardian set of size `numGuardians`. Default is 2/3 + 1
+    /// (the BFT threshold). Implementations may override this to enforce a
+    /// different threshold (e.g. 1/2 + 1).
+    function quorumThreshold(
+        uint numGuardians
+    ) internal pure virtual returns (uint) {
+        // fixed-point trick with 1 decimal to avoid integer-rounding bugs
+        return (((numGuardians * 10) / 3) * 2) / 10 + 1;
+    }
+
     /// @dev parseAndVerifyVM serves to parse an encodedVM and wholy validate it for consumption
     /// WARNING: it intentionally sets vm.signatures to an empty array since it is not needed after it is validated in this function
     /// since it not used anywhere. If you need to use vm.signatures, use parseVM and verifyVM separately.
@@ -128,15 +139,13 @@ contract ReceiverMessages is ReceiverGetters {
             }
 
             /**
-             * @dev We're using a fixed point number transformation with 1 decimal to deal with rounding.
+             * @dev See `quorumThreshold` for the threshold computation.
              *   WARNING: This quorum check is critical to assessing whether we have enough Guardian signatures to validate a VM
              *   if making any changes to this, obtain additional peer review. If guardianSet key length is 0 and
              *   vm.signatures length is 0, this could compromise the integrity of both vm and signature verification.
              */
 
-            if (
-                (((guardianSet.keys.length * 10) / 3) * 2) / 10 + 1 > signersLen
-            ) {
+            if (quorumThreshold(guardianSet.keys.length) > signersLen) {
                 return (vm, false, "no quorum");
             }
 
@@ -217,15 +226,12 @@ contract ReceiverMessages is ReceiverGetters {
         }
 
         /**
-         * @dev We're using a fixed point number transformation with 1 decimal to deal with rounding.
+         * @dev See `quorumThreshold` for the threshold computation.
          *   WARNING: This quorum check is critical to assessing whether we have enough Guardian signatures to validate a VM
          *   if making any changes to this, obtain additional peer review. If guardianSet key length is 0 and
          *   vm.signatures length is 0, this could compromise the integrity of both vm and signature verification.
          */
-        if (
-            (((guardianSet.keys.length * 10) / 3) * 2) / 10 + 1 >
-            vm.signatures.length
-        ) {
+        if (quorumThreshold(guardianSet.keys.length) > vm.signatures.length) {
             return (false, "no quorum");
         }
 

--- a/target_chains/ethereum/contracts/test/WormholeReceiverHalf.t.sol
+++ b/target_chains/ethereum/contracts/test/WormholeReceiverHalf.t.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import "../contracts/wormhole/interfaces/IWormhole.sol";
+import "./utils/WormholeTestUtils.t.sol";
+
+contract WormholeReceiverHalfTest is Test, WormholeTestUtils {
+    uint32 constant TEST_VAA_TIMESTAMP = 112;
+    uint16 constant TEST_EMITTER_CHAIN_ID = 7;
+    bytes32 constant TEST_EMITTER_ADDR =
+        0x0000000000000000000000000000000000000000000000000000000000000bad;
+    uint64 constant TEST_SEQUENCE = 10;
+    bytes constant TEST_PAYLOAD = hex"deadbeaf";
+
+    function _vaa(uint8 numSigners) internal view returns (bytes memory) {
+        return
+            generateVaa(
+                TEST_VAA_TIMESTAMP,
+                TEST_EMITTER_CHAIN_ID,
+                TEST_EMITTER_ADDR,
+                TEST_SEQUENCE,
+                TEST_PAYLOAD,
+                numSigners
+            );
+    }
+
+    // n=5: half threshold = 5/2 + 1 = 3 (default 2/3+1 would be 4)
+    function testHalfAcceptsAtThresholdOddGuardians() public {
+        IWormhole wh = IWormhole(setUpWormholeReceiverHalf(5));
+        (, bool valid, string memory reason) = wh.parseAndVerifyVM(_vaa(3));
+        assertTrue(valid);
+        assertEq(reason, "");
+    }
+
+    function testHalfRejectsBelowThresholdOddGuardians() public {
+        IWormhole wh = IWormhole(setUpWormholeReceiverHalf(5));
+        (, bool valid, string memory reason) = wh.parseAndVerifyVM(_vaa(2));
+        assertFalse(valid);
+        assertEq(reason, "no quorum");
+    }
+
+    // n=6: half threshold = 6/2 + 1 = 4 (default 2/3+1 would be 5)
+    function testHalfAcceptsAtThresholdEvenGuardians() public {
+        IWormhole wh = IWormhole(setUpWormholeReceiverHalf(6));
+        (, bool valid, string memory reason) = wh.parseAndVerifyVM(_vaa(4));
+        assertTrue(valid);
+        assertEq(reason, "");
+    }
+
+    function testHalfRejectsBelowThresholdEvenGuardians() public {
+        IWormhole wh = IWormhole(setUpWormholeReceiverHalf(6));
+        (, bool valid, string memory reason) = wh.parseAndVerifyVM(_vaa(3));
+        assertFalse(valid);
+        assertEq(reason, "no quorum");
+    }
+
+    // The key behavioural difference: a VAA that would be rejected under the
+    // default 2/3+1 quorum is accepted under the half-quorum variant.
+    function testHalfAcceptsVaaBelowDefaultTwoThirds() public {
+        // n=6: 4 sigs is below 2/3+1=5 but at half=4
+        IWormhole wh = IWormhole(setUpWormholeReceiverHalf(6));
+        (, bool valid, ) = wh.parseAndVerifyVM(_vaa(4));
+        assertTrue(valid);
+    }
+
+    function testDefaultRejectsVaaThatHalfAccepts() public {
+        // Same shape as above, but on the default impl: must be rejected.
+        IWormhole wh = IWormhole(setUpWormholeReceiver(6));
+        (, bool valid, string memory reason) = wh.parseAndVerifyVM(_vaa(4));
+        assertFalse(valid);
+        assertEq(reason, "no quorum");
+    }
+
+    // n=19 (canonical Wormhole guardian set size): half=10, default=13.
+    function testHalfLargeGuardianSetThreshold() public {
+        IWormhole wh = IWormhole(setUpWormholeReceiverHalf(19));
+
+        (, bool validAt, string memory reasonAt) = wh.parseAndVerifyVM(
+            _vaa(10)
+        );
+        assertTrue(validAt);
+        assertEq(reasonAt, "");
+
+        (, bool validBelow, string memory reasonBelow) = wh.parseAndVerifyVM(
+            _vaa(9)
+        );
+        assertFalse(validBelow);
+        assertEq(reasonBelow, "no quorum");
+    }
+
+    function testHalfAcceptsAboveThreshold() public {
+        // All guardians signing should always work.
+        IWormhole wh = IWormhole(setUpWormholeReceiverHalf(5));
+        (, bool valid, string memory reason) = wh.parseAndVerifyVM(_vaa(5));
+        assertTrue(valid);
+        assertEq(reason, "");
+    }
+}

--- a/target_chains/ethereum/contracts/test/utils/WormholeTestUtils.t.sol
+++ b/target_chains/ethereum/contracts/test/utils/WormholeTestUtils.t.sol
@@ -8,6 +8,7 @@ import "../../contracts/wormhole/Wormhole.sol";
 import "../../contracts/wormhole/interfaces/IWormhole.sol";
 
 import "../../contracts/wormhole-receiver/ReceiverImplementation.sol";
+import "../../contracts/wormhole-receiver/ReceiverImplementationHalf.sol";
 import "../../contracts/wormhole-receiver/ReceiverSetup.sol";
 import "../../contracts/wormhole-receiver/WormholeReceiver.sol";
 import "../../contracts/wormhole-receiver/ReceiverGovernanceStructs.sol";
@@ -47,6 +48,37 @@ abstract contract WormholeTestUtils is Test {
         );
 
         return address(wormhole);
+    }
+
+    function setUpWormholeReceiverHalf(
+        uint8 numGuardians
+    ) public returns (address) {
+        ReceiverImplementationHalf wormholeReceiverImpl = new ReceiverImplementationHalf();
+        ReceiverSetup wormholeReceiverSetup = new ReceiverSetup();
+
+        WormholeReceiver wormholeReceiver = new WormholeReceiver(
+            address(wormholeReceiverSetup),
+            new bytes(0)
+        );
+
+        address[] memory initSigners = new address[](numGuardians);
+        currentSigners = new uint256[](numGuardians);
+
+        for (uint256 i = 0; i < numGuardians; ++i) {
+            currentSigners[i] = i + 1;
+            initSigners[i] = vm.addr(currentSigners[i]);
+        }
+
+        ReceiverSetup(address(wormholeReceiver)).setup(
+            address(wormholeReceiverImpl),
+            initSigners,
+            CHAIN_ID,
+            GOVERNANCE_CHAIN_ID,
+            GOVERNANCE_CONTRACT
+        );
+        wormholeReceiverAddr = address(wormholeReceiver);
+
+        return wormholeReceiverAddr;
     }
 
     function setUpWormholeReceiver(


### PR DESCRIPTION
## Summary

add lazer hermes evm deployment

Add a new wormhole contract version to support 1/2 + 1 guardians
Update contract manager to be able to deploy pyth contracts for lazer hermes

## Rationale

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
