### PR TITLE
lazer/cardano/sdk: Update and pin Evolution SDK dependency

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/cardano.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/cardano.mdx
@@ -126,13 +126,15 @@ The `pyth_id` below is the Pyth deployment policy ID for your network. The Pyth 
 <Tab value="Evolution SDK">
 
 ```typescript copy
-import { ScriptHash } from "@evolution-sdk/evolution";
+import { Client, preprod, ScriptHash } from "@evolution-sdk/evolution";
 import {
   getPythScriptHash,
   getPythState,
 } from "@pythnetwork/pyth-lazer-cardano-js";
 
-const client = createClient({ network, provider });
+const client = Client.make(preprod).withKoios({
+  baseUrl: "https://preprod.koios.rest/api/v1",
+});
 
 const pythState = await getPythState(POLICY_ID, client);
 const pythScript = getPythScriptHash(pythState);
@@ -141,9 +143,8 @@ const pythScript = getPythScriptHash(pythState);
 // trigger 0-withdrawal on the verification script, together with the price
 // update as a redeemer, to perform price verification on-chain.
 
-const wallet = client.attachWallet({
+const wallet = client.withSeed({
   mnemonic: CARDANO_MNEMONIC,
-  type: "seed"
 });
 
 const now = BigInt(Date.now());

--- a/lazer/contracts/cardano/cli/js/package.json
+++ b/lazer/contracts/cardano/cli/js/package.json
@@ -1,12 +1,12 @@
 {
   "dependencies": {
-    "@evolution-sdk/devnet": "^1.1.28",
-    "@evolution-sdk/evolution": "^0.3.28",
+    "@evolution-sdk/devnet": "1.1.29",
+    "@evolution-sdk/evolution": "0.3.29",
     "@noble/curves": "^2.0.1",
     "@pythnetwork/xc-admin-common": "workspace:*",
     "@wormhole-foundation/sdk-definitions": "^0.10.12",
     "date-fns": "catalog:",
-    "effect": "^3.19.19",
+    "effect": "3.19.19",
     "yargs": "catalog:"
   },
   "description": "TypeScript SDK for the Pyth Lazer Cardano contract",
@@ -22,6 +22,73 @@
   },
   "engines": {
     "node": "^24.0.0"
+  },
+  "exports": {
+    "./cli": {
+      "import": {
+        "default": "./dist/esm/cli.mjs"
+      },
+      "require": {
+        "default": "./dist/cjs/cli.cjs"
+      }
+    },
+    "./client": {
+      "import": {
+        "default": "./dist/esm/client.mjs"
+      },
+      "require": {
+        "default": "./dist/cjs/client.cjs"
+      }
+    },
+    "./devnet": {
+      "import": {
+        "default": "./dist/esm/devnet.mjs"
+      },
+      "require": {
+        "default": "./dist/cjs/devnet.cjs"
+      }
+    },
+    "./eval": {
+      "import": {
+        "default": "./dist/esm/eval.mjs"
+      },
+      "require": {
+        "default": "./dist/cjs/eval.cjs"
+      }
+    },
+    "./offchain": {
+      "import": {
+        "default": "./dist/esm/offchain.mjs"
+      },
+      "require": {
+        "default": "./dist/cjs/offchain.cjs"
+      }
+    },
+    "./package.json": "./package.json",
+    "./transactions": {
+      "import": {
+        "default": "./dist/esm/transactions.mjs"
+      },
+      "require": {
+        "default": "./dist/cjs/transactions.cjs"
+      }
+    },
+    "./utils": {
+      "import": {
+        "default": "./dist/esm/utils.mjs"
+      },
+      "require": {
+        "default": "./dist/cjs/utils.cjs"
+      }
+    },
+    "./wormhole": {
+      "import": {
+        "default": "./dist/esm/wormhole.mjs"
+      },
+      "require": {
+        "default": "./dist/cjs/wormhole.cjs"
+      }
+    }
   },
   "files": [
     "dist/**"

--- a/lazer/contracts/cardano/sdk/js/package.json
+++ b/lazer/contracts/cardano/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@evolution-sdk/evolution": "0.3.32"
+    "@evolution-sdk/evolution": "0.5.9"
   },
   "description": "User-facing SDK for the Pyth Lazer Cardano integration",
   "devDependencies": {

--- a/lazer/contracts/cardano/sdk/js/package.json
+++ b/lazer/contracts/cardano/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@evolution-sdk/evolution": "^0.3.29"
+    "@evolution-sdk/evolution": "0.3.32"
   },
   "description": "User-facing SDK for the Pyth Lazer Cardano integration",
   "devDependencies": {

--- a/lazer/contracts/cardano/sdk/js/src/examples/fetch-and-verify.ts
+++ b/lazer/contracts/cardano/sdk/js/src/examples/fetch-and-verify.ts
@@ -1,71 +1,23 @@
 /** biome-ignore-all lint/suspicious/noConsole: code example */
 
 import process from "node:process";
-import type { ProviderOnlyClient } from "@evolution-sdk/evolution";
+import type { ReadClient } from "@evolution-sdk/evolution";
 import {
-  createClient,
+  client,
+  mainnet,
+  preprod,
+  preview,
   ScriptHash,
   TransactionHash,
 } from "@evolution-sdk/evolution";
-import type { NetworkId } from "@evolution-sdk/evolution/sdk/client/Client";
 import { PythLazerClient } from "@pythnetwork/pyth-lazer-sdk";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { getPythScriptHash, getPythState } from "../index.js";
 
-/** Cardano network identifier. */
-export type Network = Exclude<NetworkId, number>;
+const networks = { mainnet, preprod, preview };
 
-/** Provider configuration for connecting to a Cardano node. */
-export type Provider =
-  | {
-      type: "blockfrost";
-      projectId: string;
-    }
-  | {
-      type: "koios";
-      token?: string;
-    }
-  | {
-      type: "maestro";
-      apiKey: string;
-    };
-
-function resolveBaseUrl(network: Network, provider: Provider): string {
-  switch (provider.type) {
-    case "blockfrost": {
-      return `https://cardano-${network}.blockfrost.io/api/v0`;
-    }
-    case "koios": {
-      return `https://${
-        {
-          mainnet: "api",
-          preprod: "preprod",
-          preview: "preview",
-        }[network]
-      }.koios.rest/api/v1`;
-    }
-    case "maestro": {
-      return `https://${network}.gomaestro-api.org/v1`;
-    }
-  }
-}
-
-/**
- * Create Cardano client using Evolution SDK.
- * @param network public network to use
- * @param provider API provider and token
- * @returns
- */
-export function createEvolutionClient(
-  network: Network,
-  provider: Provider,
-): ProviderOnlyClient {
-  return createClient({
-    network,
-    provider: { ...provider, baseUrl: resolveBaseUrl(network, provider) },
-  });
-}
+type Network = keyof typeof networks;
 
 const {
   network,
@@ -75,7 +27,7 @@ const {
   providerToken,
 } = await yargs(hideBin(process.argv))
   .option("network", {
-    choices: ["mainnet", "preprod", "preview"] as const,
+    choices: Object.keys(networks) as Network[],
     default: "preprod" as const,
     description: "Cardano network name, e.g. 'preprod'",
   })
@@ -102,33 +54,39 @@ const {
   .help()
   .parseAsync();
 
-let provider: Provider;
+let evolutionClient: ReadClient;
 switch (providerType) {
   case "blockfrost": {
     if (!providerToken) {
       throw new Error("missing --provider-token");
     }
-    provider = {
+    evolutionClient = client(networks[network]).withBlockfrost({
+      baseUrl: `https://cardano-${network}.blockfrost.io/api/v0`,
       projectId: providerToken,
-      type: providerType,
-    };
+    });
     break;
   }
   case "koios": {
-    provider = {
-      type: providerType,
+    evolutionClient = client(networks[network]).withKoios({
+      baseUrl: `https://${
+        {
+          mainnet: "api",
+          preprod: "preprod",
+          preview: "preview",
+        }[network]
+      }.koios.rest/api/v1`,
       ...(providerToken ? { token: providerToken } : {}),
-    };
+    });
     break;
   }
   case "maestro": {
     if (!providerToken) {
       throw new Error("missing --provider-token");
     }
-    provider = {
+    evolutionClient = client(networks[network]).withMaestro({
       apiKey: providerToken,
-      type: providerType,
-    };
+      baseUrl: `https://${network}.gomaestro-api.org/v1`,
+    });
     break;
   }
 }
@@ -162,9 +120,8 @@ console.log("Fetched update bytes:", update.toString("hex"));
 if (!process.env.CARDANO_MNEMONIC) {
   throw new Error("CARDANO_MNEMONIC environment variable not set");
 }
-const client = createEvolutionClient(network, provider);
 
-const pythState = await getPythState(POLICY_ID, client);
+const pythState = await getPythState(POLICY_ID, evolutionClient);
 const pythScript = getPythScriptHash(pythState);
 
 console.log("Active withdraw script hash:", pythScript);
@@ -173,9 +130,8 @@ console.log("Active withdraw script hash:", pythScript);
 // trigger 0-withdrawal on the verification script, together with the price
 // update as a redeemer, to perform price verification on-chain.
 
-const wallet = client.attachWallet({
+const wallet = evolutionClient.withSeed({
   mnemonic: process.env.CARDANO_MNEMONIC,
-  type: "seed",
 });
 
 const now = BigInt(Date.now());
@@ -197,6 +153,6 @@ const digest = await builtTx.signAndSubmit();
 
 console.log("Transaction Hash:", TransactionHash.toHex(digest));
 
-await client.awaitTx(digest);
+await evolutionClient.awaitTx(digest);
 
 console.log("Transaction successful.");

--- a/lazer/contracts/cardano/sdk/js/src/examples/fetch-and-verify.ts
+++ b/lazer/contracts/cardano/sdk/js/src/examples/fetch-and-verify.ts
@@ -1,15 +1,15 @@
 /** biome-ignore-all lint/suspicious/noConsole: code example */
 
 import process from "node:process";
-import type { ReadClient } from "@evolution-sdk/evolution";
 import {
-  client,
+  Client,
   mainnet,
   preprod,
   preview,
   ScriptHash,
   TransactionHash,
 } from "@evolution-sdk/evolution";
+import type { ReadClient } from "@evolution-sdk/evolution/sdk/client/Client";
 import { PythLazerClient } from "@pythnetwork/pyth-lazer-sdk";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
@@ -60,14 +60,14 @@ switch (providerType) {
     if (!providerToken) {
       throw new Error("missing --provider-token");
     }
-    evolutionClient = client(networks[network]).withBlockfrost({
+    evolutionClient = Client.make(networks[network]).withBlockfrost({
       baseUrl: `https://cardano-${network}.blockfrost.io/api/v0`,
       projectId: providerToken,
     });
     break;
   }
   case "koios": {
-    evolutionClient = client(networks[network]).withKoios({
+    evolutionClient = Client.make(networks[network]).withKoios({
       baseUrl: `https://${
         {
           mainnet: "api",
@@ -83,7 +83,7 @@ switch (providerType) {
     if (!providerToken) {
       throw new Error("missing --provider-token");
     }
-    evolutionClient = client(networks[network]).withMaestro({
+    evolutionClient = Client.make(networks[network]).withMaestro({
       apiKey: providerToken,
       baseUrl: `https://${network}.gomaestro-api.org/v1`,
     });

--- a/lazer/contracts/cardano/sdk/js/src/index.ts
+++ b/lazer/contracts/cardano/sdk/js/src/index.ts
@@ -6,7 +6,7 @@ import {
   Schema,
   TSchema,
 } from "@evolution-sdk/evolution";
-import type { ProviderOnlyClient } from "@evolution-sdk/evolution/sdk/client/Client";
+import type { ReadClient } from "@evolution-sdk/evolution/sdk/client/Client";
 
 const PYTH_STATE_NFT = AssetName.fromBytes(Buffer.from("Pyth State", "utf-8"));
 
@@ -32,7 +32,7 @@ const PythStateDatum = TSchema.Struct({
 
 export async function getPythState(
   policyId: string,
-  client: ProviderOnlyClient,
+  client: ReadClient,
 ): Promise<UTxO.UTxO> {
   const unit = policyId + AssetName.toHex(PYTH_STATE_NFT);
   return await client.getUtxoByUnit(unit);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1886,10 +1886,10 @@ importers:
     dependencies:
       '@evolution-sdk/devnet':
         specifier: ^1.1.28
-        version: 1.1.28(f5ca8007af6180979f1a24ea5c694f0f)
+        version: 1.1.28(6c2e44bcef0705103d111d427d8a5132)
       '@evolution-sdk/evolution':
         specifier: ^0.3.28
-        version: 0.3.28(@effect/cluster@0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 0.3.28(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@noble/curves':
         specifier: ^2.0.1
         version: 2.0.1
@@ -1937,8 +1937,8 @@ importers:
   lazer/contracts/cardano/sdk/js:
     dependencies:
       '@evolution-sdk/evolution':
-        specifier: 0.3.32
-        version: 0.3.32(@effect/cluster@0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        specifier: 0.5.9
+        version: 0.5.9(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     devDependencies:
       '@cprussin/tsconfig':
         specifier: 'catalog:'
@@ -5072,6 +5072,24 @@ packages:
       '@effect/sql': ^0.44.2
       effect: ^3.17.13
 
+  '@effect/platform-node-shared@0.59.0':
+    resolution: {integrity: sha512-3bq2YKKfLY7UFauZSxqZUneCXoA3SMSls82V+0RKunvRlfPuPQW0hVn6t1RkvEdh0PDoygWG2mZXYQa6Iqgp9A==}
+    peerDependencies:
+      '@effect/cluster': ^0.58.0
+      '@effect/platform': ^0.96.0
+      '@effect/rpc': ^0.75.0
+      '@effect/sql': ^0.51.0
+      effect: ^3.21.0
+
+  '@effect/platform-node@0.106.0':
+    resolution: {integrity: sha512-mpsJK2jNLVd0jQAjHKBo8j3wdKWznSGvfnKBcAuG/9Rr4mb8bMRZFLXHHT9wUP7EvnZ0tDZJgEDxkC+j+ByRag==}
+    peerDependencies:
+      '@effect/cluster': ^0.58.0
+      '@effect/platform': ^0.96.0
+      '@effect/rpc': ^0.75.0
+      '@effect/sql': ^0.51.0
+      effect: ^3.21.0
+
   '@effect/platform-node@0.96.1':
     resolution: {integrity: sha512-4nfB/XRJJ246MCdI7klTE/aVvA9txfI83RnymS7pNyoG4CXUKELi87JrkrWFTtOlewzt5UMWpmqsFmm2qHxx3A==}
     peerDependencies:
@@ -5085,6 +5103,11 @@ packages:
     resolution: {integrity: sha512-QhDPgCaLfIMQKOCoCPQvRUS+Y34iYJ07jdZ/CBAvYFvg/iUBebsmFuHL63RCD/YZH9BuK/kqqLYAA3M0fmUEgg==}
     peerDependencies:
       effect: ^3.17.13
+
+  '@effect/platform@0.96.1':
+    resolution: {integrity: sha512-cjB1QZZYEP8JXCFNGvBLVi0T6YUBQTmOVEUA3SDbiQ6RUO+p6CE3eyD2vMWmrz5nE8yY5QSAuOV9v0boEcUv+A==}
+    peerDependencies:
+      effect: ^3.21.2
 
   '@effect/rpc@0.69.5':
     resolution: {integrity: sha512-LLCZP/aiaW4HeoIaoZuVZpJb/PFCwdJP21b3xP6l+1yoRVw8HlKYyfy/outRCF+BT4ndtY0/utFSeGWC21Qr7w==}
@@ -6215,8 +6238,8 @@ packages:
   '@evolution-sdk/evolution@0.3.28':
     resolution: {integrity: sha512-rgB7bswriAQeLcLSq+HT+nAugsmgdHor9skk6nT9ewTgk1fP9Wq55AxH118Jb5gFAnST40GGEh9SJfswpOeDTg==}
 
-  '@evolution-sdk/evolution@0.3.32':
-    resolution: {integrity: sha512-D0PZgkW55V1sPmul+WbdWNDon7aN8s4+SXuKAkJBRsHVbMvpvrM2doQwSCjQ1cB4zrW9LQGlLKt2SpGdAtLrLQ==}
+  '@evolution-sdk/evolution@0.5.9':
+    resolution: {integrity: sha512-+hQiDp624Yu/SR91k+f2HtHez27KbhybEb+giN2jztcu2ckOWUxBihzR98c/j/Zo/7gdnYhX9nVvb3/WipmVxA==}
 
   '@evolution-sdk/scalus-uplc@0.0.9':
     resolution: {integrity: sha512-ByC7I00NmgTUEhC3ZFr+wjFCAmZrKuV5yE5l4naHf9EhkYLgPVOM+NokLhb2j+CyXuOCB7ePvlcoidFkAJ/DiQ==}
@@ -7665,6 +7688,10 @@ packages:
 
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
 
   '@noble/secp256k1@1.6.3':
@@ -15965,6 +15992,9 @@ packages:
   effect@3.19.19:
     resolution: {integrity: sha512-Yc8U/SVXo2dHnaP7zNBlAo83h/nzSJpi7vph6Hzyl4ulgMBIgPmz3UzOjb9sBgpFE00gC0iETR244sfXDNLHRg==}
 
+  effect@3.21.2:
+    resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -19678,6 +19708,9 @@ packages:
   msgpackr-extract@3.0.3:
     resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
     hasBin: true
+
+  msgpackr@1.11.12:
+    resolution: {integrity: sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==}
 
   msgpackr@1.11.8:
     resolution: {integrity: sha512-bC4UGzHhVvgDNS7kn9tV8fAucIYUBuGojcaLiz7v+P63Lmtm0Xeji8B/8tYKddALXxJLpwIeBmUN3u64C4YkRA==}
@@ -27975,28 +28008,44 @@ snapshots:
     dependencies:
       '@edge-runtime/primitives': 4.1.0
 
-  '@effect/cluster@0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)':
+  '@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)':
     dependencies:
-      '@effect/platform': 0.90.10(effect@3.19.19)
-      '@effect/rpc': 0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)
-      '@effect/sql': 0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)
-      '@effect/workflow': 0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
+      '@effect/platform': 0.96.1(effect@3.19.19)
+      '@effect/rpc': 0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)
+      '@effect/sql': 0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)
+      '@effect/workflow': 0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
       effect: 3.19.19
 
-  '@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0)':
+  '@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)':
     dependencies:
-      '@effect/platform': 0.90.10(effect@3.19.19)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/rpc': 0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/sql': 0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/workflow': 0.9.6(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      effect: 3.21.2
+
+  '@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0)':
+    dependencies:
+      '@effect/platform': 0.96.1(effect@3.19.19)
       effect: 3.19.19
       uuid: 11.1.0
     optionalDependencies:
       ioredis: 5.10.0
 
-  '@effect/platform-node-shared@0.49.2(@effect/cluster@0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(effect@3.19.19)(utf-8-validate@6.0.6)':
+  '@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0)':
     dependencies:
-      '@effect/cluster': 0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      effect: 3.21.2
+      uuid: 11.1.0
+    optionalDependencies:
+      ioredis: 5.10.0
+
+  '@effect/platform-node-shared@0.49.2(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(effect@3.19.19)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@effect/cluster': 0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
       '@effect/platform': 0.90.10(effect@3.19.19)
-      '@effect/rpc': 0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)
-      '@effect/sql': 0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)
+      '@effect/rpc': 0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)
+      '@effect/sql': 0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)
       '@parcel/watcher': 2.5.6
       effect: 3.19.19
       multipasta: 0.2.7
@@ -28005,13 +28054,71 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@0.96.1(@effect/cluster@0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(effect@3.19.19)(utf-8-validate@6.0.6)':
+  '@effect/platform-node-shared@0.59.0(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(effect@3.19.19)(utf-8-validate@6.0.6)':
     dependencies:
-      '@effect/cluster': 0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
+      '@effect/cluster': 0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
+      '@effect/platform': 0.96.1(effect@3.19.19)
+      '@effect/rpc': 0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)
+      '@effect/sql': 0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)
+      '@parcel/watcher': 2.5.6
+      effect: 3.19.19
+      multipasta: 0.2.7
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@effect/platform-node-shared@0.59.0(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(bufferutil@4.1.0)(effect@3.21.2)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@effect/cluster': 0.48.16(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/rpc': 0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/sql': 0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@parcel/watcher': 2.5.6
+      effect: 3.21.2
+      multipasta: 0.2.7
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@effect/platform-node@0.106.0(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(effect@3.19.19)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@effect/cluster': 0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
+      '@effect/platform': 0.96.1(effect@3.19.19)
+      '@effect/platform-node-shared': 0.59.0(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(effect@3.19.19)(utf-8-validate@6.0.6)
+      '@effect/rpc': 0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)
+      '@effect/sql': 0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)
+      effect: 3.19.19
+      mime: 3.0.0
+      undici: 7.22.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@effect/platform-node@0.106.0(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(bufferutil@4.1.0)(effect@3.21.2)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@effect/cluster': 0.48.16(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/platform-node-shared': 0.59.0(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(bufferutil@4.1.0)(effect@3.21.2)(utf-8-validate@6.0.6)
+      '@effect/rpc': 0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/sql': 0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      effect: 3.21.2
+      mime: 3.0.0
+      undici: 7.22.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@effect/platform-node@0.96.1(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(effect@3.19.19)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@effect/cluster': 0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
       '@effect/platform': 0.90.10(effect@3.19.19)
-      '@effect/platform-node-shared': 0.49.2(@effect/cluster@0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(effect@3.19.19)(utf-8-validate@6.0.6)
-      '@effect/rpc': 0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)
-      '@effect/sql': 0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)
+      '@effect/platform-node-shared': 0.49.2(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(effect@3.19.19)(utf-8-validate@6.0.6)
+      '@effect/rpc': 0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)
+      '@effect/sql': 0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)
       effect: 3.19.19
       mime: 3.0.0
       undici: 7.22.0
@@ -28027,23 +28134,55 @@ snapshots:
       msgpackr: 1.11.8
       multipasta: 0.2.7
 
-  '@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)':
+  '@effect/platform@0.96.1(effect@3.19.19)':
     dependencies:
-      '@effect/platform': 0.90.10(effect@3.19.19)
+      effect: 3.19.19
+      find-my-way-ts: 0.1.6
+      msgpackr: 1.11.12
+      multipasta: 0.2.7
+
+  '@effect/platform@0.96.1(effect@3.21.2)':
+    dependencies:
+      effect: 3.21.2
+      find-my-way-ts: 0.1.6
+      msgpackr: 1.11.12
+      multipasta: 0.2.7
+
+  '@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)':
+    dependencies:
+      '@effect/platform': 0.96.1(effect@3.19.19)
       effect: 3.19.19
 
-  '@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)':
+  '@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)':
     dependencies:
-      '@effect/experimental': 0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0)
-      '@effect/platform': 0.90.10(effect@3.19.19)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      effect: 3.21.2
+
+  '@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)':
+    dependencies:
+      '@effect/experimental': 0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0)
+      '@effect/platform': 0.96.1(effect@3.19.19)
       effect: 3.19.19
       uuid: 11.1.0
 
-  '@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)':
+  '@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)':
     dependencies:
-      '@effect/platform': 0.90.10(effect@3.19.19)
-      '@effect/rpc': 0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)
+      '@effect/experimental': 0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      effect: 3.21.2
+      uuid: 11.1.0
+
+  '@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)':
+    dependencies:
+      '@effect/platform': 0.96.1(effect@3.19.19)
+      '@effect/rpc': 0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)
       effect: 3.19.19
+
+  '@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)':
+    dependencies:
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/rpc': 0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      effect: 3.21.2
 
   '@emnapi/core@1.9.0':
     dependencies:
@@ -29239,28 +29378,28 @@ snapshots:
       '@ethersproject/properties': 5.8.0
       '@ethersproject/strings': 5.8.0
 
-  '@evolution-sdk/aiken-uplc@0.0.11(@evolution-sdk/evolution@0.3.28(@effect/cluster@0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@evolution-sdk/aiken-uplc@0.0.11(@evolution-sdk/evolution@0.3.28(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@evolution-sdk/evolution': 0.3.28(@effect/cluster@0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@evolution-sdk/evolution': 0.3.28(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       effect: 3.19.19
 
-  '@evolution-sdk/devnet@1.1.28(f5ca8007af6180979f1a24ea5c694f0f)':
+  '@evolution-sdk/devnet@1.1.28(6c2e44bcef0705103d111d427d8a5132)':
     dependencies:
-      '@effect/platform': 0.90.10(effect@3.19.19)
-      '@effect/platform-node': 0.96.1(@effect/cluster@0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(effect@3.19.19)(utf-8-validate@6.0.6)
-      '@evolution-sdk/aiken-uplc': 0.0.11(@evolution-sdk/evolution@0.3.28(@effect/cluster@0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      '@evolution-sdk/evolution': 0.3.28(@effect/cluster@0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@evolution-sdk/scalus-uplc': 0.0.9(@evolution-sdk/evolution@0.3.28(@effect/cluster@0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@effect/platform': 0.96.1(effect@3.19.19)
+      '@effect/platform-node': 0.106.0(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(effect@3.19.19)(utf-8-validate@6.0.6)
+      '@evolution-sdk/aiken-uplc': 0.0.11(@evolution-sdk/evolution@0.3.28(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@evolution-sdk/evolution': 0.3.28(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@evolution-sdk/scalus-uplc': 0.0.9(@evolution-sdk/evolution@0.3.28(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@noble/hashes': 1.8.0
       dockerode: 4.0.9
       effect: 3.19.19
     transitivePeerDependencies:
       - supports-color
 
-  '@evolution-sdk/evolution@0.3.28(@effect/cluster@0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@evolution-sdk/evolution@0.3.28(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@effect/platform': 0.90.10(effect@3.19.19)
-      '@effect/platform-node': 0.96.1(@effect/cluster@0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(effect@3.19.19)(utf-8-validate@6.0.6)
+      '@effect/platform-node': 0.96.1(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(effect@3.19.19)(utf-8-validate@6.0.6)
       '@noble/curves': 2.0.1
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
@@ -29276,18 +29415,18 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@evolution-sdk/evolution@0.3.32(@effect/cluster@0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@evolution-sdk/evolution@0.5.9(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
-      '@effect/platform': 0.90.10(effect@3.19.19)
-      '@effect/platform-node': 0.96.1(@effect/cluster@0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(effect@3.19.19)(utf-8-validate@6.0.6)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/platform-node': 0.106.0(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(bufferutil@4.1.0)(effect@3.21.2)(utf-8-validate@6.0.6)
       '@noble/curves': 2.0.1
-      '@noble/hashes': 1.8.0
-      '@scure/base': 1.2.6
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
+      '@noble/hashes': 2.2.0
+      '@scure/base': 2.0.0
+      '@scure/bip32': 2.0.1
+      '@scure/bip39': 2.0.1
       '@types/bip39': 3.0.4
       bip39: 3.1.0
-      effect: 3.19.19
+      effect: 3.21.2
     transitivePeerDependencies:
       - '@effect/cluster'
       - '@effect/rpc'
@@ -29295,9 +29434,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@evolution-sdk/scalus-uplc@0.0.9(@evolution-sdk/evolution@0.3.28(@effect/cluster@0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@evolution-sdk/scalus-uplc@0.0.9(@evolution-sdk/evolution@0.3.28(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@evolution-sdk/evolution': 0.3.28(@effect/cluster@0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@evolution-sdk/evolution': 0.3.28(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       effect: 3.19.19
       scalus: 0.14.2
 
@@ -32250,6 +32389,8 @@ snapshots:
 
   '@noble/hashes@2.0.1': {}
 
+  '@noble/hashes@2.2.0': {}
+
   '@noble/secp256k1@1.6.3': {}
 
   '@noble/secp256k1@1.7.1': {}
@@ -34655,7 +34796,7 @@ snapshots:
       debug: 2.6.9
       invariant: 2.2.4
       metro: 0.81.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      metro-config: 0.81.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      metro-config: 0.81.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       metro-core: 0.81.5
       readline: 1.3.0
       semver: 7.7.4
@@ -46133,6 +46274,11 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
+  effect@3.21.2:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
   ejs@3.1.10:
     dependencies:
       jake: 10.9.2
@@ -51270,6 +51416,22 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
+
+  metro-config@0.81.5(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    dependencies:
+      connect: 3.7.0
+      cosmiconfig: 5.2.1
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.81.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      metro-cache: 0.81.5
+      metro-core: 0.81.5
+      metro-runtime: 0.81.5
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   metro-core@0.81.5:
     dependencies:
@@ -51361,6 +51523,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   metro-transform-worker@0.81.5(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
@@ -51428,6 +51591,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   metro@0.81.5(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
@@ -51455,7 +51619,7 @@ snapshots:
       metro-babel-transformer: 0.81.5
       metro-cache: 0.81.5
       metro-cache-key: 0.81.5
-      metro-config: 0.81.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      metro-config: 0.81.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       metro-core: 0.81.5
       metro-file-map: 0.81.5
       metro-resolver: 0.81.5
@@ -52068,6 +52232,10 @@ snapshots:
       '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
       '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
     optional: true
+
+  msgpackr@1.11.12:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
 
   msgpackr@1.11.8:
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1885,11 +1885,11 @@ importers:
   lazer/contracts/cardano/cli/js:
     dependencies:
       '@evolution-sdk/devnet':
-        specifier: ^1.1.28
-        version: 1.1.28(6c2e44bcef0705103d111d427d8a5132)
+        specifier: 1.1.29
+        version: 1.1.29(3d2afd979887ecfa30eaa7b18e3110ba)
       '@evolution-sdk/evolution':
-        specifier: ^0.3.28
-        version: 0.3.28(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        specifier: 0.3.29
+        version: 0.3.29(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@noble/curves':
         specifier: ^2.0.1
         version: 2.0.1
@@ -1903,7 +1903,7 @@ importers:
         specifier: 'catalog:'
         version: 4.1.0
       effect:
-        specifier: ^3.19.19
+        specifier: 3.19.19
         version: 3.19.19
       yargs:
         specifier: 'catalog:'
@@ -6225,18 +6225,18 @@ packages:
     peerDependencies:
       '@evolution-sdk/evolution': 0.3.19
 
-  '@evolution-sdk/devnet@1.1.28':
-    resolution: {integrity: sha512-LYT8v0svokCcdBE4zS17crhXBR+iulrLH+EJG3c+7P2/xqHfgXHjHPA07U6YDckxKqac8d3+tzEDpkCXfs/2Qw==}
+  '@evolution-sdk/devnet@1.1.29':
+    resolution: {integrity: sha512-jfUBFi17q+Xbv24QxKYGNmvEPfpe7N3dEvbCadsqb3xbUcRlpXB7CU+x1+oHoiqAXZILb8ppMH8TnU7/ei+SEQ==}
     peerDependencies:
       '@effect/platform': ^0.90.10
       '@effect/platform-node': ^0.96.1
-      '@evolution-sdk/aiken-uplc': 0.0.20
-      '@evolution-sdk/evolution': 0.3.28
-      '@evolution-sdk/scalus-uplc': 0.0.18
+      '@evolution-sdk/aiken-uplc': 0.0.21
+      '@evolution-sdk/evolution': 0.3.29
+      '@evolution-sdk/scalus-uplc': 0.0.19
       effect: ^3.19.3
 
-  '@evolution-sdk/evolution@0.3.28':
-    resolution: {integrity: sha512-rgB7bswriAQeLcLSq+HT+nAugsmgdHor9skk6nT9ewTgk1fP9Wq55AxH118Jb5gFAnST40GGEh9SJfswpOeDTg==}
+  '@evolution-sdk/evolution@0.3.29':
+    resolution: {integrity: sha512-6cHRRy5pem7IbV2l9QI9MRxz0Gy1UkU2ur6ZnfGBsTxYsWWzqQwQAmvC0T7dHgvdL4k/cgAprs2fe2gGylM4ew==}
 
   '@evolution-sdk/evolution@0.5.9':
     resolution: {integrity: sha512-+hQiDp624Yu/SR91k+f2HtHez27KbhybEb+giN2jztcu2ckOWUxBihzR98c/j/Zo/7gdnYhX9nVvb3/WipmVxA==}
@@ -19712,9 +19712,6 @@ packages:
   msgpackr@1.11.12:
     resolution: {integrity: sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==}
 
-  msgpackr@1.11.8:
-    resolution: {integrity: sha512-bC4UGzHhVvgDNS7kn9tV8fAucIYUBuGojcaLiz7v+P63Lmtm0Xeji8B/8tYKddALXxJLpwIeBmUN3u64C4YkRA==}
-
   msw@2.12.10:
     resolution: {integrity: sha512-G3VUymSE0/iegFnuipujpwyTM2GuZAKXNeerUSrG2+Eg391wW63xFs5ixWsK9MWzr1AGoSkYGmyAzNgbR3+urw==}
     engines: {node: '>=18'}
@@ -19775,9 +19772,6 @@ packages:
 
   nan@2.14.0:
     resolution: {integrity: sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==}
-
-  nan@2.22.2:
-    resolution: {integrity: sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==}
 
   nan@2.25.0:
     resolution: {integrity: sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==}
@@ -22614,9 +22608,6 @@ packages:
   tar-fs@2.0.1:
     resolution: {integrity: sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==}
 
-  tar-fs@2.1.2:
-    resolution: {integrity: sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==}
-
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
@@ -23535,6 +23526,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -28131,7 +28123,7 @@ snapshots:
     dependencies:
       effect: 3.19.19
       find-my-way-ts: 0.1.6
-      msgpackr: 1.11.8
+      msgpackr: 1.11.12
       multipasta: 0.2.7
 
   '@effect/platform@0.96.1(effect@3.19.19)':
@@ -28698,7 +28690,7 @@ snapshots:
       '@ethereumjs/rlp': 10.1.1
       '@ethereumjs/util': 10.1.1
       '@noble/curves': 2.0.1
-      '@noble/hashes': 2.0.1
+      '@noble/hashes': 2.2.0
 
   '@ethereumjs/tx@3.3.2':
     dependencies:
@@ -28721,7 +28713,7 @@ snapshots:
     dependencies:
       '@ethereumjs/rlp': 10.1.1
       '@noble/curves': 2.0.1
-      '@noble/hashes': 2.0.1
+      '@noble/hashes': 2.2.0
 
   '@ethereumjs/util@8.1.0':
     dependencies:
@@ -29378,25 +29370,25 @@ snapshots:
       '@ethersproject/properties': 5.8.0
       '@ethersproject/strings': 5.8.0
 
-  '@evolution-sdk/aiken-uplc@0.0.11(@evolution-sdk/evolution@0.3.28(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@evolution-sdk/aiken-uplc@0.0.11(@evolution-sdk/evolution@0.3.29(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@evolution-sdk/evolution': 0.3.28(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@evolution-sdk/evolution': 0.3.29(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       effect: 3.19.19
 
-  '@evolution-sdk/devnet@1.1.28(6c2e44bcef0705103d111d427d8a5132)':
+  '@evolution-sdk/devnet@1.1.29(3d2afd979887ecfa30eaa7b18e3110ba)':
     dependencies:
       '@effect/platform': 0.96.1(effect@3.19.19)
       '@effect/platform-node': 0.106.0(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(effect@3.19.19)(utf-8-validate@6.0.6)
-      '@evolution-sdk/aiken-uplc': 0.0.11(@evolution-sdk/evolution@0.3.28(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      '@evolution-sdk/evolution': 0.3.28(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@evolution-sdk/scalus-uplc': 0.0.9(@evolution-sdk/evolution@0.3.28(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@evolution-sdk/aiken-uplc': 0.0.11(@evolution-sdk/evolution@0.3.29(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@evolution-sdk/evolution': 0.3.29(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@evolution-sdk/scalus-uplc': 0.0.9(@evolution-sdk/evolution@0.3.29(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@noble/hashes': 1.8.0
       dockerode: 4.0.9
       effect: 3.19.19
     transitivePeerDependencies:
       - supports-color
 
-  '@evolution-sdk/evolution@0.3.28(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@evolution-sdk/evolution@0.3.29(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@effect/platform': 0.90.10(effect@3.19.19)
       '@effect/platform-node': 0.96.1(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(effect@3.19.19)(utf-8-validate@6.0.6)
@@ -29434,9 +29426,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@evolution-sdk/scalus-uplc@0.0.9(@evolution-sdk/evolution@0.3.28(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@evolution-sdk/scalus-uplc@0.0.9(@evolution-sdk/evolution@0.3.29(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@evolution-sdk/evolution': 0.3.28(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@evolution-sdk/evolution': 0.3.29(@effect/cluster@0.48.16(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.96.1(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.96.1(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       effect: 3.19.19
       scalus: 0.14.2
 
@@ -48418,7 +48410,7 @@ snapshots:
 
   get-stream@5.2.0:
     dependencies:
-      pump: 3.0.2
+      pump: 3.0.4
 
   get-stream@6.0.1: {}
 
@@ -52237,10 +52229,6 @@ snapshots:
     optionalDependencies:
       msgpackr-extract: 3.0.3
 
-  msgpackr@1.11.8:
-    optionalDependencies:
-      msgpackr-extract: 3.0.3
-
   msw@2.12.10(@types/node@22.14.0)(typescript@5.9.3):
     dependencies:
       '@inquirer/confirm': 5.1.21(@types/node@22.14.0)
@@ -52340,10 +52328,7 @@ snapshots:
   nan@2.14.0:
     optional: true
 
-  nan@2.22.2: {}
-
-  nan@2.25.0:
-    optional: true
+  nan@2.25.0: {}
 
   nano-json-stream-parser@0.1.2: {}
 
@@ -53641,10 +53626,10 @@ snapshots:
       mkdirp-classic: 0.5.3
       napi-build-utils: 2.0.0
       node-abi: 3.74.0
-      pump: 3.0.2
+      pump: 3.0.4
       rc: 1.2.8
       simple-get: 4.0.1
-      tar-fs: 2.1.2
+      tar-fs: 2.1.4
       tunnel-agent: 0.6.0
 
   precond@0.2.3: {}
@@ -56374,13 +56359,6 @@ snapshots:
       pump: 3.0.4
       tar-stream: 2.2.0
 
-  tar-fs@2.1.2:
-    dependencies:
-      chownr: 1.1.4
-      mkdirp-classic: 0.5.3
-      pump: 3.0.4
-      tar-stream: 2.2.0
-
   tar-fs@2.1.4:
     dependencies:
       chownr: 1.1.4
@@ -56555,7 +56533,7 @@ snapshots:
       bn.js: 4.12.3
       create-hmac: 1.1.7
       elliptic: 6.6.1
-      nan: 2.22.2
+      nan: 2.25.0
 
   tinybench@2.9.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1937,7 +1937,7 @@ importers:
   lazer/contracts/cardano/sdk/js:
     dependencies:
       '@evolution-sdk/evolution':
-        specifier: ^0.3.29
+        specifier: 0.3.32
         version: 0.3.32(@effect/cluster@0.48.16(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.9.6(@effect/platform@0.90.10(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/rpc@0.69.5(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19)(ioredis@5.10.0))(@effect/platform@0.90.10(effect@3.19.19))(effect@3.19.19))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     devDependencies:
       '@cprussin/tsconfig':
@@ -34655,7 +34655,7 @@ snapshots:
       debug: 2.6.9
       invariant: 2.2.4
       metro: 0.81.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      metro-config: 0.81.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      metro-config: 0.81.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       metro-core: 0.81.5
       readline: 1.3.0
       semver: 7.7.4
@@ -51270,22 +51270,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-    optional: true
-
-  metro-config@0.81.5(bufferutil@4.1.0)(utf-8-validate@5.0.10):
-    dependencies:
-      connect: 3.7.0
-      cosmiconfig: 5.2.1
-      flow-enums-runtime: 0.0.6
-      jest-validate: 29.7.0
-      metro: 0.81.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      metro-cache: 0.81.5
-      metro-core: 0.81.5
-      metro-runtime: 0.81.5
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
 
   metro-core@0.81.5:
     dependencies:
@@ -51377,7 +51361,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-    optional: true
 
   metro-transform-worker@0.81.5(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
@@ -51445,7 +51428,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-    optional: true
 
   metro@0.81.5(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
@@ -51473,7 +51455,7 @@ snapshots:
       metro-babel-transformer: 0.81.5
       metro-cache: 0.81.5
       metro-cache-key: 0.81.5
-      metro-config: 0.81.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      metro-config: 0.81.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       metro-core: 0.81.5
       metro-file-map: 0.81.5
       metro-resolver: 0.81.5


### PR DESCRIPTION
## Summary

Refactors SDK to use the latest 0.5.9 version of Evolution SDK and pins version in package.json

## Rationale

Evolution SDK doesn't seem to strictly follow semver, and broke CI on a patch update.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [X] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->