### PR TITLE
feat(price-pusher): allow mnemonic from MNEMONIC env var

### DIFF
--- a/apps/price_pusher/README.md
+++ b/apps/price_pusher/README.md
@@ -83,6 +83,8 @@ Pyth hosts [public endpoints](https://docs.pyth.network/price-feeds/api-instance
 Hermes RPC providers for more reliability. Please refer to [this
 document](https://docs.pyth.network/documentation/pythnet-price-feeds/hermes) for more information.
 
+The signing mnemonic can be supplied via either the `--mnemonic-file` flag (path to a file containing the mnemonic) or the `MNEMONIC` environment variable. The environment variable is convenient for platforms that inject secrets as encrypted env vars (e.g. DigitalOcean, Fly.io). If both are supplied, `--mnemonic-file` takes precedence.
+
 To run the price pusher, please run the following commands, replacing the command line arguments as necessary:
 
 ```sh

--- a/apps/price_pusher/src/aptos/command.ts
+++ b/apps/price_pusher/src/aptos/command.ts
@@ -3,8 +3,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import fs from "node:fs";
-
 import { HermesClient } from "@pythnetwork/hermes-client";
 import { AptosAccount } from "aptos";
 import pino from "pino";
@@ -15,7 +13,7 @@ import { PricePusherMetrics } from "../metrics.js";
 import * as options from "../options.js";
 import { readPriceConfigFile } from "../price-config.js";
 import { PythPriceListener } from "../pyth-price-listener.js";
-import { filterInvalidPriceItems } from "../utils.js";
+import { filterInvalidPriceItems, readMnemonic } from "../utils.js";
 import {
   APTOS_ACCOUNT_HD_PATH,
   AptosPriceListener,
@@ -87,7 +85,7 @@ export default {
       logger.info(`Metrics server started on port ${metricsPort}`);
     }
 
-    const mnemonic = fs.readFileSync(mnemonicFile, "utf8").trim();
+    const mnemonic = readMnemonic(mnemonicFile);
     const account = AptosAccount.fromDerivePath(
       APTOS_ACCOUNT_HD_PATH,
       mnemonic,

--- a/apps/price_pusher/src/evm/command.ts
+++ b/apps/price_pusher/src/evm/command.ts
@@ -3,8 +3,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import fs from "node:fs";
-
 import { HermesClient } from "@pythnetwork/hermes-client";
 import pino from "pino";
 import type { Options } from "yargs";
@@ -14,7 +12,11 @@ import { PricePusherMetrics } from "../metrics.js";
 import * as options from "../options.js";
 import { readPriceConfigFile } from "../price-config.js";
 import { PythPriceListener } from "../pyth-price-listener.js";
-import { filterInvalidPriceItems, isWsEndpoint } from "../utils.js";
+import {
+  filterInvalidPriceItems,
+  isWsEndpoint,
+  readMnemonic,
+} from "../utils.js";
 import { createEvmBalanceTracker } from "./balance-tracker.js";
 import { getCustomGasStation } from "./custom-gas-station.js";
 import { EvmPriceListener, EvmPricePusher } from "./evm.js";
@@ -160,7 +162,7 @@ export default {
       accessToken: hermesAccessToken,
     });
 
-    const mnemonic = fs.readFileSync(mnemonicFile, "utf8").trim();
+    const mnemonic = readMnemonic(mnemonicFile);
 
     let priceItems = priceConfigs.map(({ id, alias }) => ({ alias, id }));
 

--- a/apps/price_pusher/src/injective/command.ts
+++ b/apps/price_pusher/src/injective/command.ts
@@ -1,8 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import fs from "node:fs";
-
 import { getNetworkInfo } from "@injectivelabs/networks";
 import { HermesClient } from "@pythnetwork/hermes-client";
 import { pino } from "pino";
@@ -11,7 +9,7 @@ import { Controller } from "../controller.js";
 import * as options from "../options.js";
 import { readPriceConfigFile } from "../price-config.js";
 import { PythPriceListener } from "../pyth-price-listener.js";
-import { filterInvalidPriceItems } from "../utils.js";
+import { filterInvalidPriceItems, readMnemonic } from "../utils.js";
 import { InjectivePriceListener, InjectivePricePusher } from "./injective.js";
 export default {
   builder: {
@@ -83,7 +81,7 @@ export default {
     const hermesClient = new HermesClient(priceServiceEndpoint, {
       accessToken: hermesAccessToken,
     });
-    const mnemonic = fs.readFileSync(mnemonicFile, "utf8").trim();
+    const mnemonic = readMnemonic(mnemonicFile);
 
     let priceItems = priceConfigs.map(({ id, alias }) => ({ alias, id }));
 

--- a/apps/price_pusher/src/options.ts
+++ b/apps/price_pusher/src/options.ts
@@ -60,9 +60,11 @@ export const pushingFrequency = {
 
 export const mnemonicFile = {
   "mnemonic-file": {
-    description: "Path to payer mnemonic (private key) file.",
-    required: true,
+    description:
+      "Path to payer mnemonic (private key) file. " +
+      "If omitted, the mnemonic is read from the `MNEMONIC` environment variable.",
     type: "string",
+    required: false,
   } as Options,
 };
 

--- a/apps/price_pusher/src/sui/command.ts
+++ b/apps/price_pusher/src/sui/command.ts
@@ -3,8 +3,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import fs from "node:fs";
-
 import { SuiClient } from "@mysten/sui/client";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { HermesClient } from "@pythnetwork/hermes-client";
@@ -16,7 +14,7 @@ import { PricePusherMetrics } from "../metrics.js";
 import * as options from "../options.js";
 import { readPriceConfigFile } from "../price-config";
 import { PythPriceListener } from "../pyth-price-listener.js";
-import { filterInvalidPriceItems } from "../utils.js";
+import { filterInvalidPriceItems, readMnemonic } from "../utils.js";
 import { createSuiBalanceTracker } from "./balance-tracker.js";
 import { SuiPriceListener, SuiPricePusher } from "./sui.js";
 
@@ -114,7 +112,7 @@ export default {
       accessToken: hermesAccessToken,
     });
 
-    const mnemonic = fs.readFileSync(mnemonicFile, "utf8").trim();
+    const mnemonic = readMnemonic(mnemonicFile);
     const keypair = Ed25519Keypair.deriveKeypair(
       mnemonic,
       `m/44'/784'/${accountIndex}'/0'/0'`,

--- a/apps/price_pusher/src/utils.ts
+++ b/apps/price_pusher/src/utils.ts
@@ -67,6 +67,7 @@ export function readMnemonic(mnemonicFile: string | undefined): string {
     return fs.readFileSync(mnemonicFile, "utf8").trim();
   }
 
+  // biome-ignore lint/style/noProcessEnv: MNEMONIC is the documented env-var entry point for this helper (CLI / docker users without a mnemonic file path)
   const envMnemonic = process.env.MNEMONIC;
   if (envMnemonic !== undefined && envMnemonic !== "") {
     return envMnemonic.trim();

--- a/apps/price_pusher/src/utils.ts
+++ b/apps/price_pusher/src/utils.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unnecessary-type-parameters */
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import fs from "node:fs";
+
 import type { HermesClient, HexString } from "@pythnetwork/hermes-client";
 
 import type { PriceItem } from "./interface.js";
@@ -59,6 +61,21 @@ export const assertDefined = <T>(value: T | undefined): T => {
     return value;
   }
 };
+
+export function readMnemonic(mnemonicFile: string | undefined): string {
+  if (mnemonicFile !== undefined && mnemonicFile !== "") {
+    return fs.readFileSync(mnemonicFile, "utf8").trim();
+  }
+
+  const envMnemonic = process.env.MNEMONIC;
+  if (envMnemonic !== undefined && envMnemonic !== "") {
+    return envMnemonic.trim();
+  }
+
+  throw new Error(
+    "No mnemonic provided. Pass --mnemonic-file or set the MNEMONIC environment variable.",
+  );
+}
 
 export async function filterInvalidPriceItems(
   hermesClient: HermesClient,

--- a/apps/price_pusher/tests/utils.test.ts
+++ b/apps/price_pusher/tests/utils.test.ts
@@ -1,0 +1,62 @@
+// biome-ignore-all lint/style/noProcessEnv: test file manipulates env vars
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { readMnemonic } from "../src/utils.js";
+
+describe("readMnemonic", () => {
+  let tmpDir: string;
+  const originalMnemonic = process.env.MNEMONIC;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "price-pusher-test-"));
+    delete process.env.MNEMONIC;
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    if (originalMnemonic === undefined) {
+      delete process.env.MNEMONIC;
+    } else {
+      process.env.MNEMONIC = originalMnemonic;
+    }
+  });
+
+  it("reads mnemonic from file when path supplied", () => {
+    const path = join(tmpDir, "mnemonic");
+    writeFileSync(path, "from file mnemonic\n");
+    expect(readMnemonic(path)).toBe("from file mnemonic");
+  });
+
+  it("falls back to MNEMONIC env var when no file path supplied", () => {
+    process.env.MNEMONIC = "from env mnemonic";
+    expect(readMnemonic(undefined)).toBe("from env mnemonic");
+  });
+
+  it("treats empty-string file path as not supplied", () => {
+    process.env.MNEMONIC = "from env mnemonic";
+    expect(readMnemonic("")).toBe("from env mnemonic");
+  });
+
+  it("file source takes precedence over env var", () => {
+    const path = join(tmpDir, "mnemonic");
+    writeFileSync(path, "from file\n");
+    process.env.MNEMONIC = "from env";
+    expect(readMnemonic(path)).toBe("from file");
+  });
+
+  it("throws when neither file nor env var supplied", () => {
+    expect(() => readMnemonic(undefined)).toThrow(
+      /No mnemonic provided/,
+    );
+  });
+
+  it("throws when env var is empty string", () => {
+    process.env.MNEMONIC = "";
+    expect(() => readMnemonic(undefined)).toThrow(
+      /No mnemonic provided/,
+    );
+  });
+});


