### PR TITLE
fix(dev-hub): fix broken Sui/IOTA/Near links on use-real-time-data page

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/index.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/index.mdx
@@ -42,9 +42,9 @@ Consult the relevant ecosystem guide to get started using **pull integration**:
 - [Starknet](../use-real-time-data/pull-integration/starknet)
 - [Aptos](../use-real-time-data/pull-integration/aptos)
 - [CosmWasm](../use-real-time-data/pull-integration/cosmwasm)
-- [Sui](./pull-integration/sui)
-- [IOTA](./pull-integration/iota)
-- [Near](./pull-integration/near)
+- [Sui](../use-real-time-data/pull-integration/sui)
+- [IOTA](../use-real-time-data/pull-integration/iota)
+- [Near](../use-real-time-data/pull-integration/near)
 
 ## Push Integration
 


### PR DESCRIPTION
Fixes broken Sui, IOTA, and Near links on the use-real-time-data index page. Changed from ./pull-integration/{sui,iota,near} to ../use-real-time-data/pull-integration/{sui,iota,near} to match the convention used by the other links (EVM, Solana, Starknet, Aptos, CosmWasm). The ./ prefix resolved against the parent segment due to the URL having no trailing slash, producing 404s.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3737" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->