### PR TITLE
docs: refresh stale docs.pyth.network URLs in on-chain contract comments

### DIFF
--- a/target_chains/aptos/contracts/Move.toml
+++ b/target_chains/aptos/contracts/Move.toml
@@ -18,7 +18,7 @@ wormhole = "_"
 
 [dev-addresses]
 # Note that these are localnet addresses, for use in testing. The contracts are deployed to the real networks at the
-# addresses documented at https://docs.pyth.network/documentation/pythnet-price-feeds/aptos#addresses
+# addresses documented at https://docs.pyth.network/price-feeds/core/contract-addresses/aptos
 pyth = "0x377f0d7c4aaeea8dd73a7a2c6bc817e59aea569e1f9ae0d2f4a80ea1be93bf01"
 deployer = "0x277fa055b6a73c42c0662d5236c65c864ccbf2d4abd21f174a30c8b786eab84b"
 wormhole = "0xde0036a9600559e295d5f6802ef6f3f802f510366e0c23912b0655d972166017"

--- a/target_chains/aptos/contracts/sources/price.move
+++ b/target_chains/aptos/contracts/sources/price.move
@@ -7,7 +7,7 @@ module pyth::price {
     /// Both the price and confidence are stored in a fixed-point numeric representation,
     /// `x * (10^expo)`, where `expo` is the exponent.
     //
-    /// Please refer to the documentation at https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices for how
+    /// Please refer to the documentation at https://docs.pyth.network/price-feeds/core/best-practices for how
     /// to how this price safely.
     struct Price has copy, drop, store {
         price: I64,

--- a/target_chains/aptos/contracts/sources/pyth.move
+++ b/target_chains/aptos/contracts/sources/pyth.move
@@ -128,7 +128,7 @@ module pyth::pyth {
 // Update the cached prices
 //
 // Pyth uses an uses an on-demand update model, where consumers need to update the
-/// cached prices before using them. Please read more about this at https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand.
+/// cached prices before using them. Please read more about this at https://docs.pyth.network/price-feeds/core/use-real-time-data/pull-integration/aptos.
 
     /// Update the cached price feeds with the data in the given VAAs. This is a
     /// convenience wrapper around update_price_feeds(), which allows you to update the price feeds
@@ -143,7 +143,7 @@ module pyth::pyth {
     /// to perform this update can be queried with get_update_fee(&vaas). The signer must have sufficient
     /// account balance to pay this fee, otherwise the transaction will abort.
     ///
-    /// Please read more information about the update fee here: https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand#fees
+    /// Please read more information about the update fee here: https://docs.pyth.network/price-feeds/core/use-real-time-data/pull-integration/aptos#update-fee
     public entry fun update_price_feeds_with_funder(account: &signer, vaas: vector<vector<u8>>) {
         let total_updates = 0;
         // Update the price feed from each VAA
@@ -161,12 +161,12 @@ module pyth::pyth {
     ///
     /// The javascript https://github.com/pyth-network/pyth-js/tree/main/pyth-aptos-js package
     /// should be used to fetch these VAAs from the Price Service. More information about this
-    /// process can be found at https://docs.pyth.network/documentation/pythnet-price-feeds.
+    /// process can be found at https://docs.pyth.network/price-feeds/core/use-real-time-data/pull-integration/aptos.
     ///
     /// The given fee must contain a sufficient number of coins to pay the update fee for the given vaas.
     /// The update fee amount can be queried by calling get_update_fee(&vaas).
     ///
-    /// Please read more information about the update fee here: https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand#fees
+    /// Please read more information about the update fee here: https://docs.pyth.network/price-feeds/core/use-real-time-data/pull-integration/aptos#update-fee
     public fun update_price_feeds(vaas: vector<vector<u8>>, fee: Coin<AptosCoin>) {
         let total_updates = 0;
         // Update the price feed from each VAA
@@ -409,11 +409,11 @@ module pyth::pyth {
     /// Get the latest available price cached for the given price identifier, if that price is
     /// no older than the stale price threshold.
     ///
-    /// Please refer to the documentation at https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices for
+    /// Please refer to the documentation at https://docs.pyth.network/price-feeds/core/best-practices for
     /// how to how this price safely.
     ///
     /// Important: Pyth uses an on-demand update model, where consumers need to update the
-    /// cached prices before using them. Please read more about this at https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand.
+    /// cached prices before using them. Please read more about this at https://docs.pyth.network/price-feeds/core/use-real-time-data/pull-integration/aptos.
     /// get_price() is likely to abort unless you call update_price_feeds() to update the cached price
     /// beforehand, as the cached prices may be older than the stale price threshold.
     ///
@@ -489,7 +489,7 @@ module pyth::pyth {
     /// price identifier, if that price is no older than the stale price threshold.
     ///
     /// Important: Pyth uses an on-demand update model, where consumers need to update the
-    /// cached prices before using them. Please read more about this at https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand.
+    /// cached prices before using them. Please read more about this at https://docs.pyth.network/price-feeds/core/use-real-time-data/pull-integration/aptos.
     /// get_ema_price() is likely to abort unless you call update_price_feeds() to update the cached price
     /// beforehand, as the cached prices may be older than the stale price threshold.
     public fun get_ema_price(price_identifier: PriceIdentifier): Price {
@@ -520,7 +520,7 @@ module pyth::pyth {
 
     /// Get the number of AptosCoin's required to perform the given price updates.
     ///
-    /// Please read more information about the update fee here: https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand#fees
+    /// Please read more information about the update fee here: https://docs.pyth.network/price-feeds/core/use-real-time-data/pull-integration/aptos#update-fee
     public fun get_update_fee(update_data: &vector<vector<u8>>): u64 {
         let i = 0;
         let total_updates = 0;

--- a/target_chains/cosmwasm/examples/cw-contract/src/contract.rs
+++ b/target_chains/cosmwasm/examples/cw-contract/src/contract.rs
@@ -78,7 +78,7 @@ fn query_fetch_price(deps: Deps, env: Env) -> StdResult<FetchPriceResponse> {
     // specific times, or network outages may prevent the price feed from updating.
     //
     // The example code below throws an error if the price is not available. It is recommended that
-    // you handle this scenario more carefully. Consult the [consumer best practices](https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices)
+    // you handle this scenario more carefully. Consult the [consumer best practices](https://docs.pyth.network/price-feeds/core/best-practices)
     // for recommendations.
     let current_price = price_feed
         .get_price_no_older_than(env.block.time.seconds() as i64, 60)
@@ -122,7 +122,7 @@ mod test {
     };
 
     // Dummy contract address for testing.
-    // For real deployments, see list of contract addresses here https://docs.pyth.network/documentation/pythnet-price-feeds/cosmwasm
+    // For real deployments, see list of contract addresses here https://docs.pyth.network/price-feeds/core/contract-addresses/cosmwasm
     const PYTH_CONTRACT_ADDR: &str = "pyth_contract_addr";
     // For real deployments, see list of price feed ids here https://pyth.network/developers/price-feed-ids
     const PRICE_ID: &str = "63f341689d98a12ef60a5cff1d7f85c70a9e17bf1575f0e7c0b2512d48b1c8b3";

--- a/target_chains/ethereum/sdk/solidity/IPyth.sol
+++ b/target_chains/ethereum/sdk/solidity/IPyth.sol
@@ -5,7 +5,7 @@ import "./PythStructs.sol";
 import "./IPythEvents.sol";
 
 /// @title Consume prices from the Pyth Network (https://pyth.network/).
-/// @dev Please refer to the guidance at https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices for how to consume prices safely.
+/// @dev Please refer to the guidance at https://docs.pyth.network/price-feeds/core/best-practices for how to consume prices safely.
 /// @author Pyth Data Association
 interface IPyth is IPythEvents {
     /// @notice Returns the price of a price feed without any sanity checks.

--- a/target_chains/ethereum/sdk/solidity/PythStructs.sol
+++ b/target_chains/ethereum/sdk/solidity/PythStructs.sol
@@ -8,7 +8,7 @@ contract PythStructs {
     // Both the price and confidence are stored in a fixed-point numeric representation,
     // `x * (10^expo)`, where `expo` is the exponent.
     //
-    // Please refer to the documentation at https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices for how
+    // Please refer to the documentation at https://docs.pyth.network/price-feeds/core/best-practices for how
     // to how this price safely.
     struct Price {
         // Price

--- a/target_chains/fuel/contracts/pyth-interface/src/data_structures/price.sw
+++ b/target_chains/fuel/contracts/pyth-interface/src/data_structures/price.sw
@@ -15,7 +15,7 @@ const TAI64_DIFFERENCE = 4611686018427387904;
 // Both the price and confidence are stored in a fixed-point numeric representation,
 // `x * (10^expo)`, where `expo` is the exponent.
 //
-// Please refer to the documentation at https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices for how
+// Please refer to the documentation at https://docs.pyth.network/price-feeds/core/best-practices for how
 // to how this price safely.
 pub struct Price {
     // Confidence interval around the price

--- a/target_chains/near/receiver/src/lib.rs
+++ b/target_chains/near/receiver/src/lib.rs
@@ -451,12 +451,12 @@ impl Pyth {
     /// Get the latest available price cached for the given price identifier, if that price is
     /// no older than the stale price threshold.
     ///
-    /// Please refer to the documentation at https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices for
+    /// Please refer to the documentation at https://docs.pyth.network/price-feeds/core/best-practices for
     /// how to how this price safely.
     ///
     /// IMPORTANT:
     /// Pyth uses an on-demand update model, where consumers need to update the cached prices
-    /// before using them. Please read more about this at https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand.
+    /// before using them. Please read more about this at https://docs.pyth.network/price-feeds/core/use-real-time-data/pull-integration/near.
     pub fn get_price(&self, price_identifier: PriceIdentifier) -> Option<Price> {
         self.get_price_no_older_than(price_identifier, self.stale_threshold)
     }

--- a/target_chains/near/receiver/src/state.rs
+++ b/target_chains/near/receiver/src/state.rs
@@ -89,7 +89,7 @@ impl JsonSchema for PriceIdentifier {
 /// Both the price and confidence are stored in a fixed-point numeric representation,
 /// `x * (10^expo)`, where `expo` is the exponent.
 //
-/// Please refer to the documentation at https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices for how
+/// Please refer to the documentation at https://docs.pyth.network/price-feeds/core/best-practices for how
 /// to how this price safely.
 #[derive(BorshDeserialize, BorshSerialize, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[borsh(crate = "near_sdk::borsh")]

--- a/target_chains/sui/contracts/sources/price.move
+++ b/target_chains/sui/contracts/sources/price.move
@@ -7,7 +7,7 @@ module pyth::price {
     /// Both the price and confidence are stored in a fixed-point numeric representation,
     /// `x * (10^expo)`, where `expo` is the exponent.
     ///
-    /// Please refer to the documentation at https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices for how
+    /// Please refer to the documentation at https://docs.pyth.network/price-feeds/core/best-practices for how
     /// to use this price safely.
     struct Price has copy, drop, store {
         price: I64,

--- a/target_chains/sui/contracts/sources/pyth.move
+++ b/target_chains/sui/contracts/sources/pyth.move
@@ -258,7 +258,7 @@ module pyth::pyth {
     /// The given fee must contain a sufficient number of coins to pay the update fee for the given vaas.
     /// The update fee amount can be queried by calling get_update_fee(&vaas).
     ///
-    /// Please read more information about the update fee here: https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand#fees
+    /// Please read more information about the update fee here: https://docs.pyth.network/price-feeds/core/use-real-time-data/pull-integration/sui#update-fee
     public fun update_single_price_feed(
         pyth_state: &PythState,
         price_updates: HotPotatoVector<PriceInfo>,
@@ -351,11 +351,11 @@ module pyth::pyth {
     /// Get the latest available price cached for the given price identifier, if that price is
     /// no older than the stale price threshold.
     ///
-    /// Please refer to the documentation at https://docs.pyth.network/documentation/pythnet-price-feeds/best-practices for
+    /// Please refer to the documentation at https://docs.pyth.network/price-feeds/core/best-practices for
     /// how to how this price safely.
     ///
     /// Important: Pyth uses an on-demand update model, where consumers need to update the
-    /// cached prices before using them. Please read more about this at https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand.
+    /// cached prices before using them. Please read more about this at https://docs.pyth.network/price-feeds/core/use-real-time-data/pull-integration/sui.
     /// get_price() is likely to abort unless you call update_price_feeds() to update the cached price
     /// beforehand, as the cached prices may be older than the stale price threshold.
     ///
@@ -409,7 +409,7 @@ module pyth::pyth {
         assert!(age < max_age_secs, E_STALE_PRICE_UPDATE);
     }
 
-    /// Please read more information about the update fee here: https://docs.pyth.network/documentation/pythnet-price-feeds/on-demand#fees
+    /// Please read more information about the update fee here: https://docs.pyth.network/price-feeds/core/use-real-time-data/pull-integration/sui#update-fee
     public fun get_total_update_fee(pyth_state: &PythState, n: u64): u64 {
         state::get_base_update_fee(pyth_state) * n
     }


### PR DESCRIPTION
## Summary

Follow-up to #3718 (TS/JS SDK README refresh) covering the same stale `docs.pyth.network/documentation/pythnet-price-feeds/*` paths embedded in on-chain NatSpec / Move / Rust doc-comments. The legacy URL space has been retired in favour of `price-feeds/core/*` under the developer-hub content tree, so these doc-comments currently link to 404s for anyone reading the source on chain or via a block explorer.

Refs #3228.

## URL mapping applied

| Old path | New path |
|---|---|
| `documentation/pythnet-price-feeds/best-practices` | `price-feeds/core/best-practices` |
| `documentation/pythnet-price-feeds/on-demand` | `price-feeds/core/use-real-time-data/pull-integration/<chain>` |
| `documentation/pythnet-price-feeds/on-demand#fees` | `price-feeds/core/use-real-time-data/pull-integration/<chain>#update-fee` |
| `documentation/pythnet-price-feeds/cosmwasm` | `price-feeds/core/contract-addresses/cosmwasm` |
| `documentation/pythnet-price-feeds` (bare root) | `price-feeds/core/use-real-time-data/pull-integration/aptos` (only call-site was in `aptos/pyth.move` pointing at the integration walkthrough) |

Notes:
- For chain-specific `on-demand` mentions I picked the chain-specific `pull-integration/<chain>` page over the parent `use-real-time-data` index — each chain page surfaces the update flow + fee discussion the original link was trying to point at.
- The `cw-contract` example specifically wanted the reader to find a contract address, so `contract-addresses/cosmwasm` is the right landing page rather than `pull-integration/cosmwasm`.

## Files touched

Pure doc-comment / NatSpec change — no Move bytecode, no Solidity ABI, no Rust runtime behavior is affected:

- `target_chains/ethereum/sdk/solidity/IPyth.sol` (NatSpec)
- `target_chains/ethereum/sdk/solidity/PythStructs.sol` (NatSpec)
- `target_chains/sui/contracts/sources/price.move`
- `target_chains/sui/contracts/sources/pyth.move`
- `target_chains/aptos/contracts/sources/price.move`
- `target_chains/aptos/contracts/sources/pyth.move`
- `target_chains/cosmwasm/examples/cw-contract/src/contract.rs`
- `target_chains/near/receiver/src/lib.rs`
- `target_chains/near/receiver/src/state.rs`

Splitting from #3718 to keep the on-chain churn reviewable against its own consumers (Solidity SDK publishers, Move package upgrade authorities, NEAR contract maintainers).

## Test plan

- [x] `grep -rn "documentation/pythnet-price-feeds" --include="*.move" --include="*.sol" --include="*.rs"` returns no remaining matches
- [x] Every new URL verified to exist as an `.mdx` page under `apps/developer-hub/content/docs/price-feeds/core/`
- [x] No code changes — only `///` doc-comments and `//` line comments
- [ ] Maintainer confirmation that the chain-specific `pull-integration/<chain>` page is preferred over the parent `use-real-time-data` for `on-demand` references in on-chain doc-comments
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->