### PR TITLE
fix(developer-hub): move remarkMdxMermaid to remarkPlugins for Mermaid rendering

### DIFF
--- a/apps/developer-hub/source.config.ts
+++ b/apps/developer-hub/source.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
         dark: "github-dark",
       },
     },
-    remarkPlugins: [remarkMath],
-    rehypePlugins: (v) => [rehypeKatex, rehypeCode, remarkMdxMermaid, ...v],
+    remarkPlugins: [remarkMath, remarkMdxMermaid],
+    rehypePlugins: (v) => [rehypeKatex, rehypeCode, ...v],
   },
 });


### PR DESCRIPTION
## Summary

- `remarkMdxMermaid` was incorrectly placed in `rehypePlugins` in `source.config.ts`. Since it's a remark plugin (operates on markdown AST), it needs to be in `remarkPlugins` to properly intercept and process mermaid code blocks before MDX compilation.
- This one-line config fix restores Mermaid diagram rendering on the TON pull-integration page (and any future pages using mermaid code fences).

## Root Cause

In `apps/developer-hub/source.config.ts`, the `remarkMdxMermaid` plugin was added to the `rehypePlugins` array instead of `remarkPlugins`. Rehype plugins operate on the HTML AST (after markdown-to-HTML conversion), so the remark-stage mermaid plugin never got a chance to find and transform mermaid code blocks in the markdown AST. The TON page is currently the only docs page with mermaid diagrams, which is why only it was affected.

## Test plan

- [ ] Build the developer-hub app and verify the TON pull-integration page renders all 7 mermaid sequence diagrams
- [ ] Verify other docs pages (KaTeX math, code blocks) still render correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->