### PR TITLE
docs(sui): point Sui integration links at the new docs URL

### DIFF
--- a/apps/price_pusher/src/sui/command.ts
+++ b/apps/price_pusher/src/sui/command.ts
@@ -58,14 +58,14 @@ export default {
     "pyth-state-id": {
       description:
         "Pyth State Id. Can be found here" +
-        "https://docs.pyth.network/documentation/pythnet-price-feeds/sui",
+        "https://docs.pyth.network/price-feeds/core/contract-addresses/sui",
       required: true,
       type: "string",
     } as Options,
     "wormhole-state-id": {
       description:
         "Wormhole State Id. Can be found here" +
-        "https://docs.pyth.network/documentation/pythnet-price-feeds/sui",
+        "https://docs.pyth.network/price-feeds/core/contract-addresses/sui",
       required: true,
       type: "string",
     } as Options,

--- a/target_chains/sui/README.md
+++ b/target_chains/sui/README.md
@@ -6,4 +6,4 @@ This directory contains the Pyth contract for Sui and utilities to deploy and us
 - `contracts` folder contains the Pyth contract source code in Move.
 - `sdk` folder contains the Pyth javascript SDK for Sui that should be used by dApp developers.
 
-For more information regarding Pyth integration on Sui please refer to our [docs](https://docs.pyth.network/documentation/pythnet-price-feeds/sui).
+For more information regarding Pyth integration on Sui please refer to our [docs](https://docs.pyth.network/price-feeds/core/contract-addresses/sui).

--- a/target_chains/sui/sdk/js-iota/README.md
+++ b/target_chains/sui/sdk/js-iota/README.md
@@ -67,7 +67,7 @@ const priceUpdateData = await connection.getPriceFeedsUpdateData(priceIds); // s
 // It is either injected from browser or instantiated in backend via some private key
 const wallet: SignerWithProvider = getWallet();
 // Get the state ids of the Pyth and Wormhole contracts from
-// https://docs.pyth.network/price-feeds/core/contract-addresses/sui
+// https://docs.pyth.network/price-feeds/core/contract-addresses/iota
 const wormholeStateId = " 0xFILL_ME";
 const pythStateId = "0xFILL_ME";
 

--- a/target_chains/sui/sdk/js-iota/README.md
+++ b/target_chains/sui/sdk/js-iota/README.md
@@ -67,7 +67,7 @@ const priceUpdateData = await connection.getPriceFeedsUpdateData(priceIds); // s
 // It is either injected from browser or instantiated in backend via some private key
 const wallet: SignerWithProvider = getWallet();
 // Get the state ids of the Pyth and Wormhole contracts from
-// https://docs.pyth.network/documentation/pythnet-price-feeds/sui
+// https://docs.pyth.network/price-feeds/core/contract-addresses/sui
 const wormholeStateId = " 0xFILL_ME";
 const pythStateId = "0xFILL_ME";
 


### PR DESCRIPTION
### Summary

Closes #3228.

The Sui READMEs link to `docs.pyth.network/documentation/pythnet-price-feeds/sui`, which returns HTTP 404 since the docs site reshuffle. @merolish [confirmed on the issue](https://github.com/pyth-network/pyth-crosschain/issues/3228#issuecomment-) that the current URL is `docs.pyth.network/price-feeds/core/contract-addresses/sui`.

### Change

Update both Sui-specific occurrences of the broken URL:

- `target_chains/sui/README.md` (the link the bug report points at)
- `target_chains/sui/sdk/js-iota/README.md` (the same URL in a code comment showing where to find Pyth/Wormhole state IDs)

### Verification

```
$ curl -sI -o /dev/null -w "%{http_code}\n" https://docs.pyth.network/documentation/pythnet-price-feeds/sui
404
$ curl -sI -o /dev/null -w "%{http_code}\n" https://docs.pyth.network/price-feeds/core/contract-addresses/sui
200
```

### Out of scope

Other `documentation/pythnet-price-feeds/<topic>` URLs in the repo (best-practices, on-demand, hermes, near, ...) cover non-Sui topics and the new URL for each is not necessarily a 1:1 mapping with the old one. Happy to follow up with a broader sweep in a separate PR if you'd like.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->