### PR TITLE
docs: refresh stale docs.pyth.network URLs across TS/JS SDK READMEs

### DIFF
--- a/apps/hermes/client/js/README.md
+++ b/apps/hermes/client/js/README.md
@@ -93,4 +93,4 @@ pnpm turbo --filter @pythnetwork/hermes-client example -- \
 Pyth offers a free public endpoint at [https://hermes.pyth.network](https://hermes.pyth.network). However, it is
 recommended to obtain a private endpoint from one of the Hermes RPC providers for more reliability. You can find more
 information about Hermes RPC providers
-[here](https://docs.pyth.network/documentation/pythnet-price-feeds/hermes#public-endpoint).
+[here](https://docs.pyth.network/price-feeds/core/api-instances-and-providers/hermes#public-endpoints).

--- a/apps/hermes/server/README.md
+++ b/apps/hermes/server/README.md
@@ -16,7 +16,7 @@ To set up and run a Hermes node, follow the steps below:
 
 0. **Prerequisites**: Hermes requires a running instance of Pythnet and the Wormhole spy RPC. You can find instructions
    for getting a Pythnet RPC instance from a node provider
-   [here](https://docs.pyth.network/documentation/pythnet-price-feeds/hermes#hermes-node-providers) and instructions
+   [here](https://docs.pyth.network/price-feeds/core/api-instances-and-providers/hermes#node-providers) and instructions
    for running a Wormhole spy RPC instance [here](https://docs.wormhole.com/wormhole/explore-wormhole/spy). We recommend
    using [Beacon](https://github.com/pyth-network/beacon), a highly available rewrite for spy, for production purposes.
 1. **Install Rust 1.82.0**: If you haven't already, you'll need to install Rust. You can

--- a/apps/price_pusher/README.md
+++ b/apps/price_pusher/README.md
@@ -79,9 +79,9 @@ updates.
 
 NOTE: It is recommended to use stable hermes endpoints. If you are running the price pusher for **Aptos Testnet**, **Sui Testnet**, or **Near Testnet**, we recommend you use beta hermes endpoints.
 
-Pyth hosts [public endpoints](https://docs.pyth.network/price-feeds/api-instances-and-providers/hermes) for Hermes; however, it is recommended to get a private endpoint from one of the
+Pyth hosts [public endpoints](https://docs.pyth.network/price-feeds/core/api-instances-and-providers/hermes#public-endpoints) for Hermes; however, it is recommended to get a private endpoint from one of the
 Hermes RPC providers for more reliability. Please refer to [this
-document](https://docs.pyth.network/documentation/pythnet-price-feeds/hermes) for more information.
+document](https://docs.pyth.network/price-feeds/core/api-instances-and-providers/hermes) for more information.
 
 To run the price pusher, please run the following commands, replacing the command line arguments as necessary:
 

--- a/apps/price_pusher/src/sui/command.ts
+++ b/apps/price_pusher/src/sui/command.ts
@@ -58,14 +58,14 @@ export default {
     "pyth-state-id": {
       description:
         "Pyth State Id. Can be found here" +
-        "https://docs.pyth.network/documentation/pythnet-price-feeds/sui",
+        "https://docs.pyth.network/price-feeds/core/contract-addresses/sui",
       required: true,
       type: "string",
     } as Options,
     "wormhole-state-id": {
       description:
         "Wormhole State Id. Can be found here" +
-        "https://docs.pyth.network/documentation/pythnet-price-feeds/sui",
+        "https://docs.pyth.network/price-feeds/core/contract-addresses/sui",
       required: true,
       type: "string",
     } as Options,

--- a/price_service/client/js/README.md
+++ b/price_service/client/js/README.md
@@ -93,4 +93,4 @@ npm run example -- \
 Pyth offers a free public endpoint at [https://hermes.pyth.network](https://hermes.pyth.network). However, it is
 recommended to obtain a private endpoint from one of the Hermes RPC providers for more reliability. You can find more
 information about Hermes RPC providers
-[here](https://docs.pyth.network/documentation/pythnet-price-feeds/hermes#public-endpoint).
+[here](https://docs.pyth.network/price-feeds/core/api-instances-and-providers/hermes#public-endpoints).

--- a/price_service/sdk/js/README.md
+++ b/price_service/sdk/js/README.md
@@ -2,7 +2,7 @@
 
 The Pyth JavaScript SDK provides definitions and utilities for Pyth data structures.
 
-Please see the [pyth.network documentation](https://docs.pyth.network/documentation/) for more information on how to use Pyth prices in various blockchains.
+Please see the [pyth.network documentation](https://docs.pyth.network/price-feeds) for more information on how to use Pyth prices in various blockchains.
 
 ## Releases
 

--- a/target_chains/aptos/sdk/js/README.md
+++ b/target_chains/aptos/sdk/js/README.md
@@ -19,7 +19,7 @@ $ yarn add @pythnetwork/pyth-aptos-js
 ## Quickstart
 
 Pyth stores prices off-chain to minimize gas fees, which allows us to offer a wider selection of products and faster update times.
-See [On-Demand Updates](https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand) for more information about this approach.
+See [Pull Integration on Aptos](https://docs.pyth.network/price-feeds/core/use-real-time-data/pull-integration/aptos) for more information about this approach.
 To use Pyth prices on chain,
 they must be fetched from a Hermes instance. The `AptosPriceServiceConnection` class can be used to interact with these services,
 providing a way to fetch these prices directly in your code. The following example wraps an existing RPC provider and shows how to obtain
@@ -79,7 +79,7 @@ module example::your_module {
 }
 ```
 
-We strongly recommend reading our guide which explains [how to work with Pyth price feeds](https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices).
+We strongly recommend reading our guide which explains [how to work with Pyth price feeds](https://docs.pyth.network/price-feeds/core/best-practices).
 
 ### Off-chain prices
 
@@ -136,4 +136,4 @@ npm run example-relay -- \
 
 ## Hermes endpoints
 
-Please find the list of public Hermes endpoints [here](https://docs.pyth.network/documentation/pythnet-price-feeds/hermes#public-endpoints).
+Please find the list of public Hermes endpoints [here](https://docs.pyth.network/price-feeds/core/api-instances-and-providers/hermes#public-endpoints).

--- a/target_chains/ethereum/entropy_sdk/solidity/README.md
+++ b/target_chains/ethereum/entropy_sdk/solidity/README.md
@@ -33,7 +33,7 @@ Then add the following line to your `remappings.txt` file:
 ## Setup
 
 To use the SDK, you need the address of an Entropy contract on your blockchain and a randomness provider.
-You can find current deployments on this [page](https://docs.pyth.network/documentation/entropy/evm).
+You can find current deployments on this [page](https://docs.pyth.network/entropy/contract-addresses).
 
 Choose one of the networks and instantiate an `IEntropy` contract in your solidity contract:
 

--- a/target_chains/ethereum/sdk/solidity/README.md
+++ b/target_chains/ethereum/sdk/solidity/README.md
@@ -3,7 +3,7 @@
 This package provides utilities for consuming prices from the [Pyth Network](https://pyth.network/) Oracle using Solidity. Also, it contains [the Pyth Interface ABI](./abis/IPyth.json) that you can use in your libraries
 to communicate with the Pyth contract.
 
-It is **strongly recommended** to follow the [consumer best practices](https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices) when consuming Pyth data.
+It is **strongly recommended** to follow the [consumer best practices](https://docs.pyth.network/price-feeds/core/best-practices) when consuming Pyth data.
 
 ## Installation
 
@@ -76,7 +76,7 @@ Pyth prices are published on Pythnet, and relayed to EVM chains using the [Wormh
 
 This signed message can then be submitted to the Pyth contract on the EVM networks along the required update fee for it, which will verify the Wormhole message and update the Pyth contract with the new price.
 
-Please refer to [Pyth On-Demand Updates page](https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand) for more information.
+Please refer to [Pull Integration on EVM](https://docs.pyth.network/price-feeds/core/use-real-time-data/pull-integration/evm) for more information.
 
 ## Solidity Target Chains
 

--- a/target_chains/ethereum/sdk/stylus/README.md
+++ b/target_chains/ethereum/sdk/stylus/README.md
@@ -2,7 +2,7 @@
 
 This package provides utilities for consuming prices from the [Pyth Network](https://pyth.network/) Oracle in Rust with Stylus. It also includes the [Pyth Interface ABI](./abis/IPyth.json), which can be used in your libraries to interact with the Pyth contract.
 
-It is **strongly recommended** to follow the [consumer best practices](https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices) when consuming data from Pyth.
+It is **strongly recommended** to follow the [consumer best practices](https://docs.pyth.network/price-feeds/core/best-practices) when consuming data from Pyth.
 
 ## Features
 

--- a/target_chains/fuel/sdk/js/README.md
+++ b/target_chains/fuel/sdk/js/README.md
@@ -31,7 +31,7 @@ $ yarn add fuels @pythnetwork/hermes-client
 ```
 
 Pyth stores prices off-chain to minimize gas fees, which allows us to offer a wider selection of products and faster update times.
-See [On-Demand Updates](https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand) for more information about this approach.
+See [Pull Integration on Fuel](https://docs.pyth.network/price-feeds/core/use-real-time-data/pull-integration/fuel) for more information about this approach.
 To use Pyth prices on chain,
 they must be fetched from a Hermes instance. The `HermesClient` class from Pyth's `hermes-client` library can be used to interact with Hermes,
 providing a way to fetch these prices directly in your code.
@@ -40,4 +40,4 @@ chain.
 
 For a complete example of how to obtain Pyth prices and submit them to a Fuel network, check out the [usage example](src/examples/usage.ts) in the `src/examples` directory.
 
-We strongly recommend reading our guide which explains [how to work with Pyth price feeds](https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices).
+We strongly recommend reading our guide which explains [how to work with Pyth price feeds](https://docs.pyth.network/price-feeds/core/best-practices).

--- a/target_chains/near/README.md
+++ b/target_chains/near/README.md
@@ -47,4 +47,4 @@ near view --network-id mainnet contract-url.near get_price_unsafe '{ "price_iden
 You can find more in-depth documentation on the [Pyth Website][pyth website] for a more in-depth guide to
 working with Pyth concepts in general in the context of NEAR.
 
-[pyth website]: https://docs.pyth.network/documentation/pythnet-price-feeds/near
+[pyth website]: https://docs.pyth.network/price-feeds/core/use-real-time-data/pull-integration/near

--- a/target_chains/solana/sdk/js/pyth_solana_receiver/README.md
+++ b/target_chains/solana/sdk/js/pyth_solana_receiver/README.md
@@ -20,9 +20,9 @@ You can install the package using your favorite typescript version manager
 This SDK is designed to be used in combination with a source of Pyth pricing data.
 There are two different sources of pricing data that users can choose from.
 
-- [Hermes](https://docs.pyth.network/price-feeds/pythnet-price-feeds/hermes) is a webservice that provides HTTP and websocket endpoints for retrieving real-time Pyth prices.
+- [Hermes](https://docs.pyth.network/price-feeds/core/api-instances-and-providers/hermes#public-endpoints) is a webservice that provides HTTP and websocket endpoints for retrieving real-time Pyth prices.
   The example code below uses the public Hermes instance hosted by the Pyth Data Association at `https://hermes.pyth.network/`.
-  Hermes is also available from several infrastructure providers [listed here](https://docs.pyth.network/price-feeds/api-instances-and-providers/hermes).
+  Hermes is also available from several infrastructure providers [listed here](https://docs.pyth.network/price-feeds/core/api-instances-and-providers/hermes).
   The [Price Service Client](https://github.com/pyth-network/pyth-crosschain/tree/main/price_service/client/js) can be used to access Hermes prices in a convenient way.
 - [Benchmarks](https://docs.pyth.network/benchmarks) is a webservice that provides HTTP endpoints for accessing historical Pyth prices.
   This service can be used for applications that require prices from specific times in the past.

--- a/target_chains/starknet/sdk/js/README.md
+++ b/target_chains/starknet/sdk/js/README.md
@@ -31,7 +31,7 @@ $ yarn add starknet @pythnetwork/price-service-client
 ```
 
 Pyth stores prices off-chain to minimize gas fees, which allows us to offer a wider selection of products and faster update times.
-See [On-Demand Updates](https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand) for more information about this approach.
+See [Pull Integration on Starknet](https://docs.pyth.network/price-feeds/core/use-real-time-data/pull-integration/starknet) for more information about this approach.
 To use Pyth prices on chain,
 they must be fetched from a Hermes instance. The `PriceServiceConnection` class from Pyth's `price-service-client` library can be used to interact with Hermes,
 providing a way to fetch these prices directly in your code.
@@ -111,4 +111,4 @@ await provider.waitForTransaction(tx.transaction_hash);
 console.log("transaction confirmed:", tx.transaction_hash);
 ```
 
-We strongly recommend reading our guide which explains [how to work with Pyth price feeds](https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices).
+We strongly recommend reading our guide which explains [how to work with Pyth price feeds](https://docs.pyth.network/price-feeds/core/best-practices).

--- a/target_chains/sui/README.md
+++ b/target_chains/sui/README.md
@@ -6,4 +6,4 @@ This directory contains the Pyth contract for Sui and utilities to deploy and us
 - `contracts` folder contains the Pyth contract source code in Move.
 - `sdk` folder contains the Pyth javascript SDK for Sui that should be used by dApp developers.
 
-For more information regarding Pyth integration on Sui please refer to our [docs](https://docs.pyth.network/documentation/pythnet-price-feeds/sui).
+For more information regarding Pyth integration on Sui please refer to our [docs](https://docs.pyth.network/price-feeds/core/use-real-time-data/pull-integration/sui).

--- a/target_chains/sui/sdk/js-iota/README.md
+++ b/target_chains/sui/sdk/js-iota/README.md
@@ -20,7 +20,7 @@ $ yarn add @pythnetwork/pyth-iota-js
 ## Quickstart
 
 Pyth stores prices off-chain to minimize gas fees, which allows us to offer a wider selection of products and faster update times.
-See [On-Demand Updates](https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand) for more information about this approach.
+See [Pull Integration on Iota](https://docs.pyth.network/price-feeds/core/use-real-time-data/pull-integration/iota) for more information about this approach.
 Typically, to use Pyth prices on chain,
 they must be fetched from an off-chain Hermes instance. The `IotaPriceServiceConnection` class can be used to interact with these services,
 providing a way to fetch these prices directly in your code. The following example wraps an existing RPC provider and shows how to obtain
@@ -67,7 +67,7 @@ const priceUpdateData = await connection.getPriceFeedsUpdateData(priceIds); // s
 // It is either injected from browser or instantiated in backend via some private key
 const wallet: SignerWithProvider = getWallet();
 // Get the state ids of the Pyth and Wormhole contracts from
-// https://docs.pyth.network/documentation/pythnet-price-feeds/sui
+// https://docs.pyth.network/price-feeds/core/contract-addresses/sui
 const wormholeStateId = " 0xFILL_ME";
 const pythStateId = "0xFILL_ME";
 
@@ -152,4 +152,4 @@ setTimeout(() => {
 
 ## Hermes endpoints
 
-You can find the list of Hermes public endpoints [here](https://docs.pyth.network/documentation/pythnet-price-feeds/hermes#public-endpoints).
+You can find the list of Hermes public endpoints [here](https://docs.pyth.network/price-feeds/core/api-instances-and-providers/hermes#public-endpoints).

--- a/target_chains/sui/sdk/js/README.md
+++ b/target_chains/sui/sdk/js/README.md
@@ -14,7 +14,7 @@ $ pnpm install
 ## Quickstart
 
 Pyth stores prices off-chain to minimize gas fees, which allows us to offer a wider selection of products and faster update times.
-See [On-Demand Updates](https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand) for more information about this approach.
+See [Pull Integration on Sui](https://docs.pyth.network/price-feeds/core/use-real-time-data/pull-integration/sui) for more information about this approach.
 Typically, to use Pyth prices on chain,
 they must be fetched from an off-chain Hermes instance. The `SuiPriceServiceConnection` class can be used to interact with these services,
 providing a way to fetch these prices directly in your code. The following example wraps an existing RPC provider and shows how to obtain
@@ -149,4 +149,4 @@ eventSource.close();
 
 ## Hermes endpoints
 
-You can find the list of Hermes public endpoints [here](https://docs.pyth.network/documentation/pythnet-price-feeds/hermes#public-endpoints).
+You can find the list of Hermes public endpoints [here](https://docs.pyth.network/price-feeds/core/api-instances-and-providers/hermes#public-endpoints).


### PR DESCRIPTION
## Summary

The `docs.pyth.network/documentation/pythnet-price-feeds/*` URL space has been retired in favour of the `price-feeds/core/*` layout under the developer-hub app (see `apps/developer-hub/content/docs/price-feeds/core/` and `apps/developer-hub/src/app/llms-price-feeds-core.txt/route.ts`). Most chain SDK READMEs and a couple of the app READMEs still point at the dead URLs, which 404 for any developer who follows them.

Refs #3228, complements #3677 (which only refreshed the Sui-specific links in the main README and `price_pusher` CLI help text).

## URL mapping applied

| Old path | New path |
|---|---|
| `documentation/pythnet-price-feeds/best-practices` | `price-feeds/core/best-practices` |
| `documentation/pythnet-price-feeds/on-demand` | `price-feeds/core/use-real-time-data/pull-integration/<chain>` |
| `documentation/pythnet-price-feeds/hermes#public-endpoint(s)` | `price-feeds/core/api-instances-and-providers/hermes#public-endpoints` |
| `documentation/pythnet-price-feeds/hermes#hermes-node-providers` | `price-feeds/core/api-instances-and-providers/hermes#node-providers` |
| `documentation/pythnet-price-feeds/near` | `price-feeds/core/use-real-time-data/pull-integration/near` |
| `documentation/pythnet-price-feeds/sui` | `price-feeds/core/use-real-time-data/pull-integration/sui` (and `contract-addresses/sui` for the iota README's inline code comment that specifically pointed at state/package IDs) |

Notes:
- For chain-specific `on-demand` mentions I picked the chain-specific `pull-integration/<chain>` page (rather than the parent `use-real-time-data` index) because each chain page already has the integration flow + fee guidance the original link was trying to surface.
- For Hermes anchors: the new page uses `## Node Providers`, so the auto-generated slug is `#node-providers` (no `hermes-` prefix). Public-endpoint anchor was inconsistent in old READMEs (`#public-endpoint` vs `#public-endpoints`) — both are now normalized to `#public-endpoints` (matching `## Public Endpoints` on the new page).
- `apps/price_pusher/README.md` had previously been partially updated to `price-feeds/api-instances-and-providers/hermes`, but that path has since moved under `core/`; this PR switches it to `price-feeds/core/api-instances-and-providers/hermes` and adds the missing `#public-endpoints` anchor for the public-endpoint reference.

## Scope

JS/TS SDK READMEs and app READMEs only — keeping this diff documentation-only for a clean review:

- `apps/hermes/client/js/README.md`
- `apps/hermes/server/README.md`
- `apps/price_pusher/README.md`
- `price_service/client/js/README.md`
- `target_chains/aptos/sdk/js/README.md`
- `target_chains/ethereum/sdk/solidity/README.md`
- `target_chains/ethereum/sdk/stylus/README.md`
- `target_chains/fuel/sdk/js/README.md`
- `target_chains/near/README.md`
- `target_chains/starknet/sdk/js/README.md`
- `target_chains/sui/README.md`
- `target_chains/sui/sdk/js-iota/README.md`
- `target_chains/sui/sdk/js/README.md`

The on-chain contract NatSpec / Move doc-comments / Rust doc-comments contain the same stale paths (Solidity `IPyth.sol`/`PythStructs.sol`, Sui/Aptos `pyth.move`/`price.move`, NEAR `receiver/src/{lib,state}.rs`, CosmWasm `cw-contract/src/contract.rs`) and will be refreshed in a follow-up PR so this diff stays JS-only and the on-chain churn can be reviewed against its own consumers.

## Test plan

- [x] `grep -rn "documentation/pythnet-price-feeds" --include="*.md"` returns no remaining matches in the touched scope
- [x] Every new URL verified to exist as an `.mdx` page under `apps/developer-hub/content/docs/price-feeds/core/`
- [x] Anchor slugs cross-checked against the headings in `apps/developer-hub/content/docs/price-feeds/core/api-instances-and-providers/hermes.mdx`
- [ ] Maintainer spot-check that the chain-specific `pull-integration/<chain>` page is the preferred landing target over the parent `use-real-time-data` index for "on-demand"-style references
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->