### PR TITLE
bump: hydra CLI pin v0.9.0 → v0.22.0 in Dockerfile.metis

### DIFF
--- a/Dockerfile.metis
+++ b/Dockerfile.metis
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     jq \
     file \
     ripgrep \
+    unzip \
     ca-certificates \
     gnupg \
     # Puppeteer / Chromium dependencies

--- a/Dockerfile.metis
+++ b/Dockerfile.metis
@@ -55,7 +55,7 @@ RUN curl -fsSL https://downloads.1password.com/linux/keys/1password.asc \
 RUN op --version
 
 # Install hydra CLI binary
-RUN curl -fsSL https://github.com/dourolabs/metis-releases/releases/download/v0.9.0/hydra-x86_64-unknown-linux-gnu \
+RUN curl -fsSL https://github.com/dourolabs/metis-releases/releases/download/v0.22.0/hydra-x86_64-unknown-linux-gnu \
       -o /usr/local/bin/hydra \
     && chmod +x /usr/local/bin/hydra
 


### PR DESCRIPTION
One-line change: bump Hydra CLI version from v0.9.0 to v0.22.0 in Dockerfile.metis.