### PR TITLE
feat(hyperliquid-recorder): record Hyperliquid funding rates (PFG-911)

### DIFF
--- a/apps/hyperliquid-recorder/README.md
+++ b/apps/hyperliquid-recorder/README.md
@@ -1,8 +1,9 @@
 # Hyperliquid Recorder (Rust)
 
 `hyperliquid-recorder` continuously ingests Hyperliquid `StreamL2Book` snapshots
-and `StreamData` trades from QuickNode gRPC, then writes them into ClickHouse
-for market analysis.
+and `StreamData` trades from QuickNode gRPC, plus applied per-hour funding
+rates polled from the Hyperliquid Info REST API, then writes them into
+ClickHouse for market analysis.
 
 ## Features
 
@@ -10,6 +11,10 @@ for market analysis.
 - Batched ClickHouse ingestion with in-batch dedupe.
 - `ReplacingMergeTree(ingested_at)` table keyed by
   `(coin, block_time, block_number, n_levels, n_sig_figs, mantissa)`.
+- Funding rates: per-market HTTP poll worker against Hyperliquid's Info API
+  (`POST /info` with `fundingHistory`) persisting applied per-hour funding
+  events into `hyperliquid_funding_rates`, with the same dedupe / TTL /
+  readiness story as the L2 and trades lanes.
 - Prometheus metrics and `/live` + `/ready` endpoints.
 - Tilt-based local stack (recorder + local ClickHouse + Prometheus + Grafana).
 
@@ -194,3 +199,31 @@ ClickHouse configuration:
 - `HYPERLIQUID_RECORDER__CLICKHOUSE__DATABASE` (default `pyth_analytics`)
 - `HYPERLIQUID_RECORDER__CLICKHOUSE__L2_SNAPSHOTS_TABLE` (default `hyperliquid_l2_snapshots`)
 - `HYPERLIQUID_RECORDER__CLICKHOUSE__TRADES_TABLE` (default `hyperliquid_trades`)
+- `HYPERLIQUID_RECORDER__CLICKHOUSE__FUNDING_RATES_TABLE` (default `hyperliquid_funding_rates`)
+
+Funding-rate ingestion:
+
+- `HYPERLIQUID_RECORDER__INFO_API_URL` (default `https://api.hyperliquid.xyz/info`) — Hyperliquid Info REST endpoint used for `fundingHistory` polls.
+- `HYPERLIQUID_RECORDER__FUNDING_POLL_SECONDS` (default `300`) — interval between funding polls. Must be `>= 30`.
+- `HYPERLIQUID_RECORDER__FUNDING_LOOKBACK_SECONDS` (default `21600`) — `startTime` window per poll. Must be `>= funding_poll_seconds`.
+
+## Schema deployment
+
+`ClickHouseClient::ensure_schema` is **documentation-only** — it lists the
+canonical Rust reference DDL for every table the recorder writes to, but it is
+never invoked from `main`. Production / staging runs against ClickHouse Cloud
+with credentials that lack DDL permissions, so schema changes are applied
+**out-of-band by the operator** as a separate DDL deploy.
+
+For the local stack, schema is applied automatically by
+`sql/001-init.sql`, which is mounted into the `clickhouse-local` container's
+`docker-entrypoint-initdb.d/`. Note: `001-init.sql` only runs against an empty
+data volume — to pick up new tables against an already-initialized local
+volume, either `tilt down -v && tilt up` to reset, or apply the new
+`CREATE TABLE` against the running container via `docker exec`.
+
+When adding a new table, update **all three** of these in lock-step:
+
+1. `ensure_schema` in `src/clickhouse.rs` (canonical Rust reference).
+2. `sql/001-init.sql` (local stack).
+3. The operator's out-of-band DDL deploy (production / staging).

--- a/apps/hyperliquid-recorder/config.sample.yml
+++ b/apps/hyperliquid-recorder/config.sample.yml
@@ -15,6 +15,7 @@ clickhouse:
   database: "pyth_analytics"
   l2_snapshots_table: "hyperliquid_l2_snapshots"
   trades_table: "hyperliquid_trades"
+  funding_rates_table: "hyperliquid_funding_rates"
 
 metrics_port: 9092
 health_port: 8082
@@ -25,3 +26,7 @@ batch_flush_seconds: 2.0
 retention_days: 90
 insert_async: true
 reconnect_max_backoff_seconds: 60
+
+info_api_url: "https://api.hyperliquid.xyz/info"
+funding_poll_seconds: 300
+funding_lookback_seconds: 21600

--- a/apps/hyperliquid-recorder/grafana/dashboards/hyperliquid-recorder-overview.json
+++ b/apps/hyperliquid-recorder/grafana/dashboards/hyperliquid-recorder-overview.json
@@ -551,50 +551,6 @@
         "defaults": {
           "color": {
             "mode": "palette-classic"
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 20
-      },
-      "id": 12,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "expr": "hyperliquid_recorder_funding_queue_depth",
-          "legendFormat": "depth",
-          "refId": "A"
-        },
-        {
-          "expr": "hyperliquid_recorder_funding_queue_fill_ratio",
-          "legendFormat": "fill ratio",
-          "refId": "B"
-        }
-      ],
-      "title": "Funding Queue Depth / Fill",
-      "type": "timeseries"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
           },
           "unit": "ops"
         },

--- a/apps/hyperliquid-recorder/grafana/dashboards/hyperliquid-recorder-overview.json
+++ b/apps/hyperliquid-recorder/grafana/dashboards/hyperliquid-recorder-overview.json
@@ -454,6 +454,265 @@
       ],
       "title": "Market Message Age (seconds)",
       "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 20
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(hyperliquid_recorder_funding_poll_attempts_total[5m])) by (coin, outcome)",
+          "legendFormat": "{{coin}} {{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Funding Poll Attempts/sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 20
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(hyperliquid_recorder_funding_insert_latency_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(hyperliquid_recorder_funding_insert_latency_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(hyperliquid_recorder_funding_insert_latency_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Funding Insert Latency Quantiles (s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 20
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "hyperliquid_recorder_funding_queue_depth",
+          "legendFormat": "depth",
+          "refId": "A"
+        },
+        {
+          "expr": "hyperliquid_recorder_funding_queue_fill_ratio",
+          "legendFormat": "fill ratio",
+          "refId": "B"
+        }
+      ],
+      "title": "Funding Queue Depth / Fill",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 28
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(hyperliquid_recorder_funding_insert_attempts_total[5m])) by (outcome)",
+          "legendFormat": "insert {{outcome}}",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(hyperliquid_recorder_funding_payload_errors_total[5m])",
+          "legendFormat": "payload errors",
+          "refId": "B"
+        }
+      ],
+      "title": "Funding Insert Attempts & Payload Errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "rowsps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 28
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(hyperliquid_recorder_funding_insert_rows_total[5m])",
+          "legendFormat": "rows/sec",
+          "refId": "A"
+        }
+      ],
+      "title": "Funding Insert Throughput (rows/sec)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 28
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "time() - hyperliquid_recorder_funding_last_event_time_seconds",
+          "legendFormat": "{{coin}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Funding Last Event Age (seconds)",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",

--- a/apps/hyperliquid-recorder/scripts/local_e2e_check.sh
+++ b/apps/hyperliquid-recorder/scripts/local_e2e_check.sh
@@ -5,13 +5,20 @@ container_name="${CLICKHOUSE_CONTAINER_NAME:-hyperliquid-recorder-clickhouse-loc
 user_name="${CLICKHOUSE_USER:-${CLICKHOUSE_LOCAL_USER:-recorder}}"
 password="${CLICKHOUSE_PASSWORD:-${CLICKHOUSE_LOCAL_PASSWORD:-recorder}}"
 database_name="${CLICKHOUSE_DATABASE:-pyth_analytics}"
-table_name="${CLICKHOUSE_TABLE:-hyperliquid_l2_snapshots}"
+tables="${CLICKHOUSE_TABLES:-hyperliquid_l2_snapshots hyperliquid_funding_rates}"
 
-query="SELECT count() FROM ${database_name}.${table_name}"
-count="$(docker exec "${container_name}" clickhouse-client --user "${user_name}" --password "${password}" -q "${query}")"
+failed=0
+for table_name in ${tables}; do
+  query="SELECT count() FROM ${database_name}.${table_name}"
+  count="$(docker exec "${container_name}" clickhouse-client --user "${user_name}" --password "${password}" -q "${query}")"
 
-echo "local_e2e_check: table=${database_name}.${table_name} rows=${count}"
-if [[ "${count}" -le 0 ]]; then
-  echo "local_e2e_check: no rows found yet; ensure stream auth/market config is correct."
+  echo "local_e2e_check: table=${database_name}.${table_name} rows=${count}"
+  if [[ "${count}" -le 0 ]]; then
+    echo "local_e2e_check: no rows found in ${database_name}.${table_name} yet; ensure stream auth/market config is correct."
+    failed=1
+  fi
+done
+
+if [[ "${failed}" -ne 0 ]]; then
   exit 1
 fi

--- a/apps/hyperliquid-recorder/sql/001-init.sql
+++ b/apps/hyperliquid-recorder/sql/001-init.sql
@@ -50,3 +50,17 @@ ENGINE = ReplacingMergeTree(ingested_at)
 PARTITION BY toYYYYMM(trade_time)
 ORDER BY (coin, trade_time, block_number, tid, oid, user)
 TTL toDateTime(trade_time) + INTERVAL 90 DAY DELETE;
+
+CREATE TABLE IF NOT EXISTS pyth_analytics.hyperliquid_funding_rates
+(
+    coin LowCardinality(String),
+    funding_time DateTime64(3),
+    funding_rate Decimal64(12),
+    premium Nullable(Decimal64(12)),
+    source_endpoint LowCardinality(String),
+    ingested_at DateTime64(3) DEFAULT now64(3)
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toYYYYMM(funding_time)
+ORDER BY (coin, funding_time)
+TTL toDateTime(funding_time) + INTERVAL 90 DAY DELETE;

--- a/apps/hyperliquid-recorder/src/clickhouse.rs
+++ b/apps/hyperliquid-recorder/src/clickhouse.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 
 use crate::{
     config::ClickHouseTarget,
-    models::{L2Snapshot, TradeRecord},
+    models::{FundingRateRecord, L2Snapshot, TradeRecord},
 };
 
 #[derive(Clone)]
@@ -91,6 +91,26 @@ impl ClickHouseClient {
             self.target.database, self.target.trades_table
         ))
         .await?;
