### PR TITLE
ci: add AI gatekeeper wrapper

### DIFF
--- a/.github/workflows/ci-ai-gatekeeper.yml
+++ b/.github/workflows/ci-ai-gatekeeper.yml
@@ -1,0 +1,30 @@
+name: AI Gatekeeper
+
+# Wrapper around the reusable workflow in pyth-network/shared-actions.
+#
+# Why a wrapper instead of attaching the workflow via the org ruleset's
+# "Require workflows to pass before merging" rule?
+#
+# Ruleset-attached workflows only run on the default activity types of
+# `pull_request`, `pull_request_target` and `merge_group`. The `pull_request_review`
+# event (and even the `ready_for_review` activity type of `pull_request`) is
+# ignored. We need the gatekeeper to re-evaluate when reviewers approve or
+# dismiss reviews, so we run it as a regular workflow here.
+#
+# See: https://docs.github.com/en/enterprise-cloud@latest/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+jobs:
+  gatekeeper:
+    name: Bot Proxy Gatekeeper
+    uses: pyth-network/shared-actions/.github/workflows/ai-gatekeeper.yaml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      checks: write


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci-ai-gatekeeper.yml` — a thin wrapper that calls the reusable workflow `pyth-network/shared-actions/.github/workflows/ai-gatekeeper.yaml@main`.
- Runs on both `pull_request` (open / push / reopen / ready_for_review) and `pull_request_review` (submit / dismiss) so the gatekeeper re-evaluates whenever reviewers approve or dismiss reviews.

## Why a wrapper instead of attaching via the org ruleset?

The `Enforce human review` org ruleset has "Require workflows to pass before merging" pointing at `pyth-network/shared-actions/.github/workflows/ai-gatekeeper.yaml@main`. That alone is **not enough** for our case.

Per [GitHub docs on available rules for rulesets](https://docs.github.com/en/enterprise-cloud@latest/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets):

> Ruleset workflows support using the `pull_request`, `pull_request_target` and `merge_group` events. […] Any filters you specify for the supported events are ignored — for example, `branches`, `branches-ignore`, `paths`, `types` and so on. The workflow is only triggered, and is always triggered, by the default activity types of the supported events.

So a ruleset-attached workflow only fires on `pull_request.{opened,synchronize,reopened}` (and `merge_group.checks_requested`). The `pull_request_review` event isn't supported at all, and even custom `pull_request` activity types like `ready_for_review` are stripped.

The gatekeeper needs to recount human approvals when reviewers approve / dismiss → must subscribe to `pull_request_review`. The cleanest workaround is a per-repo wrapper that uses the gatekeeper as a reusable workflow.

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->