### PR TITLE
fix(dev-hub): fix double-escaped backticks in llms.txt auto-update workflow

### DIFF
--- a/.github/workflows/update-llms-txt.yml
+++ b/.github/workflows/update-llms-txt.yml
@@ -338,8 +338,19 @@ jobs:
             # Extract the new header content from the JSON decision
             echo "$DECISIONS" | jq -r --arg key "$product" '.[$key]' > /tmp/new-header.txt
 
-            # Escape any unescaped backticks for JS template literal safety
-            sed -i 's/\\`/__ESC__/g; s/`/\\`/g; s/__ESC__/\\`/g' /tmp/new-header.txt
+            # Normalize backtick escaping for JS template literal safety.
+            # Strip ALL levels of backslash-escaping from backticks, then
+            # re-escape them uniformly. This prevents double-escaping (\\`)
+            # which would prematurely close the template literal and break
+            # the build.
+            sed -i ':a; s/\\`/`/g; ta; s/`/\\`/g' /tmp/new-header.txt
+
+            # Sanity-check: reject content that looks like GPT wrapped the
+            # markdown in a JS function expression (observed failure mode).
+            if head -1 /tmp/new-header.txt | grep -qE '^\s*function\s*\('; then
+              echo "::warning::GPT-4o returned content wrapped in a function expression for $product, skipping"
+              continue
+            fi
 
             # Use Python to safely replace the CONTENT content in the route file
             cat > /tmp/replace-header.py << 'PYEOF'
@@ -373,6 +384,13 @@ jobs:
           print(f"Updated {file_path}")
           PYEOF
             python3 /tmp/replace-header.py "$ROUTE_FILE" "/tmp/new-header.txt"
+
+            # Verify the updated route file has no syntax errors
+            if ! node --check "$ROUTE_FILE" 2>/dev/null; then
+              echo "::error::Updated $ROUTE_FILE has syntax errors, reverting"
+              git checkout -- "$ROUTE_FILE"
+              continue
+            fi
           done
 
       - name: Format updated files


### PR DESCRIPTION
## Summary

The update-llms-txt GitHub Action workflow was breaking the developer-hub build when GPT-4o returned content with pre-escaped backticks. The old sed escaping command preserved double-escaped backticks which prematurely close JavaScript template literals, causing syntax errors during the Next.js build.

### Fix

- Normalize-then-escape: Replace the sed logic to strip ALL levels of backslash-escaping from backticks, then uniformly re-escape them.
- GPT-4o output validation: Skip content that starts with function expression syntax (observed failure mode).
- Post-replacement syntax check: Run node --check on the updated route file and revert if it has syntax errors.

Refs: pyth-network/pyth-crosschain#3712 (commit 8248348)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->