+
+        self.command(&format!(
+            "
+            CREATE TABLE IF NOT EXISTS {}.{}
+            (
+                coin LowCardinality(String),
+                funding_time DateTime64(3),
+                funding_rate Decimal64(12),
+                premium Nullable(Decimal64(12)),
+                source_endpoint LowCardinality(String),
+                ingested_at DateTime64(3) DEFAULT now64(3)
+            )
+            ENGINE = ReplacingMergeTree(ingested_at)
+            PARTITION BY toYYYYMM(funding_time)
+            ORDER BY (coin, funding_time)
+            TTL toDateTime(funding_time) + INTERVAL {retention_days} DAY DELETE
+            ",
+            self.target.database, self.target.funding_rates_table
+        ))
+        .await?;
         Ok(())
     }
 
@@ -159,6 +179,36 @@ impl ClickHouseClient {
         );
         self.command(&query).await?;
         Ok((trades.len(), start.elapsed().as_secs_f64()))
+    }
+
+    pub async fn insert_funding_batch(
+        &self,
+        rates: &[FundingRateRecord],
+        insert_async: bool,
+    ) -> Result<(usize, f64)> {
+        if rates.is_empty() {
+            return Ok((0, 0.0));
+        }
+        let start = Instant::now();
+
+        let rows = rates
+            .iter()
+            .map(funding_to_values)
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let settings = if insert_async {
+            " SETTINGS async_insert=1,wait_for_async_insert=1"
+        } else {
+            ""
+        };
+
+        let query = format!(
+            "INSERT INTO {}.{} (coin,funding_time,funding_rate,premium,source_endpoint){settings} VALUES {rows}",
+            self.target.database, self.target.funding_rates_table
+        );
+        self.command(&query).await?;
+        Ok((rates.len(), start.elapsed().as_secs_f64()))
     }
 
     async fn command(&self, sql: &str) -> Result<String> {
@@ -270,6 +320,25 @@ fn trade_to_values(trade: &TradeRecord) -> String {
         nullable_decimal(liquidation_mark_px),
         nullable_string(liquidation_method),
         escape(&trade.source_endpoint),
+    )
+}
+
+fn funding_to_values(rate: &FundingRateRecord) -> String {
+    let funding_time = DateTime::<Utc>::from_timestamp_millis(rate.funding_time_ms as i64)
+        .unwrap_or(DateTime::<Utc>::UNIX_EPOCH)
+        .format("%Y-%m-%d %H:%M:%S%.3f");
+    let premium = nullable_decimal(
+        rate.premium
+            .as_ref()
+            .map(|value| value.normalize().to_string()),
+    );
+    format!(
+        "('{}','{}',toDecimal64('{}',12),{},'{}')",
+        escape(&rate.coin),
+        funding_time,
+        rate.funding_rate.normalize(),
+        premium,
+        escape(&rate.source_endpoint),
     )
 }
 

--- a/apps/hyperliquid-recorder/src/config.rs
+++ b/apps/hyperliquid-recorder/src/config.rs
@@ -26,6 +26,7 @@ pub struct ClickHouseTarget {
     pub database: String,
     pub l2_snapshots_table: String,
     pub trades_table: String,
+    pub funding_rates_table: String,
 }
 
 #[derive(Clone, Debug)]
@@ -43,6 +44,9 @@ pub struct AppConfig {
     pub retention_days: u16,
     pub insert_async: bool,
     pub reconnect_max_backoff_seconds: u64,
+    pub info_api_url: String,
+    pub funding_poll_seconds: u64,
+    pub funding_lookback_seconds: u64,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -73,6 +77,8 @@ struct ClickHouseConfig {
     l2_snapshots_table: String,
     #[serde(default = "default_clickhouse_trades_table")]
     trades_table: String,
+    #[serde(default = "default_clickhouse_funding_rates_table")]
+    funding_rates_table: String,
 }
 
 impl AppConfig {
@@ -130,6 +136,38 @@ impl AppConfig {
                 "reconnect_max_backoff_seconds",
                 default_reconnect_max_backoff_seconds,
             )?,
+            info_api_url: get_or_default(&loaded, "info_api_url", default_info_api_url)?,
+            funding_poll_seconds: {
+                let value: u64 = get_or_default(
+                    &loaded,
+                    "funding_poll_seconds",
+                    default_funding_poll_seconds,
+                )?;
+                if value < 30 {
+                    return Err(ConfigError::Invalid(
+                        "funding_poll_seconds must be >= 30".to_string(),
+                    ));
+                }
+                value
+            },
+            funding_lookback_seconds: {
+                let value: u64 = get_or_default(
+                    &loaded,
+                    "funding_lookback_seconds",
+                    default_funding_lookback_seconds,
+                )?;
+                let poll: u64 = get_or_default(
+                    &loaded,
+                    "funding_poll_seconds",
+                    default_funding_poll_seconds,
+                )?;
+                if value < poll {
+                    return Err(ConfigError::Invalid(
+                        "funding_lookback_seconds must be >= funding_poll_seconds".to_string(),
+                    ));
+                }
+                value
+            },
         })
     }
 
@@ -217,6 +255,7 @@ fn parse_clickhouse_target(input: ClickHouseConfig) -> Result<ClickHouseTarget, 
         database: input.database,
         l2_snapshots_table: input.l2_snapshots_table,
         trades_table: input.trades_table,
+        funding_rates_table: input.funding_rates_table,
     })
 }
 
