### PR TITLE
fix(dev-hub): fix broken Sui/IOTA/Near links on use-real-time-data page

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/index.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/index.mdx
@@ -42,9 +42,9 @@ Consult the relevant ecosystem guide to get started using **pull integration**:
 - [Starknet](../use-real-time-data/pull-integration/starknet)
 - [Aptos](../use-real-time-data/pull-integration/aptos)
 - [CosmWasm](../use-real-time-data/pull-integration/cosmwasm)
-- [Sui](./pull-integration/sui)
-- [IOTA](./pull-integration/iota)
-- [Near](./pull-integration/near)
+- [Sui](../use-real-time-data/pull-integration/sui)
+- [IOTA](../use-real-time-data/pull-integration/iota)
+- [Near](../use-real-time-data/pull-integration/near)
 
 ## Push Integration
 


### PR DESCRIPTION
Use ../use-real-time-data/pull-integration/ prefix (matching EVM, Solana, etc.) instead of ./pull-integration/ which resolves against the parent segment when there is no trailing slash, producing 404s.

## Summary

<!-- Briefly describe the changes -->

## Rationale

<!-- Why are these changes necessary? -->

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->