### PR TITLE
[codex] fix pro price feed symbols endpoint

### DIFF
--- a/apps/developer-hub/src/app/api/search/route.ts
+++ b/apps/developer-hub/src/app/api/search/route.ts
@@ -2,6 +2,7 @@ import type { AdvancedIndex } from "fumadocs-core/search/server";
 import { createSearchAPI } from "fumadocs-core/search/server";
 import { z } from "zod";
 
+import { SYMBOLS_API_URL } from "../../../config/pyth-pro-public";
 import { source } from "../../../lib/source";
 
 // Define schemas for type safety
@@ -64,10 +65,7 @@ async function getHermesFeeds(): Promise<AdvancedIndex[]> {
 
 async function getLazerFeeds(): Promise<AdvancedIndex[]> {
   try {
-    const res = await fetch(
-      "https://pyth.dourolabs.app/v1/symbols",
-      { next: { revalidate: 3600 } },
-    );
+    const res = await fetch(SYMBOLS_API_URL, { next: { revalidate: 3600 } });
     const parsed = lazerSchema.safeParse(await res.json());
 
     if (!parsed.success) {

--- a/apps/developer-hub/src/components/Playground/PriceFeedSelector/use-price-feeds.ts
+++ b/apps/developer-hub/src/components/Playground/PriceFeedSelector/use-price-feeds.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { z } from "zod";
 
-import { SYMBOLS_API_URL } from "../types";
+import { SYMBOLS_API_URL } from "../../../config/pyth-pro-public";
 
 const priceFeedSchema = z.object({
   pyth_lazer_id: z.number().int().positive(),

--- a/apps/developer-hub/src/components/Playground/types.ts
+++ b/apps/developer-hub/src/components/Playground/types.ts
@@ -192,7 +192,3 @@ export const PYTH_PRO_ENDPOINTS = [
   "wss://pyth-lazer-1.dourolabs.app/v1/stream",
   "wss://pyth-lazer-2.dourolabs.app/v1/stream",
 ];
-
-// API endpoint for symbols
-export const SYMBOLS_API_URL =
-  "https://history.pyth-lazer.dourolabs.app/history/v1/symbols";

--- a/apps/developer-hub/src/components/PriceFeedIdsProTable/index.tsx
+++ b/apps/developer-hub/src/components/PriceFeedIdsProTable/index.tsx
@@ -12,6 +12,7 @@ import { matchSorter } from "match-sorter";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { z } from "zod";
 
+import { SYMBOLS_API_URL } from "../../config/pyth-pro-public";
 import styles from "./index.module.scss";
 
 const CHANNEL_ORDER = [
@@ -356,9 +357,10 @@ const State = {
 type State = ReturnType<(typeof State)[keyof typeof State]>;
 
 const getPythProFeeds = async () => {
-  const result: Response = await fetch(
-    "https://history.pyth-lazer.dourolabs.app/history/v1/symbols",
-  );
+  const result: Response = await fetch(SYMBOLS_API_URL);
+  if (!result.ok) {
+    throw new Error(`Failed to fetch Pyth Pro feeds: ${String(result.status)}`);
+  }
   const data = pythProSchema.parse(await result.json());
   return data.toSorted(
     (firstFeed, secondFeed) =>

--- a/apps/developer-hub/src/config/pyth-pro-public.ts
+++ b/apps/developer-hub/src/config/pyth-pro-public.ts
@@ -1,0 +1,1 @@
+export const SYMBOLS_API_URL = "https://pyth.dourolabs.app/v1/symbols";


### PR DESCRIPTION
## Summary

Fixes the Developer Hub Pro Price Feed ID table and playground feed selector to use the current Pyth Pro Symbols API endpoint through a shared client-safe constant.

## Root Cause

The table and playground selector were fetching from `https://history.pyth-lazer.dourolabs.app/history/v1/symbols`, which currently returns `404`. The docs and search index already pointed at `https://pyth.dourolabs.app/v1/symbols`, which returns the feed list successfully, but the URL was duplicated across source files.

## Changes

- Added `SYMBOLS_API_URL` in `apps/developer-hub/src/config/pyth-pro-public.ts`.
- Updated the Pro Price Feed ID table to import the shared Symbols API URL.
- Updated the playground symbol selector to import the shared Symbols API URL directly, without coupling through `Playground/types.ts`.
- Updated the Developer Hub search route to use the same shared Symbols API URL.
- Kept the explicit HTTP status check before parsing the table response.

## Validation

- Confirmed the working endpoint returns HTTP `200` with `3190` feeds.
- `pnpm --filter @pythnetwork/developer-hub test:types`
- `pnpm --filter @pythnetwork/developer-hub test:lint:stylelint`
- `pnpm turbo run test:lint --filter=@pythnetwork/developer-hub`