### PR TITLE
fix(solana-utils): lazy-load jito-ts so non-Jito consumers don't crash

### DIFF
--- a/target_chains/solana/sdk/js/solana_utils/package.json
+++ b/target_chains/solana/sdk/js/solana_utils/package.json
@@ -81,5 +81,5 @@
   },
   "type": "module",
   "types": "./dist/cjs/index.d.ts",
-  "version": "0.6.0"
+  "version": "0.6.1"
 }

--- a/target_chains/solana/sdk/js/solana_utils/src/__tests__/JitoLazyImport.test.ts
+++ b/target_chains/solana/sdk/js/solana_utils/src/__tests__/JitoLazyImport.test.ts
@@ -1,0 +1,33 @@
+// Regression test for https://github.com/pyth-network/pyth-crosschain/issues/1838.
+//
+// `jito.ts` historically eager-imported `jito-ts/dist/sdk/block-engine/{searcher,types}`,
+// which transitively required `jito-ts`'s nested `@solana/web3.js@~1.77.3` ->
+// `rpc-websockets/dist/lib/client` — a path removed in `rpc-websockets@>=7.11`.
+// Consumers that loaded any `@pythnetwork/solana-utils` export therefore
+// crashed with `Cannot find module 'rpc-websockets/dist/lib/client'`, even
+// when they never used the Jito helpers.
+//
+// We now type-only-import `SearcherClient`/`Bundle` and dynamic-import
+// `Bundle` inside `sendTransactionsJito`. This test guards that contract.
+
+describe("jito-ts lazy loading", () => {
+  it("does not load jito-ts when importing transaction helpers", async () => {
+    await import("../transaction");
+
+    const cachedJitoPath = Object.keys(require.cache).find((p) =>
+      p.includes(`${"/node_modules/"}jito-ts/`),
+    );
+
+    expect(cachedJitoPath).toBeUndefined();
+  });
+
+  it("does not load jito-ts when importing jito.ts itself", async () => {
+    await import("../jito");
+
+    const cachedJitoPath = Object.keys(require.cache).find((p) =>
+      p.includes(`${"/node_modules/"}jito-ts/`),
+    );
+
+    expect(cachedJitoPath).toBeUndefined();
+  });
+});

--- a/target_chains/solana/sdk/js/solana_utils/src/jito.ts
+++ b/target_chains/solana/sdk/js/solana_utils/src/jito.ts
@@ -9,8 +9,13 @@ import type {
 } from "@solana/web3.js";
 import { PublicKey, SystemProgram } from "@solana/web3.js";
 import bs58 from "bs58";
+// jito-ts is loaded lazily inside `sendTransactionsJito` so that consumers
+// who only use the non-Jito transaction helpers do not pay the cost of
+// jito-ts pulling its nested `@solana/web3.js@~1.77.3` (which transitively
+// `require`s a rpc-websockets path removed in rpc-websockets@>=7.11). See
+// https://github.com/pyth-network/pyth-crosschain/issues/1838.
 import type { SearcherClient } from "jito-ts/dist/sdk/block-engine/searcher";
-import { Bundle } from "jito-ts/dist/sdk/block-engine/types";
+import type { Bundle as BundleType } from "jito-ts/dist/sdk/block-engine/types";
 import type { Logger } from "ts-log";
 import { dummyLogger } from "ts-log";
 
@@ -85,7 +90,10 @@ export async function sendTransactionsJito(
     signedTransactions[0]?.signatures[0]!,
   );
 
-  const bundle = new Bundle(signedTransactions, 2);
+  // Dynamic import so jito-ts (and its old @solana/web3.js transitive dep)
+  // is only resolved when this code path is actually taken.
+  const { Bundle } = await import("jito-ts/dist/sdk/block-engine/types");
+  const bundle: BundleType = new Bundle(signedTransactions, 2);
 
   let lastError: Error | null | undefined;
   let totalAttempts = 0;


### PR DESCRIPTION
### Summary

Closes #1838.

`target_chains/solana/sdk/js/solana_utils/src/jito.ts` previously did top-level value imports of `jito-ts/dist/sdk/block-engine/{searcher,types}`. Loading those modules transitively pulls `jito-ts`'s nested `@solana/web3.js@~1.77.3`, which in turn `require`s `rpc-websockets/dist/lib/client` — a path removed in `rpc-websockets@>=7.11`.

Because `solana_utils/transaction.ts` imports `buildJitoTipInstruction` from `./jito`, any consumer that loaded a `@pythnetwork/solana-utils` export — including `PythSolanaReceiver` from `@pythnetwork/pyth-solana-receiver` — eagerly walked the broken chain and crashed at module load with:

```
Error: Cannot find module 'rpc-websockets/dist/lib/client'
Require stack:
  - .../jito-ts/node_modules/@solana/web3.js/lib/index.cjs.js
  - .../jito-ts/dist/sdk/block-engine/types.js
  - .../@pythnetwork/solana-utils/lib/jito.js
  - .../@pythnetwork/solana-utils/lib/transaction.js
  - .../@pythnetwork/solana-utils/lib/index.js
  - .../@pythnetwork/pyth-solana-receiver/lib/PythSolanaReceiver.js
  ...
```

(matches the stack the issue reporter pasted)

### Change

Split `jito.ts` imports so that `jito-ts` only resolves when the Jito send path is actually exercised:

- `SearcherClient` and `Bundle` become `import type` (they were only used as types in function signatures and as a constructor inside one function).
- `sendTransactionsJito` `await import`s `Bundle` immediately before constructing the bundle. The function is already async, so this is zero-cost for callers.
- A short comment in `jito.ts` records the why so this isn't undone in a future cleanup.

Non-Jito consumers (the case reported in the issue) no longer trigger the broken require. Jito users still get the same runtime path; the underlying `jito-ts` / `rpc-websockets` clash there is a separate problem for `jito-ts` itself to resolve.

### Verification

Added `src/__tests__/JitoLazyImport.test.ts` with two cases that assert importing either `../transaction` or `../jito` leaves `jito-ts/*` out of Node's `require.cache`. Both pass; existing `TransactionSize.test.ts` still passes.

```
$ pnpm --filter @pythnetwork/solana-utils test:unit
PASS src/__tests__/JitoLazyImport.test.ts
PASS src/__tests__/TransactionSize.test.ts
Test Suites: 2 passed, 2 total
Tests:       4 passed, 4 total
```

`pnpm --filter @pythnetwork/solana-utils build` succeeds (esm + cjs). No public API change — runtime contract is preserved, only the module-load order changes.

Bumped patch version `0.6.0` -> `0.6.1`.

### Out of scope

- I did not bump `jito-ts` itself. Even the latest `jito-ts@4.x` still pins `@solana/web3.js@~1.77.3`, so the bump alone wouldn't have helped here; lazy-loading is the more robust fix and survives whatever `jito-ts` decides to do upstream.
- Consumer-side `rpc-websockets` overrides (the workaround in the issue comment thread) remain a valid escape hatch if a user explicitly needs the Jito path on a newer rpc-websockets.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->