### PR TITLE
docs(subscribe-to-prices): emphasize ignoreInvalidFeeds for production

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/faq.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/faq.mdx
@@ -19,6 +19,26 @@ If you have questions that are not answered here, feel free to add a question to
 
 There is **no hard cap**, but for optimal performance we recommend splitting large subscriptions across multiple connections. The number of connections is limited by your specific usage agreement. If you need to subscribe to many feeds, contact support for guidance on high-volume subscriptions. For more on rate limits, see [Rate Limits](/price-feeds/pro/rate-limits).
 
+#### Q. How should I handle feed expiration or invalid feed IDs in production?
+
+Feed IDs can become invalid over time — for example, when a feed is retired or an equity is delisted. By default, a subscription request containing **any** invalid feed ID will fail entirely with a `subscriptionError`, dropping all of your valid feeds along with it.
+
+For production deployments, set `ignoreInvalidFeeds: true` in your subscribe message:
+
+```js copy
+client.subscribe({
+  type: "subscribe",
+  subscriptionId: 1,
+  priceFeedIds: [1, 2],
+  properties: ["price", "feedUpdateTimestamp"],
+  formats: ["solana"],
+  channel: "fixed_rate@200ms",
+  ignoreInvalidFeeds: true,
+});
+```
+
+With this flag enabled, invalid feeds are skipped and listed in the subscription response, while the rest of your feeds continue to stream without interruption. Inspect the response to learn which feeds were dropped and why, then update your subscription accordingly. See [Subscribe to Prices](/price-feeds/pro/subscribe-to-prices) and [Error Codes](/price-feeds/pro/error-codes) for details.
+
 #### Q. What is the "client too slow" error?
 
 This error occurs when the client cannot process incoming messages fast enough. Common causes:

--- a/apps/developer-hub/content/docs/price-feeds/pro/subscribe-to-prices.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/subscribe-to-prices.mdx
@@ -139,12 +139,14 @@ npm install --save @pythnetwork/pyth-lazer-sdk
 import { PythLazerClient } from "@pythnetwork/pyth-lazer-sdk";
 
 const client = await PythLazerClient.create({
-  urls: [
-    "wss://pyth-lazer-0.dourolabs.app/v1/stream",
-    "wss://pyth-lazer-1.dourolabs.app/v1/stream",
-    "wss://pyth-lazer-2.dourolabs.app/v1/stream",
-  ],
   token: process.env.ACCESS_TOKEN,
+  webSocketPoolConfig: {
+    urls: [
+      "wss://pyth-lazer-0.dourolabs.app/v1/stream",
+      "wss://pyth-lazer-1.dourolabs.app/v1/stream",
+      "wss://pyth-lazer-2.dourolabs.app/v1/stream",
+    ],
+  },
 });
 ```
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/subscribe-to-prices.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/subscribe-to-prices.mdx
@@ -138,14 +138,14 @@ npm install --save @pythnetwork/pyth-lazer-sdk
 ```js copy
 import { PythLazerClient } from "@pythnetwork/pyth-lazer-sdk";
 
-const client = await PythLazerClient.create(
-  [
+const client = await PythLazerClient.create({
+  urls: [
     "wss://pyth-lazer-0.dourolabs.app/v1/stream",
     "wss://pyth-lazer-1.dourolabs.app/v1/stream",
     "wss://pyth-lazer-2.dourolabs.app/v1/stream",
   ],
-  "YOUR_API_KEY",
-);
+  token: process.env.ACCESS_TOKEN,
+});
 ```
 
 3. After the client is created, subscribe to prices (using the configuration parameters from step 2):

--- a/apps/developer-hub/content/docs/price-feeds/pro/subscribe-to-prices.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/subscribe-to-prices.mdx
@@ -61,6 +61,7 @@ client.send({
   properties: ["price", "feedUpdateTimestamp"],
   formats: ["solana"],
   channel: "fixed_rate@200ms",
+  ignoreInvalidFeeds: true,
 });
 ```
 
@@ -98,6 +99,17 @@ The most significant parameters are:
     are available for each feed.
   </Callout>
 - `ignoreInvalidFeeds` (optional, default: `false`) — if `true`, the subscription will ignore invalid feed IDs and subscribe to any valid feeds. The response will include details about which feeds were ignored and why. If all feeds are invalid, the subscription will still fail with a `subscriptionError`. See [Error Codes](/price-feeds/pro/error-codes) for the response format.
+
+<Callout type="warning" title="Recommended for production: set ignoreInvalidFeeds: true">
+  Feed IDs can become invalid over time — for example, when a feed is retired or
+  an equity is delisted. By default (`ignoreInvalidFeeds: false`), a single
+  invalid feed in your subscription request will cause the **entire**
+  subscription to fail with a `subscriptionError`, dropping all your other valid
+  feeds along with it. Setting `ignoreInvalidFeeds: true` makes your subscription
+  resilient: invalid feeds are skipped and reported in the response, while valid
+  feeds continue to stream uninterrupted. Inspect the response to learn which
+  feeds were dropped and why, then update your subscription accordingly.
+</Callout>
 
 There are also a few other configuration parameters -- see the [API documentation](https://pyth-lazer.dourolabs.app/docs) for more details.
 
@@ -146,6 +158,7 @@ client.subscribe({
   properties: ["price", "feedUpdateTimestamp"],
   formats: ["solana"],
   channel: "fixed_rate@200ms",
+  ignoreInvalidFeeds: true,
 });
 ```
 


### PR DESCRIPTION
## Summary

Promote `ignoreInvalidFeeds: true` as the recommended setting for production Pyth Pro subscriptions across the Developer Hub docs:

- **`subscribe-to-prices.mdx`** — Add a prominent `warning`-style callout immediately under the `ignoreInvalidFeeds` parameter description explaining the failure mode, and update both the configuration example (Step 2) and the SDK `client.subscribe(...)` example (Step 3) to set `ignoreInvalidFeeds: true`.
- **`faq.mdx`** — Add a new entry under "Connection & Subscription" titled "How should I handle feed expiration or invalid feed IDs in production?" with a code snippet and links to Subscribe to Prices and Error Codes.

No new pages were created.

## Rationale

By default, `ignoreInvalidFeeds` is `false`, which means a single retired or delisted feed in a subscription request causes the **entire** subscription to fail with a `subscriptionError` — silently dropping all the user's other valid feeds along with it. This is a sharp edge for production integrations, since feed IDs can become invalid over time (e.g. equity delistings, retired feeds). The docs previously mentioned the parameter only as a brief bullet; this PR makes the production recommendation explicit and shows it in the canonical code examples so consumers reach for the resilient default.

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

Documentation-only change — verified the rendered MDX structure (callout component import already present, Step/Steps wrappers preserved, no broken links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
