### PR TITLE
fix(developer-hub): copy nits on upgrade banner & prepare-for-upgrade page

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/index.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/index.mdx
@@ -13,7 +13,7 @@ Pyth Network is upgrading [Pyth Core](/price-feeds/core) on **July 31, 2026**. T
 - **Additional price feeds** beyond the current Core catalog.
 - **Lower latency** across the data path.
 
-Existing integrations keep working through the cutover. The one new requirement is authentication on Hermes: every Hermes user needs a [Pyth API Key](https://pythdata.app/signup?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=overview) by July 31, 2026.
+Most existing integrations keep working through the cutover. [Prepare for the upgrade](/price-feeds/core/upgrade/preparing) to check whether you're covered. The one new requirement is authentication on Hermes: every Hermes user needs a [Pyth API Key](https://pythdata.app/signup?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=overview) by July 31, 2026.
 
 ## Next steps
 

--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/index.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/index.mdx
@@ -201,7 +201,7 @@ for (const update of [newUpdate, oldUpdate]) {
 
 ## Chain support
 
-Pyth Core will be supported on the chains listed on the [upgraded Pyth Core Contract addresses page](/price-feeds/core/upgrade/contracts). If your chain isn't listed, [contact the team](#get-help). Additional support is available by custom arrangement.
+Pyth Core will be supported on major EVM chains, Solana and Sui. See the [upgraded Pyth Core contract addresses page](/price-feeds/core/upgrade/contracts) for more details.
 
 ### Feed support
 

--- a/apps/developer-hub/src/components/Pages/Homepage/index.tsx
+++ b/apps/developer-hub/src/components/Pages/Homepage/index.tsx
@@ -28,8 +28,7 @@ export const Homepage = () => {
               Pyth Core is upgrading on July 31, 2026
             </h2>
             <p className={styles.migrationFeatureBody}>
-              Pyth API Key required for everyone using Pyth Core, new or
-              existing.
+              All Pyth Core users must register for an API Key
             </p>
           </div>
           <div className={styles.migrationFeatureActions}>


### PR DESCRIPTION
Apply three copy-only fixes to the developer-hub docs app:

1. Banner: Changed second sentence to 'All Pyth Core users must register for an API Key'
2. Upgrade overview: Added 'Most' qualifier and link to prepare-for-upgrade page
3. Chain Support: Replaced sentence with major EVM chains, Solana and Sui wording