### PR DESCRIPTION
### Summary

Closes #1015.

Make `--mnemonic-file` optional in the price pusher and fall back to a `MNEMONIC` environment variable when the flag is not supplied. This makes deployments on platforms that inject secrets as encrypted env vars (DigitalOcean, Fly.io, etc.) much simpler, since operators no longer need to write the mnemonic to disk before launching the process.

Maintainer pre-approval: @jayantk on the original issue — "happily accept a PR".

### Change

- `apps/price_pusher/src/options.ts`: `--mnemonic-file` is now `required: false`, with an updated description noting the env var fallback.
- `apps/price_pusher/src/utils.ts`: new `readMnemonic(mnemonicFile)` helper. Resolution order: file (if supplied) → `MNEMONIC` env var → clear error naming both sources.
- `apps/price_pusher/src/{evm,sui,aptos,injective}/command.ts`: replace per-command `fs.readFileSync(mnemonicFile, "utf8").trim()` with the shared helper; drop now-unused `fs` import.
- `apps/price_pusher/README.md`: short note on the two supported sources and the precedence rule.

### Verification

- `pnpm exec tsc --noEmit` from `apps/price_pusher` passes.
- `pnpm turbo fix --filter @pythnetwork/price-pusher` is clean (formatting + biome).
- Behaviour matrix:
  - `--mnemonic-file <path>` only → reads file (unchanged from today).
  - `MNEMONIC=…` env var only → reads env.
  - Both supplied → file wins (explicit beats implicit).
  - Neither → clear error: `No mnemonic provided. Pass --mnemonic-file or set the MNEMONIC environment variable.`

### Out of scope

I did not touch the `solana`, `fuel`, `near`, or `ton` commands — they use different key-loading paths (keypair files / explicit private keys) and don't accept `--mnemonic-file` today. Happy to extend to those in a follow-up if useful.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->