### PR TITLE
Remove unneeded browserslist settings

### DIFF
--- a/apps/api-reference/package.json
+++ b/apps/api-reference/package.json
@@ -1,10 +1,4 @@
 {
-  "browserslist": [
-    "last 1 chrome version",
-    "last 1 firefox version",
-    "last 1 safari version",
-    "not dead"
-  ],
   "dependencies": {
     "@amplitude/analytics-browser": "catalog:",
     "@amplitude/plugin-autocapture-browser": "catalog:",

--- a/apps/developer-hub/package.json
+++ b/apps/developer-hub/package.json
@@ -1,10 +1,4 @@
 {
-  "browserslist": [
-    "last 1 chrome version",
-    "last 1 firefox version",
-    "last 1 safari version",
-    "not dead"
-  ],
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
     "@next/third-parties": "catalog:",

--- a/apps/entropy-explorer/package.json
+++ b/apps/entropy-explorer/package.json
@@ -1,10 +1,4 @@
 {
-  "browserslist": [
-    "last 1 chrome version",
-    "last 1 firefox version",
-    "last 1 safari version",
-    "not dead"
-  ],
   "dependencies": {
     "@phosphor-icons/react": "catalog:",
     "@pythnetwork/component-library": "workspace:*",

--- a/apps/insights/package.json
+++ b/apps/insights/package.json
@@ -1,10 +1,4 @@
 {
-  "browserslist": [
-    "last 1 chrome version",
-    "last 1 firefox version",
-    "last 1 safari version",
-    "not dead"
-  ],
   "dependencies": {
     "@clickhouse/client": "catalog:",
     "@phosphor-icons/react": "catalog:",

--- a/apps/staking/package.json
+++ b/apps/staking/package.json
@@ -1,10 +1,4 @@
 {
-  "browserslist": [
-    "last 1 chrome version",
-    "last 1 firefox version",
-    "last 1 safari version",
-    "not dead"
-  ],
   "dependencies": {
     "@amplitude/analytics-browser": "catalog:",
     "@amplitude/plugin-autocapture-browser": "catalog:",

--- a/governance/xc_admin/packages/xc_admin_frontend/package.json
+++ b/governance/xc_admin/packages/xc_admin_frontend/package.json
@@ -1,10 +1,4 @@
 {
-  "browserslist": [
-    "last 1 chrome version",
-    "last 1 firefox version",
-    "last 1 safari version",
-    "not dead"
-  ],
   "dependencies": {
     "@coral-xyz/anchor": "^0.29.0",
     "@headlessui/react": "^2.2.0",

--- a/packages/create-pyth-package/src/templates/web-app/package.json
+++ b/packages/create-pyth-package/src/templates/web-app/package.json
@@ -1,10 +1,4 @@
 {
-  "browserslist": [
-    "last 1 chrome version",
-    "last 1 firefox version",
-    "last 1 safari version",
-    "not dead"
-  ],
   "dependencies": {
     "@next/third-parties": "catalog:",
     "@phosphor-icons/react": "catalog:",


### PR DESCRIPTION
## Summary

Remove the `browserslist` setting on the nextjs apps

## Rationale

This setting is redundant given nextjs [has built in support for a browser range which is very sufficient](https://nextjs.org/docs/architecture/supported-browsers) and making the browser range tighter is not really solving any actual problems we have.  It seems like next [has some bug](https://github.com/vercel/next.js/issues/86792) related to setting browserlist causing font loader calls to fail, so I'm hoping that removing these redundant settings resolves that issue.

Note I plan to ignore biome failures here because I don't want to reformat & rearrange all the package.json files right now.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->
