### PR TITLE
feat: minor changes to the solana contracts

### DIFF
--- a/target_chains/solana/Cargo.toml
+++ b/target_chains/solana/Cargo.toml
@@ -20,7 +20,7 @@ bincode = "1.3.3"
 byteorder = "1.4.3"
 pyth-solana-receiver-sdk = { path = "./pyth_solana_receiver_sdk" }
 pythnet-sdk = { path = "../../pythnet/pythnet_sdk", version = "2.3.1" }
-wormhole-core-bridge-solana = { path = "./programs/core-bridge" }
+wormhole-core-bridge-solana = { path = "./programs/core-bridge", features = ["no-entrypoint"] }
 wormhole-vaas-serde = "0.1.0"
 wormhole-raw-vaas = { version = "0.1.3", features = [
     "ruint",

--- a/target_chains/solana/programs/core-bridge/Cargo.toml
+++ b/target_chains/solana/programs/core-bridge/Cargo.toml
@@ -12,12 +12,14 @@ repository = "https://github.com/wormhole-foundation/wormhole"
 crate-type = ["cdylib", "lib"]
 
 [features]
-default = ["cpi", "no-idl"]
+default = []
 anchor-debug = []
 no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
+custom-heap = []
+custom-panic = []
 lazer = []
 
 [dependencies]

--- a/target_chains/solana/programs/core-bridge/src/lib.rs
+++ b/target_chains/solana/programs/core-bridge/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::result_large_err)]
+#![allow(clippy::result_large_err, unexpected_cfgs)]
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "lazer")] {

--- a/target_chains/solana/programs/pyth-solana-receiver/src/lib.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/src/lib.rs
@@ -593,7 +593,7 @@ fn pay_single_update_fee<'info>(
     payer: &Signer<'info>,
 ) -> Result<()> {
     // Handle treasury payment
-    let amount_to_pay = if treasury.lamports() == 0 {
+    let amount_to_pay = if treasury.lamports() == 0 && config.single_update_fee_in_lamports > 0 {
         Rent::get()?
             .minimum_balance(0)
             .max(config.single_update_fee_in_lamports)
@@ -609,11 +609,14 @@ fn pay_single_update_fee<'info>(
         return err!(ReceiverError::InsufficientFunds);
     }
 
-    let transfer_instruction = system_instruction::transfer(payer.key, treasury.key, amount_to_pay);
-    anchor_lang::solana_program::program::invoke(
-        &transfer_instruction,
-        &[payer.to_account_info(), treasury.to_account_info()],
-    )?;
+    if amount_to_pay > 0 {
+        let transfer_instruction =
+            system_instruction::transfer(payer.key, treasury.key, amount_to_pay);
+        anchor_lang::solana_program::program::invoke(
+            &transfer_instruction,
+            &[payer.to_account_info(), treasury.to_account_info()],
+        )?;
+    }
     Ok(())
 }
 

--- a/target_chains/solana/programs/pyth-solana-receiver/tests/test_post_price_update_from_vaa.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/tests/test_post_price_update_from_vaa.rs
@@ -604,4 +604,37 @@ async fn test_post_price_update_from_vaa() {
         price_update_account.verification_level,
         VerificationLevel::Partial { num_signatures: 9 }
     );
+
+    // With fee=0, posting to a brand-new treasury should not fund its rent
+    program_simulator
+        .process_ix_with_default_compute_limit(
+            SetFee::populate(governance_authority.pubkey(), 0),
+            &vec![&governance_authority],
+            None,
+        )
+        .await
+        .unwrap();
+
+    const NEW_TREASURY_ID: u8 = 1;
+    assert_treasury_balance(&mut program_simulator, 0, NEW_TREASURY_ID).await;
+
+    program_simulator
+        .process_ix_with_default_compute_limit(
+            PostUpdateAtomic::populate(
+                poster.pubkey(),
+                poster.pubkey(),
+                price_update_keypair.pubkey(),
+                BRIDGE_ID,
+                DEFAULT_GUARDIAN_SET_INDEX,
+                vaa.clone(),
+                merkle_price_updates[1].clone(),
+                NEW_TREASURY_ID,
+            ),
+            &vec![&poster, &price_update_keypair],
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_treasury_balance(&mut program_simulator, 0, NEW_TREASURY_ID).await;
 }


### PR DESCRIPTION
## Summary

- build core-bridge without the `cpi` and `no-idl` features by default. `cpi` must be disabled when building the .so to deploy to Solana, `no-idl` must be disabled so we can upload an anchor idl on-chain.
- don't fund treasury account rent if the fee is 0. The contract was designed with a non-zero fee in mind, so it charges the wallet that pushes the first update some rent for the treasury account. This is unnecessary with 0 fees.



<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->