### PR TITLE
contract_manager/cardano: Add utility to fetch emitted VAAs

### DIFF
--- a/contract_manager/scripts/manage_cardano_governance.ts
+++ b/contract_manager/scripts/manage_cardano_governance.ts
@@ -1,7 +1,10 @@
 /** biome-ignore-all lint/suspicious/noConsole: this is a CLI script */
+
+import { parseVaa } from "@certusone/wormhole-sdk";
 import type { Wallet } from "@coral-xyz/anchor";
 import type { PythCluster } from "@pythnetwork/client";
 import {
+  decodeGovernancePayload,
   UpdateTrustedSigner256Bit,
   UpgradeCardanoSpendScript,
   UpgradeCardanoWithdrawScript,
@@ -9,7 +12,11 @@ import {
 import type { Options } from "yargs";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { loadHotWallet, WormholeEmitter } from "../src/node/utils/governance";
+import {
+  loadHotWallet,
+  SubmittedWormholeMessage,
+  WormholeEmitter,
+} from "../src/node/utils/governance";
 import { DefaultStore } from "../src/node/utils/store";
 
 function getMainnetVault() {
@@ -247,6 +254,48 @@ parser.command(
     ).encode();
     const proposal = await vault.proposeWormholeMessage([payload]);
     console.log("Proposal address:", proposal.address.toBase58());
+  },
+);
+
+parser.command(
+  "fetch-vaas",
+  "fetch hex-encoded VAAs targeting the specified chain since a given sequence number",
+  (b) =>
+    b.options({
+      since: {
+        coerce: Number,
+        demandOption: true,
+        description: "sequence number to start fetching from (inclusive)",
+        type: "number",
+      },
+    }),
+  async ({ chain, since }) => {
+    const vault = getMainnetVault();
+    const emitter = await vault.getEmitter();
+    const lastSequence = await vault.getLastSequenceNumber();
+
+    process.stderr.write(
+      `Fetching sequences ${since}..${lastSequence} from emitter ${emitter.toBase58()}\n`,
+    );
+
+    for (let seq = since; seq <= lastSequence; seq++) {
+      const msg = new SubmittedWormholeMessage(emitter, seq, vault.cluster);
+      let vaa: Buffer;
+      try {
+        vaa = await msg.fetchVaa(10);
+      } catch {
+        process.stderr.write(`Sequence ${seq}: not found, skipping\n`);
+        continue;
+      }
+      const action = decodeGovernancePayload(parseVaa(vaa).payload);
+      if (!action || action.targetChainId !== chain) {
+        process.stderr.write(
+          `Sequence ${seq}: could not decode as action for this chain, skipping\n`,
+        );
+        continue;
+      }
+      process.stdout.write(`${vaa.toString("hex")}\n`);
+    }
   },
 );
 


### PR DESCRIPTION
## Summary

Adds command to fetch emitted cardano VAAs since specified sequence number.

## Rationale

Makes contract maintenance much easier compared to trying to find VAAs manually. We'll probably automate this from Cardano CLI at some point, but it will still need to happen through CM because of dependencies.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [X] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->