### PR TITLE
feat(solana-cli): support guardian set 6 and per-chain Wormhole config

### DIFF
--- a/target_chains/solana/cli/src/cli.rs
+++ b/target_chains/solana/cli/src/cli.rs
@@ -1,8 +1,15 @@
 use {
+    anyhow::{anyhow, Result},
     clap::{Parser, Subcommand},
     solana_sdk::pubkey::Pubkey,
     std::str::FromStr,
 };
+
+pub fn require_wormhole(wormhole: Option<Pubkey>) -> Result<Pubkey> {
+    wormhole.ok_or_else(|| {
+        anyhow!("--wormhole/-w is required for this subcommand (only `initialize-wormhole-receiver-all-svm` may omit it)")
+    })
+}
 
 #[derive(Parser, Debug)]
 #[clap(
@@ -24,8 +31,13 @@ pub struct Cli {
         help = "RPC endpoint of the solana"
     )]
     pub url: String,
-    #[clap(short = 'w', long, parse(try_from_str = Pubkey::from_str), help = "Address of the wormhole contract")]
-    pub wormhole: Pubkey,
+    #[clap(
+        short = 'w',
+        long,
+        parse(try_from_str = Pubkey::from_str),
+        help = "Address of the wormhole contract. Required for all subcommands except `initialize-wormhole-receiver-all-svm`, which uses the per-chain address from the built-in chain table."
+    )]
+    pub wormhole: Option<Pubkey>,
     #[clap(subcommand)]
     pub action: Action,
 }
@@ -66,7 +78,13 @@ pub enum Action {
     #[clap(
         about = "Initialize a wormhole receiver contract by sequentially replaying the guardian set updates"
     )]
