### PR TITLE
feat(developer-hub): channels indicator + legend on Pyth Pro Price Feed IDs page

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/price-feed-ids.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/price-feed-ids.mdx
@@ -2,24 +2,24 @@
 title: Price Feed IDs
 description: List of price feed IDs for all the assets supported by Pyth Pro
 slug: /price-feeds/pro/price-feed-ids
+full: true
 ---
 
 import { Suspense } from "react";
-import { PriceFeedIdsProTable } from "../../../../src/components/PriceFeedIdsProTable";
+import {
+  ChannelLegend,
+  PriceFeedIdsProTable,
+} from "../../../../src/components/PriceFeedIdsProTable";
 
 import { Callout } from "fumadocs-ui/components/callout";
 
 <Callout type="info">
   You can also access the list of symbols programmatically via the [Symbols List
   API](https://pyth.dourolabs.app/v1/symbols).
+</Callout>
 
-You can optionally filter results using:
-
-- `query`: filter by symbol name (e.g., [?query=AAPL](https://pyth.dourolabs.app/v1/symbols?query=AAPL))
-- `asset_type`: filter by asset type (e.g., [?asset_type=crypto](https://pyth.dourolabs.app/v1/symbols?asset_type=crypto))
-
-You can use either parameter, both, or neither.
-
+<Callout type="info" title="Channels legend">
+  <ChannelLegend />
 </Callout>
 
 <Suspense>

--- a/apps/developer-hub/src/app/api/search/route.ts
+++ b/apps/developer-hub/src/app/api/search/route.ts
@@ -2,6 +2,7 @@ import type { AdvancedIndex } from "fumadocs-core/search/server";
 import { createSearchAPI } from "fumadocs-core/search/server";
 import { z } from "zod";
 
+import { SYMBOLS_API_URL } from "../../../config/pyth-pro-public";
 import { source } from "../../../lib/source";
 
 // Define schemas for type safety
@@ -64,10 +65,7 @@ async function getHermesFeeds(): Promise<AdvancedIndex[]> {
 
 async function getLazerFeeds(): Promise<AdvancedIndex[]> {
   try {
-    const res = await fetch(
-      "https://pyth.dourolabs.app/v1/symbols",
-      { next: { revalidate: 3600 } },
-    );
+    const res = await fetch(SYMBOLS_API_URL, { next: { revalidate: 3600 } });
     const parsed = lazerSchema.safeParse(await res.json());
 
     if (!parsed.success) {

--- a/apps/developer-hub/src/components/Playground/PriceFeedSelector/use-price-feeds.ts
+++ b/apps/developer-hub/src/components/Playground/PriceFeedSelector/use-price-feeds.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { z } from "zod";
 
-import { SYMBOLS_API_URL } from "../types";
+import { SYMBOLS_API_URL } from "../../../config/pyth-pro-public";
 
 const priceFeedSchema = z.object({
   pyth_lazer_id: z.number().int().positive(),

--- a/apps/developer-hub/src/components/Playground/types.ts
+++ b/apps/developer-hub/src/components/Playground/types.ts
@@ -192,7 +192,3 @@ export const PYTH_PRO_ENDPOINTS = [
   "wss://pyth-lazer-1.dourolabs.app/v1/stream",
   "wss://pyth-lazer-2.dourolabs.app/v1/stream",
 ];
-
-// API endpoint for symbols
-export const SYMBOLS_API_URL =
-  "https://history.pyth-lazer.dourolabs.app/history/v1/symbols";

--- a/apps/developer-hub/src/components/PriceFeedIdsProTable/index.module.scss
+++ b/apps/developer-hub/src/components/PriceFeedIdsProTable/index.module.scss
@@ -8,6 +8,13 @@
   overflow-x: auto;
 }
 
+.descriptionContent {
+  max-width: 15rem;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  line-height: 1.35;
+}
+
 .paginator {
   margin-bottom: theme.spacing(8);
 }
@@ -36,4 +43,91 @@
   width: theme.spacing(3);
   height: theme.spacing(3);
   flex-shrink: 0;
+}
+
+.channelIndicator {
+  display: flex;
+  width: 8.25rem;
+  min-width: 8.25rem;
+  flex-direction: column;
+  gap: theme.spacing(1);
+}
+
+.channelTrack,
+.channelLabels {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.channelTrack {
+  column-gap: 2px;
+}
+
+.channelSegment {
+  height: 4px;
+  border-radius: theme.border-radius("full");
+  background: theme.color("muted");
+  opacity: 0.35;
+}
+
+.channelSegmentActive {
+  background: theme.color("highlight");
+  opacity: 1;
+}
+
+.channelLabels {
+  column-gap: theme.spacing(1);
+}
+
+.channelLabel {
+  overflow: hidden;
+  color: theme.color("muted");
+  cursor: help;
+  font-size: theme.font-size("xs");
+  line-height: 1;
+  text-align: center;
+  text-overflow: clip;
+  white-space: nowrap;
+}
+
+.channelLabelActive {
+  color: theme.color("highlight");
+  font-weight: theme.font-weight("medium");
+}
+
+.channelUnknown {
+  color: theme.color("muted");
+  font-size: theme.font-size("xs");
+}
+
+.legend {
+  display: flex;
+  flex-direction: column;
+  gap: theme.spacing(3);
+}
+
+.legendIntro {
+  margin: 0;
+  font-size: theme.font-size("sm");
+  line-height: 1.5;
+}
+
+.legendRows {
+  display: flex;
+  flex-direction: column;
+  gap: theme.spacing(2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.legendRow {
+  display: flex;
+  align-items: center;
+  gap: theme.spacing(4);
+}
+
+.legendText {
+  font-size: theme.font-size("sm");
+  line-height: 1.4;
 }

--- a/apps/developer-hub/src/components/PriceFeedIdsProTable/index.tsx
+++ b/apps/developer-hub/src/components/PriceFeedIdsProTable/index.tsx
@@ -15,19 +15,104 @@ import { z } from "zod";
 import { SYMBOLS_API_URL } from "../../config/pyth-pro-public";
 import styles from "./index.module.scss";
 
-const CHANNEL_ORDER = [
-  "real_time",
-  "fixed_rate@1ms",
-  "fixed_rate@50ms",
-  "fixed_rate@200ms",
-  "fixed_rate@1000ms",
+const CHANNELS = [
+  { id: "real_time", label: "RT", fullName: "Real Time" },
+  { id: "fixed_rate@50ms", label: "50ms", fullName: "fixed_rate@50ms" },
+  { id: "fixed_rate@200ms", label: "200ms", fullName: "fixed_rate@200ms" },
+  { id: "fixed_rate@1000ms", label: "1s", fullName: "fixed_rate@1000ms" },
 ] as const;
 
+const normalizeChannelId = (channelId: string) =>
+  channelId === "fixed_rate@1ms" ? "real_time" : channelId;
+
 const getSupportedChannels = (minChannel: string): string[] => {
-  const idx = CHANNEL_ORDER.indexOf(minChannel as (typeof CHANNEL_ORDER)[number]);
+  const normalizedMinChannel = normalizeChannelId(minChannel);
+  const idx = CHANNELS.findIndex(
+    (channel) => channel.id === normalizedMinChannel,
+  );
   if (idx === -1) return [minChannel];
-  return [...CHANNEL_ORDER.slice(idx)];
+  return CHANNELS.slice(idx).map((channel) => channel.label);
 };
+
+const getChannelLabel = (channelId: string) =>
+  CHANNELS.find((channel) => channel.id === normalizeChannelId(channelId))
+    ?.label ?? channelId;
+
+const ChannelSupportIndicator = ({ minChannel }: { minChannel: string }) => {
+  const normalizedMinChannel = normalizeChannelId(minChannel);
+  const minChannelIndex = CHANNELS.findIndex(
+    (channel) => channel.id === normalizedMinChannel,
+  );
+
+  if (minChannelIndex === -1) {
+    return <span className={styles.channelUnknown}>{minChannel}</span>;
+  }
+
+  const minChannelLabel = getChannelLabel(minChannel);
+  const supportedChannels = getSupportedChannels(minChannel).join(", ");
+  const label = `Fastest channel: ${minChannelLabel}. Supported channels: ${supportedChannels}.`;
+
+  return (
+    <div className={styles.channelIndicator} role="img" aria-label={label}>
+      <div className={styles.channelTrack} aria-hidden="true">
+        {CHANNELS.map((channel, index) => (
+          <span
+            key={channel.id}
+            className={[
+              styles.channelSegment,
+              index >= minChannelIndex ? styles.channelSegmentActive : "",
+            ].join(" ")}
+          />
+        ))}
+      </div>
+      <div className={styles.channelLabels} aria-hidden="true">
+        {CHANNELS.map((channel, index) => (
+          <span
+            key={channel.id}
+            className={[
+              styles.channelLabel,
+              index >= minChannelIndex ? styles.channelLabelActive : "",
+            ].join(" ")}
+            title={channel.fullName}
+          >
+            {channel.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const LEGEND_DESCRIPTIONS: Record<(typeof CHANNELS)[number]["id"], string> = {
+  real_time:
+    "Minimum channel: Real Time. Published on Real Time, fixed_rate@50ms, fixed_rate@200ms, and fixed_rate@1000ms.",
+  "fixed_rate@50ms":
+    "Minimum channel: fixed_rate@50ms. Published on fixed_rate@50ms, fixed_rate@200ms, and fixed_rate@1000ms.",
+  "fixed_rate@200ms":
+    "Minimum channel: fixed_rate@200ms. Published on fixed_rate@200ms and fixed_rate@1000ms.",
+  "fixed_rate@1000ms":
+    "Minimum channel: fixed_rate@1000ms. Published on fixed_rate@1000ms only.",
+};
+
+export const ChannelLegend = () => (
+  <div className={styles.legend}>
+    <p className={styles.legendIntro}>
+      The <strong>Channels</strong> column shows the fastest tier a feed
+      supports. Every slower channel is also delivered, so highlighted segments
+      cascade to the right.
+    </p>
+    <ul className={styles.legendRows}>
+      {CHANNELS.map((channel) => (
+        <li key={channel.id} className={styles.legendRow}>
+          <ChannelSupportIndicator minChannel={channel.id} />
+          <span className={styles.legendText}>
+            {LEGEND_DESCRIPTIONS[channel.id]}
+          </span>
+        </li>
+      ))}
+    </ul>
+  </div>
+);
 
 const FEED_STATES = ["stable", "coming_soon", "inactive"] as const;
 type FeedState = (typeof FEED_STATES)[number];
@@ -242,7 +327,9 @@ export const PriceFeedIdsProTable = () => {
     id: feed.pyth_lazer_id,
     data: {
       asset_type: feed.asset_type,
-      description: feed.description,
+      description: (
+        <div className={styles.descriptionContent}>{feed.description}</div>
+      ),
       name: feed.name,
       symbol: feed.symbol,
       pyth_lazer_id: feed.pyth_lazer_id,
@@ -252,7 +339,7 @@ export const PriceFeedIdsProTable = () => {
           {FEED_STATE_LABELS[feed.state]}
         </Badge>
       ),
-      channels: getSupportedChannels(feed.min_channel).join(", "),
+      channels: <ChannelSupportIndicator minChannel={feed.min_channel} />,
     },
   }));
 

--- a/apps/developer-hub/src/components/PriceFeedIdsProTable/index.tsx
+++ b/apps/developer-hub/src/components/PriceFeedIdsProTable/index.tsx
@@ -12,6 +12,7 @@ import { matchSorter } from "match-sorter";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { z } from "zod";
 
+import { SYMBOLS_API_URL } from "../../config/pyth-pro-public";
 import styles from "./index.module.scss";
 
 const CHANNEL_ORDER = [
@@ -356,9 +357,10 @@ const State = {
 type State = ReturnType<(typeof State)[keyof typeof State]>;
 
 const getPythProFeeds = async () => {
-  const result: Response = await fetch(
-    "https://history.pyth-lazer.dourolabs.app/history/v1/symbols",
-  );
+  const result: Response = await fetch(SYMBOLS_API_URL);
+  if (!result.ok) {
+    throw new Error(`Failed to fetch Pyth Pro feeds: ${String(result.status)}`);
+  }
   const data = pythProSchema.parse(await result.json());
   return data.toSorted(
     (firstFeed, secondFeed) =>

--- a/apps/developer-hub/src/config/pyth-pro-public.ts
+++ b/apps/developer-hub/src/config/pyth-pro-public.ts
@@ -1,0 +1,1 @@
+export const SYMBOLS_API_URL = "https://pyth.dourolabs.app/v1/symbols";


### PR DESCRIPTION
## Summary

- Adds a segmented **Channels** indicator to each row of the Pyth Pro Price Feed IDs table. The indicator highlights the feed's fastest (minimum) channel and every slower channel it cascades to, replacing the previous comma-joined string.
- Adds a **Channels legend** Callout above the table that explains the visualization with one example per tier (`real_time`, `fixed_rate@50ms`, `fixed_rate@200ms`, `fixed_rate@1000ms`).
- Adds native hover tooltips (`title` attribute + `cursor: help`) on the compact `RT / 50ms / 200ms / 1s` labels so users can see the full channel name (`Real Time`, `fixed_rate@50ms`, etc.).
- Wraps long descriptions (max-width `15rem`, `white-space: normal`, `overflow-wrap: anywhere`) so the Status and Channels columns stay visible for feeds with verbose names like "ARTIFICIAL SUPERINTELLIGENCE ALLIANCE / US DOLLAR".
- Sets the Price Feed IDs page to **full width** (`full: true` frontmatter) so the table has more horizontal room.
- Drops a stale prose paragraph in the existing intro Callout that referenced `?query` / `?asset_type` filters not exposed by this page.
- Also folds in the prior commit on this branch which fixed the Pyth Pro symbols endpoint and Playground types.

## Test plan

- [ ] Visit `/price-feeds/pro/price-feed-ids` — page renders full-width.
- [ ] Channels column shows a segmented bar; for `real_time` feeds all four segments are highlighted, `fixed_rate@50ms` highlights three, `fixed_rate@200ms` two, `fixed_rate@1000ms` one.
- [ ] Hovering an `RT / 50ms / 200ms / 1s` label shows the corresponding full channel name as a native tooltip.
- [ ] The new "Channels legend" Callout above the table renders four example rows with descriptions.
- [ ] Long descriptions (e.g. ARTIFICIAL SUPERINTELLIGENCE ALLIANCE / US DOLLAR) wrap to a second line; Status and Channels remain visible without horizontal scrolling on a typical desktop viewport.
- [ ] Sort, search, and status filters still work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->