### PR TITLE
feat(cardano): make cli package private

### DIFF
--- a/lazer/contracts/cardano/cli/js/package.json
+++ b/lazer/contracts/cardano/cli/js/package.json
@@ -94,10 +94,7 @@
     "dist/**"
   ],
   "name": "@pythnetwork/pyth-lazer-cardano-cli",
-  "private": false,
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "repository": {
     "directory": "lazer/contracts/cardano/cli/js",
     "type": "git",


### PR DESCRIPTION
## Summary

Make Cardano cli package private.

## Rationale

It's making the workflow for publishing js packages fail. I think it's supposed to be private.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->