### PR TITLE
fix(hyperliquid-recorder): widen L2 bid/ask decimals to Decimal128 to match prod

### DIFF
--- a/apps/hyperliquid-recorder/sql/001-init.sql
+++ b/apps/hyperliquid-recorder/sql/001-init.sql
@@ -9,8 +9,8 @@ CREATE TABLE IF NOT EXISTS pyth_analytics.hyperliquid_l2_snapshots
     n_sig_figs UInt8 DEFAULT 0,
     mantissa UInt8 DEFAULT 0,
     source_endpoint LowCardinality(String),
-    bids Array(Tuple(Decimal64(12), Decimal64(12), UInt32)),
-    asks Array(Tuple(Decimal64(12), Decimal64(12), UInt32)),
+    bids Array(Tuple(Decimal(38, 12), Decimal(38, 12), UInt32)),
+    asks Array(Tuple(Decimal(38, 12), Decimal(38, 12), UInt32)),
     ingested_at DateTime64(3) DEFAULT now64(3)
 )
 ENGINE = ReplacingMergeTree(ingested_at)
@@ -29,19 +29,19 @@ CREATE TABLE IF NOT EXISTS pyth_analytics.hyperliquid_trades
     oid UInt64,
     side LowCardinality(String),
     dir LowCardinality(String),
-    px Decimal64(12),
-    sz Decimal64(12),
-    start_position Decimal64(12),
-    closed_pnl Decimal64(12),
+    px Decimal(18, 12),
+    sz Decimal(18, 12),
+    start_position Decimal(18, 12),
+    closed_pnl Decimal(18, 12),
     crossed Bool,
-    fee Decimal64(12),
+    fee Decimal(18, 12),
     fee_token LowCardinality(String),
     twap_id Nullable(UInt64),
     cloid Nullable(String),
     builder Nullable(String),
-    builder_fee Nullable(Decimal64(12)),
+    builder_fee Nullable(Decimal(18, 12)),
     liquidated_user Nullable(String),
-    liquidation_mark_px Nullable(Decimal64(12)),
+    liquidation_mark_px Nullable(Decimal(18, 12)),
     liquidation_method Nullable(String),
     source_endpoint LowCardinality(String),
     ingested_at DateTime64(3) DEFAULT now64(3)
@@ -55,8 +55,8 @@ CREATE TABLE IF NOT EXISTS pyth_analytics.hyperliquid_funding_rates
 (
     coin LowCardinality(String),
     funding_time DateTime64(3),
-    funding_rate Decimal64(12),
-    premium Nullable(Decimal64(12)),
+    funding_rate Decimal(18, 12),
+    premium Nullable(Decimal(18, 12)),
     source_endpoint LowCardinality(String),
     ingested_at DateTime64(3) DEFAULT now64(3)
 )

