### PR TITLE
fix: add build script back to price_pusher

### DIFF
--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -211,10 +211,12 @@
     "url": "https://github.com/pyth-network/pyth-crosschain"
   },
   "scripts": {
+    "build": "ts-duality --noEsm",
+    "clean": "rm -rf ./dist",
     "dev": "ts-node src/index.ts",
     "prepublishOnly": "pnpm run build",
     "start": "node dist/index.cjs",
-    "version": "pnpm run test:format && git add -A src"
+    "test:types": "tsc"
   },
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -200,7 +200,6 @@
   ],
   "license": "Apache-2.0",
   "main": "./dist/index.cjs",
-  "module": "./dist/esm/index.js",
   "name": "@pythnetwork/price-pusher",
   "publishConfig": {
     "access": "public"

--- a/apps/price_pusher/tsconfig.build.json
+++ b/apps/price_pusher/tsconfig.build.json
@@ -1,15 +1,10 @@
 {
-  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": false,
-    "incremental": false,
     "declaration": true,
-    "isolatedModules": false
+    "incremental": false,
+    "isolatedModules": false,
+    "noEmit": false
   },
-  "exclude": [
-    "node_modules",
-    "dist",
-    "examples/",
-    "**/__tests__/*"
-  ]
+  "exclude": ["node_modules", "dist", "examples/", "**/__tests__/*"],
+  "extends": "./tsconfig.json"
 }


### PR DESCRIPTION
## Summary

<!-- Briefly describe the changes -->

## Rationale

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->