### PR TITLE
Pin hydra CLI to v0.21.0 in Dockerfile.metis

### DIFF
--- a/Dockerfile.metis
+++ b/Dockerfile.metis
@@ -55,7 +55,7 @@ RUN curl -fsSL https://downloads.1password.com/linux/keys/1password.asc \
 RUN op --version
 
 # Install hydra CLI binary
-RUN curl -fsSL https://github.com/dourolabs/metis-releases/releases/download/v0.9.0/hydra-x86_64-unknown-linux-gnu \
+RUN curl -fsSL https://github.com/dourolabs/metis-releases/releases/download/v0.21.0/hydra-x86_64-unknown-linux-gnu \
       -o /usr/local/bin/hydra \
     && chmod +x /usr/local/bin/hydra
 


### PR DESCRIPTION
## Summary
Pin the hydra CLI install in `Dockerfile.metis` from `v0.9.0` → `v0.21.0` to align with the fleet-wide pin tracked in parent issue i-fokxmcqu.

- Before: `https://github.com/dourolabs/metis-releases/releases/download/v0.9.0/hydra-x86_64-unknown-linux-gnu`
- After:  `https://github.com/dourolabs/metis-releases/releases/download/v0.21.0/hydra-x86_64-unknown-linux-gnu`

Parent issue: i-fokxmcqu
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->