--- a/apps/hyperliquid-recorder/sql/backfill-fills.sql
+++ b/apps/hyperliquid-recorder/sql/backfill-fills.sql
@@ -50,7 +50,7 @@ INSERT INTO { database :Identifier }.{ trades_table :Identifier } (
             builder,
             if(
                 isNull(builder_fee),
-                CAST(NULL, 'Nullable(Decimal64(12))'),
+                CAST(NULL, 'Nullable(Decimal(18, 12))'),
                 toDecimal64(toString(builder_fee), 12)
             ) AS builder_fee,
             if(
@@ -60,7 +60,7 @@ INSERT INTO { database :Identifier }.{ trades_table :Identifier } (
             ) AS liquidated_user,
             if(
                 isNull(liquidation_mark_px),
-                CAST(NULL, 'Nullable(Decimal64(12))'),
+                CAST(NULL, 'Nullable(Decimal(18, 12))'),
                 toDecimal64(toString(liquidation_mark_px), 12)
             ) AS liquidation_mark_px,
             liquidation_method,

--- a/apps/hyperliquid-recorder/src/clickhouse.rs
+++ b/apps/hyperliquid-recorder/src/clickhouse.rs
@@ -120,8 +120,8 @@ struct L2SnapshotRow {
     n_sig_figs: u8,
     mantissa: u8,
     source_endpoint: String,
-    bids: Vec<(i64, i64, u32)>,
-    asks: Vec<(i64, i64, u32)>,
+    bids: Vec<(i128, i128, u32)>,
+    asks: Vec<(i128, i128, u32)>,
 }
 
 impl From<&L2Snapshot> for L2SnapshotRow {
@@ -222,16 +222,37 @@ impl From<&FundingRateRecord> for FundingRateRow {
     }
 }
 
-fn level_to_tuple(level: &L2Level) -> (i64, i64, u32) {
-    (decimal_to_d64(&level.px), decimal_to_d64(&level.sz), level.n)
+fn level_to_tuple(level: &L2Level) -> (i128, i128, u32) {
+    (decimal_to_d128(&level.px), decimal_to_d128(&level.sz), level.n)
 }
 
-/// Convert a `Decimal` to its `Decimal64(12)` wire representation (i64).
+/// Convert a `Decimal` to its `Decimal(38, 12)` (`Decimal128`) wire
+/// representation (i128). Used by `L2SnapshotRow` since the L2 schema uses
+/// `Decimal(38, 12)` for bid/ask prices and sizes.
 ///
-/// On overflow we log and write 0 rather than failing the insert: the old
-/// text-INSERT path would have been rejected by CH and retried forever, and
-/// silently zeroing a single field is preferable to losing the whole batch.
-/// In practice HL prices and sizes fit comfortably in Decimal64(12).
+/// The only realistic failure is `rescale` no-op'ing because the target scale
+/// would overflow `rust_decimal`'s 96-bit mantissa — i.e. the input has more
+/// than 26 digits left of the decimal point. We log and write 0 in that case
+/// rather than losing the whole batch.
+fn decimal_to_d128(value: &Decimal) -> i128 {
+    const SCALE: u32 = 12;
+    let mut scaled = *value;
+    scaled.rescale(SCALE);
+    if scaled.scale() != SCALE {
+        tracing::warn!(
+            value = %value,
+            "Decimal value too large to rescale to Decimal(38, 12); writing 0"
+        );
+        return 0;
+    }
+    scaled.mantissa()
+}
+
+/// Convert a `Decimal` to its `Decimal(18, 12)` (`Decimal64`) wire
+/// representation (i64). Used by `TradeRow` and `FundingRateRow`, which both
+/// use `Decimal(18, 12)` in CH. Same failure modes as `decimal_to_d128`, plus
+/// the additional `i128 → i64` truncation guard for values that fit
+/// `Decimal128` but not `Decimal64`.
 fn decimal_to_d64(value: &Decimal) -> i64 {
     const SCALE: u32 = 12;
     let mut scaled = *value;
@@ -239,7 +260,7 @@ fn decimal_to_d64(value: &Decimal) -> i64 {
     if scaled.scale() != SCALE {
         tracing::warn!(
             value = %value,
-            "Decimal value too large to rescale to Decimal64(12); writing 0"
+            "Decimal value too large to rescale to Decimal(18, 12); writing 0"
         );
         return 0;
     }
@@ -248,7 +269,7 @@ fn decimal_to_d64(value: &Decimal) -> i64 {
         Err(_) => {
             tracing::warn!(
                 value = %value,
-                "Decimal value overflows Decimal64(12); writing 0"
+                "Decimal value overflows Decimal(18, 12); writing 0"
             );
             0
         }


### PR DESCRIPTION
## Summary

Fix runtime insert failures against the prod CH L2 table. The schema in prod is `Decimal(38, 12)` (i.e. `Decimal128`) for bid/ask price/size, but the wire row `L2SnapshotRow` declared `Vec<(i64, i64, u32)>` (`Decimal64`). The `clickhouse` crate is strict about the bit-width and rejected every insert with:

```
schema mismatch: While processing column L2SnapshotRow.bids defined as
Array(Tuple(Decimal(38, 12), Decimal(38, 12), UInt32)): attempting to
(de)serialize nested ClickHouse type Decimal(38, 12) as i64 which is not compatible
```

## Changes

- `src/clickhouse.rs`: widen `L2SnapshotRow.bids` / `asks` to `Vec<(i128, i128, u32)>` and route through a new `decimal_to_d128` helper. `TradeRow` and `FundingRateRow` keep `i64` / `decimal_to_d64` — prod's trades and funding tables are still `Decimal(18, 12)`.
- `sql/001-init.sql`: match prod widths. L2 columns use `Decimal(38, 12)`; trades + funding columns use `Decimal(18, 12)`.
- `sql/backfill-fills.sql`: keeps `toDecimal64` and `Nullable(Decimal(18, 12))` since the backfill writes only to the trades table, which is still narrow.

Follow-up to [PFG-923](https://linear.app/douro-labs/issue/PFG-923) / #3691.

## Test plan

- [x] `cargo +1.91.1 clippy --all-targets -- -D warnings` — clean
- [x] `cargo +1.91.1 test --quiet` — all tests passing
- [ ] Deploy and confirm `insert_attempts_total{status="error"}` stops climbing on the L2 lane; `insert_rows_total` resumes climbing
- [ ] Local Tilt smoke after `tilt down -v && tilt up` (fresh volume so `sql/001-init.sql` re-applies with the new widths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->