### PR TITLE
docs(aptos): document why framework dependency revisions are pinned

### DIFF
--- a/target_chains/aptos/contracts/Move.toml
+++ b/target_chains/aptos/contracts/Move.toml
@@ -4,6 +4,12 @@ version = "0.0.1"
 upgrade_policy = "compatible"
 
 [dependencies]
+# The AptosFramework / MoveStdlib / AptosStdlib / AptosToken revisions below
+# are pinned to match the version of `aptos-core` that the on-chain Wormhole
+# package (pinned just under here) was compiled and deployed against. Bumping
+# them in isolation will produce bytecode that no longer links against the
+# deployed Wormhole package, so do not update either pin without coordinating a
+# matching Wormhole upgrade on every network we ship to.
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "6f83bc6d02207298b2dee91133d75538789bf582" }
 MoveStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/move-stdlib/", rev = "6f83bc6d02207298b2dee91133d75538789bf582" }
 AptosStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-stdlib/", rev = "6f83bc6d02207298b2dee91133d75538789bf582" }


### PR DESCRIPTION
### Summary

Closes #2511.

The Move.toml in `target_chains/aptos/contracts/` pins `AptosFramework`, `MoveStdlib`, `AptosStdlib`, and `AptosToken` to a specific `aptos-core` revision that predates several recent mainnet upgrades. Without context, contributors keep proposing to bump these to "latest mainnet" — which would silently break ABI compatibility with the on-chain Wormhole package the Pyth contract depends on.

This PR adds a short comment above the `[dependencies]` block explaining:
- Why the rev is locked (must match the `aptos-core` rev that the deployed Wormhole package was compiled against).
- That bumping it in isolation produces bytecode that no longer links against the deployed Wormhole package.
- That the only safe update path is a coordinated Wormhole upgrade across all supported networks.

### Change

One file, six lines of comments added — no code or version changes:

- `target_chains/aptos/contracts/Move.toml`

### Verification

- Comment is in a TOML `[dependencies]` table, parsed identically to the existing trailing `[dev-addresses]` comment (line 20–21).
- No actual dependency rev changes — `move build` produces identical bytecode.

### Out of scope

The issue also asks about updating the rev to a newer mainnet version. That's a deployment-coordination question (needs Wormhole + Pyth governance + redeploy on every chain) and well outside what an outside PR should attempt. This change just documents the lock so the question doesn't keep recurring.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->