-    InitializeWormholeReceiver {},
+    InitializeWormholeReceiver {
+        #[clap(
+            long,
+            help = "Treat the on-chain guardian set account as the legacy (non-Anchor) layout for every upgrade step. Required for Pythnet and other deployments running the legacy Wormhole bridge program."
+        )]
+        legacy: bool,
+    },
     #[clap(about = "Initialize wormhole receiver on all known SVM chains with retries")]
     InitializeWormholeReceiverAllSvm {
         #[clap(

--- a/target_chains/solana/cli/src/main.rs
+++ b/target_chains/solana/cli/src/main.rs
@@ -5,7 +5,7 @@ use {
     anyhow::{anyhow, Context, Result},
     borsh::BorshDeserialize,
     clap::Parser,
-    cli::{Action, Cli},
+    cli::{require_wormhole, Action, Cli},
     pyth_solana_receiver::sdk::{
         deserialize_accumulator_update_data, get_random_treasury_id, VAA_SPLIT_INDEX,
     },
@@ -24,7 +24,7 @@ use {
         system_instruction,
         transaction::Transaction,
     },
-    std::{thread::sleep, time::Duration},
+    std::{str::FromStr, thread::sleep, time::Duration},
     wormhole_core_bridge_solana::sdk::{WriteEncodedVaaArgs, VAA_START},
     wormhole_sdk::{
         vaa::{Body, Header},
@@ -44,24 +44,77 @@ const UPGRADE_GUARDIAN_SET_VAA_2 : &str = "01000000010d0012e6b39c6da90c5dfd3c228
 const UPGRADE_GUARDIAN_SET_VAA_3 : &str = "01000000020d00ce45474d9e1b1e7790a2d210871e195db53a70ffd6f237cfe70e2686a32859ac43c84a332267a8ef66f59719cf91cc8df0101fd7c36aa1878d5139241660edc0010375cc906156ae530786661c0cd9aef444747bc3d8d5aa84cac6a6d2933d4e1a031cffa30383d4af8131e929d9f203f460b07309a647d6cd32ab1cc7724089392c000452305156cfc90343128f97e499311b5cae174f488ff22fbc09591991a0a73d8e6af3afb8a5968441d3ab8437836407481739e9850ad5c95e6acfcc871e951bc30105a7956eefc23e7c945a1966d5ddbe9e4be376c2f54e45e3d5da88c2f8692510c7429b1ea860ae94d929bd97e84923a18187e777aa3db419813a80deb84cc8d22b00061b2a4f3d2666608e0aa96737689e3ba5793810ff3a52ff28ad57d8efb20967735dc5537a2e43ef10f583d144c12a1606542c207f5b79af08c38656d3ac40713301086b62c8e130af3411b3c0d91b5b50dcb01ed5f293963f901fc36e7b0e50114dce203373b32eb45971cef8288e5d928d0ed51cd86e2a3006b0af6a65c396c009080009e93ab4d2c8228901a5f4525934000b2c26d1dc679a05e47fdf0ff3231d98fbc207103159ff4116df2832eea69b38275283434e6cd4a4af04d25fa7a82990b707010aa643f4cf615dfff06ffd65830f7f6cf6512dabc3690d5d9e210fdc712842dc2708b8b2c22e224c99280cd25e5e8bfb40e3d1c55b8c41774e287c1e2c352aecfc010b89c1e85faa20a30601964ccc6a79c0ae53cfd26fb10863db37783428cd91390a163346558239db3cd9d420cfe423a0df84c84399790e2e308011b4b63e6b8015010ca31dcb564ac81a053a268d8090e72097f94f366711d0c5d13815af1ec7d47e662e2d1bde22678113d15963da100b668ba26c0c325970d07114b83c5698f46097010dc9fda39c0d592d9ed92cd22b5425cc6b37430e236f02d0d1f8a2ef45a00bde26223c0a6eb363c8b25fd3bf57234a1d9364976cefb8360e755a267cbbb674b39501108db01e444ab1003dd8b6c96f8eb77958b40ba7a85fefecf32ad00b7a47c0ae7524216262495977e09c0989dd50f280c21453d3756843608eacd17f4fdfe47600001261025228ef5af837cb060bcd986fcfa84ccef75b3fa100468cfd24e7fadf99163938f3b841a33496c2706d0208faab088bd155b2e20fd74c625bb1cc8c43677a0163c53c409e0c5dfa000100000000000000000000000000000000000000000000000000000000000000046c5a054d7833d1e42000000000000000000000000000000000000000000000000000000000436f7265020000000000031358cc3ae5c097b213ce3c81979e1b9f9570746aa5ff6cb952589bde862c25ef4392132fb9d4a42157114de8460193bdf3a2fcf81f86a09765f4762fd1107a0086b32d7a0977926a205131d8731d39cbeb8c82b2fd82faed2711d59af0f2499d16e726f6b211b39756c042441be6d8650b69b54ebe715e234354ce5b4d348fb74b958e8966e2ec3dbd4958a7cd15e7caf07c4e3dc8e7c469f92c8cd88fb8005a2074a3bf913953d695260d88bc1aa25a4eee363ef0000ac0076727b35fbea2dac28fee5ccb0fea768eaf45ced136b9d9e24903464ae889f5c8a723fc14f93124b7c738843cbb89e864c862c38cddcccf95d2cc37a4dc036a8d232b48f62cdd4731412f4890da798f6896a3331f64b48c12d1d57fd9cbe7081171aa1be1d36cafe3867910f99c09e347899c19c38192b6e7387ccd768277c17dab1b7a5027c0b3cf178e21ad2e77ae06711549cfbb1f9c7a9d8096e85e1487f35515d02a92753504a8d75471b9f49edb6fbebc898f403e4773e95feb15e80c9a99c8348d";
 const UPGRADE_GUARDIAN_SET_VAA_4 : &str = "01000000030d03d4a37a6ff4361d91714730831e9d49785f61624c8f348a9c6c1d82bc1d98cadc5e936338204445c6250bb4928f3f3e165ad47ca03a5d63111168a2de4576856301049a5df10464ea4e1961589fd30fc18d1970a7a2ffaad617e56a0f7777f25275253af7d10a0f0f2494dc6e99fc80e444ab9ebbbee252ded2d5dcb50cbf7a54bb5a01055f4603b553b9ba9e224f9c55c7bca3da00abb10abd19e0081aecd3b352be061a70f79f5f388ebe5190838ef3cd13a2f22459c9a94206883b739c90b40d5d74640006a8fade3997f650a36e46bceb1f609edff201ab32362266f166c5c7da713f6a19590c20b68ed3f0119cb24813c727560ede086b3d610c2d7a1efa66f655bad90900080f5e495a75ea52241c59d145c616bfac01e57182ad8d784cbcc9862ed3afb60c0983ccbc690553961ffcf115a0c917367daada8e60be2cbb8b8008bac6341a8c010935ab11e0eea28b87a1edc5ccce3f1fac25f75b5f640fe6b0673a7cd74513c9dc01c544216cf364cc9993b09fda612e0cd1ced9c00fb668b872a16a64ebb55d27010ab2bc39617a2396e7defa24cd7c22f42dc31f3c42ffcd9d1472b02df8468a4d0563911e8fb6a4b5b0ce0bd505daa53779b08ff660967b31f246126ed7f6f29a7e000bdb6d3fd7b33bdc9ac3992916eb4aacb97e7e21d19649e7fa28d2dd6e337937e4274516a96c13ac7a8895da9f91948ea3a09c25f44b982c62ce8842b58e20c8a9000d3d1b19c8bb000856b6610b9d28abde6c35cb7705c6ca5db711f7be96d60eed9d72cfa402a6bfe8bf0496dbc7af35796fc768da51a067b95941b3712dce8ae1e7010ec80085033157fd1a5628fc0c56267469a86f0e5a66d7dede1ad4ce74ecc3dff95b60307a39c3bfbeedc915075070da30d0395def9635130584f709b3885e1bdc0010fc480eb9ee715a2d151b23722b48b42581d7f4001fc1696c75425040bfc1ffc5394fe418adb2b64bd3dc692efda4cc408163677dbe233b16bcdabb853a20843301118ee9e115e1a0c981f19d0772b850e666591322da742a9a12cce9f52a5665bd474abdd59c580016bee8aae67fdf39b315be2528d12eec3a652910e03cc4c6fa3801129d0d1e2e429e969918ec163d16a7a5b2c6729aa44af5dccad07d25d19891556a79b574f42d9adbd9e2a9ae5a6b8750331d2fccb328dd94c3bf8791ee1bfe85aa00661e99781981faea00010000000000000000000000000000000000000000000000000000000000000004fd4c6c55ec8dfd342000000000000000000000000000000000000000000000000000000000436f726502000000000004135893b5a76c3f739645648885bdccc06cd70a3cd3ff6cb952589bde862c25ef4392132fb9d4a42157114de8460193bdf3a2fcf81f86a09765f4762fd1107a0086b32d7a0977926a205131d8731d39cbeb8c82b2fd82faed2711d59af0f2499d16e726f6b211b39756c042441be6d8650b69b54ebe715e234354ce5b4d348fb74b958e8966e2ec3dbd4958a7cd15e7caf07c4e3dc8e7c469f92c8cd88fb8005a2074a3bf913953d695260d88bc1aa25a4eee363ef0000ac0076727b35fbea2dac28fee5ccb0fea768eaf45ced136b9d9e24903464ae889f5c8a723fc14f93124b7c738843cbb89e864c862c38cddcccf95d2cc37a4dc036a8d232b48f62cdd4731412f4890da798f6896a3331f64b48c12d1d57fd9cbe7081171aa1be1d36cafe3867910f99c09e347899c19c38192b6e7387ccd768277c17dab1b7a5027c0b3cf178e21ad2e77ae06711549cfbb1f9c7a9d8096e85e1487f35515d02a92753504a8d75471b9f49edb6fbebc898f403e4773e95feb15e80c9a99c8348d";
 const UPGRADE_GUARDIAN_SET_VAA_5 : &str = "01000000040d00ada3cbcc53ec9abef64822eb3bf61784a1cf36dd7975a6f1fa793dfd35cd5b865b0b8daf6e7eec309d870423c5a5b7898cd56933ca82c824941d932766a014a70001b7731ff820ad5b3f97972428a81c8c8b1c55a42e8ae55f46a95ee7423fd4074b3f03c609cfff926a096fe642a1c939d7946972e1bea2bce02b40b766eb5b23e1010321738f8fb68652f1bb485b171badc3b0d347ad3cbcdc95aad0119020a5f1d46d1d9d92fd423a345b0f2ab2a722a25cace96acca0d1c4f2c839285ed06a6f0fb20104e67cedf1d48251817accb73647b0d16e1d565d1951baf62b1654b0bb26d516992df131dfdefcc499a41b7a49dead0cb03498ef6108018d88ab5c80397a83432401057f6a06e6d10f5d6cd84b552e866abc58c9899bb2a68956eaafca5988c19e8fc979a1d530636f1f897fb039d108d0b7fd4fde8679f75244cf3e10ffd1f605190c010675dac57d998d88ea80ad7078b6bf88d73abe8ed2ca960a17736c9a7dbfa168fa1c843b7e43883a0a15d0884bf2a397acacef142da51eec01bac331bd6e3aeb160008391dc0b9eed3fadc57528f2c32a6a060833aced6d617b95d39ea00300ca3e15951b175d1da741d31293d3bbedd1826d708675feb3bce56c58535592cdd4a5592000a8f30bde711c2d2b7e7f453be7a42b8da724008a34597c329c3989ecdd4f368f50d61b7b8c4c7d9f46e28334c4185d03284d90552b1f98cf0cd82c63fb5ecab63000cf67fb4e05463c3982a2379d1f779ad4364ba6ca5b240de82af4affc4c6ee58a52a972e21bbb254f15a4ea74cb511e32f06c021d9e774b34526e681dfa3537593000ea13cf78e719c7238fceb16f6fa1eb08de4c516b3e4c491b63382fdf3df5199543183c1ca67625178fb341484f58a18379bad73625637f0b64bae6b676b89033d000f8e4cfb95d01f4f84bf249038f64c10fb2d94f3a0429b01f853665deeebeae5e47e9d93926c97e1925b4be373e6ef96a606bc032b27a1bbcef95caa5c4f24dea0011111a9fc56e090fb01a739611ca9fd3de40ec53eeeb833e2b4fbab2dfdc176d60c734532248f2b2e5e0fbee8408245a8ca5d57440c6d596e981ade750a6e17928a011296e2fd4197141394987d06218f7b99b709adfb9e0511a177f9bfde8e7fbe1d4b55b9e4c2af3a70d2f73d6df12c3a60e6a677d476ff4393b9779f2735dbcd36e80169b6aee4a49c205b00010000000000000000000000000000000000000000000000000000000000000004fcdad9b63b91b4422000000000000000000000000000000000000000000000000000000000436f726502000000000005135893b5a76c3f739645648885bdccc06cd70a3cd3ff6cb952589bde862c25ef4392132fb9d4a42157114de8460193bdf3a2fcf81f86a09765f4762fd1107a0086b32d7a0977926a205131d8731d39cbeb8c82b2fd82faed2711d59af0f2499d16e726f6b211b39756c042441be6d8650b69b54ebe715e2343938f104aeb5581293216ce97d771e0cb721221b115e7caf07c4e3dc8e7c469f92c8cd88fb8005a2074a3bf913953d695260d88bc1aa25a4eee363ef0000ac0076727b35fbea2dac28fee5ccb0fea768eaf45ced136b9d9e24903464ae889f5c8a723fc14f93124b7c738843cbb89e864c862c38cddcccf95d2cc37a4dc036a8d232b48f62cdd4731412f4890da798f6896a3331f64b48c12d1d57fd9cbe70811d1f64e26238811de5553c40f64af41ee1b6057cc43ac8f567a31e7850da532b361988bfe0d3ae11b178e21ad2e77ae06711549cfbb1f9c7a9d8096e85e1487f35515d02a92753504a8d75471b9f49edb6fbebc898f403e4773e95feb15e80c9a99c8348d";
+const UPGRADE_GUARDIAN_SET_VAA_6 : &str = "01000000050e0040f721aa71977e93c4297ee5027db92d74e86001049d0a99ff442105396ddcaf28de133c695cb0cb548a08ad23d5f14d77b39d604adbe281669f97d6495f22300103fe6c6b9f8bbd6f0fcfa60dba52178d0b29a8bb3d344c2767c6eb9698f54e98d646b12043b00a32363ae282642fc2dcd3d359aa2f04e5b2744eb40fb5f31a9405010435740fb61d0742696db96e8182c5cf614d416335bed293ff4ebd89a2531ec5ff2d26bc2ec674f9b7bf7370ef861bc7ca4c2b32b179bee9ea4375ea85bce11d360005ec1360558155a5bbcf6165e3bf546a4b493813dbbdf08b09506c888cf963bf6014063d4d5a2541c10ebe1d6b9cfc4b9c812646187d498f875d170082a6fcde7b00063f1a1550666f124c0f6159f536e9ef5431242779947d01bd4d9178792fbf9f8f35cebf2d97ed8cbd1e0975d62badc8eabf13c62ff625b15f66c00e576c8d1e520108c244d100681b5f34534758d62d2d81d397bbdf609a0cab7faa4dcb81ae1316cd15074e78e121c7e98548974e87d8f168179e52acbd711ede350901d0ada5d0ab0109c3245a8c14562ec8fd18ba6d5ed701b39ac4b9411274d1757892a0add90812b4746434a1ca8160b674ec933590b41f6370fbf57cb6e45571fce84a9b1a7a00d2000ade545b0d4b5769ad15f2e8934bc2bd3230182e41255c9770843f74e0ef56197c69a9e8010afaa14582f41699eecee06467cd9f24f1272571ef4f973a02b8e9d8010b3f1ba7bba4858a7255734cc32bd6d7824f3ecdc13cb5f9fef2c14d7f11633c625848ce99008ea77ae8af44a5589152c92ecc79f6ab42055307416578056e1969000d947aa5fbf0c11e6f685ccb009d18fd16702798059e63dbd61556b44c6e447b5b26a96b868ec3f539f937f0e35363a02648a7fad11cc9a1bf13820ef158624ee6000e8ce8bb7dcb3cad043358244207bce942e91a103816ffa92c71fb41258195fb9f708df00d69820efda3538ed109ccba14f86d427ba40f06238e071462fe5c8d06010f5d7a50de510a75e0fbf869c6c12e417375041c3de405233873e044877d680d7949d0be292edf52b63ae2a25242b0f12284e8149d06ed028fadee8cc2065631850110e47fb8e41cf017c4564b488a1ad6ca39a1cb2e46082a46560237bbcaa88c5c366743856a3a799fd99baf0e47d3e6d681d611bcea0bec82a78bc09c6a9e94be3a01126c5146bbaf0c0caaaa0184ca73398efb6a5082b8f659f61cab57e40aa4988c9823fb4e78bc3b39baa57cb9a091d9dcdaeb581cdba994cc1d313609704e72ba6a0069f9d9ec67a1482300010000000000000000000000000000000000000000000000000000000000000004b4e575b84bc1db212000000000000000000000000000000000000000000000000000000000436f726502000000000006135893b5a76c3f739645648885bdccc06cd70a3cd3ff6cb952589bde862c25ef4392132fb9d4a42157114de8460193bdf3a2fcf81f86a09765f4762fd1107a0086b32d7a0977926a205131d8731d39cbeb8c82b2fd82faed2711d59af0f2499d16e726f6b242579bffbcf4276e290ab8e4c162bd4052b97970938f104aeb5581293216ce97d771e0cb721221b118e41674ccf26329cd111406c1d05c6c80b23edc9d16870160e703324d057c3361c34c5befba2c34000ac0076727b35fbea2dac28fee5ccb0fea768eaf45ced136b9d9e24903464ae889f5c8a723fc14f93124b7c738843cbb89e864c862c38cddcccf95d2cc37a4dc036a8d232b48f62cdd4731412f4890da798f6896a3331f64b48c12d1d57fd9cbe70811d1f64e26238811de5553c40f64af41ee1b6057cc3f851ad586a47cef8d04748f33ab0d71395f06b4178e21ad2e77ae06711549cfbb1f9c7a9d8096e87899ceab1dc961dae9defdb7a4f521269a5448fc6fbebc898f403e4773e95feb15e80c9a99c8348d";
 const GUARDIAN_EXPIRATION_TIME: u32 = 86400;
-const SVM_CHAINS_WITH_RPC: &[(&str, Option<&str>)] = &[
-    (
-        "eclipse_testnet",
-        Some("https://testnet.dev2.eclipsenetwork.xyz"),
-    ),
-    (
-        "eclipse_mainnet",
-        Some("https://mainnetbeta-rpc.eclipse.xyz"),
-    ),
-    ("sonic_devnet", Some("https://api.testnet.sonic.game")),
-    ("sonic_testnet", Some("https://api.testnet.sonic.game")),
-    (
-        "sonic_mainnet",
-        Some("https://api.mainnet-alpha.sonic.game"),
-    ),
-    ("fogo_mainnet", Some("https://mainnet.fogo.io")),
-    // Fogo testnet uses testnet WH guardians
+/// Configuration for one SVM chain that the `initialize-wormhole-receiver-all-svm`
+/// subcommand should target.
+///
+/// `legacy_guardian_set` should be `true` for chains running the legacy Wormhole
+/// bridge program (e.g. Pythnet), where guardian set accounts are stored without
+/// the Anchor discriminator for every guardian set index, not just index 0.
+#[derive(Copy, Clone)]
+struct SvmChain {
+    name: &'static str,
+    rpc_url: Option<&'static str>,
+    /// Wormhole core / receiver program ID on this chain, as a base58 string.
+    /// Parsed at runtime since `Pubkey::from_str` is not const.
+    wormhole: &'static str,
+    legacy_guardian_set: bool,
+}
+
+const PYTH_SVM_WORMHOLE_RECEIVER: &str = "HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ";
+const PYTHNET_WORMHOLE_RECEIVER: &str = "H3fxXJ86ADW2PNuDDmZJg6mzTtPxkYCpNuQUTgmJ7AjU";
+
+const SVM_CHAINS: &[SvmChain] = &[
+    SvmChain {
+        name: "solana_mainnet",
+        rpc_url: Some("https://api.mainnet-beta.solana.com"),
+        wormhole: PYTH_SVM_WORMHOLE_RECEIVER,
+        legacy_guardian_set: false,
+    },
+    SvmChain {
+        name: "eclipse_testnet",
+        rpc_url: Some("https://testnet.dev2.eclipsenetwork.xyz"),
+        wormhole: PYTH_SVM_WORMHOLE_RECEIVER,
+        legacy_guardian_set: false,
+    },
+    SvmChain {
+        name: "eclipse_mainnet",
+        rpc_url: Some("https://mainnetbeta-rpc.eclipse.xyz"),
+        wormhole: PYTH_SVM_WORMHOLE_RECEIVER,
+        legacy_guardian_set: false,
+    },
+    SvmChain {
+        name: "sonic_devnet",
+        rpc_url: Some("https://api.testnet.sonic.game"),
+        wormhole: PYTH_SVM_WORMHOLE_RECEIVER,
+        legacy_guardian_set: false,
+    },
+    SvmChain {
+        name: "sonic_testnet",
+        rpc_url: Some("https://api.testnet.sonic.game"),
+        wormhole: PYTH_SVM_WORMHOLE_RECEIVER,
+        legacy_guardian_set: false,
+    },
+    SvmChain {
+        name: "sonic_mainnet",
+        rpc_url: Some("https://api.mainnet-alpha.sonic.game"),
+        wormhole: PYTH_SVM_WORMHOLE_RECEIVER,
+        legacy_guardian_set: false,
+    },
+    SvmChain {
+        name: "fogo_mainnet",
+        rpc_url: Some("https://mainnet.fogo.io"),
+        wormhole: PYTH_SVM_WORMHOLE_RECEIVER,
+        legacy_guardian_set: false,
+    },
+    // Fogo testnet uses testnet WH guardians; intentionally omitted here.
+    SvmChain {
+        name: "pythnet",
+        rpc_url: Some("https://pythnet.rpcpool.com"),
+        wormhole: PYTHNET_WORMHOLE_RECEIVER,
+        legacy_guardian_set: true,
+    },
 ];
 
 fn main() -> Result<()> {
@@ -75,6 +128,7 @@ fn main() -> Result<()> {
 
     match action {
         Action::PostPriceUpdate { payload } => {
+            let wormhole = require_wormhole(wormhole)?;
             let rpc_client = RpcClient::new(url);
             let payer =
                 read_keypair_file(&*shellexpand::tilde(&keypair)).expect("Keypair not found");
@@ -94,6 +148,7 @@ fn main() -> Result<()> {
             payload,
             n_signatures,
         } => {
+            let wormhole = require_wormhole(wormhole)?;
             let rpc_client = RpcClient::new(url);
             let payer =
                 read_keypair_file(&*shellexpand::tilde(&keypair)).expect("Keypair not found");
@@ -114,6 +169,7 @@ fn main() -> Result<()> {
             start_payload,
             end_payload,
         } => {
+            let wormhole = require_wormhole(wormhole)?;
             let rpc_client = RpcClient::new(url);
             let payer =
                 read_keypair_file(&*shellexpand::tilde(&keypair)).expect("Keypair not found");
@@ -136,11 +192,12 @@ fn main() -> Result<()> {
                 &end_merkle_price_updates[0],
             )?;
         }
-        Action::InitializeWormholeReceiver {} => {
+        Action::InitializeWormholeReceiver { legacy } => {
+            let wormhole = require_wormhole(wormhole)?;
             let rpc_client = RpcClient::new(url);
             let payer =
                 read_keypair_file(&*shellexpand::tilde(&keypair)).expect("Keypair not found");
-            initialize_wormhole_receiver(&rpc_client, wormhole, &payer)?;
+            initialize_wormhole_receiver(&rpc_client, wormhole, &payer, legacy)?;
         }
         Action::InitializeWormholeReceiverAllSvm {
             retries,
@@ -152,30 +209,53 @@ fn main() -> Result<()> {
             let retry_delay = Duration::from_secs(retry_delay_seconds);
             let mut failures: Vec<(String, String)> = vec![];
 
-            for &(chain, default_url) in SVM_CHAINS_WITH_RPC {
-                let Some(rpc_url) = default_url else {
-                    eprintln!("[{chain}] skipping: unresolved RPC URL");
+            for chain_cfg in SVM_CHAINS {
+                let SvmChain {
+                    name,
+                    rpc_url,
+                    wormhole,
+                    legacy_guardian_set,
+                } = *chain_cfg;
+
+                let Some(rpc_url) = rpc_url else {
+                    eprintln!("[{name}] skipping: unresolved RPC URL");
                     continue;
                 };
 
-                println!("\n[{chain}] rpc={rpc_url}");
+                let chain_wormhole = match Pubkey::from_str(wormhole) {
+                    Ok(pk) => pk,
+                    Err(err) => {
+                        eprintln!("[{name}] skipping: invalid wormhole pubkey {wormhole:?}: {err}");
+                        failures.push((name.to_string(), format!("invalid wormhole pubkey: {err}")));
+                        continue;
+                    }
+                };
+
+                println!(
+                    "\n[{name}] rpc={rpc_url} wormhole={chain_wormhole} legacy={legacy_guardian_set}"
+                );
 
                 let mut last_error = String::new();
                 let mut succeeded = false;
                 for attempt in 1..=retries {
-                    println!("[{chain}] attempt {attempt}/{retries}");
+                    println!("[{name}] attempt {attempt}/{retries}");
                     let rpc_client = RpcClient::new(rpc_url.to_owned());
-                    match initialize_wormhole_receiver(&rpc_client, wormhole, &payer) {
+                    match initialize_wormhole_receiver(
+                        &rpc_client,
+                        chain_wormhole,
+                        &payer,
+                        legacy_guardian_set,
+                    ) {
                         Ok(()) => {
-                            println!("[{chain}] success");
+                            println!("[{name}] success");
                             succeeded = true;
                             break;
                         }
                         Err(err) => {
                             last_error = format!("{err:#}");
-                            eprintln!("[{chain}] attempt {attempt} failed: {last_error}");
+                            eprintln!("[{name}] attempt {attempt} failed: {last_error}");
                             if attempt < retries {
-                                eprintln!("[{chain}] retrying in {retry_delay_seconds} seconds...");
+                                eprintln!("[{name}] retrying in {retry_delay_seconds} seconds...");
                                 sleep(retry_delay);
                             }
                         }
@@ -183,7 +263,7 @@ fn main() -> Result<()> {
                 }
 
                 if !succeeded {
-                    failures.push((chain.to_string(), last_error));
+                    failures.push((name.to_string(), last_error));
                 }
             }
 
@@ -200,6 +280,7 @@ fn main() -> Result<()> {
         }
 
         Action::UpdateGuardianSetTtl {} => {
+            let wormhole = require_wormhole(wormhole)?;
             let rpc_client = RpcClient::new(url);
             let payer =
                 read_keypair_file(&*shellexpand::tilde(&keypair)).expect("Keypair not found");
@@ -219,6 +300,7 @@ fn main() -> Result<()> {
             chain,
             governance_authority,
         } => {
+            let wormhole = require_wormhole(wormhole)?;
             let rpc_client = RpcClient::new(url);
             let payer =
                 read_keypair_file(&*shellexpand::tilde(&keypair)).expect("Keypair not found");
@@ -250,6 +332,7 @@ fn initialize_wormhole_receiver(
     rpc_client: &RpcClient,
     wormhole: Pubkey,
     payer: &Keypair,
+    legacy_guardian_set: bool,
 ) -> Result<()> {
     // Check whether the wormhole config account exists, if it does not exist, initialize the wormhole receiver
     let wormhole_config = BridgeConfig::key(&wormhole, ());
@@ -302,7 +385,7 @@ fn initialize_wormhole_receiver(
                 .context("failed to decode guardian set VAA 2")?,
             wormhole,
             payer,
-            false,
+            legacy_guardian_set,
         )?;
         current_guardian_set_index += 1;
     }
@@ -315,7 +398,7 @@ fn initialize_wormhole_receiver(
                 .context("failed to decode guardian set VAA 3")?,
             wormhole,
             payer,
-            false,
+            legacy_guardian_set,
         )?;
         current_guardian_set_index += 1;
     }
@@ -328,7 +411,7 @@ fn initialize_wormhole_receiver(
                 .context("failed to decode guardian set VAA 4")?,
             wormhole,
             payer,
-            false,
+            legacy_guardian_set,
         )?;
         current_guardian_set_index += 1;
     }
@@ -341,7 +424,20 @@ fn initialize_wormhole_receiver(
                 .context("failed to decode guardian set VAA 5")?,
             wormhole,
             payer,
-            false,
+            legacy_guardian_set,
+        )?;
+        current_guardian_set_index += 1;
+    }
+
+    if current_guardian_set_index == 5 {
+        println!("Upgrading guardian set from 5 to 6");
+        process_upgrade_guardian_set(
+            rpc_client,
+            &hex::decode(UPGRADE_GUARDIAN_SET_VAA_6)
+                .context("failed to decode guardian set VAA 6")?,
+            wormhole,
+            payer,
+            legacy_guardian_set,
         )?;
     }
 


### PR DESCRIPTION
## Summary

- Adds the canonical mainnet **guardian set 5 → 6 upgrade VAA** to the `pyth-solana-receiver-cli`, so `initialize-wormhole-receiver` (and `-all-svm`) now bring chains up to guardian set 6.
- Replaces the `SVM_CHAINS_WITH_RPC` tuple list with a `SvmChain` struct carrying `name`, `rpc_url`, per-chain `wormhole` program ID, and a `legacy_guardian_set` flag.
- Adds **Solana mainnet** and **Pythnet** to the bulk chain table. Pythnet runs the legacy Wormhole bridge program at `H3fxXJ86ADW2PNuDDmZJg6mzTtPxkYCpNuQUTgmJ7AjU`, which requires `legacy_guardian_set: true` (no Anchor discriminator on the guardian set account at any index, not just 0). All other SVM chains stay on the receiver-side Wormhole at `HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ` with the standard layout.
- Plumbs the `legacy` flag through `initialize_wormhole_receiver` so steps 1→2 through 5→6 honor it (step 0→1 is unconditionally legacy regardless, since `initialize` always writes the account without the discriminator).
- Adds an `--legacy` flag to the single-chain `initialize-wormhole-receiver` subcommand for ad-hoc reruns against legacy chains.
- Makes the top-level `--wormhole / -w` flag `Option<Pubkey>`. The bulk `-all-svm` subcommand sources it from the chain table; single-chain subcommands call a new `cli::require_wormhole` helper that errors out clearly if it's missing.

## How to run

Bulk upgrade across every chain in the table (Solana mainnet, Eclipse mainnet/testnet, Sonic mainnet/devnet/testnet, Fogo mainnet, Pythnet):

\`\`\`bash
cd target_chains/solana/cli

cargo run --release -- \
  --keypair ~/.config/solana/svm_deployment_key.json \
  initialize-wormhole-receiver-all-svm \
  --retries 3 \
  --retry-delay-seconds 2
\`\`\`

Single-chain rerun (e.g. Sonic testnet):

\`\`\`bash
cargo run --release -- \
  --url https://api.testnet.sonic.game \
  --keypair ~/.config/solana/svm_deployment_key.json \
  --wormhole HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ \
  initialize-wormhole-receiver
\`\`\`

Single-chain Pythnet run (uses the legacy account layout for every step):

\`\`\`bash
cargo run --release -- \
  --url https://pythnet.rpcpool.com \
  --keypair ~/.config/solana/svm_deployment_key.json \
  --wormhole H3fxXJ86ADW2PNuDDmZJg6mzTtPxkYCpNuQUTgmJ7AjU \
  initialize-wormhole-receiver \
  --legacy
\`\`\`

The flow is idempotent — each chain's bridge config is read first and only the missing upgrade VAAs are applied, so rerunning is safe.

## Test plan

- [ ] `cargo check` passes (verified locally).
- [ ] `cargo run -- --help` and subcommand `--help` look correct.
- [ ] Dry-run `initialize-wormhole-receiver` against an SVM testnet (e.g. Sonic devnet) and confirm it logs the current guardian set index and applies only 5→6.
- [ ] Run `initialize-wormhole-receiver --legacy` against Pythnet and verify it advances guardian set index past 5.
- [ ] Run `-all-svm` on staging-equivalent RPCs and confirm each chain ends at guardian set 6.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
