### PR TITLE
chore(pyth-solana-receiver): bump to 0.16.0 for releasing

### DIFF
--- a/target_chains/solana/sdk/js/pyth_solana_receiver/package.json
+++ b/target_chains/solana/sdk/js/pyth_solana_receiver/package.json
@@ -131,5 +131,5 @@
   },
   "type": "module",
   "types": "./dist/cjs/index.d.ts",
-  "version": "0.15.0"
+  "version": "0.16.0"
 }


### PR DESCRIPTION
Bump @pythnetwork/pyth-solana-receiver version from 0.15.0 to 0.16.0. Single-line version change, no other files affected. pnpm install and build both pass cleanly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->