### PR TITLE
docs(core): add upgrade callout to legacy contract-addresses pages

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/api-reference/index.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/api-reference/index.mdx
@@ -16,5 +16,5 @@ The following on-chain contracts are documented in the API reference:
 
 Hermes also has interactive API documentation hosted by the service itself:
 
-- [Hermes](https://pyth.dourolabs.app/hermes/docs/)
+- [Hermes](https://pyth.dourolabs.app/docs/?urls.primaryName=Hermes+API)
 - [Benchmarks / Historical Prices](https://benchmarks.pyth.network/docs)

--- a/apps/developer-hub/content/docs/price-feeds/core/api-reference/index.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/api-reference/index.mdx
@@ -8,11 +8,13 @@ The API reference is a comprehensive guide to the various APIs -- both on- and o
 Developers can consult this reference to better understand what methods exist and what they do.
 The API reference is interactive, so developers can try out the APIs from the website to better understand their behavior.
 
+<UpgradeCallout chain="index" />
+
 The following on-chain contracts are documented in the API reference:
 
 - [EVM](https://api-reference.pyth.network/price-feeds/evm/getPriceNoOlderThan)
 
 Hermes also has interactive API documentation hosted by the service itself:
 
-- [Hermes](https://hermes.pyth.network/docs/)
+- [Hermes](https://pyth.dourolabs.app/hermes/docs/)
 - [Benchmarks / Historical Prices](https://benchmarks.pyth.network/docs)

--- a/apps/developer-hub/content/docs/price-feeds/core/best-practices.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/best-practices.mdx
@@ -7,6 +7,8 @@ slug: /price-feeds/core/best-practices
 This page provides some technical details about Pyth price feeds that are necessary to use them safely and correctly.
 Please read this page before using Pyth price feeds in your application.
 
+<UpgradeCallout chain="index" />
+
 ## Fixed-Point Numeric Representation
 
 Price feeds represent numbers in a fixed-point format. The same exponent is used for both the price and confidence interval. The integer representation of these values can be computed by multiplying by `10^exponent`. As an example, imagine Pyth reported the following values for AAPL/USD:
@@ -64,7 +66,7 @@ Derivative protocols are encouraged to consider the following strategies to miti
 
 1. **Use Delayed Settlement**: Derivative protocols can introduce a delay between the time an order is created and the time it is executed. This delay gives the protocol time to observe price changes and reject trades/transactions that profit over latency.
    Suppose a user submits a trade transaction at a time `t`. The protocol should execute the trade by using the price at the time `t`, which will be available to the protocol after a short delay.
-   The protocol can fetch this price update of a specific timestamp from [Hermes](https://hermes.pyth.network/docs/#/rest/timestamp_price_updates) and can use [`parsePriceFeedUpdates()`](https://api-reference.pyth.network/price-feeds/evm/parsePriceFeedUpdates) to parse the prices and submit to prevent price frontrunning.
+   The protocol can fetch this price update of a specific timestamp from [Hermes](https://pyth.dourolabs.app/hermes/docs/#/rest/timestamp_price_updates) and can use [`parsePriceFeedUpdates()`](https://api-reference.pyth.network/price-feeds/evm/parsePriceFeedUpdates) to parse the prices and submit to prevent price frontrunning.
 
 1. **Use a Spread**: Pyth provides a confidence interval for each price update. Derivative protocols can use this confidence interval to determine the range in which the true price probably lies.
    By using the lower bound of the confidence interval, derivative protocols can protect themselves from price manipulation that drives the price down. By using the upper bound of the confidence interval, derivative protocols can protect themselves from price manipulation that drives the price up.
@@ -89,7 +91,7 @@ Protocols offering executable prices are encouraged to consider the following ri
 1. **Staleness in Executable Prices**: Adversaries may see price updates before your protocol does, or they may select favorable historical price updates that satisfy staleness constraints.
    This latency advantage allows sophisticated traders to exploit price differences.
    **Use `getPriceNoOlderThan()` with strict staleness thresholds** when filling orders.
-   For delayed execution models, fetch the price at the order timestamp from [Hermes](https://hermes.pyth.network/docs/#/rest/timestamp_price_updates) and parse it using [`parsePriceFeedUpdates()`](https://api-reference.pyth.network/price-feeds/evm/parsePriceFeedUpdates).
+   For delayed execution models, fetch the price at the order timestamp from [Hermes](https://pyth.dourolabs.app/hermes/docs/#/rest/timestamp_price_updates) and parse it using [`parsePriceFeedUpdates()`](https://api-reference.pyth.network/price-feeds/evm/parsePriceFeedUpdates).
 
 1. **High Volatility and Wide Confidence Intervals**: During periods of high volatility, large price moves widen confidence intervals and can cause significant slippage relative to your executable quote.
    The executable price you quote may not reflect the true market price when confidence intervals are wide.

--- a/apps/developer-hub/content/docs/price-feeds/core/best-practices.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/best-practices.mdx
@@ -66,7 +66,7 @@ Derivative protocols are encouraged to consider the following strategies to miti
 
 1. **Use Delayed Settlement**: Derivative protocols can introduce a delay between the time an order is created and the time it is executed. This delay gives the protocol time to observe price changes and reject trades/transactions that profit over latency.
    Suppose a user submits a trade transaction at a time `t`. The protocol should execute the trade by using the price at the time `t`, which will be available to the protocol after a short delay.
-   The protocol can fetch this price update of a specific timestamp from [Hermes](https://pyth.dourolabs.app/hermes/docs/#/rest/timestamp_price_updates) and can use [`parsePriceFeedUpdates()`](https://api-reference.pyth.network/price-feeds/evm/parsePriceFeedUpdates) to parse the prices and submit to prevent price frontrunning.
+   The protocol can fetch this price update of a specific timestamp from [Hermes](https://pyth.dourolabs.app/docs/?urls.primaryName=Hermes+API#/rest/timestamp_price_updates) and can use [`parsePriceFeedUpdates()`](https://api-reference.pyth.network/price-feeds/evm/parsePriceFeedUpdates) to parse the prices and submit to prevent price frontrunning.
 
 1. **Use a Spread**: Pyth provides a confidence interval for each price update. Derivative protocols can use this confidence interval to determine the range in which the true price probably lies.
    By using the lower bound of the confidence interval, derivative protocols can protect themselves from price manipulation that drives the price down. By using the upper bound of the confidence interval, derivative protocols can protect themselves from price manipulation that drives the price up.
@@ -91,7 +91,7 @@ Protocols offering executable prices are encouraged to consider the following ri
 1. **Staleness in Executable Prices**: Adversaries may see price updates before your protocol does, or they may select favorable historical price updates that satisfy staleness constraints.
    This latency advantage allows sophisticated traders to exploit price differences.
    **Use `getPriceNoOlderThan()` with strict staleness thresholds** when filling orders.
-   For delayed execution models, fetch the price at the order timestamp from [Hermes](https://pyth.dourolabs.app/hermes/docs/#/rest/timestamp_price_updates) and parse it using [`parsePriceFeedUpdates()`](https://api-reference.pyth.network/price-feeds/evm/parsePriceFeedUpdates).
+   For delayed execution models, fetch the price at the order timestamp from [Hermes](https://pyth.dourolabs.app/docs/?urls.primaryName=Hermes+API#/rest/timestamp_price_updates) and parse it using [`parsePriceFeedUpdates()`](https://api-reference.pyth.network/price-feeds/evm/parsePriceFeedUpdates).
 
 1. **High Volatility and Wide Confidence Intervals**: During periods of high volatility, large price moves widen confidence intervals and can cause significant slippage relative to your executable quote.
    The executable price you quote may not reflect the true market price when confidence intervals are wide.

--- a/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/aptos.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/aptos.mdx
@@ -8,6 +8,8 @@ import CopyAddress from "../../../../../src/components/CopyAddress";
 
 Pyth is currently deployed on Aptos Mainnet, Aptos Testnet, and Movement devnet.
 
+<UpgradeCallout chain="aptos" />
+
 When deploying contracts using Pyth, the [named addresses](https://diem.github.io/move/address.html#named-addresses) `pyth`, `wormhole` and `deployer` need to be defined at compile time. These addresses are the same across both Aptos Mainnet and Testnet:
 
 | Named Address | Value                                                                                                                                                                                               |

--- a/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/cosmwasm.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/cosmwasm.mdx
@@ -6,6 +6,8 @@ slug: /price-feeds/core/contract-addresses/cosmwasm
 
 Pyth is currently available on the following cosmwasm chains:
 
+<UpgradeCallout chain="cosmwasm" />
+
 ### Stable
 
 | Network           | Contract address                                                     |

--- a/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/evm.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/evm.mdx
@@ -4,7 +4,7 @@ description: List of Pyth price feed contract addresses on supported EVM mainnet
 slug: /price-feeds/core/contract-addresses/evm
 ---
 
-import CopyAddress from "../../../../../src/components/CopyAddress";
+import EvmContractsStatusTable from "../../../../../src/components/EvmContractsStatusTable";
 
 Pyth is currently available on the EVM networks below using Pyth Stable price sources that are accessible via Hermes Stable.
 
@@ -12,168 +12,11 @@ Pyth is currently available on the EVM networks below using Pyth Stable price so
 
 ## Mainnets
 
-| Network           | Contract address                                                                                                                                                     |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 0G                | <CopyAddress address="0x2880ab155794e7179c9ee2e38200202908c17b43" url="https://chainscan.0g.ai/address/0x2880ab155794e7179c9ee2e38200202908c17b43" />                |
-| Abstract          | <CopyAddress address="0x8739d5024B5143278E2b15Bd9e7C26f6CEc658F1" url="https://abscan.org/address/0x8739d5024B5143278E2b15Bd9e7C26f6CEc658F1" />                     |
-| Apechain          | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://apechain.calderaexplorer.xyz/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />   |
-| Arbitrum          | <CopyAddress address="0xff1a0f4744e8582DF1aE09D5611b887B6a12925C" url="https://arbiscan.io/address/0xff1a0f4744e8582df1ae09d5611b887b6a12925c" />                    |
-| Aurora            | <CopyAddress address="0xF89C7b475821EC3fDC2dC8099032c05c6c0c9AB9" url="https://explorer.aurora.dev/address/0xF89C7b475821EC3fDC2dC8099032c05c6c0c9AB9" />            |
-| Avalanche         | <CopyAddress address="0x4305FB66699C3B2702D4d05CF36551390A4c69C6" url="https://snowtrace.io/address/0x4305fb66699c3b2702d4d05cf36551390a4c69c6" />                   |
-| Berachain         | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://berascan.com/address/0x2880ab155794e7179c9ee2e38200202908c17b43" />                   |
-| Bittensor         | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://evm.taostats.io/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                |
-| Blast             | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://blastscan.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />                   |
-| BNB               | <CopyAddress address="0x4D7E825f80bDf85e913E0DD2A2D54927e9dE1594" url="https://bscscan.com/address/0x4d7e825f80bdf85e913e0dd2a2d54927e9de1594" />                    |
-| BTTC              | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://bttcscan.com/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />                   |
-| Base              | <CopyAddress address="0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a" url="https://basescan.org/address/0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a" />                   |
-| Boba              | <CopyAddress address="0x4374e5a8b9C22271E9EB878A2AA31DE97DF15DAF" url="https://bobascan.com/address/0x4374e5a8b9C22271E9EB878A2AA31DE97DF15DAF" />                   |
-| Camp Network      | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://camp.cloud.blockscout.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />      |
-| Celo              | <CopyAddress address="0xff1a0f4744e8582DF1aE09D5611b887B6a12925C" url="https://celoscan.io/address/0xff1a0f4744e8582df1ae09d5611b887b6a12925c" />                    |
-| Chiliz            | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://scan.chiliz.com/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />                |
-| Conflux eSpace    | <CopyAddress address="0xe9d69CdD6Fe41e7B621B4A688C5D1a68cB5c8ADc" url="https://evm.confluxscan.io/address/0xe9d69cdd6fe41e7b621b4a688c5d1a68cb5c8adc" />             |
-| Core DAO          | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://scan.coredao.org/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />               |
-| Cronos            | <CopyAddress address="0xE0d0e68297772Dd5a1f1D99897c581E2082dbA5B" url="https://cronoscan.com/address/0xe0d0e68297772dd5a1f1d99897c581e2082dba5b" />                  |
-| Cronos zkEVM      | <CopyAddress address="0x056f829183Ec806A78c26C98961678c24faB71af" url="https://explorer.zkevm.cronos.org/address/0x056f829183ec806a78c26c98961678c24fab71af" />      |
-| Ethereum          | <CopyAddress address="0x4305FB66699C3B2702D4d05CF36551390A4c69C6" url="https://etherscan.io/address/0x4305fb66699c3b2702d4d05cf36551390a4c69c6" />                   |
-| Etherlink         | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://explorer.etherlink.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />         |
-| Eventum           | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://explorer.evedex.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />            |
-| Filecoin          | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://filfox.info/en/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />                 |
-| Flow              | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://evm.flowscan.io/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                |
-| Gnosis            | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://gnosisscan.io/address/0x2880ab155794e7179c9ee2e38200202908c17b43" />                  |
-| Gravity           | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://explorer.gravity.xyz/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />           |
-| Hedera            | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://hashscan.io/mainnet/contract/0.0.4622850" />                                          |
-| Hemi              | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://explorer.hemi.xyz/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />              |
-| HyperEVM          | <CopyAddress address="0xe9d69CdD6Fe41e7B621B4A688C5D1a68cB5c8ADc" url="https://www.hyperscan.com/address/0xe9d69CdD6Fe41e7B621B4A688C5D1a68cB5c8ADc" />                    |
-| Injective EVM     | <CopyAddress address="0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320" url="https://blockscout.injective.network/address/0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320" />   |
-| Ink               | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://explorer.inkonchain.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />        |
-| Iota              | <CopyAddress address="0x8D254a21b3C86D32F7179855531CE99164721933" url="https://explorer.evm.iota.org/address/0x8D254a21b3C86D32F7179855531CE99164721933" />          |
-| Kaia              | <CopyAddress address="0x2880ab155794e7179c9ee2e38200202908c17b43" url="https://kaiascan.io/address/0x2880ab155794e7179c9ee2e38200202908c17b43" />                    |
-| LightLink Phoenix | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://phoenix.lightlink.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />           |
-| Linea             | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://explorer.linea.build/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />           |
-| Manta             | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://pacific-explorer.manta.network/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" /> |
-| Mantle            | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://mantlescan.xyz/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />                 |
-| Merlin            | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://scan.merlinchain.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />            |
-| MegaETH           | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://mega.etherscan.io/address/0x2880aB155794e7179c9eE2e38200202908C17B43" /> |
-| Meter             | <CopyAddress address="0xbFe3f445653f2136b2FD1e6DdDb5676392E3AF16" url="https://scan.meter.io/address/0xbfe3f445653f2136b2fd1e6dddb5676392e3af16" />                  |
-| Mezo              | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://explorer.mezo.org/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />              |
-| Mode              | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://explorer.mode.network/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />          |
-| Monad             | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://monadvision.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                |
-| Morph             | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://explorer.morph.network/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />         |
-| Neon              | <CopyAddress address="0x7f2dB085eFC3560AFF33865dD727225d91B4f9A5" url="https://neonscan.org/address/0x7f2dB085eFC3560AFF33865dD727225d91B4f9A5" />                   |
-| OpBNB             | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://opbnbscan.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                  |
-| Optimism          | <CopyAddress address="0xff1a0f4744e8582DF1aE09D5611b887B6a12925C" url="https://optimistic.etherscan.io/address/0xff1a0f4744e8582df1ae09d5611b887b6a12925c" />        |
-| Plasma            | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://plasmascan.to/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                  |
-| Polygon           | <CopyAddress address="0xff1a0f4744e8582DF1aE09D5611b887B6a12925C" url="https://polygonscan.com/address/0xff1a0f4744e8582df1ae09d5611b887b6a12925c" />                |
-| Polygon zkEVM     | <CopyAddress address="0xC5E56d6b40F3e3B5fbfa266bCd35C37426537c65" url="https://www.oklink.com/polygon-zkevm/address/0xc5e56d6b40f3e3b5fbfa266bcd35c37426537c65" />   |
-| Ronin             | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://app.roninchain.com/address/0x2880ab155794e7179c9ee2e38200202908c17b43" />             |
-| Scroll            | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://blockscout.scroll.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />           |
-| Superseed         | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://explorer.superseed.xyz/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />         |
-| Sei EVM           | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://seitrace.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43?chain=pacific-1" />   |
-| Shimmer           | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://explorer.evm.shimmer.network/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />   |
-| Skate             | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://scan.skatechain.org/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />            |
-| Sonic             | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://sonicscan.org/address/0x2880ab155794e7179c9ee2e38200202908c17b43" />                  |
-| Soneium           | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://soneium.blockscout.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />         |
-| Story Protocol    | <CopyAddress address="0xD458261E832415CFd3BAE5E416FdF3230ce6F134" url="https://www.storyscan.xyz/address/0xD458261E832415CFd3BAE5E416FdF3230ce6F134" />              |
-| Taiko             | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://taikoscan.io/address/0x2880ab155794e7179c9ee2e38200202908c17b43" />                   |
-| Unichain          | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://uniscan.xyz/address/0x2880ab155794e7179c9ee2e38200202908c17b43" />                    |
-| Viction           | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://tomoscan.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />                    |
-| WEMIX             | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://scan.wemix.com/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />             |
-| Worldchain        | <CopyAddress address="0xe9d69cdd6fe41e7b621b4a688c5d1a68cb5c8adc" url="https://worldscan.org/address/0xe9d69cdd6fe41e7b621b4a688c5d1a68cb5c8adc" />                  |
-| zkSync Era        | <CopyAddress address="0xf087c864AEccFb6A2Bf1Af6A0382B0d0f6c5D834" url="https://explorer.zksync.io/address/0xf087c864AEccFb6A2Bf1Af6A0382B0d0f6c5D834" />             |
-| zetachain         | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://zetachain.blockscout.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />       |
+<EvmContractsStatusTable isMainnet={true} />
 
 ## Testnets
 
-| Network                           | Contract address                                                                                                                                                                                        |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Abstract testnet                  | <CopyAddress address="0x47F2A9BDAd52d65b66287253cf5ca0D2b763b486" url="https://explorer.testnet.abs.xyz/address/0x47F2A9BDAd52d65b66287253cf5ca0D2b763b486" />                                          |
-| ApeChain (testnet)                | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://curtis.explorer.caldera.xyz/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                       |
-| Arc testnet                       | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://testnet.arcscan.app/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                               |
-| Arbitrum Blueberry (testnet)      | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://arb-blueberry.gelatoscout.com/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />                                     |
-| Arbitrum Sepolia (testnet)        | <CopyAddress address="0x4374e5a8b9C22271E9EB878A2AA31DE97DF15DAF" url="https://sepolia-explorer.arbitrum.io/address/0x4374e5a8b9C22271E9EB878A2AA31DE97DF15DAF" />                                      |
-| Aurora testnet                    | <CopyAddress address="0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E" url="https://explorer.testnet.aurora.dev/address/0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E" />                                       |
-| BNB testnet                       | <CopyAddress address="0x5744Cbf430D99456a0A8771208b674F27f8EF0Fb" url="https://testnet.bscscan.com/address/0x5744Cbf430D99456a0A8771208b674F27f8EF0Fb" />                                               |
-| BTTC testnet                      | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://testnet.bttcscan.com/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />                                              |
-| Base Sepolia (testnet)            | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://base-sepolia.blockscout.com/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />                                       |
-| Berachain Bepolia testnet         | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://bepolia.beratrail.io/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                              |
-| Bittensor testnet                 | <CopyAddress address="0x41955476936DdA8d0fA98b8d1778172F7E4fCcA1" url="" />                                                                                                                             |
-| Blast Sepolia                     | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://testnet.blastscan.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />                                              |
-| Ble testnet                       | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://explorer-ethena-testnet-0.t.conduit.xyz/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                           |
-| Boba Sepolia (testnet)            | <CopyAddress address="0x8D254a21b3C86D32F7179855531CE99164721933" url="https://28882.testnet.routescan.io/address/0x8D254a21b3C86D32F7179855531CE99164721933" />                                        |
-| Celo Alfajores (testnet)          | <CopyAddress address="0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E" url="https://explorer.celo.org/alfajores/address/0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E" />                                       |
-| Celo Sepolia (testnet)            | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://sepolia.celoscan.io/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                               |
-| Chiado (Gnosis testnet)           | <CopyAddress address="0x98046Bd286715D3B0BC227Dd7a956b83D8978603" url="https://blockscout.com/gnosis/chiado/address/0x98046Bd286715D3B0BC227Dd7a956b83D8978603" />                                      |
-| Chiliz testnet                    | <CopyAddress address="0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509" url="https://spicy-explorer.chiliz.com/address/0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509" />                                         |
-| Conflux eSpace testnet            | <CopyAddress address="0xDd24F84d36BF92C65F92307595335bdFab5Bbd21" url="https://evmtestnet.confluxscan.io/address/0xDd24F84d36BF92C65F92307595335bdFab5Bbd21" />                                         |
-| Core DAO testnet                  | <CopyAddress address="0x8D254a21b3C86D32F7179855531CE99164721933" url="https://scan.test.btcs.network/address/0x8D254a21b3C86D32F7179855531CE99164721933" />                                            |
-| Converge testnet                  | <CopyAddress address="0x87047526937246727E4869C5f76A347160e08672" url="https://explorer-converge-testnet-1.t.conduit.xyz/address/0x87047526937246727E4869C5f76A347160e08672" />                         |
-| Cronos testnet                    | <CopyAddress address="0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320" url="https://cronos.org/explorer/testnet3/address/0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320" />                                      |
-| Cronos zkEVM Testnet              | <CopyAddress address="0xB1DB1498902F08E16E11F1a423ec9CCB9537E1D6" url="https://explorer.zkevm.cronos.org/testnet/address/0xb1db1498902f08e16e11f1a423ec9ccb9537e1d6" />                                 |
-| Dela Deperp Testnet               | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://sepolia-delascan.deperp.com/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />                                       |
-| Dela Deperp Mithreum Testnet      | <CopyAddress address="0xe9d69CdD6Fe41e7B621B4A688C5D1a68cB5c8ADc" url="https://mithreum-sepolia.deperp.com/address/0xe9d69CdD6Fe41e7B621B4A688C5D1a68cB5c8ADc" />                                       |
-| Etherlink Ghostnet testnet        | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://testnet.explorer.etherlink.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                    |
-| Etherlink Shadownet testnet       | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://shadownet.explorer.etherlink.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                  |
-| Eventum testnet                   | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://testnet-blockscout.eh-dev.app/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                     |
-| Filecoin calibration              | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://calibration.filfox.info/en/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />                                        |
-| Flow Testnet                      | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://evm-testnet.flowscan.io/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                           |
-| Fluent testnet                    | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://testnet.fluentscan.xyz/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                            |
-| Fuji (Avalanche testnet)          | <CopyAddress address="0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509" url="https://testnet.snowtrace.io/address/0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509" />                                              |
-| Giwa Testnet                      | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://sepolia-explorer.giwa.io/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                          |
-| Hedera testnet                    | <CopyAddress address="0xa2aa501b19aff244d90cc15a4cf739d2725b5729" url="https://hashscan.io/testnet/contract/0.0.3042133" />                                                                             |
-| Hemi testnet                      | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://testnet.explorer.hemi.xyz/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                         |
-| Hoodi                             | <CopyAddress address="0x87047526937246727E4869C5f76A347160e08672" url="https://hoodi.etherscan.io/address/0x87047526937246727E4869C5f76A347160e08672" />                                                |
-| HyperEVM testnet                  | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://testnet.purrsec.com/address/0x2880ab155794e7179c9ee2e38200202908c17b43" />                                               |
-| Kakarot Sepolia testnet           | <CopyAddress address="0xe9d69CdD6Fe41e7B621B4A688C5D1a68cB5c8ADc" url="https://sepolia.kakarotscan.org/address/0xe9d69CdD6Fe41e7B621B4A688C5D1a68cB5c8ADc" />                                           |
-| Klaytn                            | <CopyAddress address="0x2880ab155794e7179c9ee2e38200202908c17b43" url="https://baobab.klaytnfinder.io/account/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                            |
-| Injective EVM                     | <CopyAddress address="0xDd24F84d36BF92C65F92307595335bdFab5Bbd21" url="https://testnet.blockscout.injective.network/address/0xDd24F84d36BF92C65F92307595335bdFab5Bbd21" />                              |
-| Ink Sepolia                       | <CopyAddress address="0x2880ab155794e7179c9ee2e38200202908c17b43" url="https://explorer-sepolia.inkonchain.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                   |
-| Kaia testnet                      | <CopyAddress address="0x2880ab155794e7179c9ee2e38200202908c17b43" url="https://kairos.kaiascan.io/address/0x2880ab155794e7179c9ee2e38200202908c17b43?tabId=txList&page=1" />                            |
-| LightLink Pegasus                 | <CopyAddress address="0x5D289Ad1CE59fCC25b6892e7A303dfFf3a9f7167" url="https://pegasus.lightlink.io/address/0x5D289Ad1CE59fCC25b6892e7A303dfFf3a9f7167" />                                              |
-| Linea Sepolia                     | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://sepolia.lineascan.build/address/0xa2aa501b19aff244d90cc15a4cf739d2725b5729" />                                           |
-| Manta testnet                     | <CopyAddress address="0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c" url="https://pacific-explorer.testnet.manta.network/address/0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c" />                            |
-| Manta Sepolia                     | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://pacific-explorer.sepolia-testnet.manta.network/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />                    |
-| Mantle sepolia                    | <CopyAddress address="0x98046Bd286715D3B0BC227Dd7a956b83D8978603" url="https://explorer.sepolia.mantle.xyz/address/0x98046Bd286715D3B0BC227Dd7a956b83D8978603" />                                       |
-| MegaEth Testnet                   | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://www.megaexplorer.xyz/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                              |
-| Merlin testnet                    | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://testnet-scan.merlinchain.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />                                       |
-| Merlin testnet V2                 | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://testnet-scan-v2.merlinchain.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />                                    |
-| Meter testnet                     | <CopyAddress address="0x5a71C07a0588074443545eE0c08fb0375564c3E4" url="https://scan-warringstakes.meter.io/address/0x5a71C07a0588074443545eE0c08fb0375564c3E4" />                                       |
-| Mezo testnet                      | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://explorer.test.mezo.org/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                            |
-| Mode testnet                      | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://sepolia.explorer.mode.network/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />                                     |
-| Monad testnet                     | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://testnet.monadexplorer.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                         |
-| Morph Hoodi                       | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://explorer-hoodi.morph.network/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                      |
-| Morph Holesky testnet             | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://explorer-holesky.morphl2.io/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                       |
-| Morph testnet                     | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://explorer-testnet.morphl2.io/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />                                       |
-| Neon devnet                       | <CopyAddress address="0x0708325268dF9F66270F1401206434524814508b" url="https://devnet.neonscan.org/address/0x0708325268dF9F66270F1401206434524814508b" />                                               |
-| Olive Testnet                     | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://olive-network-testnet.explorer.caldera.xyz/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                        |
-| OpBNB Testnet                     | <CopyAddress address="0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c" url="https://testnet.opbnbscan.com/address/0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c" />                                             |
-| Optimism Sepolia (testnet)        | <CopyAddress address="0x0708325268dF9F66270F1401206434524814508b" url="https://optimism-sepolia.blockscout.com/address/0x0708325268dF9F66270F1401206434524814508b" />                                   |
-| Optimism Celestia Raspberry       | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://opcelestia-raspberry.gelatoscout.com/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />                              |
-| Orange Avalanche Subnet (testnet) | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://subnets-test.avax.network/orangetest/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                              |
-| Polygon Amoy testnet              | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://www.oklink.com/amoy/address/0x2880ab155794e7179c9ee2e38200202908c17b43" />                                               |
-| Polygon Blackberry testnet        | <CopyAddress address="0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" url="https://polygon-blackberry.gelatoscout.com/address/0xA2aa501b19aff244D90cc15a4Cf739D2725B5729" />                                |
-| Polygon zkEVM testnet             | <CopyAddress address="0xFf255f800044225f54Af4510332Aa3D67CC77635" url="https://www.oklink.com/polygon-zkevm-testnet/address/0xff255f800044225f54af4510332aa3d67cc77635" />                              |
-| Reya testnet                      | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://reya-cronos.blockscout.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                        |
-| Saigon (Ronin testnet)            | <CopyAddress address="0xEbe57e8045F2F230872523bbff7374986E45C486" url="https://saigon-app.roninchain.com/address/0xEbe57e8045F2F230872523bbff7374986E45C486" />                                         |
-| Sei EVM testnet                   | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://seitrace.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43?chain=atlantic-2" />                                     |
-| Scroll Sepolia                    | <CopyAddress address="0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c" url="https://sepolia-blockscout.scroll.io/address/0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c" />                                      |
-| Sepolia (Ethereum testnet)        | <CopyAddress address="0xDd24F84d36BF92C65F92307595335bdFab5Bbd21" url="https://sepolia.etherscan.io/address/0xDd24F84d36BF92C65F92307595335bdFab5Bbd21" />                                              |
-| Shimmer testnet                   | <CopyAddress address="0x8D254a21b3C86D32F7179855531CE99164721933" url="https://explorer.evm.testnet.shimmer.network/address/0x8D254a21b3C86D32F7179855531CE99164721933" />                              |
-| Skate testnet                     | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://testnet.skalenodes.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                            |
-| Soneium (testnet)                 | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://soneium-minato.blockscout.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                     |
-| Sonic Blaze Testnet               | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://blaze.soniclabs.com/address/0x2880ab155794e7179c9ee2e38200202908c17b43" />                                               |
-| Sonic New Testnet                 | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://testnet.sonicscan.org/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                             |
-| Story Testnet                     | <CopyAddress address="0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320" url="https://aeneid.storyscan.xyz/address/0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320" />                                              |
-| Superseed Testnet                 | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://sepolia-explorer.superseed.xyz/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                    |
-| Tabi Testnet                      | <CopyAddress address="0x5744Cbf430D99456a0A8771208b674F27f8EF0Fb" url="https://testnetv2.tabiscan.com/address/0x5744Cbf430D99456a0A8771208b674F27f8EF0Fb" />                                            |
-| Taiko Hekla                       | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://hekla.taikoscan.network/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                           |
-| Taiko Hoodi                       | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://hoodi.taikoscan.network/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                           |
-| Tempo Testnet                     | <CopyAddress address="0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E" url="https://explore.tempo.xyz/address/0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E" />                                                 |
-| Unichain Sepolia                  | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://unichain-sepolia.blockscout.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                                   |
-| Viction testnet                   | <CopyAddress address="0x5D289Ad1CE59fCC25b6892e7A303dfFf3a9f7167" url="https://testnet.tomoscan.io/address/0x5D289Ad1CE59fCC25b6892e7A303dfFf3a9f7167" />                                               |
-| WEMIX testnet                     | <CopyAddress address="0x26DD80569a8B23768A1d80869Ed7339e07595E85" url="https://explorer.test.wemix.com/address/0x26DD80569a8B23768A1d80869Ed7339e07595E85" />                                           |
-| Worldchain testnet                | <CopyAddress address="0x2880aB155794e7179c9eE2e38200202908C17B43" url="https://worldchain-sepolia.explorer.alchemy.com/address/0x2880aB155794e7179c9eE2e38200202908C17B43" />                           |
-| zetachain testnet                 | <CopyAddress address="0x0708325268dF9F66270F1401206434524814508b" url="https://explorer.zetachain.com/address/0x0708325268dF9F66270F1401206434524814508b" />                                            |
-| zkSync Era Sepolia (testnet)      | <CopyAddress address="0x056f829183Ec806A78c26C98961678c24faB71af" url="https://sepolia.explorer.zksync.io/address/0x056f829183Ec806A78c26C98961678c24faB71af" />                                        |
+<EvmContractsStatusTable isMainnet={false} />
 
 ## Price Feed IDs
 

--- a/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/evm.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/evm.mdx
@@ -8,6 +8,8 @@ import CopyAddress from "../../../../../src/components/CopyAddress";
 
 Pyth is currently available on the EVM networks below using Pyth Stable price sources that are accessible via Hermes Stable.
 
+<UpgradeCallout chain="evm" />
+
 ## Mainnets
 
 | Network           | Contract address                                                                                                                                                     |

--- a/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/fuel.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/fuel.mdx
@@ -8,6 +8,8 @@ import CopyAddress from "../../../../../src/components/CopyAddress";
 
 Pyth is currently deployed on Fuel Mainnet and Fuel Testnet.
 
+<UpgradeCallout chain="fuel" />
+
 | Network      | Contract address                                                                                                                                                                                                  |
 | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Fuel Mainnet | <CopyAddress address={`0x1c86fdd9e0e7bc0d2ae1bf6817ef4834ffa7247655701ee1b031b52a24c523da`} url="https://app.fuel.network/contract/0x1c86fdd9e0e7bc0d2ae1bf6817ef4834ffa7247655701ee1b031b52a24c523da" />         |

--- a/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/index.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/index.mdx
@@ -7,6 +7,8 @@ slug: /price-feeds/core/contract-addresses
 The following sections list the addresses of deployed Pyth Price Feed contracts across blockchains.
 The contracts are split by ecosystem into several different documents:
 
+<UpgradeCallout chain="index" />
+
 - [EVM](/price-feeds/core/contract-addresses/evm)
 - [Solana/SVM](/price-feeds/core/contract-addresses/solana)
 - [Aptos](/price-feeds/core/contract-addresses/aptos)

--- a/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/iota.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/iota.mdx
@@ -6,6 +6,8 @@ slug: /price-feeds/core/contract-addresses/iota
 
 Pyth is currently deployed on IOTA mainnet and testnet.
 
+<UpgradeCallout chain="iota" />
+
 #### IOTA mainnet
 
 | Name                | Address                                                                                                                                                                     |

--- a/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/movement.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/movement.mdx
@@ -6,6 +6,8 @@ slug: /price-feeds/core/contract-addresses/movement
 
 import CopyAddress from "../../../../../src/components/CopyAddress";
 
+<UpgradeCallout chain="movement" />
+
 ## Mainnet
 
 Use the following addresses for the Movement Mainnet and testnets:

--- a/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/near.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/near.mdx
@@ -4,6 +4,8 @@ description: List of Pyth price feed contract addresses on NEAR networks
 slug: /price-feeds/core/contract-addresses/near
 ---
 
+<UpgradeCallout chain="near" />
+
 | Network      | Contract address      |
 | ------------ | --------------------- |
 | NEAR Mainnet | `pyth-oracle.near`    |

--- a/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/solana.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/solana.mdx
@@ -8,6 +8,8 @@ import CopyAddress from "../../../../../src/components/CopyAddress";
 
 The Pyth Oracle consists of two different programs.
 
+<UpgradeCallout chain="solana" />
+
 The **Solana receiver program** is deployed at the following addresses:
 
 | Network         | Program address                                                                                                                                                                           |

--- a/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/starknet.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/starknet.mdx
@@ -8,6 +8,8 @@ import CopyAddress from "../../../../../src/components/CopyAddress";
 
 Pyth is deployed on both Starknet Mainnet and Testnet.
 
+<UpgradeCallout chain="starknet" />
+
 | Network          | Contract address                                                                                                                                                                                              |
 | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Starknet Mainnet | <CopyAddress address={`0x062ab68d8e23a7aa0d5bf4d25380c2d54f2dd8f83012e047851c3706b53d64d1`} url="https://starkscan.co/contract/0x062ab68d8e23a7aa0d5bf4d25380c2d54f2dd8f83012e047851c3706b53d64d1" />         |

--- a/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/sui.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/sui.mdx
@@ -6,6 +6,8 @@ slug: /price-feeds/core/contract-addresses/sui
 
 Pyth is currently available on the following sui-based chains:
 
+<UpgradeCallout chain="sui" />
+
 ### Stable channel
 
 #### Sui Mainnet

--- a/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/ton.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/contract-addresses/ton.mdx
@@ -8,6 +8,8 @@ import CopyAddress from "../../../../../src/components/CopyAddress";
 
 Pyth is currently deployed on TON Mainnet and TON Testnet. If you are using the deprecated TON Mainnet deployment, please migrate to the new address.
 
+<UpgradeCallout chain="ton" />
+
 | Network                  | Contract address                                                                                                                                                        |
 | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | TON Mainnet (deprecated) | <CopyAddress address={`EQBU6k8HH6yX4Jf3d18swWbnYr31D3PJI7PgjXT-flsKHqql`} url="https://tonscan.org/address/EQBU6k8HH6yX4Jf3d18swWbnYr31D3PJI7PgjXT-flsKHqql" />         |

--- a/apps/developer-hub/content/docs/price-feeds/core/create-tradingview-charts.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/create-tradingview-charts.mdx
@@ -12,7 +12,7 @@ The TradingView integration allows users to view Pyth prices on their own websit
 <UpgradeCallout chain="index" />
 
 <Callout type="warn">
-  The Benchmarks endpoints below stay at the same URLs after the upgrade, but from **July 31, 2026** every request must include an `Authorization: Bearer $PYTH_API_KEY` header. Sign up for a Pyth API Key on the [upgrade guide](/price-feeds/core/upgrade/preparing).
+  The Benchmarks endpoints below stay at the same URLs after the upgrade, but from **July 31, 2026** every request must include an `Authorization: Bearer $PYTH_API_KEY` header. Get a Pyth API Key on the [billing page](https://app.pyth.com/billing/plans?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=benchmarks-tv-billing).
 </Callout>
 
 ## Choosing an Implementation Method for TradingView Integration

--- a/apps/developer-hub/content/docs/price-feeds/core/create-tradingview-charts.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/create-tradingview-charts.mdx
@@ -4,9 +4,16 @@ description: Learn how to build TradingView charts powered by Pyth price feeds
 slug: /price-feeds/core/create-tradingview-charts
 ---
 
+import { Callout } from "fumadocs-ui/components/callout";
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 The TradingView integration allows users to view Pyth prices on their own website. All Pyth prices made available through the TradingView integration are originating from [Pythnet](/price-feeds/core/how-pyth-works/pythnet).
+
+<UpgradeCallout chain="index" />
+
+<Callout type="warn">
+  The Benchmarks endpoints below stay at the same URLs after the upgrade, but from **July 31, 2026** every request must include an `Authorization: Bearer $PYTH_API_KEY` header. Sign up for a Pyth API Key on the [upgrade guide](/price-feeds/core/upgrade/preparing).
+</Callout>
 
 ## Choosing an Implementation Method for TradingView Integration
 

--- a/apps/developer-hub/content/docs/price-feeds/core/create-your-first-pyth-app/evm/part-2.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/create-your-first-pyth-app/evm/part-2.mdx
@@ -20,6 +20,8 @@ This part of the tutorial will conver the following:
   before continuing.
 </Callout>
 
+<UpgradeCallout chain="evm" />
+
 ## Deploy the contract
 
 Now, let's deploy the contract to a test network.
@@ -99,9 +101,25 @@ Let's try out the deployed contract.
 In order to do so, we will need to get a price update to pass to the `updateAndMint` function.
 We can fetch this update from Hermes:
 
+<Tabs items={["Upgraded endpoint", "Current endpoint"]}>
+<Tab value="Upgraded endpoint">
+
 ```bash copy
-curl -s "https://hermes.pyth.network/v2/updates/price/latest?&ids[]=$ETH_USD_ID" | jq -r ".binary.data[0]" > price_update.txt
+curl -s -H "Authorization: Bearer $PYTH_API_KEY" \
+  "https://pyth.dourolabs.app/hermes/v2/updates/price/latest?&ids[]=$ETH_USD_ID" | jq -r ".binary.data[0]" > price_update.txt
 ```
+
+</Tab>
+<Tab value="Current endpoint">
+
+```bash copy
+# Authentication becomes required on July 31, 2026.
+curl -s -H "Authorization: Bearer $PYTH_API_KEY" \
+  "https://hermes.pyth.network/v2/updates/price/latest?&ids[]=$ETH_USD_ID" | jq -r ".binary.data[0]" > price_update.txt
+```
+
+</Tab>
+</Tabs>
 
 This command will fetch a fresh price update from Hermes and save it in the file `price_update.txt`.
 The update is a binary payload represented as a hexadecimal string.
@@ -242,7 +260,9 @@ async function run() {
     client,
   });
 
-  const connection = new HermesClient("https://hermes.pyth.network");
+  const connection = new HermesClient("https://pyth.dourolabs.app/hermes", {
+    accessToken: process.env.PYTH_API_KEY,
+  });
   const priceIds = [process.env["ETH_USD_ID"] as string];
   const priceFeedUpdateData = await connection.getLatestPriceUpdates(priceIds);
   console.log("Retrieved Pyth price update:");

--- a/apps/developer-hub/content/docs/price-feeds/core/fetch-price-updates.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/fetch-price-updates.mdx
@@ -115,7 +115,7 @@ The output will be similar to the following containing the requested price updat
 }
 ```
 
-Hermes offers several other endpoints for retrieving price updates. For more information, see the [Hermes API Reference](https://pyth.dourolabs.app/hermes/docs/#/).
+Hermes offers several other endpoints for retrieving price updates. For more information, see the [Hermes API Reference](https://pyth.dourolabs.app/docs/?urls.primaryName=Hermes+API#/).
 
 ## Streaming
 

--- a/apps/developer-hub/content/docs/price-feeds/core/fetch-price-updates.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/fetch-price-updates.mdx
@@ -15,6 +15,8 @@ The following guide explains how to fetch price updates.
 Price updates can be submitted to the Pyth Price Feeds contract to update the on-chain price.
 Please see [What is a Pull Oracle?](/price-feeds/core/pull-updates) to learn more.
 
+<UpgradeCallout chain="index" />
+
 Price updates are served from [Hermes](/price-feeds/core/how-pyth-works/hermes), which
 provides three different ways to fetch price updates:
 
@@ -36,10 +38,27 @@ Use the `/v2/updates/price/latest` endpoint to fetch the latest price update for
 This endpoint allows you to fetch the latest price updates for multiple feeds in a single request.
 For example, the following command retrieves the latest price updates for BTC/USD and ETH/USD:
 
+<Tabs items={["Upgraded endpoint", "Current endpoint"]}>
+<Tab value="Upgraded endpoint">
+
 ```bash copy
 curl -X 'GET' \
+  -H "Authorization: Bearer $PYTH_API_KEY" \
+  'https://pyth.dourolabs.app/hermes/v2/updates/price/latest?ids%5B%5D=0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43&ids%5B%5D=0xc96458d393fe9deb7a7d63a0ac41e2898a67a7750dbd166673279e06c868df0a'
+```
+
+</Tab>
+<Tab value="Current endpoint">
+
+```bash copy
+# Authentication becomes required on July 31, 2026.
+curl -X 'GET' \
+  -H "Authorization: Bearer $PYTH_API_KEY" \
   'https://hermes.pyth.network/v2/updates/price/latest?ids%5B%5D=0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43&ids%5B%5D=0xc96458d393fe9deb7a7d63a0ac41e2898a67a7750dbd166673279e06c868df0a'
 ```
+
+</Tab>
+</Tabs>
 
 The output will be similar to the following containing the requested price update:
 
@@ -96,7 +115,7 @@ The output will be similar to the following containing the requested price updat
 }
 ```
 
-Hermes offers several other endpoints for retrieving price updates. For more information, see the [Hermes API Reference](https://hermes.pyth.network/docs/#/).
+Hermes offers several other endpoints for retrieving price updates. For more information, see the [Hermes API Reference](https://pyth.dourolabs.app/hermes/docs/#/).
 
 ## Streaming
 
@@ -108,7 +127,8 @@ The connection will automatically close after 24 hours to prevent resource leaks
 For example, to stream price updates for BTC/USD, run:
 
 ```bash copy
-curl -N 'https://hermes.pyth.network/v2/updates/price/stream?ids[]=0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43'
+curl -N -H "Authorization: Bearer $PYTH_API_KEY" \
+  'https://pyth.dourolabs.app/hermes/v2/updates/price/stream?ids[]=0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43'
 ```
 
 The output is a stream of events containing the requested price updates, similar to the following:
@@ -125,7 +145,9 @@ Pyth provides a typescript SDK for Hermes to fetch price updates.
 The [`HermesClient`](https://github.com/pyth-network/pyth-crosschain/blob/main/apps/hermes/client/js/src/HermesClient.ts#L41) class in this [SDK](https://github.com/pyth-network/pyth-crosschain/tree/main/apps/hermes/client/js) connects to Hermes to fetch and stream price updates.
 
 ```typescript copy
-const connection = new HermesClient("https://hermes.pyth.network", {});
+const connection = new HermesClient("https://pyth.dourolabs.app/hermes", {
+  accessToken: process.env.PYTH_API_KEY,
+});
 
 const priceIds = [
   // You can find the ids of prices at https://docs.pyth.network/price-feeds/price-feeds

--- a/apps/developer-hub/content/docs/price-feeds/core/getting-started.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/getting-started.mdx
@@ -4,7 +4,9 @@ description: Explore key resources to begin integrating Pyth price feeds
 slug: /price-feeds/core/getting-started
 ---
 
-Integrating Pyth price feeds is quick and easy. Pyth price feeds are permissionless and available on-chain. You **don't** need to sign up or request an API key
+Integrating Pyth price feeds is quick and easy. Pyth price feeds are permissionless on-chain. From **July 31, 2026**, calling the Hermes price API requires a Pyth API Key — see the upgrade callout below.
+
+<UpgradeCallout chain="index" />
 
 Pyth offers several different resources to help you get started.
 The [Build](#build) section provides resources for developers integrating Pyth price feeds into their applications.

--- a/apps/developer-hub/content/docs/price-feeds/core/how-pyth-works/cross-chain.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/how-pyth-works/cross-chain.mdx
@@ -5,7 +5,13 @@ slug: /price-feeds/core/how-pyth-works/cross-chain
 ---
 
 Pyth uses a cross-chain mechanism to transfer prices from [Pythnet](pythnet) to target chains. The diagram below
-shows how prices are delivered from Pythnet to target chains:
+shows how prices are delivered from Pythnet to target chains.
+
+<UpgradeCallout chain="index" />
+
+<Callout type="info">
+  The architecture described on this page reflects the **pre-upgrade** cross-chain flow (Wormhole guardians). After **July 31, 2026**, Wormhole is replaced by a 5-router 3-of-5 quorum. See [How the Pyth Core upgrade works](/price-feeds/core/upgrade/how-it-works) for the post-upgrade architecture.
+</Callout>
 
 <figure className="image-container">
   <img

--- a/apps/developer-hub/content/docs/price-feeds/core/how-pyth-works/hermes.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/how-pyth-works/hermes.mdx
@@ -17,7 +17,7 @@ for streaming updates. The Pyth Network's Javascript SDKs connect to an instance
 
 ## Documentation
 
-The [Hermes API Documentation](https://pyth.dourolabs.app/hermes/docs) provides a comprehensive explanation of Hermes API for
+The [Hermes API Documentation](https://pyth.dourolabs.app/docs/?urls.primaryName=Hermes+API) provides a comprehensive explanation of Hermes API for
 user interaction. You can use the [@pythnetwork/hermes-client](https://github.com/pyth-network/pyth-crosschain/tree/main/apps/hermes/client/js) library to interact with Hermes.
 
 Here's an example of retrieving the latest update of the ETH/USD price feed using `curl`.

--- a/apps/developer-hub/content/docs/price-feeds/core/how-pyth-works/hermes.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/how-pyth-works/hermes.mdx
@@ -11,23 +11,40 @@ to verify and use on-chain.
 Hermes allows users to easily query for recent price updates via a REST API, or subscribe to a server-side events stream
 for streaming updates. The Pyth Network's Javascript SDKs connect to an instance of Hermes to fetch price updates.
 
+<UpgradeCallout chain="index" />
+
 [hermes-repo]: https://github.com/pyth-network/pyth-crosschain/tree/main/apps/hermes
 
 ## Documentation
 
-The [Hermes API Documentation](https://hermes.pyth.network/docs) provides a comprehensive explanation of Hermes API for
-user interaction. You can use [the price service client library in
-JS](https://github.com/pyth-network/pyth-crosschain/tree/main/price_service/client/js) to interact with Hermes.
+The [Hermes API Documentation](https://pyth.dourolabs.app/hermes/docs) provides a comprehensive explanation of Hermes API for
+user interaction. You can use the [@pythnetwork/hermes-client](https://github.com/pyth-network/pyth-crosschain/tree/main/apps/hermes/client/js) library to interact with Hermes.
 
 Here's an example of retrieving the latest update of the ETH/USD price feed using `curl`.
 
+<Tabs items={["Upgraded endpoint", "Current endpoint"]}>
+<Tab value="Upgraded endpoint">
+
 ```bash
 # Example API call
-$ curl https://hermes.pyth.network/api/latest_price_feeds?ids[]=0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace
+$ curl -H "Authorization: Bearer $PYTH_API_KEY" \
+  "https://pyth.dourolabs.app/hermes/api/latest_price_feeds?ids[]=0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace"
 
 # Example Response
 [{"id":"ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace","price":{"price":"184136023127","conf":"177166324","expo":-8,"publish_time":1692110601},"ema_price":{"price":"184100641000","conf":"178704085","expo":-8,"publish_time":1692110601}}]
 ```
+
+</Tab>
+<Tab value="Current endpoint">
+
+```bash
+# Authentication becomes required on July 31, 2026.
+$ curl -H "Authorization: Bearer $PYTH_API_KEY" \
+  "https://hermes.pyth.network/api/latest_price_feeds?ids[]=0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace"
+```
+
+</Tab>
+</Tabs>
 
 ## Accessing Hermes
 

--- a/apps/developer-hub/content/docs/price-feeds/core/rate-limits.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/rate-limits.mdx
@@ -4,6 +4,8 @@ description: Rate Limits for the Pyth Hermes and Benchmarks APIs
 slug: /price-feeds/core/rate-limits
 ---
 
+<UpgradeCallout chain="index" />
+
 In order to maximize the reliability of the Pyth Hermes and Benchmarks APIs, a request rate limit is enforced. All endpoints limits are set at **10 requests every 10 seconds per IP address**.
 
 **One exception**: the TradingView endpoint will allow 90 requests every 10 seconds. Clients issuing request above the limit will receive a 429 (Too Many Requests) response for the subsequent 60-second period.

--- a/apps/developer-hub/content/docs/price-feeds/core/schedule-price-updates/using-price-pusher.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/schedule-price-updates/using-price-pusher.mdx
@@ -12,6 +12,8 @@ Anyone can operate this service to keep on-chain Pyth prices current based on co
 
 <UpgradeCallout chain="index" />
 
-From **July 31, 2026** onward the Price Pusher must be configured with a Pyth API Key. Pass it via the `--hermes-access-token <YOUR_KEY>` command-line flag so its Hermes calls can authenticate against the upgraded backend. Refer to the project README for setup instructions and configuration details.
+From **July 31, 2026** onward the Price Pusher must be configured with a Pyth API Key. Pass it via the `--hermes-access-token <YOUR_KEY>` command-line flag so its Hermes calls can authenticate against the upgraded backend.
+
+The `--hermes-access-token` flag was added in [Price Pusher v10.5.0](https://github.com/pyth-network/pyth-crosschain/commit/bab960de82fc881fd3c9397627d4e1831aeec934). Make sure you are running v10.5.0 or later. Refer to the project README for setup instructions and configuration details.
 
 Running the Price Pusher is a straightforward way to migrate from a push oracle: protocols that depend on regular updates can achieve the same behavior by operating this service.

--- a/apps/developer-hub/content/docs/price-feeds/core/schedule-price-updates/using-price-pusher.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/schedule-price-updates/using-price-pusher.mdx
@@ -12,6 +12,6 @@ Anyone can operate this service to keep on-chain Pyth prices current based on co
 
 <UpgradeCallout chain="index" />
 
-From **July 31, 2026** onward the Price Pusher must be configured with a Pyth API Key (set the `PYTH_API_KEY` environment variable) so its Hermes calls can authenticate against the upgraded backend. Refer to the project README for setup instructions and configuration details.
+From **July 31, 2026** onward the Price Pusher must be configured with a Pyth API Key. Pass it via the `--hermes-access-token <YOUR_KEY>` command-line flag so its Hermes calls can authenticate against the upgraded backend. Refer to the project README for setup instructions and configuration details.
 
 Running the Price Pusher is a straightforward way to migrate from a push oracle: protocols that depend on regular updates can achieve the same behavior by operating this service.

--- a/apps/developer-hub/content/docs/price-feeds/core/schedule-price-updates/using-price-pusher.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/schedule-price-updates/using-price-pusher.mdx
@@ -10,4 +10,8 @@ The [Price Pusher](https://github.com/pyth-network/pyth-crosschain/tree/main/app
 is an off-chain service that continuously pulls price updates onto a blockchain.
 Anyone can operate this service to keep on-chain Pyth prices current based on configurable criteria such as minimum update intervals or price change thresholds.
 
-Running the Price Pusher is a straightforward way to migrate from a push oracle: protocols that depend on regular updates can achieve the same behavior by operating this service. Refer to the project README for setup instructions and configuration details.
+<UpgradeCallout chain="index" />
+
+From **July 31, 2026** onward the Price Pusher must be configured with a Pyth API Key (set the `PYTH_API_KEY` environment variable) so its Hermes calls can authenticate against the upgraded backend. Refer to the project README for setup instructions and configuration details.
+
+Running the Price Pusher is a straightforward way to migrate from a push oracle: protocols that depend on regular updates can achieve the same behavior by operating this service.

--- a/apps/developer-hub/content/docs/price-feeds/core/troubleshoot/evm.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/troubleshoot/evm.mdx
@@ -16,7 +16,7 @@ This error occurs when the requested price feed has not been updated within the 
 To resolve this issue:
 
 - Update the prices by calling [`updatePriceFeeds()`](https://github.com/pyth-network/pyth-crosschain/blob/main/target_chains/ethereum/sdk/solidity/AbstractPyth.sol#L90)
-  by passing the latest updateData from [Hermes](https://pyth.dourolabs.app/hermes/docs/#/rest/latest_vaas).
+  by passing the latest updateData from [Hermes](https://pyth.dourolabs.app/docs/?urls.primaryName=Hermes+API#/rest/latest_vaas).
 - Another method to fetch the price is [`getPriceUnsafe()`](https://github.com/pyth-network/pyth-crosschain/blob/main/target_chains/ethereum/sdk/solidity/AbstractPyth.sol#L43)
   If the price feed is available, the method will return the latest prices with timestamp of last update.
   NOTE: `getPriceUnsafe()` method does not check the freshness of the price.
@@ -28,7 +28,7 @@ This error occurs when the requested price feed has not been updated on-chain, o
 To resolve this issue:
 
 - Update the prices by calling [`updatePriceFeeds()`](https://api-reference.pyth.network/price-feeds/evm/updatePriceFeeds)
-  by passing the latest updateData from [Hermes](https://pyth.dourolabs.app/hermes/docs/#/rest/latest_vaas).
+  by passing the latest updateData from [Hermes](https://pyth.dourolabs.app/docs/?urls.primaryName=Hermes+API#/rest/latest_vaas).
 - Check the entered [price feed id](../price-feeds) and [pyth-contract address](https://docs.pyth.network/price-feeds/contract-addresses/evm) to make sure they are correct.
 
 #### updatePriceFeeds() reverts with `InsufficientFee()` or `0x025dbdd4` error

--- a/apps/developer-hub/content/docs/price-feeds/core/troubleshoot/evm.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/troubleshoot/evm.mdx
@@ -7,6 +7,8 @@ slug: /price-feeds/core/troubleshoot/evm
 This reference page is designed to help you troubleshoot common issues you may encounter when using Pyth Price Feeds on EVM chains.
 Follow the steps provided below to diagnose and resolve the issue.
 
+<UpgradeCallout chain="evm" />
+
 #### getPriceNoOlderThan() reverts with `StalePrice()` or `0x19abf40e` error
 
 This error occurs when the requested price feed has not been updated within the specified `age` parameter.
@@ -14,7 +16,7 @@ This error occurs when the requested price feed has not been updated within the 
 To resolve this issue:
 
 - Update the prices by calling [`updatePriceFeeds()`](https://github.com/pyth-network/pyth-crosschain/blob/main/target_chains/ethereum/sdk/solidity/AbstractPyth.sol#L90)
-  by passing the latest updateData from [Hermes](https://hermes.pyth.network/docs/#/rest/latest_vaas).
+  by passing the latest updateData from [Hermes](https://pyth.dourolabs.app/hermes/docs/#/rest/latest_vaas).
 - Another method to fetch the price is [`getPriceUnsafe()`](https://github.com/pyth-network/pyth-crosschain/blob/main/target_chains/ethereum/sdk/solidity/AbstractPyth.sol#L43)
   If the price feed is available, the method will return the latest prices with timestamp of last update.
   NOTE: `getPriceUnsafe()` method does not check the freshness of the price.
@@ -26,7 +28,7 @@ This error occurs when the requested price feed has not been updated on-chain, o
 To resolve this issue:
 
 - Update the prices by calling [`updatePriceFeeds()`](https://api-reference.pyth.network/price-feeds/evm/updatePriceFeeds)
-  by passing the latest updateData from [Hermes](https://hermes.pyth.network/docs/#/rest/latest_vaas).
+  by passing the latest updateData from [Hermes](https://pyth.dourolabs.app/hermes/docs/#/rest/latest_vaas).
 - Check the entered [price feed id](../price-feeds) and [pyth-contract address](https://docs.pyth.network/price-feeds/contract-addresses/evm) to make sure they are correct.
 
 #### updatePriceFeeds() reverts with `InsufficientFee()` or `0x025dbdd4` error

--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/index.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/index.mdx
@@ -56,7 +56,7 @@ Sign up at Pyth Terminal: a free trial is included, paid plans cover ongoing use
   Sign up at Pyth Terminal
 </Button>
 
-### Step 2: Upgrade now or wait for automatic?
+### Step 2: Early upgrade or wait for automatic?
 
 After Step 1, choose how and when to move to the upgraded infrastructure. Your choice is saved in the URL so you can share or bookmark a specific path.
 
@@ -74,7 +74,7 @@ After Step 1, choose how and when to move to the upgraded infrastructure. Your c
 
 <BranchToggle />
 
-|                  | Upgrade now (recommended)                  | Wait for automatic                                                   |
+|                  | Early upgrade (recommended)                | Wait for automatic                                                   |
 | ---------------- | ------------------------------------------ | -------------------------------------------------------------------- |
 | Timing           | You choose                                 | July 31, 2026                                                        |
 | Downtime         | Up to you                                       | Brief, during the switch                                             |
@@ -83,7 +83,7 @@ After Step 1, choose how and when to move to the upgraded infrastructure. Your c
 
 <BranchSection path="now">
 
-## Upgrading Now
+## Early upgrade
 
 This is the recommended path, as it makes the **July 31 cutover a non-event for your integration**. Please note that if you swap the endpoint but not the contract address or vice versa you won't be able to verify price updates. 
 

--- a/apps/developer-hub/content/docs/price-feeds/core/use-historical-price-data.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-historical-price-data.mdx
@@ -9,6 +9,12 @@ import { Step, Steps } from "fumadocs-ui/components/steps";
 
 This guide explains how to integrate **Pyth Benchmarks** to access historical price data across applications. The Benchmarks API is available on all Pythnet chains.
 
+<UpgradeCallout chain="index" />
+
+<Callout type="warn">
+  The Benchmarks endpoints stay at the same URLs after the upgrade, but from **July 31, 2026** every request must include an `Authorization: Bearer $PYTH_API_KEY` header. Sign up for a Pyth API Key on the [upgrade guide](/price-feeds/core/upgrade/preparing).
+</Callout>
+
 <Callout type="info" title="Benchmarks Terminology">
   Throughout this guide, **Benchmarks** refers to Pyth’s historical price data
   service.
@@ -28,7 +34,7 @@ Benchmarks supports two complementary flows:
 <Steps>
   <Step title="Fetch historical prices via the Benchmarks API">
     Retrieve data from the [Benchmarks API](https://benchmarks.pyth.network/docs#/Updates/price_updates_timestamp_route_v1_updates_price__timestamp__get) or through the
-    [Hermes timestamp API](https://hermes.pyth.network/docs/#/rest/timestamp_price_updates).
+    [Hermes timestamp API](https://pyth.dourolabs.app/hermes/docs/#/rest/timestamp_price_updates).
     Two REST endpoints are available:
 
     - [`/v1/updates/price/{timestamp}`](https://benchmarks.pyth.network/docs#/Updates/price_updates_timestamp_route_v1_updates_price__timestamp__get): returns prices for the requested feeds at a given timestamp.

--- a/apps/developer-hub/content/docs/price-feeds/core/use-historical-price-data.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-historical-price-data.mdx
@@ -34,7 +34,7 @@ Benchmarks supports two complementary flows:
 <Steps>
   <Step title="Fetch historical prices via the Benchmarks API">
     Retrieve data from the [Benchmarks API](https://benchmarks.pyth.network/docs#/Updates/price_updates_timestamp_route_v1_updates_price__timestamp__get) or through the
-    [Hermes timestamp API](https://pyth.dourolabs.app/hermes/docs/#/rest/timestamp_price_updates).
+    [Hermes timestamp API](https://pyth.dourolabs.app/docs/?urls.primaryName=Hermes+API#/rest/timestamp_price_updates).
     Two REST endpoints are available:
 
     - [`/v1/updates/price/{timestamp}`](https://benchmarks.pyth.network/docs#/Updates/price_updates_timestamp_route_v1_updates_price__timestamp__get): returns prices for the requested feeds at a given timestamp.

--- a/apps/developer-hub/content/docs/price-feeds/core/use-historical-price-data.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-historical-price-data.mdx
@@ -12,7 +12,7 @@ This guide explains how to integrate **Pyth Benchmarks** to access historical pr
 <UpgradeCallout chain="index" />
 
 <Callout type="warn">
-  The Benchmarks endpoints stay at the same URLs after the upgrade, but from **July 31, 2026** every request must include an `Authorization: Bearer $PYTH_API_KEY` header. Sign up for a Pyth API Key on the [upgrade guide](/price-feeds/core/upgrade/preparing).
+  The Benchmarks endpoints stay at the same URLs after the upgrade, but from **July 31, 2026** every request must include an `Authorization: Bearer $PYTH_API_KEY` header. Get a Pyth API Key on the [billing page](https://app.pyth.com/billing/plans?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=benchmarks-historical-billing).
 </Callout>
 
 <Callout type="info" title="Benchmarks Terminology">

--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/aptos.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/aptos.mdx
@@ -8,6 +8,8 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 This guide explains how to use real-time Pyth data in Aptos applications.
 
+<UpgradeCallout chain="aptos" />
+
 ## Configuring the `Move.toml` file
 
 Add the Pyth Contract to your project dependencies in the `Move.toml` file:

--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/cosmwasm.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/cosmwasm.mdx
@@ -7,6 +7,8 @@ slug: /price-feeds/core/use-real-time-data/pull-integration/cosmwasm
 Cosmwasm contracts can update and fetch the Pyth prices using the Pyth Cosmwasm Contract, deployed on their network.
 The documented source code can be found [here](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/cosmwasm/contracts/pyth).
 
+<UpgradeCallout chain="cosmwasm" />
+
 ## Update Price Feeds
 
 The mechanism by which price feeds are updated on Cosmwasm is explained [here](../../pull-updates). The [@pythnetwork/price-service-client](https://github.com/pyth-network/pyth-crosschain/tree/main/price_service/client/js) typescript package can be used to fetch the latest price feed data which then can be passed to the contract as the `UpdatePriceFeeds` ExecuteMsg.

--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/evm.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/evm.mdx
@@ -6,11 +6,6 @@ slug: /price-feeds/core/use-real-time-data/pull-integration/evm
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-<YouTubeEmbed
-  id="6Kk57nSOVIU"
-  title="How to Integrate Pyth Price Feeds on Any EVM chain"
-/>
-
 This guide explains how to use real-time Pyth data in EVM contracts using the pull integration.
 
 For an interactive playground to explore the methods supported by the Pyth contract, see the [EVM API reference](../../../api-reference).

--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/fuel.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/fuel.mdx
@@ -9,6 +9,8 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 This guide explains how to use real-time Pyth data in Fuel contracts.
 
+<UpgradeCallout chain="fuel" />
+
 ## Install the Pyth SDK
 
 Use the following dependency in your `Forc.toml` file to use the latest Pyth Fuel package:

--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/iota.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/iota.mdx
@@ -9,6 +9,8 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 This guide explains how to use real-time Pyth data in IOTA applications.
 
+<UpgradeCallout chain="iota" />
+
 ## Install Pyth SDK
 
 Use the following dependency in your `Move.toml` file to use the latest Pyth IOTA package and its dependencies:

--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/near.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/near.mdx
@@ -4,6 +4,8 @@ description: Consume Pyth Network prices in Near applications
 slug: /price-feeds/core/use-real-time-data/pull-integration/near
 ---
 
+<UpgradeCallout chain="near" />
+
 ## Pyth on NEAR
 
 Pyth price feeds on NEAR are managed through the main NEAR Pyth smart

--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/solana.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/solana.mdx
@@ -8,6 +8,8 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 This guide explains how to use real-time Pyth data in Solana applications.
 
+<UpgradeCallout chain="solana" />
+
 ## Install Pyth SDKs
 
 Pyth provides two SDKs for Solana applications to cover the on- and off-chain portions of the integration:
@@ -155,18 +157,37 @@ To use price update accounts, the frontend code needs to perform two different t
 
 #### Fetch price updates
 
-Use `PriceServiceConnection` from `@pythnetwork/hermes-client` to fetch Pyth price updates from Hermes:
+Use `HermesClient` from `@pythnetwork/hermes-client` to fetch Pyth price updates from Hermes. The new endpoint `pyth.dourolabs.app/hermes` is the upgraded backend (recommended); the current `hermes.pyth.network` keeps working until cutover and requires an API key from July 31, 2026:
+
+<Tabs items={["Upgraded endpoint", "Current endpoint"]}>
+<Tab value="Upgraded endpoint">
 
 ```typescript copy
 import { HermesClient } from "@pythnetwork/hermes-client";
 
-// The URL below is a public Hermes instance operated by the Pyth Data Association.
-// Hermes is also available from several third-party providers listed here:
-// https://docs.pyth.network/price-feeds/api-instances-and-providers/hermes
 const priceServiceConnection = new HermesClient(
-  "https://hermes.pyth.network/",
-  {},
+  "https://pyth.dourolabs.app/hermes",
+  { accessToken: process.env.PYTH_API_KEY },
 );
+```
+
+</Tab>
+<Tab value="Current endpoint">
+
+```typescript copy
+import { HermesClient } from "@pythnetwork/hermes-client";
+
+// Authentication becomes required on July 31, 2026.
+const priceServiceConnection = new HermesClient(
+  "https://hermes.pyth.network",
+  { accessToken: process.env.PYTH_API_KEY },
+);
+```
+
+</Tab>
+</Tabs>
+
+```typescript copy
 
 // Hermes provides other methods for retrieving price updates. See
 // https://hermes.pyth.network/docs for more information.

--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/stacks.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/stacks.mdx
@@ -10,6 +10,8 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 This guide explains how to use real-time Pyth data in [Clarity](https://clarity-lang.org/) smart contracts on Stacks.
 
+<UpgradeCallout chain="stacks" />
+
 ## Write Contract Code
 
 The Pyth protocol integration for Stacks is available as a Beta on both testnet and mainnet networks, to help developers test, give feedback, and ensure the reliability and stability of the integration.

--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/starknet.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/starknet.mdx
@@ -9,6 +9,8 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 This guide explains how to use real-time Pyth data in Starknet contracts.
 
+<UpgradeCallout chain="starknet" />
+
 ## Install the Pyth SDK
 
 Use the following dependency in your `Scarb.toml` file to use the latest Pyth Starknet package:

--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/sui.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/sui.mdx
@@ -9,6 +9,15 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 This guide explains how to use real-time Pyth data in Sui applications.
 
+<UpgradeCallout chain="sui" />
+
+<Callout type="info">
+  After **July 31, 2026**, replace the Pyth package `rev` below with
+  `sui-pro-compatible-contract-mainnet` (or `sui-pro-compatible-contract-testnet`)
+  and update the Pyth State / Wormhole State IDs to the [upgraded Sui addresses](/price-feeds/core/upgrade/contracts#sui).
+  See the [upgrade guide](/price-feeds/core/upgrade/preparing) for details.
+</Callout>
+
 ## Install Pyth SDK
 
 Use the following dependency in your `Move.toml` file to use the latest Pyth Sui package and its dependencies:
@@ -136,9 +145,10 @@ import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 
 /// Step 1: Get the off-chain data.
 const connection = new SuiPriceServiceConnection(
-  "https://hermes-beta.pyth.network", // [!] Only for Sui Testnet
-  // "https://hermes.pyth.network/", // Use this for Mainnet
+  "https://pyth.dourolabs.app/hermes", // upgraded endpoint
+  // Or: "https://hermes.pyth.network" — auth required from July 31, 2026
   {
+    accessToken: process.env.PYTH_API_KEY,
     // Provide this option to retrieve signed price updates for on-chain contracts!
     priceFeedRequestConfig: {
       binary: true,
@@ -237,7 +247,7 @@ You can run this example with `npm run example-relay`. A full command that updat
 ```bash
 export SUI_KEY=YOUR_PRIV_KEY;
 npm run example-relay -- --feed-id "5a035d5440f5c163069af66062bac6c79377bf88396fa27e6067bfca8096d280" \
---hermes "https://hermes-beta.pyth.network" \
+--hermes "https://pyth.dourolabs.app/hermes" \
 --full-node "https://fullnode.testnet.sui.io:443" \
 --pyth-state-id "0x243759059f4c3111179da5878c12f68d612c21a8d54d85edc86164bb18be1c7c" \
 --wormhole-state-id "0x31358d198147da50db32eda2562951d53973a0c0ad5ed738e9b17d88b213d790"
@@ -245,7 +255,7 @@ npm run example-relay -- --feed-id "5a035d5440f5c163069af66062bac6c79377bf88396f
 
 ### Contract Addresses
 
-Consult [Sui Contract Addresses](../../contract-addresses/sui) to find the package IDs.
+Consult [Sui Contract Addresses](../../contract-addresses/sui) to find the current package IDs, or the [upgraded Sui addresses](/price-feeds/core/upgrade/contracts#sui) for the post-July 31, 2026 upgrade.
 
 ### Pyth Price Feed IDs
 

--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/ton.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/ton.mdx
@@ -9,6 +9,8 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 This guide explains how to use real-time Pyth data in TON applications.
 
+<UpgradeCallout chain="ton" />
+
 ## Install the Pyth SDK
 
 Install the Pyth TON SDK and other necessary dependencies using npm:

--- a/apps/developer-hub/src/components/EvmContractsStatusTable/index.tsx
+++ b/apps/developer-hub/src/components/EvmContractsStatusTable/index.tsx
@@ -89,10 +89,11 @@ const renderAddress = (address: string, explorer?: string) =>
   explorer ? (
     <CopyAddress
       address={address}
+      maxLength={6}
       url={`${explorer.replace(/\/$/, "")}/address/${address}`}
     />
   ) : (
-    <CopyAddress address={address} />
+    <CopyAddress address={address} maxLength={6} />
   );
 
 const EvmContractsStatusTable = async ({
@@ -112,34 +113,54 @@ const EvmContractsStatusTable = async ({
   }
 
   return (
-    <table>
-      <thead>
-        <tr>
-          <th>Network</th>
-          <th>Current Address</th>
-          <th>Upgraded Address</th>
-        </tr>
-      </thead>
-      <tbody>
-        {statuses.map((s) => {
-          const isUpgraded = s.upgradedAddress !== null;
-          const bgClass = isUpgraded
-            ? "bg-green-50 dark:bg-green-950/30"
-            : "bg-red-50 dark:bg-red-950/30";
-          return (
-            <tr key={s.chainId} className={bgClass}>
-              <td>{s.name}</td>
-              <td>{renderAddress(s.currentAddress, s.explorer)}</td>
-              <td>
-                {isUpgraded && s.upgradedAddress !== null
-                  ? renderAddress(s.upgradedAddress, s.explorer)
-                  : null}
-              </td>
-            </tr>
-          );
-        })}
-      </tbody>
-    </table>
+    <>
+      <div className="flex gap-4 text-sm my-2">
+        <span className="inline-flex items-center gap-2">
+          <span
+            aria-hidden
+            className="inline-block w-3 h-3 rounded-sm border bg-green-50 dark:bg-green-950/30"
+          />
+          Upgraded
+        </span>
+        <span className="inline-flex items-center gap-2">
+          <span
+            aria-hidden
+            className="inline-block w-3 h-3 rounded-sm border bg-red-50 dark:bg-red-950/30"
+          />
+          Will be dropped
+        </span>
+      </div>
+      <div className="overflow-x-auto">
+        <table>
+          <thead>
+          <tr>
+            <th>Network</th>
+            <th>Current Address</th>
+            <th>Upgraded Address</th>
+          </tr>
+        </thead>
+        <tbody>
+          {statuses.map((s) => {
+            const isUpgraded = s.upgradedAddress !== null;
+            const bgClass = isUpgraded
+              ? "bg-green-50 dark:bg-green-950/30"
+              : "bg-red-50 dark:bg-red-950/30";
+            return (
+              <tr key={s.chainId} className={bgClass}>
+                <td>{s.name}</td>
+                <td>{renderAddress(s.currentAddress, s.explorer)}</td>
+                <td>
+                  {isUpgraded && s.upgradedAddress !== null
+                    ? renderAddress(s.upgradedAddress, s.explorer)
+                    : null}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+    </>
   );
 };
 

--- a/apps/developer-hub/src/components/EvmContractsStatusTable/index.tsx
+++ b/apps/developer-hub/src/components/EvmContractsStatusTable/index.tsx
@@ -1,0 +1,146 @@
+import {
+  evmChains,
+  evmPriceFeedContracts,
+} from "@pythnetwork/contract-manager/utils/utils";
+
+import CopyAddress from "../CopyAddress";
+import { MigrationDeploymentsConfig } from "../MigrationContractsTable/deployments-config";
+
+type UpstreamChain = {
+  chainId: number;
+  name: string;
+  explorers?: { url: string }[];
+};
+
+type ChainStatus = {
+  chainId: string;
+  name: string;
+  networkId: number;
+  currentAddress: string;
+  upgradedAddress: string | null;
+  explorer?: string;
+};
+
+const HIDDEN_CHAIN_IDS = new Set<string>();
+const CHAIN_REGISTRY_URL = "https://chainid.network/chains.json";
+const CHAIN_REGISTRY_REVALIDATE_SECONDS = 60 * 60 * 24;
+
+const humanize = (chainId: string): string =>
+  chainId
+    .split("_")
+    .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+    .join(" ");
+
+const fetchChainRegistry = async (): Promise<Map<number, UpstreamChain>> => {
+  try {
+    const response = await fetch(CHAIN_REGISTRY_URL, {
+      next: { revalidate: CHAIN_REGISTRY_REVALIDATE_SECONDS },
+    });
+    if (!response.ok) return new Map();
+    const chains = (await response.json()) as UpstreamChain[];
+    return new Map(chains.map((c) => [c.chainId, c]));
+  } catch {
+    return new Map();
+  }
+};
+
+const buildStatuses = (
+  isMainnet: boolean,
+  registry: Map<number, UpstreamChain>,
+): ChainStatus[] => {
+  const current = new Map<string, string>();
+  const upgraded = new Map<string, string>();
+
+  for (const contract of evmPriceFeedContracts) {
+    if (HIDDEN_CHAIN_IDS.has(contract.chain)) continue;
+    if (
+      "deploymentType" in contract &&
+      contract.deploymentType === "pro-compatible-production"
+    ) {
+      upgraded.set(contract.chain, contract.address);
+    } else if (!("deploymentType" in contract)) {
+      current.set(contract.chain, contract.address);
+    }
+  }
+
+  const statuses: ChainStatus[] = [];
+  for (const [chainId, currentAddress] of current.entries()) {
+    const chain = evmChains.find((c) => c.id === chainId);
+    if (!chain || chain.mainnet !== isMainnet) continue;
+
+    const upstream = registry.get(chain.networkId);
+    const override = MigrationDeploymentsConfig[String(chain.networkId)];
+    const explorer = override?.explorer ?? upstream?.explorers?.[0]?.url;
+
+    statuses.push({
+      chainId,
+      name: override?.name ?? upstream?.name ?? humanize(chainId),
+      networkId: chain.networkId,
+      currentAddress,
+      upgradedAddress: upgraded.get(chainId) ?? null,
+      ...(explorer ? { explorer } : {}),
+    });
+  }
+
+  return statuses.sort((a, b) => a.name.localeCompare(b.name));
+};
+
+const renderAddress = (address: string, explorer?: string) =>
+  explorer ? (
+    <CopyAddress
+      address={address}
+      url={`${explorer.replace(/\/$/, "")}/address/${address}`}
+    />
+  ) : (
+    <CopyAddress address={address} />
+  );
+
+const EvmContractsStatusTable = async ({
+  isMainnet,
+}: {
+  isMainnet: boolean;
+}) => {
+  const registry = await fetchChainRegistry();
+  const statuses = buildStatuses(isMainnet, registry);
+
+  if (statuses.length === 0) {
+    return (
+      <p>
+        <em>No contracts published yet for this network type.</em>
+      </p>
+    );
+  }
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Network</th>
+          <th>Current Address</th>
+          <th>Upgraded Address</th>
+        </tr>
+      </thead>
+      <tbody>
+        {statuses.map((s) => {
+          const isUpgraded = s.upgradedAddress !== null;
+          const bgClass = isUpgraded
+            ? "bg-green-50 dark:bg-green-950/30"
+            : "bg-red-50 dark:bg-red-950/30";
+          return (
+            <tr key={s.chainId} className={bgClass}>
+              <td>{s.name}</td>
+              <td>{renderAddress(s.currentAddress, s.explorer)}</td>
+              <td>
+                {isUpgraded && s.upgradedAddress !== null
+                  ? renderAddress(s.upgradedAddress, s.explorer)
+                  : null}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+};
+
+export default EvmContractsStatusTable;

--- a/apps/developer-hub/src/components/EvmContractsStatusTable/index.tsx
+++ b/apps/developer-hub/src/components/EvmContractsStatusTable/index.tsx
@@ -85,6 +85,16 @@ const buildStatuses = (
   return statuses.sort((a, b) => a.name.localeCompare(b.name));
 };
 
+const partitionStatuses = (statuses: ChainStatus[]) => {
+  const upgraded: ChainStatus[] = [];
+  const dropped: ChainStatus[] = [];
+  for (const s of statuses) {
+    if (s.upgradedAddress !== null) upgraded.push(s);
+    else dropped.push(s);
+  }
+  return { upgraded, dropped };
+};
+
 const renderAddress = (address: string, explorer?: string) =>
   explorer ? (
     <CopyAddress
@@ -112,54 +122,70 @@ const EvmContractsStatusTable = async ({
     );
   }
 
+  const { upgraded, dropped } = partitionStatuses(statuses);
+
+  const renderRow = (s: ChainStatus, droppedSection: boolean) => (
+    <tr
+      key={s.chainId}
+      className={
+        droppedSection
+          ? "bg-red-100/70 dark:bg-red-950/40"
+          : "bg-green-100/60 dark:bg-green-950/30"
+      }
+    >
+      <td>{s.name}</td>
+      <td>{renderAddress(s.currentAddress, s.explorer)}</td>
+      <td>
+        {s.upgradedAddress !== null
+          ? renderAddress(s.upgradedAddress, s.explorer)
+          : "—"}
+      </td>
+    </tr>
+  );
+
   return (
     <>
-      <div className="flex gap-4 text-sm my-2">
+      <div className="flex flex-wrap gap-4 text-sm my-3 font-medium">
         <span className="inline-flex items-center gap-2">
           <span
             aria-hidden
-            className="inline-block w-3 h-3 rounded-sm border bg-green-50 dark:bg-green-950/30"
+            className="inline-block w-4 h-4 rounded-sm border bg-green-100/60 dark:bg-green-950/30"
           />
-          Upgraded
+          Upgraded ({upgraded.length})
         </span>
         <span className="inline-flex items-center gap-2">
           <span
             aria-hidden
-            className="inline-block w-3 h-3 rounded-sm border bg-red-50 dark:bg-red-950/30"
+            className="inline-block w-4 h-4 rounded-sm border bg-red-100/70 dark:bg-red-950/40"
           />
-          Will be dropped
+          Not upgraded ({dropped.length})
         </span>
       </div>
       <div className="overflow-x-auto">
         <table>
           <thead>
-          <tr>
-            <th>Network</th>
-            <th>Current Address</th>
-            <th>Upgraded Address</th>
-          </tr>
-        </thead>
-        <tbody>
-          {statuses.map((s) => {
-            const isUpgraded = s.upgradedAddress !== null;
-            const bgClass = isUpgraded
-              ? "bg-green-50 dark:bg-green-950/30"
-              : "bg-red-50 dark:bg-red-950/30";
-            return (
-              <tr key={s.chainId} className={bgClass}>
-                <td>{s.name}</td>
-                <td>{renderAddress(s.currentAddress, s.explorer)}</td>
-                <td>
-                  {isUpgraded && s.upgradedAddress !== null
-                    ? renderAddress(s.upgradedAddress, s.explorer)
-                    : null}
+            <tr>
+              <th>Network</th>
+              <th>Current Address</th>
+              <th>Upgraded Address</th>
+            </tr>
+          </thead>
+          <tbody>
+            {upgraded.map((s) => renderRow(s, false))}
+            {dropped.length > 0 && (
+              <tr className="bg-red-200/80 dark:bg-red-900/60">
+                <td
+                  colSpan={3}
+                  className="text-center font-semibold py-3 text-red-900 dark:text-red-100 border-y-2 border-red-300 dark:border-red-700"
+                >
+                  Chains not in the upgrade ({dropped.length})
                 </td>
               </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </div>
+            )}
+            {dropped.map((s) => renderRow(s, true))}
+          </tbody>
+        </table>
+      </div>
     </>
   );
 };

--- a/apps/developer-hub/src/components/MigrationFlow/BranchToggle.tsx
+++ b/apps/developer-hub/src/components/MigrationFlow/BranchToggle.tsx
@@ -16,7 +16,7 @@ type Option = {
 const OPTIONS: Option[] = [
   {
     value: "now",
-    title: "Upgrade now",
+    title: "Early upgrade",
     caption: "Recommended · zero downtime · ~30 min",
   },
   {
@@ -29,7 +29,7 @@ const OPTIONS: Option[] = [
 // Fumadocs auto-generates these from the H2 headings inside each
 // BranchSection. Update if those headings change.
 const HEADING_IDS: Record<MigrationPath, string> = {
-  now: "upgrading-now",
+  now: "early-upgrade",
   wait: "waiting-for-the-automatic-upgrade",
 };
 

--- a/apps/developer-hub/src/components/MigrationFlow/UpgradeCallout.tsx
+++ b/apps/developer-hub/src/components/MigrationFlow/UpgradeCallout.tsx
@@ -48,15 +48,16 @@ export const UpgradeCallout = ({ chain }: Props) => {
       <Callout type="warn" title={TITLE}>
         <ul className="list-disc pl-5 my-0! space-y-1">
           <li>
-            See the <Link href={upgradeGuide}>upgrade guide</Link> and the{" "}
+            We recommend new integrations use the{" "}
             <Link href={upgradedAddressesRoot}>
               upgraded contract addresses
-            </Link>{" "}
-            for chains in the upgrade.
+            </Link>
+            .
           </li>
           <li>
-            <a href={contactMail}>Contact the team</a> if your chain
-            isn&apos;t listed.
+            Existing integrations using the current addresses will be
+            automatically upgraded by the DAO on <strong>July 31, 2026</strong>.
+            See the <Link href={upgradeGuide}>upgrade guide</Link> for details.
           </li>
         </ul>
       </Callout>
@@ -68,12 +69,19 @@ export const UpgradeCallout = ({ chain }: Props) => {
 
   if (SUPPORTED_SIMPLE.has(chain)) {
     return (
-      <Callout type="warn" title={TITLE}>
+      <Callout
+        type="warn"
+        title={`Pyth Core on ${label} is upgrading on July 31, 2026`}
+      >
         <ul className="list-disc pl-5 my-0! space-y-1">
-          <li>The addresses below are auto-upgraded by the DAO at cutover.</li>
           <li>
-            See the <Link href={upgradeGuide}>upgrade guide</Link> and the{" "}
-            <Link href={upgradedAddresses}>upgraded {label} addresses</Link>.
+            We recommend new integrations use the{" "}
+            <Link href={upgradedAddresses}>upgraded {label} contracts</Link>.
+          </li>
+          <li>
+            Existing integrations using the current addresses will be
+            automatically upgraded by the DAO on <strong>July 31, 2026</strong>.
+            See the <Link href={upgradeGuide}>upgrade guide</Link> for details.
           </li>
         </ul>
       </Callout>
@@ -82,20 +90,23 @@ export const UpgradeCallout = ({ chain }: Props) => {
 
   if (SUPPORTED_PARTIAL.has(chain)) {
     return (
-      <Callout type="warn" title={TITLE}>
+      <Callout
+        type="warn"
+        title={`Pyth Core on ${label} chains is upgrading on July 31, 2026`}
+      >
         <ul className="list-disc pl-5 my-0! space-y-1">
           <li>
-            Check the{" "}
-            <Link href={upgradedAddresses}>upgraded {label} addresses</Link>{" "}
-            for chains in the upgrade.
+            We recommend new integrations use the{" "}
+            <Link href={upgradedAddresses}>upgraded {label} contracts</Link>.
           </li>
           <li>
-            See the <Link href={upgradeGuide}>upgrade guide</Link> for how to
-            upgrade.
+            Existing integrations on {label} chains in the upgrade will be
+            automatically upgraded by the DAO on <strong>July 31, 2026</strong>.
+            See the <Link href={upgradeGuide}>upgrade guide</Link> for details.
           </li>
           <li>
-            <a href={contactMail}>Contact the team</a> if your chain
-            isn&apos;t listed.
+            <a href={contactMail}>Contact the team</a> if your chain isn&apos;t
+            in the upgrade list.
           </li>
         </ul>
       </Callout>

--- a/apps/developer-hub/src/components/MigrationFlow/UpgradeCallout.tsx
+++ b/apps/developer-hub/src/components/MigrationFlow/UpgradeCallout.tsx
@@ -1,0 +1,89 @@
+import { Callout } from "fumadocs-ui/components/callout";
+import Link from "next/link";
+
+type Chain =
+  | "index"
+  | "evm"
+  | "sui"
+  | "solana"
+  | "aptos"
+  | "cosmwasm"
+  | "fuel"
+  | "iota"
+  | "movement"
+  | "near"
+  | "starknet"
+  | "ton";
+
+const CHAIN_LABELS: Record<Exclude<Chain, "index">, string> = {
+  evm: "EVM",
+  sui: "Sui",
+  solana: "Solana",
+  aptos: "Aptos",
+  cosmwasm: "CosmWasm",
+  fuel: "Fuel",
+  iota: "IOTA",
+  movement: "Movement",
+  near: "NEAR",
+  starknet: "Starknet",
+  ton: "TON",
+};
+
+const SUPPORTED_SIMPLE = new Set<Chain>(["sui", "solana"]);
+const SUPPORTED_PARTIAL = new Set<Chain>(["evm"]);
+
+type Props = { chain: Chain };
+
+export const UpgradeCallout = ({ chain }: Props) => {
+  const upgradeGuide = "/price-feeds/core/upgrade/preparing";
+  const upgradedAddressesRoot = "/price-feeds/core/upgrade/contracts";
+  const contactMail = "mailto:data@dourolabs.xyz";
+
+  if (chain === "index") {
+    return (
+      <Callout type="warn">
+        <strong>Pyth Core upgrades on July 31, 2026.</strong> See the{" "}
+        <Link href={upgradeGuide}>upgrade guide</Link> and the{" "}
+        <Link href={upgradedAddressesRoot}>upgraded contract addresses</Link>{" "}
+        for chains in the upgrade. <a href={contactMail}>Contact the team</a>{" "}
+        if your chain isn&apos;t listed.
+      </Callout>
+    );
+  }
+
+  const label = CHAIN_LABELS[chain];
+  const upgradedAddresses = `${upgradedAddressesRoot}#${chain}`;
+
+  if (SUPPORTED_SIMPLE.has(chain)) {
+    return (
+      <Callout type="warn">
+        <strong>Pyth Core upgrades on July 31, 2026.</strong> The addresses
+        below are auto-upgraded by the DAO at cutover. See the{" "}
+        <Link href={upgradeGuide}>upgrade guide</Link> and the{" "}
+        <Link href={upgradedAddresses}>upgraded {label} addresses</Link>.
+      </Callout>
+    );
+  }
+
+  if (SUPPORTED_PARTIAL.has(chain)) {
+    return (
+      <Callout type="warn">
+        <strong>Pyth Core upgrades on July 31, 2026.</strong> Check the{" "}
+        <Link href={upgradedAddresses}>upgraded {label} addresses</Link> for
+        chains in the upgrade and the{" "}
+        <Link href={upgradeGuide}>upgrade guide</Link> for the full path.{" "}
+        <a href={contactMail}>Contact the team</a> if your chain isn&apos;t
+        listed.
+      </Callout>
+    );
+  }
+
+  return (
+    <Callout type="warn">
+      <strong>Pyth Core upgrades on July 31, 2026.</strong> {label} is not part
+      of the upgrade. See the <Link href={upgradeGuide}>upgrade guide</Link> to
+      learn more, or <a href={contactMail}>contact the team</a> for support on
+      this chain.
+    </Callout>
+  );
+};

--- a/apps/developer-hub/src/components/MigrationFlow/UpgradeCallout.tsx
+++ b/apps/developer-hub/src/components/MigrationFlow/UpgradeCallout.tsx
@@ -71,7 +71,7 @@ export const UpgradeCallout = ({ chain }: Props) => {
         <strong>Pyth Core upgrades on July 31, 2026.</strong> Check the{" "}
         <Link href={upgradedAddresses}>upgraded {label} addresses</Link> for
         chains in the upgrade and the{" "}
-        <Link href={upgradeGuide}>upgrade guide</Link> for the full path.{" "}
+        <Link href={upgradeGuide}>upgrade guide</Link> for how to upgrade.{" "}
         <a href={contactMail}>Contact the team</a> if your chain isn&apos;t
         listed.
       </Callout>

--- a/apps/developer-hub/src/components/MigrationFlow/UpgradeCallout.tsx
+++ b/apps/developer-hub/src/components/MigrationFlow/UpgradeCallout.tsx
@@ -12,6 +12,7 @@ type Chain =
   | "iota"
   | "movement"
   | "near"
+  | "stacks"
   | "starknet"
   | "ton";
 
@@ -25,6 +26,7 @@ const CHAIN_LABELS: Record<Exclude<Chain, "index">, string> = {
   iota: "IOTA",
   movement: "Movement",
   near: "NEAR",
+  stacks: "Stacks",
   starknet: "Starknet",
   ton: "TON",
 };
@@ -101,11 +103,18 @@ export const UpgradeCallout = ({ chain }: Props) => {
   }
 
   return (
-    <Callout type="warn" title={TITLE}>
+    <Callout
+      type="warn"
+      title={`Pyth Core will no longer support ${label} after July 31, 2026`}
+    >
       <ul className="list-disc pl-5 my-0! space-y-1">
-        <li>Pyth Core on {label} will be dropped at the upgrade.</li>
         <li>
-          <a href={contactMail}>Contact the team</a> if you need support.
+          See the <Link href={upgradeGuide}>upgrade guide</Link> to learn about
+          the upgrade.
+        </li>
+        <li>
+          <a href={contactMail}>Contact the team</a> to request a Pyth Core
+          contract deployment on {label}.
         </li>
       </ul>
     </Callout>

--- a/apps/developer-hub/src/components/MigrationFlow/UpgradeCallout.tsx
+++ b/apps/developer-hub/src/components/MigrationFlow/UpgradeCallout.tsx
@@ -80,10 +80,9 @@ export const UpgradeCallout = ({ chain }: Props) => {
 
   return (
     <Callout type="warn">
-      <strong>Pyth Core upgrades on July 31, 2026.</strong> {label} is not part
-      of the upgrade. See the <Link href={upgradeGuide}>upgrade guide</Link> to
-      learn more, or <a href={contactMail}>contact the team</a> for support on
-      this chain.
+      <strong>Pyth Core upgrades on July 31, 2026.</strong> Pyth Core on {label}{" "}
+      will be dropped at the upgrade. <a href={contactMail}>Contact the team</a>{" "}
+      if you need support.
     </Callout>
   );
 };

--- a/apps/developer-hub/src/components/MigrationFlow/UpgradeCallout.tsx
+++ b/apps/developer-hub/src/components/MigrationFlow/UpgradeCallout.tsx
@@ -34,6 +34,8 @@ const SUPPORTED_PARTIAL = new Set<Chain>(["evm"]);
 
 type Props = { chain: Chain };
 
+const TITLE = "Pyth Core upgrades on July 31, 2026";
+
 export const UpgradeCallout = ({ chain }: Props) => {
   const upgradeGuide = "/price-feeds/core/upgrade/preparing";
   const upgradedAddressesRoot = "/price-feeds/core/upgrade/contracts";
@@ -41,12 +43,20 @@ export const UpgradeCallout = ({ chain }: Props) => {
 
   if (chain === "index") {
     return (
-      <Callout type="warn">
-        <strong>Pyth Core upgrades on July 31, 2026.</strong> See the{" "}
-        <Link href={upgradeGuide}>upgrade guide</Link> and the{" "}
-        <Link href={upgradedAddressesRoot}>upgraded contract addresses</Link>{" "}
-        for chains in the upgrade. <a href={contactMail}>Contact the team</a>{" "}
-        if your chain isn&apos;t listed.
+      <Callout type="warn" title={TITLE}>
+        <ul className="list-disc pl-5 my-0! space-y-1">
+          <li>
+            See the <Link href={upgradeGuide}>upgrade guide</Link> and the{" "}
+            <Link href={upgradedAddressesRoot}>
+              upgraded contract addresses
+            </Link>{" "}
+            for chains in the upgrade.
+          </li>
+          <li>
+            <a href={contactMail}>Contact the team</a> if your chain
+            isn&apos;t listed.
+          </li>
+        </ul>
       </Callout>
     );
   }
@@ -56,33 +66,48 @@ export const UpgradeCallout = ({ chain }: Props) => {
 
   if (SUPPORTED_SIMPLE.has(chain)) {
     return (
-      <Callout type="warn">
-        <strong>Pyth Core upgrades on July 31, 2026.</strong> The addresses
-        below are auto-upgraded by the DAO at cutover. See the{" "}
-        <Link href={upgradeGuide}>upgrade guide</Link> and the{" "}
-        <Link href={upgradedAddresses}>upgraded {label} addresses</Link>.
+      <Callout type="warn" title={TITLE}>
+        <ul className="list-disc pl-5 my-0! space-y-1">
+          <li>The addresses below are auto-upgraded by the DAO at cutover.</li>
+          <li>
+            See the <Link href={upgradeGuide}>upgrade guide</Link> and the{" "}
+            <Link href={upgradedAddresses}>upgraded {label} addresses</Link>.
+          </li>
+        </ul>
       </Callout>
     );
   }
 
   if (SUPPORTED_PARTIAL.has(chain)) {
     return (
-      <Callout type="warn">
-        <strong>Pyth Core upgrades on July 31, 2026.</strong> Check the{" "}
-        <Link href={upgradedAddresses}>upgraded {label} addresses</Link> for
-        chains in the upgrade and the{" "}
-        <Link href={upgradeGuide}>upgrade guide</Link> for how to upgrade.{" "}
-        <a href={contactMail}>Contact the team</a> if your chain isn&apos;t
-        listed.
+      <Callout type="warn" title={TITLE}>
+        <ul className="list-disc pl-5 my-0! space-y-1">
+          <li>
+            Check the{" "}
+            <Link href={upgradedAddresses}>upgraded {label} addresses</Link>{" "}
+            for chains in the upgrade.
+          </li>
+          <li>
+            See the <Link href={upgradeGuide}>upgrade guide</Link> for how to
+            upgrade.
+          </li>
+          <li>
+            <a href={contactMail}>Contact the team</a> if your chain
+            isn&apos;t listed.
+          </li>
+        </ul>
       </Callout>
     );
   }
 
   return (
-    <Callout type="warn">
-      <strong>Pyth Core upgrades on July 31, 2026.</strong> Pyth Core on {label}{" "}
-      will be dropped at the upgrade. <a href={contactMail}>Contact the team</a>{" "}
-      if you need support.
+    <Callout type="warn" title={TITLE}>
+      <ul className="list-disc pl-5 my-0! space-y-1">
+        <li>Pyth Core on {label} will be dropped at the upgrade.</li>
+        <li>
+          <a href={contactMail}>Contact the team</a> if you need support.
+        </li>
+      </ul>
     </Callout>
   );
 };

--- a/apps/developer-hub/src/components/MigrationFlow/index.ts
+++ b/apps/developer-hub/src/components/MigrationFlow/index.ts
@@ -1,3 +1,4 @@
 export { ActiveStepHighlighter } from "./ActiveStepHighlighter";
 export { BranchSection } from "./BranchSection";
 export { BranchToggle } from "./BranchToggle";
+export { UpgradeCallout } from "./UpgradeCallout";

--- a/apps/developer-hub/src/mdx-components.tsx
+++ b/apps/developer-hub/src/mdx-components.tsx
@@ -8,6 +8,7 @@ import { APICard, APICards } from "./components/APICard";
 import { BinaryFormatCards } from "./components/BinaryFormatCards";
 import { FieldCodePanel } from "./components/FieldCodePanel";
 import { MermaidDiagram } from "./components/MermaidDiagram";
+import { UpgradeCallout } from "./components/MigrationFlow";
 import { PropertyCard } from "./components/PropertyCard";
 import { PropertyFieldLinker } from "./components/PropertyFieldLinker";
 import { YouTubeEmbed } from "./components/YouTubeEmbed";
@@ -31,5 +32,6 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     MermaidDiagram,
     PropertyCard,
     PropertyFieldLinker,
+    UpgradeCallout,
   };
 }


### PR DESCRIPTION
## Summary

- New reusable **`<UpgradeCallout chain="..." />`** MDX component (lives at `apps/developer-hub/src/components/MigrationFlow/UpgradeCallout.tsx`) that surfaces a Warn-level Pyth Core upgrade notice on each legacy `contract-addresses/*` page.
- Globally registered in `mdx-components.tsx` — authors just write `<UpgradeCallout chain="evm" />`, no per-file import.
- Applied to all 12 legacy `/price-feeds/core/contract-addresses/*.mdx` pages (Pythnet skipped — Pythnet itself isn't part of the consumer-side upgrade).
- Picks one of 4 variants based on the chain prop:
  - **`index`** — overview page, generic copy
  - **Supported-simple** (`sui`, `solana`) — chain is fully in the upgrade
  - **Supported-partial** (`evm`) — chain is in scope but only some EVM chains are upgraded; mentions "contact team if your chain isn't listed"
  - **Not-in-upgrade** (`aptos`, `cosmwasm`, `fuel`, `iota`, `movement`, `near`, `starknet`, `ton`) — explicit "{Chain} is not part of the upgrade", contact team for support

## Test plan

- [x] `/price-feeds/core/contract-addresses` → index variant renders
- [x] `/price-feeds/core/contract-addresses/evm` → V2 (partial-coverage) variant + Contact-the-team link
- [x] `/price-feeds/core/contract-addresses/sui` → V1 (auto-upgrade) variant + correct anchor
- [x] `/price-feeds/core/contract-addresses/solana` → V1 variant
- [x] `/price-feeds/core/contract-addresses/aptos` → V3 (not-in-upgrade) variant
- [x] Spot-check remaining V3 pages: cosmwasm, fuel, iota, movement, near, starknet, ton
- [ ] Light + dark mode rendering OK
- [ ] All embedded links resolve (upgrade guide, upgraded {chain} addresses, mailto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->