### PR TITLE
fix(dev-hub): drive light-dark() polyfill via theme class, not OS preference

### DIFF
--- a/apps/developer-hub/src/components/Root/global.css
+++ b/apps/developer-hub/src/components/Root/global.css
@@ -26,7 +26,16 @@
 /* @import "./theme.css"; this overrides the default colors to match the pyth branding */
 /* @import "./fumadocs-global-style-overrides.css"; */
 
+/* Drive Lightning CSS's light-dark() polyfill via the next-themes class instead
+   of prefers-color-scheme. Specificity must beat the :root polyfill rules
+   (which Lightning CSS emits multiple times per CSS chunk), so we anchor to
+   :root.light / :root.dark (0,2,0) rather than .light / .dark (0,1,0). */
+:root.light,
 .light {
+  --lightningcss-light: initial;
+  --lightningcss-dark: ;
+  color-scheme: light;
+
   --color-fd-background: hsla(0, 16%, 96%, 1);
   --color-fd-foreground: hsla(0, 16%, 5%, 1);
   --color-fd-muted: hsla(0, 16%, 90%, 1);
@@ -45,7 +54,12 @@
   --color-fd-ring: hsla(263, 70%, 50%, 1);
 }
 
+:root.dark,
 .dark {
+  --lightningcss-light: ;
+  --lightningcss-dark: initial;
+  color-scheme: dark;
+
   --color-fd-background: hsl(240, 4%, 11%);
   --color-fd-foreground: hsl(250, 18%, 87%);
   --color-fd-muted: hsl(0, 3%, 6%);


### PR DESCRIPTION
## Summary

Drive Lightning CSS's `light-dark()` polyfill via the next-themes `.light` / `.dark` class instead of `prefers-color-scheme`, fixing washed-out text in light mode when OS is dark (and vice-versa) after #3662 removed dev-hub's browserslist override.

## Rationale

Without browserslist, Lightning CSS now polyfills `light-dark()` using `@media (prefers-color-scheme: dark)`, which ignores next-themes' class toggle. Anchored to `:root.light` / `:root.dark` (specificity 0,2,0) so it beats the per-chunk `:root` polyfill rules that load after `global.css`.

## How has this been tested?

- [x] Manually tested the code

Verified all four (class, OS-pref) combinations resolve to correct colors on homepage + API reference page; stylelint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)