@@ -290,4 +329,20 @@ fn default_clickhouse_l2_snapshots_table() -> String {
 
 fn default_clickhouse_trades_table() -> String {
     "hyperliquid_trades".to_string()
+}
+
+fn default_clickhouse_funding_rates_table() -> String {
+    "hyperliquid_funding_rates".to_string()
+}
+
+fn default_info_api_url() -> String {
+    "https://api.hyperliquid.xyz/info".to_string()
+}
+
+fn default_funding_poll_seconds() -> u64 {
+    300
+}
+
+fn default_funding_lookback_seconds() -> u64 {
+    21_600
 }

--- a/apps/hyperliquid-recorder/src/funding_client.rs
+++ b/apps/hyperliquid-recorder/src/funding_client.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -10,7 +11,10 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 
-use crate::models::{parse_funding_history, FundingRateRecord, MarketSubscription};
+use crate::{
+    metrics::RecorderMetrics,
+    models::{parse_funding_history, FundingRateRecord, MarketSubscription},
+};
 
 #[allow(clippy::too_many_arguments)]
 pub async fn run_funding_poll_worker(
@@ -20,6 +24,7 @@ pub async fn run_funding_poll_worker(
     lookback_seconds: u64,
     max_backoff_seconds: u64,
     sender: mpsc::Sender<FundingRateRecord>,
+    metrics: Arc<RecorderMetrics>,
     stop_token: CancellationToken,
 ) {
     let http = reqwest::Client::new();
@@ -50,6 +55,10 @@ pub async fn run_funding_poll_worker(
                             start_time_ms,
                             "fundingHistory poll ok"
                         );
+                        metrics
+                            .funding_poll_attempts
+                            .with_label_values(&[&coin, "success"])
+                            .inc();
                         backoff.insert(coin.clone(), 1);
                         for record in records {
                             if tokio::time::timeout(
@@ -65,11 +74,20 @@ pub async fn run_funding_poll_worker(
                     }
                     Err(err) => {
                         tracing::warn!(coin = %coin, error = ?err, "fundingHistory parse error");
+                        metrics
+                            .funding_poll_attempts
+                            .with_label_values(&[&coin, "error"])
+                            .inc();
+                        metrics.funding_payload_errors.inc();
                         sleep_backoff(&mut backoff, &coin, max_backoff_seconds).await;
                     }
                 },
                 Err(err) => {
                     tracing::warn!(coin = %coin, error = ?err, "fundingHistory request failed");
+                    metrics
+                        .funding_poll_attempts
+                        .with_label_values(&[&coin, "error"])
+                        .inc();
                     sleep_backoff(&mut backoff, &coin, max_backoff_seconds).await;
                 }
             }

--- a/apps/hyperliquid-recorder/src/funding_client.rs
+++ b/apps/hyperliquid-recorder/src/funding_client.rs
@@ -1,14 +1,9 @@
 use std::{
     collections::HashMap,
-    sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use serde::Serialize;
-use tokio::{
-    sync::mpsc,
-    time::{interval, MissedTickBehavior},
-};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -17,84 +12,65 @@ use crate::{
 };
 
 #[allow(clippy::too_many_arguments)]
-pub async fn run_funding_poll_worker(
-    info_api_url: String,
-    markets: Vec<MarketSubscription>,
-    poll_seconds: u64,
+pub async fn poll_funding_once(
+    http: &reqwest::Client,
+    info_api_url: &str,
+    markets: &[MarketSubscription],
     lookback_seconds: u64,
     max_backoff_seconds: u64,
-    sender: mpsc::Sender<FundingRateRecord>,
-    metrics: Arc<RecorderMetrics>,
-    stop_token: CancellationToken,
-) {
-    let http = reqwest::Client::new();
-    let mut backoff: HashMap<String, u64> = HashMap::new();
+    metrics: &RecorderMetrics,
+    backoff: &mut HashMap<String, u64>,
+    stop_token: &CancellationToken,
+) -> Vec<FundingRateRecord> {
+    let mut batch: Vec<FundingRateRecord> = Vec::new();
 
-    let mut ticker = interval(Duration::from_secs(poll_seconds.max(1)));
-    ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
-
-    while !stop_token.is_cancelled() {
-        ticker.tick().await;
+    for market in markets {
         if stop_token.is_cancelled() {
-            return;
+            return batch;
         }
+        let coin = market.coin.clone();
+        let start_time_ms = now_unix_ms().saturating_sub(lookback_seconds.saturating_mul(1000));
 
-        for market in &markets {
-            if stop_token.is_cancelled() {
-                return;
-            }
-            let coin = market.coin.clone();
-            let start_time_ms = now_unix_ms().saturating_sub(lookback_seconds.saturating_mul(1000));
-
-            match fetch_funding_history(&http, &info_api_url, &coin, start_time_ms).await {
-                Ok(body) => match parse_funding_history(&body, &coin, &info_api_url) {
-                    Ok(records) => {
-                        tracing::info!(
-                            coin = %coin,
-                            rows = records.len(),
-                            start_time_ms,
-                            "fundingHistory poll ok"
-                        );
-                        metrics
-                            .funding_poll_attempts
-                            .with_label_values(&[&coin, "success"])
-                            .inc();
-                        backoff.insert(coin.clone(), 1);
-                        for record in records {
-                            if tokio::time::timeout(
-                                Duration::from_secs(1),
-                                sender.send(record),
-                            )
-                            .await
-                            .is_err()
-                            {
-                                tracing::warn!(coin = %coin, "funding queue drop");
-                            }
-                        }
-                    }
-                    Err(err) => {
-                        tracing::warn!(coin = %coin, error = ?err, "fundingHistory parse error");
-                        metrics
-                            .funding_poll_attempts
-                            .with_label_values(&[&coin, "error"])
-                            .inc();
-                        metrics.funding_payload_errors.inc();
-                        sleep_backoff(&mut backoff, &coin, max_backoff_seconds).await;
-                    }
-                },
+        match fetch_funding_history(http, info_api_url, &coin, start_time_ms).await {
+            Ok(body) => match parse_funding_history(&body, &coin, info_api_url) {
+                Ok(records) => {
+                    tracing::info!(
+                        coin = %coin,
+                        rows = records.len(),
+                        start_time_ms,
+                        "fundingHistory poll ok"
+                    );
+                    metrics
+                        .funding_poll_attempts
+                        .with_label_values(&[&coin, "success"])
+                        .inc();
+                    backoff.insert(coin.clone(), 1);
+                    batch.extend(records);
+                }
                 Err(err) => {
-                    tracing::warn!(coin = %coin, error = ?err, "fundingHistory request failed");
+                    tracing::warn!(coin = %coin, error = ?err, "fundingHistory parse error");
                     metrics
                         .funding_poll_attempts
                         .with_label_values(&[&coin, "error"])
                         .inc();
-                    sleep_backoff(&mut backoff, &coin, max_backoff_seconds).await;
+                    metrics.funding_payload_errors.inc();
+                    sleep_backoff(backoff, &coin, max_backoff_seconds).await;
                 }
+            },
+            Err(err) => {
+                tracing::warn!(coin = %coin, error = ?err, "fundingHistory request failed");
+                metrics
+                    .funding_poll_attempts
+                    .with_label_values(&[&coin, "error"])
+                    .inc();
+                sleep_backoff(backoff, &coin, max_backoff_seconds).await;
             }
-
-            tokio::time::sleep(Duration::from_millis(100)).await;
         }
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
     }
+
+    batch
 }
 
 #[derive(Serialize)]

--- a/apps/hyperliquid-recorder/src/funding_client.rs
+++ b/apps/hyperliquid-recorder/src/funding_client.rs
@@ -1,0 +1,127 @@
+use std::{
+    collections::HashMap,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use serde::Serialize;
+use tokio::{
+    sync::mpsc,
+    time::{interval, MissedTickBehavior},
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::models::{parse_funding_history, FundingRateRecord, MarketSubscription};
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run_funding_poll_worker(
+    info_api_url: String,
+    markets: Vec<MarketSubscription>,
+    poll_seconds: u64,
+    lookback_seconds: u64,
+    max_backoff_seconds: u64,
+    sender: mpsc::Sender<FundingRateRecord>,
+    stop_token: CancellationToken,
+) {
+    let http = reqwest::Client::new();
+    let mut backoff: HashMap<String, u64> = HashMap::new();
+
+    let mut ticker = interval(Duration::from_secs(poll_seconds.max(1)));
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+    while !stop_token.is_cancelled() {
+        ticker.tick().await;
+        if stop_token.is_cancelled() {
+            return;
+        }
+
+        for market in &markets {
+            if stop_token.is_cancelled() {
+                return;
+            }
+            let coin = market.coin.clone();
+            let start_time_ms = now_unix_ms().saturating_sub(lookback_seconds.saturating_mul(1000));
+
+            match fetch_funding_history(&http, &info_api_url, &coin, start_time_ms).await {
+                Ok(body) => match parse_funding_history(&body, &coin, &info_api_url) {
+                    Ok(records) => {
+                        tracing::info!(
+                            coin = %coin,
+                            rows = records.len(),
+                            start_time_ms,
+                            "fundingHistory poll ok"
+                        );
+                        backoff.insert(coin.clone(), 1);
+                        for record in records {
+                            if tokio::time::timeout(
+                                Duration::from_secs(1),
+                                sender.send(record),
+                            )
+                            .await
+                            .is_err()
+                            {
+                                tracing::warn!(coin = %coin, "funding queue drop");
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        tracing::warn!(coin = %coin, error = ?err, "fundingHistory parse error");
+                        sleep_backoff(&mut backoff, &coin, max_backoff_seconds).await;
+                    }
+                },
+                Err(err) => {
+                    tracing::warn!(coin = %coin, error = ?err, "fundingHistory request failed");
+                    sleep_backoff(&mut backoff, &coin, max_backoff_seconds).await;
+                }
+            }
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct FundingHistoryRequest<'a> {
+    #[serde(rename = "type")]
+    request_type: &'a str,
+    coin: &'a str,
+    #[serde(rename = "startTime")]
+    start_time: u64,
+}
+
+async fn fetch_funding_history(
+    http: &reqwest::Client,
+    url: &str,
+    coin: &str,
+    start_time_ms: u64,
+) -> anyhow::Result<String> {
+    let request = FundingHistoryRequest {
+        request_type: "fundingHistory",
+        coin,
+        start_time: start_time_ms,
+    };
+    let response = http.post(url).json(&request).send().await?;
+    let status = response.status();
+    let body = response.text().await?;
+    if !status.is_success() {
+        anyhow::bail!("fundingHistory request failed ({status}): {body}");
+    }
+    Ok(body)
+}
+
+async fn sleep_backoff(
+    backoff: &mut HashMap<String, u64>,
+    coin: &str,
+    max_backoff_seconds: u64,
+) {
+    let current = backoff.get(coin).copied().unwrap_or(1);
+    tokio::time::sleep(Duration::from_secs(current)).await;
+    let next = current.saturating_mul(2).min(max_backoff_seconds.max(1));
+    backoff.insert(coin.to_string(), next);
+}
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/apps/hyperliquid-recorder/src/health.rs
+++ b/apps/hyperliquid-recorder/src/health.rs
@@ -62,9 +62,11 @@ impl HealthState {
 
     pub fn set_funding_event_seen(&self, coin: &str, funding_time_ms: u64) {
         let mut inner = self.inner.lock().expect("health mutex poisoned");
-        inner
+        let entry = inner
             .funding_last_event_ms
-            .insert(coin.to_string(), funding_time_ms);
+            .entry(coin.to_string())
+            .or_insert(0);
+        *entry = (*entry).max(funding_time_ms);
     }
 
     pub fn set_clickhouse_ok(&self, healthy: bool) {

--- a/apps/hyperliquid-recorder/src/health.rs
+++ b/apps/hyperliquid-recorder/src/health.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::Result;
@@ -15,12 +15,16 @@ use crate::metrics::RecorderMetrics;
 pub struct HealthState {
     expected_coins: Vec<String>,
     stale_seconds: u64,
+    funding_poll_seconds: u64,
+    funding_stale_seconds: u64,
+    started_at: Instant,
     inner: Arc<Mutex<HealthInner>>,
 }
 
 #[derive(Default)]
 struct HealthInner {
     market_last_message: HashMap<String, f64>,
+    funding_last_event_ms: HashMap<String, u64>,
     clickhouse_ok: bool,
 }
 
@@ -29,13 +33,22 @@ struct ReadyResponse {
     ready: bool,
     clickhouse_ok: bool,
     stale_markets: Vec<String>,
+    stale_funding_markets: Vec<String>,
 }
 
 impl HealthState {
-    pub fn new(expected_coins: Vec<String>, stale_seconds: u64) -> Self {
+    pub fn new(
+        expected_coins: Vec<String>,
+        stale_seconds: u64,
+        funding_poll_seconds: u64,
+        funding_stale_seconds: u64,
+    ) -> Self {
         Self {
             expected_coins,
             stale_seconds,
+            funding_poll_seconds,
+            funding_stale_seconds,
+            started_at: Instant::now(),
             inner: Arc::new(Mutex::new(HealthInner::default())),
         }
     }
@@ -45,6 +58,13 @@ impl HealthState {
         inner
             .market_last_message
             .insert(coin.to_string(), unix_seconds_now());
+    }
+
+    pub fn set_funding_event_seen(&self, coin: &str, funding_time_ms: u64) {
+        let mut inner = self.inner.lock().expect("health mutex poisoned");
+        inner
+            .funding_last_event_ms
+            .insert(coin.to_string(), funding_time_ms);
     }
 
     pub fn set_clickhouse_ok(&self, healthy: bool) {
@@ -59,6 +79,9 @@ impl HealthState {
     fn to_ready_response(&self) -> ReadyResponse {
         let inner = self.inner.lock().expect("health mutex poisoned");
         let now = unix_seconds_now();
+        let elapsed_secs = self.started_at.elapsed().as_secs();
+        let grace_secs = self.funding_poll_seconds.saturating_mul(2);
+
         let stale_markets = self
             .expected_coins
             .iter()
@@ -72,10 +95,26 @@ impl HealthState {
             .cloned()
             .collect::<Vec<_>>();
 
+        let now_ms = (now * 1000.0) as u64;
+        let stale_funding_markets = self
+            .expected_coins
+            .iter()
+            .filter(|coin| match inner.funding_last_event_ms.get(*coin) {
+                Some(event_ms) => {
+                    now_ms.saturating_sub(*event_ms) / 1000 > self.funding_stale_seconds
+                }
+                None => elapsed_secs >= grace_secs,
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+
         ReadyResponse {
-            ready: inner.clickhouse_ok && stale_markets.is_empty(),
+            ready: inner.clickhouse_ok
+                && stale_markets.is_empty()
+                && stale_funding_markets.is_empty(),
             clickhouse_ok: inner.clickhouse_ok,
             stale_markets,
+            stale_funding_markets,
         }
     }
 }

--- a/apps/hyperliquid-recorder/src/lib.rs
+++ b/apps/hyperliquid-recorder/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod clickhouse;
 pub mod config;
+pub mod funding_client;
 pub mod health;
 pub mod metrics;
 pub mod models;

--- a/apps/hyperliquid-recorder/src/main.rs
+++ b/apps/hyperliquid-recorder/src/main.rs
@@ -7,7 +7,7 @@ use hyperliquid_recorder::{
     config::AppConfig,
     health::{start_http_servers, HealthState},
     metrics::RecorderMetrics,
-    recorder::{RecorderRuntime, WriterRuntimeConfig},
+    recorder::{FundingRuntimeConfig, RecorderRuntime, WriterRuntimeConfig},
 };
 use tokio::signal::unix::{signal, SignalKind};
 
@@ -52,6 +52,11 @@ async fn run() -> Result<()> {
             batch_max_rows: config.batch_max_rows,
             batch_flush_seconds: config.batch_flush_seconds,
             queue_max_rows: config.queue_max_rows,
+        },
+        FundingRuntimeConfig {
+            info_api_url: config.info_api_url,
+            poll_seconds: config.funding_poll_seconds,
+            lookback_seconds: config.funding_lookback_seconds,
         },
         metrics.clone(),
         health.clone(),

--- a/apps/hyperliquid-recorder/src/main.rs
+++ b/apps/hyperliquid-recorder/src/main.rs
@@ -11,6 +11,8 @@ use hyperliquid_recorder::{
 };
 use tokio::signal::unix::{signal, SignalKind};
 
+const FUNDING_PERIOD_SECONDS: u64 = 3600;
+
 #[tokio::main]
 async fn main() -> ExitCode {
     init_logging();
@@ -35,6 +37,8 @@ async fn run() -> Result<()> {
     let health = HealthState::new(
         config.markets.iter().map(|m| m.coin.clone()).collect(),
         config.ready_stale_seconds,
+        config.funding_poll_seconds,
+        FUNDING_PERIOD_SECONDS * 2,
     );
     let (health_server, metrics_server) = start_http_servers(
         config.health_port,

--- a/apps/hyperliquid-recorder/src/metrics.rs
+++ b/apps/hyperliquid-recorder/src/metrics.rs
@@ -42,8 +42,6 @@ pub struct RecorderMetrics {
     pub funding_insert_attempts: CounterVec,
     pub funding_insert_rows: Counter,
     pub funding_insert_latency_seconds: Histogram,
-    pub funding_queue_depth: Gauge,
-    pub funding_queue_fill_ratio: Gauge,
     pub funding_last_event_time_seconds: GaugeVec,
 }
 
@@ -235,14 +233,6 @@ impl RecorderMetrics {
             )
             .buckets(vec![0.01, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0]),
         )?;
-        let funding_queue_depth = Gauge::with_opts(Opts::new(
-            "hyperliquid_recorder_funding_queue_depth",
-            "Current in-memory queue depth for funding records",
-        ))?;
-        let funding_queue_fill_ratio = Gauge::with_opts(Opts::new(
-            "hyperliquid_recorder_funding_queue_fill_ratio",
-            "Current in-memory queue fill ratio for funding records",
-        ))?;
         let funding_last_event_time_seconds = GaugeVec::new(
             Opts::new(
                 "hyperliquid_recorder_funding_last_event_time_seconds",
@@ -282,8 +272,6 @@ impl RecorderMetrics {
         registry.register(Box::new(funding_insert_attempts.clone()))?;
         registry.register(Box::new(funding_insert_rows.clone()))?;
         registry.register(Box::new(funding_insert_latency_seconds.clone()))?;
-        registry.register(Box::new(funding_queue_depth.clone()))?;
-        registry.register(Box::new(funding_queue_fill_ratio.clone()))?;
         registry.register(Box::new(funding_last_event_time_seconds.clone()))?;
 
         Ok(Self {
@@ -319,8 +307,6 @@ impl RecorderMetrics {
             funding_insert_attempts,
             funding_insert_rows,
             funding_insert_latency_seconds,
-            funding_queue_depth,
-            funding_queue_fill_ratio,
             funding_last_event_time_seconds,
         })
     }

--- a/apps/hyperliquid-recorder/src/metrics.rs
+++ b/apps/hyperliquid-recorder/src/metrics.rs
@@ -340,9 +340,13 @@ impl RecorderMetrics {
     }
 
     pub fn record_funding(&self, record: &FundingRateRecord) {
-        self.funding_last_event_time_seconds
-            .with_label_values(&[&record.coin])
-            .set(record.funding_time_ms as f64 / 1000.0);
+        let gauge = self
+            .funding_last_event_time_seconds
+            .with_label_values(&[&record.coin]);
+        let new_val = record.funding_time_ms as f64 / 1000.0;
+        if new_val > gauge.get() {
+            gauge.set(new_val);
+        }
     }
 
     pub fn record_trade(&self, trade: &TradeRecord) {

--- a/apps/hyperliquid-recorder/src/metrics.rs
+++ b/apps/hyperliquid-recorder/src/metrics.rs
@@ -6,7 +6,7 @@ use prometheus::{
     TextEncoder,
 };
 
-use crate::models::{L2Snapshot, TradeRecord};
+use crate::models::{FundingRateRecord, L2Snapshot, TradeRecord};
 
 #[derive(Clone)]
 pub struct RecorderMetrics {
@@ -37,6 +37,14 @@ pub struct RecorderMetrics {
     pub insert_trades_attempts: CounterVec,
     pub insert_trades_rows: Counter,
     pub insert_trades_latency_seconds: Histogram,
+    pub funding_poll_attempts: CounterVec,
+    pub funding_payload_errors: Counter,
+    pub funding_insert_attempts: CounterVec,
+    pub funding_insert_rows: Counter,
+    pub funding_insert_latency_seconds: Histogram,
+    pub funding_queue_depth: Gauge,
+    pub funding_queue_fill_ratio: Gauge,
+    pub funding_last_event_time_seconds: GaugeVec,
 }
 
 impl RecorderMetrics {
@@ -198,6 +206,50 @@ impl RecorderMetrics {
             )
             .buckets(vec![0.01, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0]),
         )?;
+        let funding_poll_attempts = CounterVec::new(
+            Opts::new(
+                "hyperliquid_recorder_funding_poll_attempts_total",
+                "Total Hyperliquid fundingHistory poll attempts by coin and outcome",
+            ),
+            &["coin", "outcome"],
+        )?;
+        let funding_payload_errors = Counter::with_opts(Opts::new(
+            "hyperliquid_recorder_funding_payload_errors_total",
+            "Total malformed fundingHistory payloads",
+        ))?;
+        let funding_insert_attempts = CounterVec::new(
+            Opts::new(
+                "hyperliquid_recorder_funding_insert_attempts_total",
+                "Total ClickHouse insert attempts for funding batches",
+            ),
+            &["outcome"],
+        )?;
+        let funding_insert_rows = Counter::with_opts(Opts::new(
+            "hyperliquid_recorder_funding_insert_rows_total",
+            "Total funding rows inserted into ClickHouse",
+        ))?;
+        let funding_insert_latency_seconds = Histogram::with_opts(
+            HistogramOpts::new(
+                "hyperliquid_recorder_funding_insert_latency_seconds",
+                "ClickHouse funding insert latency in seconds",
+            )
+            .buckets(vec![0.01, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0]),
+        )?;
+        let funding_queue_depth = Gauge::with_opts(Opts::new(
+            "hyperliquid_recorder_funding_queue_depth",
+            "Current in-memory queue depth for funding records",
+        ))?;
+        let funding_queue_fill_ratio = Gauge::with_opts(Opts::new(
+            "hyperliquid_recorder_funding_queue_fill_ratio",
+            "Current in-memory queue fill ratio for funding records",
+        ))?;
+        let funding_last_event_time_seconds = GaugeVec::new(
+            Opts::new(
+                "hyperliquid_recorder_funding_last_event_time_seconds",
+                "Unix timestamp of the most recent applied funding event observed per coin",
+            ),
+            &["coin"],
+        )?;
 
         registry.register(Box::new(stream_messages.clone()))?;
         registry.register(Box::new(stream_reconnects.clone()))?;
@@ -225,6 +277,14 @@ impl RecorderMetrics {
         registry.register(Box::new(insert_trades_attempts.clone()))?;
         registry.register(Box::new(insert_trades_rows.clone()))?;
         registry.register(Box::new(insert_trades_latency_seconds.clone()))?;
+        registry.register(Box::new(funding_poll_attempts.clone()))?;
+        registry.register(Box::new(funding_payload_errors.clone()))?;
+        registry.register(Box::new(funding_insert_attempts.clone()))?;
+        registry.register(Box::new(funding_insert_rows.clone()))?;
+        registry.register(Box::new(funding_insert_latency_seconds.clone()))?;
+        registry.register(Box::new(funding_queue_depth.clone()))?;
+        registry.register(Box::new(funding_queue_fill_ratio.clone()))?;
+        registry.register(Box::new(funding_last_event_time_seconds.clone()))?;
 
         Ok(Self {
             registry,
@@ -254,6 +314,14 @@ impl RecorderMetrics {
             insert_trades_attempts,
             insert_trades_rows,
             insert_trades_latency_seconds,
+            funding_poll_attempts,
+            funding_payload_errors,
+            funding_insert_attempts,
+            funding_insert_rows,
+            funding_insert_latency_seconds,
+            funding_queue_depth,
+            funding_queue_fill_ratio,
+            funding_last_event_time_seconds,
         })
     }
 
@@ -283,6 +351,12 @@ impl RecorderMetrics {
         let mut buffer = Vec::new();
         TextEncoder::new().encode(&metric_families, &mut buffer)?;
         Ok(buffer)
+    }
+
+    pub fn record_funding(&self, record: &FundingRateRecord) {
+        self.funding_last_event_time_seconds
+            .with_label_values(&[&record.coin])
+            .set(record.funding_time_ms as f64 / 1000.0);
     }
 
     pub fn record_trade(&self, trade: &TradeRecord) {

--- a/apps/hyperliquid-recorder/src/models.rs
+++ b/apps/hyperliquid-recorder/src/models.rs
@@ -111,12 +111,6 @@ pub struct FundingRateRecord {
     pub source_endpoint: String,
 }
 
-impl FundingRateRecord {
-    pub fn dedupe_key(&self) -> (String, u64) {
-        (self.coin.clone(), self.funding_time_ms)
-    }
-}
-
 pub fn parse_funding_history(
     body: &str,
     coin_hint: &str,

--- a/apps/hyperliquid-recorder/src/models.rs
+++ b/apps/hyperliquid-recorder/src/models.rs
@@ -102,6 +102,64 @@ pub struct TradeLiquidation {
     pub method: String,
 }
 
+#[derive(Clone, Debug)]
+pub struct FundingRateRecord {
+    pub coin: String,
+    pub funding_time_ms: u64,
+    pub funding_rate: Decimal,
+    pub premium: Option<Decimal>,
+    pub source_endpoint: String,
+}
+
+impl FundingRateRecord {
+    pub fn dedupe_key(&self) -> (String, u64) {
+        (self.coin.clone(), self.funding_time_ms)
+    }
+}
+
+pub fn parse_funding_history(
+    body: &str,
+    coin_hint: &str,
+    source_endpoint: &str,
+) -> Result<Vec<FundingRateRecord>> {
+    let raw: Vec<FundingHistoryRaw> =
+        serde_json::from_str(body).context("failed to decode fundingHistory payload")?;
+    let mut records = Vec::with_capacity(raw.len());
+    for entry in raw {
+        if entry.coin != coin_hint {
+            tracing::warn!(
+                expected = coin_hint,
+                got = entry.coin,
+                "fundingHistory coin mismatch; dropping row"
+            );
+            continue;
+        }
+        let funding_rate = parse_decimal(&entry.funding_rate, "fundingRate")?;
+        let premium = entry
+            .premium
+            .as_deref()
+            .map(|value| parse_decimal(value, "premium"))
+            .transpose()?;
+        records.push(FundingRateRecord {
+            coin: entry.coin,
+            funding_time_ms: entry.time,
+            funding_rate,
+            premium,
+            source_endpoint: source_endpoint.to_string(),
+        });
+    }
+    Ok(records)
+}
+
+#[derive(Debug, Deserialize)]
+struct FundingHistoryRaw {
+    coin: String,
+    #[serde(rename = "fundingRate")]
+    funding_rate: String,
+    premium: Option<String>,
+    time: u64,
+}
+
 pub fn parse_trades_payload(
     payload_json: &str,
     fallback_block_number: u64,

--- a/apps/hyperliquid-recorder/src/recorder.rs
+++ b/apps/hyperliquid-recorder/src/recorder.rs
@@ -9,9 +9,10 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     clickhouse::ClickHouseClient,
+    funding_client::run_funding_poll_worker,
     health::HealthState,
     metrics::RecorderMetrics,
-    models::{L2Snapshot, MarketSubscription, TradeRecord},
+    models::{FundingRateRecord, L2Snapshot, MarketSubscription, TradeRecord},
     stream_client::{run_stream_worker, run_trades_stream_worker},
 };
 
@@ -22,12 +23,20 @@ pub struct WriterRuntimeConfig {
     pub queue_max_rows: usize,
 }
 
+#[derive(Clone, Debug)]
+pub struct FundingRuntimeConfig {
+    pub info_api_url: String,
+    pub poll_seconds: u64,
+    pub lookback_seconds: u64,
+}
+
 pub struct RecorderRuntime {
     endpoint: String,
     auth_token: String,
     markets: Vec<MarketSubscription>,
     writer: ClickHouseClient,
     writer_config: WriterRuntimeConfig,
+    funding_config: FundingRuntimeConfig,
     metrics: Arc<RecorderMetrics>,
     health: HealthState,
     reconnect_max_backoff_seconds: u64,
@@ -44,6 +53,7 @@ impl RecorderRuntime {
         markets: Vec<MarketSubscription>,
         writer: ClickHouseClient,
         writer_config: WriterRuntimeConfig,
+        funding_config: FundingRuntimeConfig,
         metrics: Arc<RecorderMetrics>,
         health: HealthState,
         reconnect_max_backoff_seconds: u64,
@@ -55,6 +65,7 @@ impl RecorderRuntime {
             markets,
             writer,
             writer_config,
+            funding_config,
             metrics,
             health,
             reconnect_max_backoff_seconds,
@@ -71,8 +82,11 @@ impl RecorderRuntime {
     pub fn start(&mut self) {
         let (l2_tx, l2_rx) = mpsc::channel::<L2Snapshot>(self.writer_config.queue_max_rows);
         let (trade_tx, trade_rx) = mpsc::channel::<TradeRecord>(self.writer_config.queue_max_rows);
+        let (funding_tx, funding_rx) =
+            mpsc::channel::<FundingRateRecord>(self.writer_config.queue_max_rows);
         self.spawn_l2_writer_loop(l2_rx);
         self.spawn_trade_writer_loop(trade_rx);
+        self.spawn_funding_writer_loop(funding_rx);
 
         for market in self.markets.clone() {
             let handle = tokio::spawn(run_stream_worker(
@@ -97,6 +111,17 @@ impl RecorderRuntime {
             self.stop_token.clone(),
         ));
         self.handles.push(trade_handle);
+
+        let funding_handle = tokio::spawn(run_funding_poll_worker(
+            self.funding_config.info_api_url.clone(),
+            self.markets.clone(),
+            self.funding_config.poll_seconds,
+            self.funding_config.lookback_seconds,
+            self.reconnect_max_backoff_seconds,
+            funding_tx,
+            self.stop_token.clone(),
+        ));
+        self.handles.push(funding_handle);
 
         self.spawn_health_probe_loop();
     }
@@ -178,6 +203,7 @@ impl RecorderRuntime {
         self.handles.push(handle);
     }
 
+    #[allow(clippy::type_complexity)]
     fn spawn_trade_writer_loop(&mut self, mut receiver: mpsc::Receiver<TradeRecord>) {
         let writer = self.writer.clone();
         let metrics = self.metrics.clone();
@@ -246,6 +272,62 @@ impl RecorderRuntime {
         self.handles.push(handle);
     }
 
+    fn spawn_funding_writer_loop(&mut self, mut receiver: mpsc::Receiver<FundingRateRecord>) {
+        let writer = self.writer.clone();
+        let batch_max_rows = self.writer_config.batch_max_rows;
+        let batch_flush_seconds = self.writer_config.batch_flush_seconds;
+        let stop_token = self.stop_token.clone();
+        let insert_async = self.insert_async;
+
+        let handle = tokio::spawn(async move {
+            let mut dedupe: HashMap<(String, u64), FundingRateRecord> = HashMap::new();
+            let mut last_flush = Instant::now();
+
+            loop {
+                if stop_token.is_cancelled() && receiver.is_empty() {
+                    break;
+                }
+                let elapsed = last_flush.elapsed().as_secs_f64();
+                let wait_seconds = (batch_flush_seconds - elapsed).max(0.1);
+                match tokio::time::timeout(Duration::from_secs_f64(wait_seconds), receiver.recv())
+                    .await
+                {
+                    Ok(Some(record)) => {
+                        dedupe.insert(record.dedupe_key(), record);
+                    }
+                    Ok(None) => break,
+                    Err(_) => {}
+                }
+
+                let should_flush = dedupe.len() >= batch_max_rows
+                    || (!dedupe.is_empty()
+                        && last_flush.elapsed().as_secs_f64() >= batch_flush_seconds);
+                if should_flush {
+                    flush_funding_with_retry(
+                        &writer,
+                        dedupe.values().cloned().collect::<Vec<_>>(),
+                        stop_token.clone(),
+                        insert_async,
+                    )
+                    .await;
+                    dedupe.clear();
+                    last_flush = Instant::now();
+                }
+            }
+
+            if !dedupe.is_empty() {
+                flush_funding_with_retry(
+                    &writer,
+                    dedupe.values().cloned().collect::<Vec<_>>(),
+                    stop_token,
+                    insert_async,
+                )
+                .await;
+            }
+        });
+        self.handles.push(handle);
+    }
+
     fn spawn_health_probe_loop(&mut self) {
         let writer = self.writer.clone();
         let metrics = self.metrics.clone();
@@ -300,6 +382,36 @@ async fn flush_with_retry(
                     rows = batch.len(),
                     error = ?err,
                     "failed to insert L2 batch"
+                );
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        }
+    }
+}
+
+async fn flush_funding_with_retry(
+    writer: &ClickHouseClient,
+    batch: Vec<FundingRateRecord>,
+    stop_token: CancellationToken,
+    insert_async: bool,
+) {
+    if batch.is_empty() {
+        return;
+    }
+    loop {
+        if stop_token.is_cancelled() {
+            return;
+        }
+        match writer.insert_funding_batch(&batch, insert_async).await {
+            Ok((rows, _latency)) => {
+                tracing::info!("inserted {} funding rows into ClickHouse", rows);
+                return;
+            }
+            Err(err) => {
+                tracing::error!(
+                    rows = batch.len(),
+                    error = ?err,
+                    "failed to insert funding batch"
                 );
                 tokio::time::sleep(Duration::from_secs(1)).await;
             }

--- a/apps/hyperliquid-recorder/src/recorder.rs
+++ b/apps/hyperliquid-recorder/src/recorder.rs
@@ -119,6 +119,7 @@ impl RecorderRuntime {
             self.funding_config.lookback_seconds,
             self.reconnect_max_backoff_seconds,
             funding_tx,
+            self.metrics.clone(),
             self.stop_token.clone(),
         ));
         self.handles.push(funding_handle);
@@ -274,8 +275,10 @@ impl RecorderRuntime {
 
     fn spawn_funding_writer_loop(&mut self, mut receiver: mpsc::Receiver<FundingRateRecord>) {
         let writer = self.writer.clone();
+        let metrics = self.metrics.clone();
         let batch_max_rows = self.writer_config.batch_max_rows;
         let batch_flush_seconds = self.writer_config.batch_flush_seconds;
+        let queue_max_rows = self.writer_config.queue_max_rows;
         let stop_token = self.stop_token.clone();
         let insert_async = self.insert_async;
 
@@ -293,7 +296,13 @@ impl RecorderRuntime {
                     .await
                 {
                     Ok(Some(record)) => {
+                        metrics.record_funding(&record);
                         dedupe.insert(record.dedupe_key(), record);
+                        let size = receiver.len();
+                        metrics.funding_queue_depth.set(size as f64);
+                        metrics
+                            .funding_queue_fill_ratio
+                            .set(size as f64 / queue_max_rows.max(1) as f64);
                     }
                     Ok(None) => break,
                     Err(_) => {}
@@ -305,6 +314,7 @@ impl RecorderRuntime {
                 if should_flush {
                     flush_funding_with_retry(
                         &writer,
+                        &metrics,
                         dedupe.values().cloned().collect::<Vec<_>>(),
                         stop_token.clone(),
                         insert_async,
@@ -318,6 +328,7 @@ impl RecorderRuntime {
             if !dedupe.is_empty() {
                 flush_funding_with_retry(
                     &writer,
+                    &metrics,
                     dedupe.values().cloned().collect::<Vec<_>>(),
                     stop_token,
                     insert_async,
@@ -391,6 +402,7 @@ async fn flush_with_retry(
 
 async fn flush_funding_with_retry(
     writer: &ClickHouseClient,
+    metrics: &RecorderMetrics,
     batch: Vec<FundingRateRecord>,
     stop_token: CancellationToken,
     insert_async: bool,
@@ -403,11 +415,21 @@ async fn flush_funding_with_retry(
             return;
         }
         match writer.insert_funding_batch(&batch, insert_async).await {
-            Ok((rows, _latency)) => {
+            Ok((rows, latency)) => {
+                metrics
+                    .funding_insert_attempts
+                    .with_label_values(&["success"])
+                    .inc();
+                metrics.funding_insert_rows.inc_by(rows as f64);
+                metrics.funding_insert_latency_seconds.observe(latency);
                 tracing::info!("inserted {} funding rows into ClickHouse", rows);
                 return;
             }
             Err(err) => {
+                metrics
+                    .funding_insert_attempts
+                    .with_label_values(&["error"])
+                    .inc();
                 tracing::error!(
                     rows = batch.len(),
                     error = ?err,

--- a/apps/hyperliquid-recorder/src/recorder.rs
+++ b/apps/hyperliquid-recorder/src/recorder.rs
@@ -284,7 +284,7 @@ impl RecorderRuntime {
         let insert_async = self.insert_async;
 
         let handle = tokio::spawn(async move {
-            let mut dedupe: HashMap<(String, u64), FundingRateRecord> = HashMap::new();
+            let mut batch: Vec<FundingRateRecord> = Vec::new();
             let mut last_flush = Instant::now();
 
             loop {
@@ -299,7 +299,7 @@ impl RecorderRuntime {
                     Ok(Some(record)) => {
                         metrics.record_funding(&record);
                         health.set_funding_event_seen(&record.coin, record.funding_time_ms);
-                        dedupe.insert(record.dedupe_key(), record);
+                        batch.push(record);
                         let size = receiver.len();
                         metrics.funding_queue_depth.set(size as f64);
                         metrics
@@ -310,32 +310,24 @@ impl RecorderRuntime {
                     Err(_) => {}
                 }
 
-                let should_flush = dedupe.len() >= batch_max_rows
-                    || (!dedupe.is_empty()
+                let should_flush = batch.len() >= batch_max_rows
+                    || (!batch.is_empty()
                         && last_flush.elapsed().as_secs_f64() >= batch_flush_seconds);
                 if should_flush {
                     flush_funding_with_retry(
                         &writer,
                         &metrics,
-                        dedupe.values().cloned().collect::<Vec<_>>(),
+                        std::mem::take(&mut batch),
                         stop_token.clone(),
                         insert_async,
                     )
                     .await;
-                    dedupe.clear();
                     last_flush = Instant::now();
                 }
             }
 
-            if !dedupe.is_empty() {
-                flush_funding_with_retry(
-                    &writer,
-                    &metrics,
-                    dedupe.values().cloned().collect::<Vec<_>>(),
-                    stop_token,
-                    insert_async,
-                )
-                .await;
+            if !batch.is_empty() {
+                flush_funding_with_retry(&writer, &metrics, batch, stop_token, insert_async).await;
             }
         });
         self.handles.push(handle);

--- a/apps/hyperliquid-recorder/src/recorder.rs
+++ b/apps/hyperliquid-recorder/src/recorder.rs
@@ -278,40 +278,41 @@ impl RecorderRuntime {
             let mut ticker = interval(Duration::from_secs(poll_seconds.max(1)));
             ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
-            while !stop_token.is_cancelled() {
-                ticker.tick().await;
-                if stop_token.is_cancelled() {
-                    return;
-                }
+            while stop_token
+                .run_until_cancelled(async {
+                    ticker.tick().await;
 
-                let batch = poll_funding_once(
-                    &http,
-                    &info_api_url,
-                    &markets,
-                    lookback_seconds,
-                    max_backoff,
-                    &metrics,
-                    &mut backoff,
-                    &stop_token,
-                )
-                .await;
-
-                for record in &batch {
-                    metrics.record_funding(record);
-                    health.set_funding_event_seen(&record.coin, record.funding_time_ms);
-                }
-
-                if !batch.is_empty() {
-                    flush_funding_with_retry(
-                        &writer,
+                    let batch = poll_funding_once(
+                        &http,
+                        &info_api_url,
+                        &markets,
+                        lookback_seconds,
+                        max_backoff,
                         &metrics,
-                        batch,
-                        stop_token.clone(),
-                        insert_async,
+                        &mut backoff,
+                        &stop_token,
                     )
                     .await;
-                }
-            }
+
+                    for record in &batch {
+                        metrics.record_funding(record);
+                        health.set_funding_event_seen(&record.coin, record.funding_time_ms);
+                    }
+
+                    if !batch.is_empty() {
+                        flush_funding_with_retry(
+                            &writer,
+                            &metrics,
+                            batch,
+                            stop_token.clone(),
+                            insert_async,
+                        )
+                        .await;
+                    }
+                })
+                .await
+                .is_some()
+            {}
         });
         self.handles.push(handle);
     }

--- a/apps/hyperliquid-recorder/src/recorder.rs
+++ b/apps/hyperliquid-recorder/src/recorder.rs
@@ -276,6 +276,7 @@ impl RecorderRuntime {
     fn spawn_funding_writer_loop(&mut self, mut receiver: mpsc::Receiver<FundingRateRecord>) {
         let writer = self.writer.clone();
         let metrics = self.metrics.clone();
+        let health = self.health.clone();
         let batch_max_rows = self.writer_config.batch_max_rows;
         let batch_flush_seconds = self.writer_config.batch_flush_seconds;
         let queue_max_rows = self.writer_config.queue_max_rows;
@@ -297,6 +298,7 @@ impl RecorderRuntime {
                 {
                     Ok(Some(record)) => {
                         metrics.record_funding(&record);
+                        health.set_funding_event_seen(&record.coin, record.funding_time_ms);
                         dedupe.insert(record.dedupe_key(), record);
                         let size = receiver.len();
                         metrics.funding_queue_depth.set(size as f64);

--- a/apps/hyperliquid-recorder/src/recorder.rs
+++ b/apps/hyperliquid-recorder/src/recorder.rs
@@ -3,13 +3,13 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::{
     sync::mpsc,
     task::JoinHandle,
-    time::{Instant, MissedTickBehavior},
+    time::{interval, Instant, MissedTickBehavior},
 };
 use tokio_util::sync::CancellationToken;
 
 use crate::{
     clickhouse::ClickHouseClient,
-    funding_client::run_funding_poll_worker,
+    funding_client::poll_funding_once,
     health::HealthState,
     metrics::RecorderMetrics,
     models::{FundingRateRecord, L2Snapshot, MarketSubscription, TradeRecord},
@@ -82,11 +82,8 @@ impl RecorderRuntime {
     pub fn start(&mut self) {
         let (l2_tx, l2_rx) = mpsc::channel::<L2Snapshot>(self.writer_config.queue_max_rows);
         let (trade_tx, trade_rx) = mpsc::channel::<TradeRecord>(self.writer_config.queue_max_rows);
-        let (funding_tx, funding_rx) =
-            mpsc::channel::<FundingRateRecord>(self.writer_config.queue_max_rows);
         self.spawn_l2_writer_loop(l2_rx);
         self.spawn_trade_writer_loop(trade_rx);
-        self.spawn_funding_writer_loop(funding_rx);
 
         for market in self.markets.clone() {
             let handle = tokio::spawn(run_stream_worker(
@@ -112,17 +109,7 @@ impl RecorderRuntime {
         ));
         self.handles.push(trade_handle);
 
-        let funding_handle = tokio::spawn(run_funding_poll_worker(
-            self.funding_config.info_api_url.clone(),
-            self.markets.clone(),
-            self.funding_config.poll_seconds,
-            self.funding_config.lookback_seconds,
-            self.reconnect_max_backoff_seconds,
-            funding_tx,
-            self.metrics.clone(),
-            self.stop_token.clone(),
-        ));
-        self.handles.push(funding_handle);
+        self.spawn_funding_loop();
 
         self.spawn_health_probe_loop();
     }
@@ -273,61 +260,57 @@ impl RecorderRuntime {
         self.handles.push(handle);
     }
 
-    fn spawn_funding_writer_loop(&mut self, mut receiver: mpsc::Receiver<FundingRateRecord>) {
+    fn spawn_funding_loop(&mut self) {
+        let info_api_url = self.funding_config.info_api_url.clone();
+        let markets = self.markets.clone();
+        let poll_seconds = self.funding_config.poll_seconds;
+        let lookback_seconds = self.funding_config.lookback_seconds;
+        let max_backoff = self.reconnect_max_backoff_seconds;
         let writer = self.writer.clone();
         let metrics = self.metrics.clone();
         let health = self.health.clone();
-        let batch_max_rows = self.writer_config.batch_max_rows;
-        let batch_flush_seconds = self.writer_config.batch_flush_seconds;
-        let queue_max_rows = self.writer_config.queue_max_rows;
-        let stop_token = self.stop_token.clone();
         let insert_async = self.insert_async;
+        let stop_token = self.stop_token.clone();
 
         let handle = tokio::spawn(async move {
-            let mut batch: Vec<FundingRateRecord> = Vec::new();
-            let mut last_flush = Instant::now();
+            let http = reqwest::Client::new();
+            let mut backoff: HashMap<String, u64> = HashMap::new();
+            let mut ticker = interval(Duration::from_secs(poll_seconds.max(1)));
+            ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
-            loop {
-                if stop_token.is_cancelled() && receiver.is_empty() {
-                    break;
-                }
-                let elapsed = last_flush.elapsed().as_secs_f64();
-                let wait_seconds = (batch_flush_seconds - elapsed).max(0.1);
-                match tokio::time::timeout(Duration::from_secs_f64(wait_seconds), receiver.recv())
-                    .await
-                {
-                    Ok(Some(record)) => {
-                        metrics.record_funding(&record);
-                        health.set_funding_event_seen(&record.coin, record.funding_time_ms);
-                        batch.push(record);
-                        let size = receiver.len();
-                        metrics.funding_queue_depth.set(size as f64);
-                        metrics
-                            .funding_queue_fill_ratio
-                            .set(size as f64 / queue_max_rows.max(1) as f64);
-                    }
-                    Ok(None) => break,
-                    Err(_) => {}
+            while !stop_token.is_cancelled() {
+                ticker.tick().await;
+                if stop_token.is_cancelled() {
+                    return;
                 }
 
-                let should_flush = batch.len() >= batch_max_rows
-                    || (!batch.is_empty()
-                        && last_flush.elapsed().as_secs_f64() >= batch_flush_seconds);
-                if should_flush {
+                let batch = poll_funding_once(
+                    &http,
+                    &info_api_url,
+                    &markets,
+                    lookback_seconds,
+                    max_backoff,
+                    &metrics,
+                    &mut backoff,
+                    &stop_token,
+                )
+                .await;
+
+                for record in &batch {
+                    metrics.record_funding(record);
+                    health.set_funding_event_seen(&record.coin, record.funding_time_ms);
+                }
+
+                if !batch.is_empty() {
                     flush_funding_with_retry(
                         &writer,
                         &metrics,
-                        std::mem::take(&mut batch),
+                        batch,
                         stop_token.clone(),
                         insert_async,
                     )
                     .await;
-                    last_flush = Instant::now();
                 }
-            }
-
-            if !batch.is_empty() {
-                flush_funding_with_retry(&writer, &metrics, batch, stop_token, insert_async).await;
             }
         });
         self.handles.push(handle);

--- a/apps/hyperliquid-recorder/tests/test_config.rs
+++ b/apps/hyperliquid-recorder/tests/test_config.rs
@@ -110,6 +110,197 @@ metrics_port: 9092
 }
 
 #[test]
+fn test_funding_config_defaults_when_unspecified() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    clear_env_vars([
+        "HYPERLIQUID_RECORDER__QUICKNODE__ENDPOINT",
+        "HYPERLIQUID_RECORDER__QUICKNODE__AUTH_TOKEN",
+        "HYPERLIQUID_RECORDER__CLICKHOUSE__URL",
+        "HYPERLIQUID_RECORDER__CLICKHOUSE__USER",
+        "HYPERLIQUID_RECORDER__CLICKHOUSE__PASSWORD",
+        "HYPERLIQUID_RECORDER__CLICKHOUSE__DATABASE",
+        "HYPERLIQUID_RECORDER__CLICKHOUSE__L2_SNAPSHOTS_TABLE",
+        "HYPERLIQUID_RECORDER__CLICKHOUSE__TRADES_TABLE",
+        "HYPERLIQUID_RECORDER__CLICKHOUSE__FUNDING_RATES_TABLE",
+        "HYPERLIQUID_RECORDER__INFO_API_URL",
+        "HYPERLIQUID_RECORDER__FUNDING_POLL_SECONDS",
+        "HYPERLIQUID_RECORDER__FUNDING_LOOKBACK_SECONDS",
+    ]);
+
+    let config_file = temp_yaml_path("hrec-config-funding-defaults");
+    let yaml = r#"
+quicknode:
+  endpoint: "example:10000"
+  auth_token: "token"
+markets:
+  - coin: "BTC"
+    n_levels: 20
+clickhouse:
+  url: "http://127.0.0.1:8123"
+  user: "recorder"
+  password: "recorder"
+"#;
+    fs::write(&config_file, yaml).expect("write yaml config");
+    let config =
+        AppConfig::from_sources(Some(&config_file)).expect("config should parse with defaults");
+    assert_eq!(config.info_api_url, "https://api.hyperliquid.xyz/info");
+    assert_eq!(config.funding_poll_seconds, 300);
+    assert_eq!(config.funding_lookback_seconds, 21_600);
+    assert_eq!(
+        config.clickhouse.funding_rates_table,
+        "hyperliquid_funding_rates"
+    );
+
+    let _ = fs::remove_file(config_file);
+}
+
+#[test]
+fn test_funding_config_yaml_overrides_defaults() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    clear_env_vars([
+        "HYPERLIQUID_RECORDER__INFO_API_URL",
+        "HYPERLIQUID_RECORDER__FUNDING_POLL_SECONDS",
+        "HYPERLIQUID_RECORDER__FUNDING_LOOKBACK_SECONDS",
+        "HYPERLIQUID_RECORDER__CLICKHOUSE__FUNDING_RATES_TABLE",
+    ]);
+
+    let config_file = temp_yaml_path("hrec-config-funding-yaml");
+    let yaml = r#"
+quicknode:
+  endpoint: "example:10000"
+  auth_token: "token"
+markets:
+  - coin: "BTC"
+    n_levels: 20
+clickhouse:
+  url: "http://127.0.0.1:8123"
+  funding_rates_table: "custom_funding"
+info_api_url: "https://custom.example/info"
+funding_poll_seconds: 600
+funding_lookback_seconds: 43200
+"#;
+    fs::write(&config_file, yaml).expect("write yaml config");
+    let config = AppConfig::from_sources(Some(&config_file)).expect("config should parse");
+    assert_eq!(config.info_api_url, "https://custom.example/info");
+    assert_eq!(config.funding_poll_seconds, 600);
+    assert_eq!(config.funding_lookback_seconds, 43_200);
+    assert_eq!(config.clickhouse.funding_rates_table, "custom_funding");
+
+    let _ = fs::remove_file(config_file);
+}
+
+#[test]
+fn test_funding_config_env_overrides_yaml() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    clear_env_vars([
+        "HYPERLIQUID_RECORDER__INFO_API_URL",
+        "HYPERLIQUID_RECORDER__FUNDING_POLL_SECONDS",
+        "HYPERLIQUID_RECORDER__FUNDING_LOOKBACK_SECONDS",
+        "HYPERLIQUID_RECORDER__CLICKHOUSE__FUNDING_RATES_TABLE",
+    ]);
+
+    let config_file = temp_yaml_path("hrec-config-funding-env");
+    let yaml = r#"
+quicknode:
+  endpoint: "example:10000"
+  auth_token: "token"
+markets:
+  - coin: "BTC"
+    n_levels: 20
+clickhouse:
+  url: "http://127.0.0.1:8123"
+info_api_url: "https://yaml.example/info"
+funding_poll_seconds: 600
+"#;
+    fs::write(&config_file, yaml).expect("write yaml config");
+    std::env::set_var(
+        "HYPERLIQUID_RECORDER__INFO_API_URL",
+        "https://env.example/info",
+    );
+    std::env::set_var("HYPERLIQUID_RECORDER__FUNDING_POLL_SECONDS", "900");
+    std::env::set_var("HYPERLIQUID_RECORDER__FUNDING_LOOKBACK_SECONDS", "10800");
+    std::env::set_var(
+        "HYPERLIQUID_RECORDER__CLICKHOUSE__FUNDING_RATES_TABLE",
+        "env_funding",
+    );
+
+    let config = AppConfig::from_sources(Some(&config_file)).expect("config should parse");
+    assert_eq!(config.info_api_url, "https://env.example/info");
+    assert_eq!(config.funding_poll_seconds, 900);
+    assert_eq!(config.funding_lookback_seconds, 10_800);
+    assert_eq!(config.clickhouse.funding_rates_table, "env_funding");
+
+    clear_env_vars([
+        "HYPERLIQUID_RECORDER__INFO_API_URL",
+        "HYPERLIQUID_RECORDER__FUNDING_POLL_SECONDS",
+        "HYPERLIQUID_RECORDER__FUNDING_LOOKBACK_SECONDS",
+        "HYPERLIQUID_RECORDER__CLICKHOUSE__FUNDING_RATES_TABLE",
+    ]);
+    let _ = fs::remove_file(config_file);
+}
+
+#[test]
+fn test_funding_poll_seconds_below_minimum_rejected() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    clear_env_vars([
+        "HYPERLIQUID_RECORDER__FUNDING_POLL_SECONDS",
+        "HYPERLIQUID_RECORDER__FUNDING_LOOKBACK_SECONDS",
+    ]);
+    let config_file = temp_yaml_path("hrec-config-funding-poll-min");
+    let yaml = r#"
+quicknode:
+  endpoint: "example:10000"
+  auth_token: "token"
+markets:
+  - coin: "BTC"
+    n_levels: 20
+clickhouse:
+  url: "http://127.0.0.1:8123"
+funding_poll_seconds: 10
+"#;
+    fs::write(&config_file, yaml).expect("write yaml config");
+    let result = AppConfig::from_sources(Some(&config_file));
+    assert!(result.is_err(), "poll < 30 must be rejected");
+    let message = result.err().map(|e| e.to_string()).unwrap_or_default();
+    assert!(
+        message.contains("funding_poll_seconds"),
+        "unexpected error: {message}"
+    );
+    let _ = fs::remove_file(config_file);
+}
+
+#[test]
+fn test_funding_lookback_smaller_than_poll_rejected() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    clear_env_vars([
+        "HYPERLIQUID_RECORDER__FUNDING_POLL_SECONDS",
+        "HYPERLIQUID_RECORDER__FUNDING_LOOKBACK_SECONDS",
+    ]);
+    let config_file = temp_yaml_path("hrec-config-funding-lookback");
+    let yaml = r#"
+quicknode:
+  endpoint: "example:10000"
+  auth_token: "token"
+markets:
+  - coin: "BTC"
+    n_levels: 20
+clickhouse:
+  url: "http://127.0.0.1:8123"
+funding_poll_seconds: 300
+funding_lookback_seconds: 100
+"#;
+    fs::write(&config_file, yaml).expect("write yaml config");
+    let result = AppConfig::from_sources(Some(&config_file));
+    assert!(result.is_err(), "lookback < poll must be rejected");
+    let message = result.err().map(|e| e.to_string()).unwrap_or_default();
+    assert!(
+        message.contains("funding_lookback_seconds"),
+        "unexpected error: {message}"
+    );
+    let _ = fs::remove_file(config_file);
+}
+
+#[test]
 fn test_invalid_market_configuration_fails() {
     let _lock = ENV_LOCK.lock().expect("env lock poisoned");
     let config_file = temp_yaml_path("hrec-config-invalid-market");

--- a/apps/hyperliquid-recorder/tests/test_health.rs
+++ b/apps/hyperliquid-recorder/tests/test_health.rs
@@ -1,10 +1,19 @@
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use hyperliquid_recorder::health::HealthState;
 
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}
+
 #[test]
 fn test_health_requires_clickhouse_and_market_freshness() {
-    let state = HealthState::new(vec!["BTC".to_string(), "ETH".to_string()], 30);
+    // Generous funding grace + threshold so the L2 readiness assertions
+    // aren't perturbed by the funding gate.
+    let state = HealthState::new(vec!["BTC".to_string(), "ETH".to_string()], 30, 3600, 7200);
     assert!(!state.is_ready());
 
     state.set_clickhouse_ok(true);
@@ -17,9 +26,47 @@ fn test_health_requires_clickhouse_and_market_freshness() {
 
 #[test]
 fn test_health_becomes_unready_when_market_stale() {
-    let state = HealthState::new(vec!["BTC".to_string()], 0);
+    let state = HealthState::new(vec!["BTC".to_string()], 0, 3600, 7200);
     state.set_clickhouse_ok(true);
     state.set_market_seen("BTC");
     std::thread::sleep(Duration::from_millis(10));
+    assert!(!state.is_ready());
+}
+
+#[test]
+fn test_funding_ready_within_grace_without_event() {
+    // Generous grace window keeps us ready before the first event arrives.
+    let state = HealthState::new(vec!["BTC".to_string()], 30, 3600, 7200);
+    state.set_clickhouse_ok(true);
+    state.set_market_seen("BTC");
+    assert!(state.is_ready());
+}
+
+#[test]
+fn test_funding_unready_past_grace_with_no_event() {
+    // funding_poll_seconds = 0 ⇒ grace window = 0; we're past it immediately.
+    let state = HealthState::new(vec!["BTC".to_string()], 30, 0, 7200);
+    state.set_clickhouse_ok(true);
+    state.set_market_seen("BTC");
+    assert!(!state.is_ready());
+}
+
+#[test]
+fn test_funding_ready_after_event_seen() {
+    // Past grace (funding_poll_seconds = 0) but a fresh event flips us back.
+    let state = HealthState::new(vec!["BTC".to_string()], 30, 0, 7200);
+    state.set_clickhouse_ok(true);
+    state.set_market_seen("BTC");
+    state.set_funding_event_seen("BTC", now_ms());
+    assert!(state.is_ready());
+}
+
+#[test]
+fn test_funding_unready_when_event_older_than_threshold() {
+    // funding_stale_seconds = 1 ⇒ a 10s-old event is past the threshold.
+    let state = HealthState::new(vec!["BTC".to_string()], 30, 3600, 1);
+    state.set_clickhouse_ok(true);
+    state.set_market_seen("BTC");
+    state.set_funding_event_seen("BTC", now_ms() - 10_000);
     assert!(!state.is_ready());
 }

--- a/apps/hyperliquid-recorder/tests/test_models.rs
+++ b/apps/hyperliquid-recorder/tests/test_models.rs
@@ -1,6 +1,8 @@
 use std::str::FromStr;
 
-use hyperliquid_recorder::models::{L2Level, L2Snapshot};
+use hyperliquid_recorder::models::{
+    parse_funding_history, FundingRateRecord, L2Level, L2Snapshot,
+};
 use rust_decimal::Decimal;
 
 #[test]
@@ -25,4 +27,83 @@ fn test_snapshot_dedupe_key_uses_request_shape() {
         }],
     };
     assert_eq!(snapshot.dedupe_key(), ("BTC".to_string(), 123, 20, 3, 1));
+}
+
+#[test]
+fn test_funding_dedupe_key_is_coin_and_time() {
+    let record = FundingRateRecord {
+        coin: "BTC".to_string(),
+        funding_time_ms: 1_700_000_000_000,
+        funding_rate: Decimal::from_str("0.0000125").expect("valid decimal"),
+        premium: Some(Decimal::from_str("0.00001").expect("valid decimal")),
+        source_endpoint: "https://api.hyperliquid.xyz/info".to_string(),
+    };
+    assert_eq!(
+        record.dedupe_key(),
+        ("BTC".to_string(), 1_700_000_000_000)
+    );
+}
+
+#[test]
+fn test_parse_funding_history_canonical_payload() {
+    let body = r#"[
+        {"coin": "BTC", "fundingRate": "0.0000125", "premium": "0.00001", "time": 1700000000000},
+        {"coin": "BTC", "fundingRate": "0.0000130", "premium": "0.00002", "time": 1700003600000}
+    ]"#;
+    let records = parse_funding_history(body, "BTC", "https://api.hyperliquid.xyz/info")
+        .expect("payload should parse");
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0].coin, "BTC");
+    assert_eq!(records[0].funding_time_ms, 1_700_000_000_000);
+    assert_eq!(
+        records[0].funding_rate,
+        Decimal::from_str("0.0000125").unwrap()
+    );
+    assert_eq!(
+        records[0].premium,
+        Some(Decimal::from_str("0.00001").unwrap())
+    );
+    assert_eq!(
+        records[0].source_endpoint,
+        "https://api.hyperliquid.xyz/info"
+    );
+    assert_eq!(records[1].funding_time_ms, 1_700_003_600_000);
+}
+
+#[test]
+fn test_parse_funding_history_empty_array_is_ok() {
+    let records =
+        parse_funding_history("[]", "BTC", "src").expect("empty array should parse");
+    assert!(records.is_empty());
+}
+
+#[test]
+fn test_parse_funding_history_missing_premium_is_none() {
+    let body = r#"[
+        {"coin": "BTC", "fundingRate": "0.00002", "time": 1700000000000}
+    ]"#;
+    let records = parse_funding_history(body, "BTC", "src").expect("payload should parse");
+    assert_eq!(records.len(), 1);
+    assert!(records[0].premium.is_none());
+}
+
+#[test]
+fn test_parse_funding_history_malformed_decimal_errors() {
+    let body = r#"[
+        {"coin": "BTC", "fundingRate": "not-a-number", "time": 1700000000000}
+    ]"#;
+    let result = parse_funding_history(body, "BTC", "src");
+    assert!(result.is_err(), "malformed decimal must error");
+}
+
+#[test]
+fn test_parse_funding_history_drops_coin_mismatch() {
+    let body = r#"[
+        {"coin": "BTC", "fundingRate": "0.0000125", "time": 1700000000000},
+        {"coin": "btc", "fundingRate": "0.0000130", "time": 1700003600000}
+    ]"#;
+    let records =
+        parse_funding_history(body, "BTC", "src").expect("payload should parse");
+    assert_eq!(records.len(), 1, "lowercase coin should be dropped, not errored");
+    assert_eq!(records[0].coin, "BTC");
 }

--- a/apps/hyperliquid-recorder/tests/test_models.rs
+++ b/apps/hyperliquid-recorder/tests/test_models.rs
@@ -1,8 +1,6 @@
 use std::str::FromStr;
 
-use hyperliquid_recorder::models::{
-    parse_funding_history, FundingRateRecord, L2Level, L2Snapshot,
-};
+use hyperliquid_recorder::models::{parse_funding_history, L2Level, L2Snapshot};
 use rust_decimal::Decimal;
 
 #[test]
@@ -27,21 +25,6 @@ fn test_snapshot_dedupe_key_uses_request_shape() {
         }],
     };
     assert_eq!(snapshot.dedupe_key(), ("BTC".to_string(), 123, 20, 3, 1));
-}
-
-#[test]
-fn test_funding_dedupe_key_is_coin_and_time() {
-    let record = FundingRateRecord {
-        coin: "BTC".to_string(),
-        funding_time_ms: 1_700_000_000_000,
-        funding_rate: Decimal::from_str("0.0000125").expect("valid decimal"),
-        premium: Some(Decimal::from_str("0.00001").expect("valid decimal")),
-        source_endpoint: "https://api.hyperliquid.xyz/info".to_string(),
-    };
-    assert_eq!(
-        record.dedupe_key(),
-        ("BTC".to_string(), 1_700_000_000_000)
-    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

New funding-rate ingestion lane in `hyperliquid-recorder`. Polls Hyperliquid's Info API (`POST /info`, `type: fundingHistory`) per configured market on a 5-minute interval and writes applied per-hour funding events into a new `hyperliquid_funding_rates` ClickHouse table (`ReplacingMergeTree(ingested_at)` keyed by `(coin, funding_time)`).

A single orchestrator task in `RecorderRuntime` owns the ticker, `reqwest::Client`, and per-coin backoff state. Each tick calls a pure `funding_client::poll_funding_once` that returns the cycle's records, applies per-record metrics + health, then flushes the whole cycle once via `flush_funding_with_retry`. No in-memory dedupe — ClickHouse collapses duplicates on merge — and no separate writer task / mpsc channel (the L2 + trades streaming-writer template would be overkill for a polled, low-rate source producing ~150 rows per cycle).

- New config keys: `info_api_url`, `funding_poll_seconds`, `funding_lookback_seconds`, `clickhouse.funding_rates_table`. YAML + env overrides + validation.
- Prometheus instruments: `funding_poll_attempts_total{coin,outcome}`, `funding_insert_attempts_total{outcome}`, `funding_insert_rows_total`, `funding_insert_latency_seconds`, `funding_payload_errors_total`, `funding_last_event_time_seconds{coin}`. Grafana dashboard gains 5 funding panels.
- `/ready` aggregates per-coin funding freshness alongside L2; staleness threshold = `2 × FUNDING_PERIOD_SECONDS` (7200s). Response payload exposes `stale_funding_markets` for per-lane diagnosis.
- `sql/001-init.sql` + `ensure_schema` updated (documentation-only — production DDL is applied out-of-band).
- `scripts/local_e2e_check.sh` now iterates `${CLICKHOUSE_TABLES}` (defaults to both `hyperliquid_l2_snapshots` and `hyperliquid_funding_rates`).
- `config.sample.yml` + README updated.

Closes PFG-911 (sub-issues PFG-912, PFG-913, PFG-914, PFG-915).

## Test plan

- [ ] `cargo clippy --all-targets -- -D warnings` from `apps/hyperliquid-recorder/`
- [ ] `cargo test` from `apps/hyperliquid-recorder/` (20 tests: 8 config + 6 health + 6 models)
- [ ] Local E2E against the Tilt stack: from `apps/hyperliquid-recorder/`, `tilt up`; once the recorder is healthy, verify funding rows with `CLICKHOUSE_TABLES=hyperliquid_funding_rates bash scripts/local_e2e_check.sh`
- [ ] Spot-check Grafana "Hyperliquid Recorder Overview" — funding panels render and `Funding Insert Rows` ticks up each poll cycle
- [ ] Apply `CREATE TABLE hyperliquid_funding_rates` DDL to ClickHouse Cloud out-of-band before deploy

Note: workspace-wide `cargo check --workspace` currently fails on an unrelated `pyth-lazer-publisher-sdk` edition2024 issue in another crate; scope to `-p hyperliquid-recorder` (or run from `apps/hyperliquid-recorder/`) until that's resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
