### PR TITLE
fix(hermes): disconnect slow WS/SSE consumers to prevent OOM

### DIFF
--- a/apps/hermes/server/Cargo.lock
+++ b/apps/hermes/server/Cargo.lock
@@ -1880,7 +1880,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes"
-version = "0.10.8"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/hermes/server/Cargo.lock
+++ b/apps/hermes/server/Cargo.lock
@@ -1931,6 +1931,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "tungstenite 0.20.1",
  "utoipa",
  "utoipa-swagger-ui",
  "wormhole-sdk",

--- a/apps/hermes/server/Cargo.toml
+++ b/apps/hermes/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "hermes"
-version     = "0.10.8"
+version     = "0.11.0"
 description = "Hermes is an agent that provides Verified Prices from the Pythnet Pyth Oracle."
 edition     = "2021"
 

--- a/apps/hermes/server/Cargo.toml
+++ b/apps/hermes/server/Cargo.toml
@@ -45,6 +45,7 @@ strum              = { version = "0.24.1", features = ["derive"] }
 tokio              = { version = "1.26.0", features = ["full"] }
 tokio-stream       = { version = "0.1.15", features = ["full"] }
 tokio-tungstenite  = { version = "0.26.2", features = ["native-tls"] }
+tungstenite        = { version = "0.20.1" }
 tonic              = { version = "0.10.1", features = ["tls"] }
 tower-http         = { version = "0.4.0", features = ["cors"] }
 tracing            = { version = "0.1.37", features = ["log"] }

--- a/apps/hermes/server/src/api.rs
+++ b/apps/hermes/server/src/api.rs
@@ -20,10 +20,17 @@ pub mod token;
 pub mod types;
 mod ws;
 
+#[derive(Clone, Debug)]
+pub struct StreamingConfig {
+    pub disconnect_slow_consumers: bool,
+    pub ws_max_write_buffer_bytes: usize,
+}
+
 pub struct ApiState<S> {
     pub state: Arc<S>,
     pub ws: Arc<ws::WsState>,
     pub metrics: Arc<metrics_middleware::ApiMetrics>,
+    pub streaming: StreamingConfig,
 }
 
 /// Manually implement `Clone` as the derive macro will try and slap `Clone` on
@@ -34,12 +41,18 @@ impl<S> Clone for ApiState<S> {
             state: self.state.clone(),
             ws: self.ws.clone(),
             metrics: self.metrics.clone(),
+            streaming: self.streaming.clone(),
         }
     }
 }
 
 impl<S> ApiState<S> {
-    pub fn new(state: Arc<S>, ws_whitelist: Vec<IpNet>, requester_ip_header_name: String) -> Self
+    pub fn new(
+        state: Arc<S>,
+        ws_whitelist: Vec<IpNet>,
+        requester_ip_header_name: String,
+        streaming: StreamingConfig,
+    ) -> Self
     where
         S: Metrics,
         S: Send + Sync + 'static,
@@ -52,6 +65,7 @@ impl<S> ApiState<S> {
                 state.clone(),
             )),
             state,
+            streaming,
         }
     }
 }
@@ -71,6 +85,10 @@ where
             state,
             opts.rpc.ws_whitelist,
             opts.rpc.requester_ip_header_name,
+            StreamingConfig {
+                disconnect_slow_consumers: opts.rpc.disconnect_slow_consumers,
+                ws_max_write_buffer_bytes: opts.rpc.ws_max_write_buffer_bytes,
+            },
         )
     };
 

--- a/apps/hermes/server/src/api/metrics_middleware.rs
+++ b/apps/hermes/server/src/api/metrics_middleware.rs
@@ -9,16 +9,29 @@ use {
     },
     prometheus_client::{
         encoding::EncodeLabelSet,
-        metrics::{counter::Counter, family::Family, histogram::Histogram},
+        metrics::{
+            counter::Counter,
+            family::Family,
+            gauge::Gauge,
+            histogram::Histogram,
+        },
     },
     std::sync::Arc,
     tokio::time::Instant,
 };
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash, EncodeLabelSet)]
+pub struct StreamProtocolLabel {
+    pub protocol: String,
+}
+
 pub struct ApiMetrics {
     pub requests: Family<Labels, Counter>,
     pub latencies: Family<LatencyLabels, Histogram>,
     pub sse_broadcast_latency: Histogram,
+    pub stream_active_connections: Family<StreamProtocolLabel, Gauge>,
+    pub stream_slow_consumer_disconnects: Family<StreamProtocolLabel, Counter>,
+    pub sse_broadcast_lagged: Counter,
 }
 
 impl ApiMetrics {
@@ -43,12 +56,18 @@ impl ApiMetrics {
                 ]
                 .into_iter(),
             ),
+            stream_active_connections: Family::default(),
+            stream_slow_consumer_disconnects: Family::default(),
+            sse_broadcast_lagged: Counter::default(),
         };
 
         {
             let requests = new.requests.clone();
             let latencies = new.latencies.clone();
             let sse_broadcast_latency = new.sse_broadcast_latency.clone();
+            let stream_active_connections = new.stream_active_connections.clone();
+            let stream_slow_consumer_disconnects = new.stream_slow_consumer_disconnects.clone();
+            let sse_broadcast_lagged = new.sse_broadcast_lagged.clone();
 
             tokio::spawn(async move {
                 Metrics::register(
@@ -73,6 +92,36 @@ impl ApiMetrics {
                         "sse_broadcast_latency_seconds",
                         "Latency from Hermes receive_time to SSE send in seconds",
                         sse_broadcast_latency,
+                    ),
+                )
+                .await;
+
+                Metrics::register(
+                    &*state,
+                    (
+                        "stream_active_connections",
+                        "Number of active WebSocket and SSE streaming connections",
+                        stream_active_connections,
+                    ),
+                )
+                .await;
+
+                Metrics::register(
+                    &*state,
+                    (
+                        "stream_slow_consumer_disconnects_total",
+                        "Total streaming connections closed due to slow consumption",
+                        stream_slow_consumer_disconnects,
+                    ),
+                )
+                .await;
+
+                Metrics::register(
+                    &*state,
+                    (
+                        "sse_broadcast_lagged_total",
+                        "Total SSE broadcast lag events (client missed updates)",
+                        sse_broadcast_lagged,
                     ),
                 )
                 .await;
@@ -140,4 +189,10 @@ pub async fn track_metrics<B, S>(
         .observe(latency);
 
     response
+}
+
+pub fn stream_protocol_label(protocol: &str) -> StreamProtocolLabel {
+    StreamProtocolLabel {
+        protocol: protocol.to_string(),
+    }
 }

--- a/apps/hermes/server/src/api/metrics_middleware.rs
+++ b/apps/hermes/server/src/api/metrics_middleware.rs
@@ -9,12 +9,7 @@ use {
     },
     prometheus_client::{
         encoding::EncodeLabelSet,
-        metrics::{
-            counter::Counter,
-            family::Family,
-            gauge::Gauge,
-            histogram::Histogram,
-        },
+        metrics::{counter::Counter, family::Family, gauge::Gauge, histogram::Histogram},
     },
     std::sync::Arc,
     tokio::time::Instant,

--- a/apps/hermes/server/src/api/rest.rs
+++ b/apps/hermes/server/src/api/rest.rs
@@ -127,6 +127,7 @@ where
 mod tests {
     use {
         super::*,
+        crate::api::StreamingConfig,
         crate::state::{
             aggregate::{
                 AggregationEvent, PriceFeedsWithUpdateData, PublisherStakeCapsWithUpdateData,
@@ -215,7 +216,15 @@ mod tests {
         available_ids.insert(id2);
 
         let mock_state = MockAggregates { available_ids };
-        let api_state = ApiState::new(Arc::new(mock_state), vec![], String::new());
+        let api_state = ApiState::new(
+            Arc::new(mock_state),
+            vec![],
+            String::new(),
+            StreamingConfig {
+                disconnect_slow_consumers: true,
+                ws_max_write_buffer_bytes: 2 * 1024 * 1024,
+            },
+        );
 
         let input_ids = vec![id1, id2];
         let result = validate_price_ids(&api_state, &input_ids, false).await;
@@ -234,7 +243,15 @@ mod tests {
         available_ids.insert(id2);
 
         let mock_state = MockAggregates { available_ids };
-        let api_state = ApiState::new(Arc::new(mock_state), vec![], String::new());
+        let api_state = ApiState::new(
+            Arc::new(mock_state),
+            vec![],
+            String::new(),
+            StreamingConfig {
+                disconnect_slow_consumers: true,
+                ws_max_write_buffer_bytes: 2 * 1024 * 1024,
+            },
+        );
 
         let input_ids = vec![id1, id2, id3];
         let result = validate_price_ids(&api_state, &input_ids, true).await;
@@ -253,7 +270,15 @@ mod tests {
         available_ids.insert(id2);
 
         let mock_state = MockAggregates { available_ids };
-        let api_state = ApiState::new(Arc::new(mock_state), vec![], String::new());
+        let api_state = ApiState::new(
+            Arc::new(mock_state),
+            vec![],
+            String::new(),
+            StreamingConfig {
+                disconnect_slow_consumers: true,
+                ws_max_write_buffer_bytes: 2 * 1024 * 1024,
+            },
+        );
 
         let input_ids = vec![id1, id2, id3];
         let result = validate_price_ids(&api_state, &input_ids, false).await;

--- a/apps/hermes/server/src/api/rest/v2/sse.rs
+++ b/apps/hermes/server/src/api/rest/v2/sse.rs
@@ -39,6 +39,7 @@ use {
 // Constants
 const MAX_CONNECTION_DURATION: Duration = Duration::from_secs(24 * 60 * 60); // 24 hours
 const SLOW_CONSUMER_DISCONNECT_MESSAGE: &str = "Slow consumer: disconnected";
+const CONNECTION_TIMEOUT_MESSAGE: &str = "Connection timeout reached (24h)";
 
 struct SseConnectionGuard {
     metrics: Arc<crate::api::metrics_middleware::ApiMetrics>,
@@ -138,6 +139,7 @@ where
     let start_time = Instant::now();
     let disconnect_slow_consumers = state.streaming.disconnect_slow_consumers;
     let should_end = Arc::new(AtomicBool::new(false));
+    let should_end_for_chain = should_end.clone();
     let metrics = state.metrics.clone();
 
     let mut inner_stream = futures::stream::StreamExt::boxed(
@@ -179,7 +181,9 @@ where
                                 state_clone.metrics.sse_broadcast_lagged.inc();
                             }
                             if should_disconnect_slow_sse_consumer(&e, disconnect_slow_consumers) {
-                                tracing::info!("Slow consumer disconnected (SSE broadcast lagged).");
+                                tracing::info!(
+                                    "Slow consumer disconnected (SSE broadcast lagged)."
+                                );
                                 state_clone
                                     .metrics
                                     .stream_slow_consumer_disconnects
@@ -195,11 +199,12 @@ where
                 }
             })
             .filter_map(|x| x)
-            .chain(futures::stream::once(async {
-                Ok(Event::default()
-                    .event("error")
-                    .data("Connection timeout reached (24h)"))
-            })),
+            .chain(
+                futures::stream::once(async move { should_end_for_chain.load(Ordering::Relaxed) })
+                    .filter_map(|ended_due_to_slow_consumer| {
+                        timeout_event_if_needed(ended_due_to_slow_consumer)
+                    }),
+            ),
     );
 
     let guard = SseConnectionGuard::new(metrics);
@@ -315,6 +320,16 @@ fn slow_consumer_disconnect_event() -> Event {
         .data(SLOW_CONSUMER_DISCONNECT_MESSAGE)
 }
 
+fn timeout_event_if_needed(ended_due_to_slow_consumer: bool) -> Option<Result<Event, Infallible>> {
+    if ended_due_to_slow_consumer {
+        None
+    } else {
+        Some(Ok(Event::default()
+            .event("error")
+            .data(CONNECTION_TIMEOUT_MESSAGE)))
+    }
+}
+
 fn should_disconnect_slow_sse_consumer(
     err: &BroadcastStreamRecvError,
     disconnect_slow_consumers: bool,
@@ -353,5 +368,18 @@ mod tests {
             &BroadcastStreamRecvError::Lagged(3),
             false,
         ));
+    }
+
+    #[test]
+    fn skips_timeout_event_after_slow_consumer_disconnect() {
+        assert!(timeout_event_if_needed(true).is_none());
+    }
+
+    #[test]
+    fn emits_timeout_event_when_stream_ends_on_duration() {
+        let event = timeout_event_if_needed(false)
+            .expect("timeout event")
+            .expect("infallible");
+        assert!(format!("{event:?}").contains(CONNECTION_TIMEOUT_MESSAGE));
     }
 }

--- a/apps/hermes/server/src/api/rest/v2/sse.rs
+++ b/apps/hermes/server/src/api/rest/v2/sse.rs
@@ -1,6 +1,7 @@
 use {
     crate::{
         api::{
+            metrics_middleware::stream_protocol_label,
             rest::{validate_price_ids, RestError},
             types::{
                 BinaryUpdate, EncodingType, ParsedPriceUpdate, PriceIdInput, PriceUpdate,
@@ -19,14 +20,48 @@ use {
     pyth_sdk::PriceIdentifier,
     serde::Deserialize,
     serde_qs::axum::QsQuery,
-    std::{convert::Infallible, time::Duration},
-    tokio::{sync::broadcast, time::Instant},
-    tokio_stream::{wrappers::BroadcastStream, StreamExt as _},
+    std::{
+        convert::Infallible,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        time::Duration,
+    },
+    tokio::time::Instant,
+    tokio_stream::{
+        wrappers::{errors::BroadcastStreamRecvError, BroadcastStream},
+        StreamExt as _,
+    },
     utoipa::IntoParams,
 };
 
 // Constants
 const MAX_CONNECTION_DURATION: Duration = Duration::from_secs(24 * 60 * 60); // 24 hours
+const SLOW_CONSUMER_DISCONNECT_MESSAGE: &str = "Slow consumer: disconnected";
+
+struct SseConnectionGuard {
+    metrics: Arc<crate::api::metrics_middleware::ApiMetrics>,
+}
+
+impl SseConnectionGuard {
+    fn new(metrics: Arc<crate::api::metrics_middleware::ApiMetrics>) -> Self {
+        metrics
+            .stream_active_connections
+            .get_or_create(&stream_protocol_label("sse"))
+            .inc();
+        Self { metrics }
+    }
+}
+
+impl Drop for SseConnectionGuard {
+    fn drop(&mut self) {
+        self.metrics
+            .stream_active_connections
+            .get_or_create(&stream_protocol_label("sse"))
+            .dec();
+    }
+}
 
 #[derive(Debug, Deserialize, IntoParams)]
 #[into_params(parameter_in = Query)]
@@ -94,52 +129,86 @@ where
         validate_price_ids(&state, &price_id_inputs, params.ignore_invalid_price_ids).await?;
 
     // Clone the update_tx receiver to listen for new price updates
-    let update_rx: broadcast::Receiver<AggregationEvent> = Aggregates::subscribe(&*state.state);
+    let update_rx = Aggregates::subscribe(&*state.state);
 
     // Convert the broadcast receiver into a Stream
     let stream = BroadcastStream::new(update_rx);
 
     // Set connection start time
     let start_time = Instant::now();
+    let disconnect_slow_consumers = state.streaming.disconnect_slow_consumers;
+    let should_end = Arc::new(AtomicBool::new(false));
+    let metrics = state.metrics.clone();
 
-    let sse_stream = stream
-        .take_while(move |_| start_time.elapsed() < MAX_CONNECTION_DURATION)
-        .then(move |message| {
-            let state_clone = state.clone(); // Clone again to use inside the async block
-            let price_ids_clone = price_ids.clone(); // Clone again for use inside the async block
-            async move {
-                match message {
-                    Ok(event) => {
-                        match handle_aggregation_event(
-                            event,
-                            state_clone,
-                            price_ids_clone,
-                            params.encoding,
-                            params.parsed,
-                            params.benchmarks_only,
-                            params.allow_unordered,
-                        )
-                        .await
-                        {
-                            Ok(Some(update)) => Some(Ok(Event::default()
-                                .json_data(update)
-                                .unwrap_or_else(error_event))),
-                            Ok(None) => None,
-                            Err(e) => Some(Ok(error_event(e))),
+    let mut inner_stream = futures::stream::StreamExt::boxed(
+        stream
+            .take_while({
+                let should_end = should_end.clone();
+                move |_| {
+                    !should_end.load(Ordering::Relaxed)
+                        && start_time.elapsed() < MAX_CONNECTION_DURATION
+                }
+            })
+            .then(move |message| {
+                let state_clone = state.clone();
+                let price_ids_clone = price_ids.clone();
+                let should_end = should_end.clone();
+                async move {
+                    match message {
+                        Ok(event) => {
+                            match handle_aggregation_event(
+                                event,
+                                state_clone,
+                                price_ids_clone,
+                                params.encoding,
+                                params.parsed,
+                                params.benchmarks_only,
+                                params.allow_unordered,
+                            )
+                            .await
+                            {
+                                Ok(Some(update)) => Some(Ok(Event::default()
+                                    .json_data(update)
+                                    .unwrap_or_else(error_event))),
+                                Ok(None) => None,
+                                Err(e) => Some(Ok(error_event(e))),
+                            }
+                        }
+                        Err(e) => {
+                            if matches!(e, BroadcastStreamRecvError::Lagged(_)) {
+                                state_clone.metrics.sse_broadcast_lagged.inc();
+                            }
+                            if should_disconnect_slow_sse_consumer(&e, disconnect_slow_consumers) {
+                                tracing::info!("Slow consumer disconnected (SSE broadcast lagged).");
+                                state_clone
+                                    .metrics
+                                    .stream_slow_consumer_disconnects
+                                    .get_or_create(&stream_protocol_label("sse"))
+                                    .inc();
+                                should_end.store(true, Ordering::Relaxed);
+                                Some(Ok(slow_consumer_disconnect_event()))
+                            } else {
+                                Some(Ok(error_event(e)))
+                            }
                         }
                     }
-                    Err(e) => Some(Ok(error_event(e))),
                 }
-            }
-        })
-        .filter_map(|x| x)
-        .chain(futures::stream::once(async {
-            Ok(Event::default()
-                .event("error")
-                .data("Connection timeout reached (24h)"))
-        }));
+            })
+            .filter_map(|x| x)
+            .chain(futures::stream::once(async {
+                Ok(Event::default()
+                    .event("error")
+                    .data("Connection timeout reached (24h)"))
+            })),
+    );
 
-    Ok(Sse::new(sse_stream).keep_alive(KeepAlive::default()))
+    let guard = SseConnectionGuard::new(metrics);
+    let guarded_stream = futures::stream::poll_fn(move |cx| {
+        let _ = &guard;
+        futures::stream::StreamExt::poll_next_unpin(&mut inner_stream, cx)
+    });
+
+    Ok(Sse::new(guarded_stream).keep_alive(KeepAlive::default()))
 }
 
 async fn handle_aggregation_event<S>(
@@ -240,8 +309,49 @@ where
     }))
 }
 
+fn slow_consumer_disconnect_event() -> Event {
+    Event::default()
+        .event("error")
+        .data(SLOW_CONSUMER_DISCONNECT_MESSAGE)
+}
+
+fn should_disconnect_slow_sse_consumer(
+    err: &BroadcastStreamRecvError,
+    disconnect_slow_consumers: bool,
+) -> bool {
+    matches!(err, BroadcastStreamRecvError::Lagged(_)) && disconnect_slow_consumers
+}
+
 fn error_event<E: std::fmt::Debug>(e: E) -> Event {
     Event::default()
         .event("error")
         .data(format!("Error receiving update: {e:?}"))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slow_consumer_disconnect_event_has_expected_message() {
+        let event = slow_consumer_disconnect_event();
+        assert!(format!("{event:?}").contains(SLOW_CONSUMER_DISCONNECT_MESSAGE));
+    }
+
+    #[test]
+    fn disconnects_lagging_sse_clients_when_enabled() {
+        assert!(should_disconnect_slow_sse_consumer(
+            &BroadcastStreamRecvError::Lagged(3),
+            true,
+        ));
+    }
+
+    #[test]
+    fn keeps_lagging_sse_clients_when_disabled() {
+        assert!(!should_disconnect_slow_sse_consumer(
+            &BroadcastStreamRecvError::Lagged(3),
+            false,
+        ));
+    }
 }

--- a/apps/hermes/server/src/api/ws.rs
+++ b/apps/hermes/server/src/api/ws.rs
@@ -1,5 +1,6 @@
 use {
     super::{
+        metrics_middleware::stream_protocol_label,
         token,
         types::{PriceIdInput, RpcPriceFeed},
         ApiState,
@@ -45,6 +46,7 @@ use {
         sync::{broadcast::Receiver, watch},
         time::Instant,
     },
+    tokio_tungstenite::tungstenite::Error as WsError,
 };
 
 const PING_INTERVAL_DURATION: Duration = Duration::from_secs(30);
@@ -224,8 +226,12 @@ where
     let api_token = token::extract_token_from_headers_and_uri(&headers, &uri);
     let token_suffix = token::get_token_suffix(api_token.as_deref());
 
-    ws.max_message_size(MAX_CLIENT_MESSAGE_SIZE)
-        .on_upgrade(move |socket| websocket_handler(socket, state, requester_ip, token_suffix))
+    let mut ws = ws.max_message_size(MAX_CLIENT_MESSAGE_SIZE);
+    if state.streaming.disconnect_slow_consumers {
+        ws = ws.max_write_buffer_size(state.streaming.ws_max_write_buffer_bytes);
+    }
+
+    ws.on_upgrade(move |socket| websocket_handler(socket, state, requester_ip, token_suffix))
 }
 
 #[tracing::instrument(skip(stream, state, subscriber_ip, token_suffix))]
@@ -259,12 +265,21 @@ async fn websocket_handler<S>(
 
     let notify_receiver = Aggregates::subscribe(&*state.state);
     let (sender, receiver) = stream.split();
+
+    state
+        .metrics
+        .stream_active_connections
+        .get_or_create(&stream_protocol_label("ws"))
+        .inc();
+
     let mut subscriber = Subscriber::new(
         id,
         subscriber_ip,
         token_suffix,
         state.state.clone(),
         state.ws.clone(),
+        state.metrics.clone(),
+        state.streaming.disconnect_slow_consumers,
         notify_receiver,
         receiver,
         sender,
@@ -275,6 +290,15 @@ async fn websocket_handler<S>(
 
 pub type SubscriberId = usize;
 
+fn is_write_buffer_full(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<WsError>(),
+            Some(WsError::WriteBufferFull(_))
+        )
+    })
+}
+
 /// Subscriber is an actor that handles a single websocket connection.
 /// It listens to the store for updates and sends them to the client.
 pub struct Subscriber<S> {
@@ -284,6 +308,8 @@ pub struct Subscriber<S> {
     closed: bool,
     state: Arc<S>,
     ws_state: Arc<WsState>,
+    metrics: Arc<super::metrics_middleware::ApiMetrics>,
+    disconnect_slow_consumers: bool,
     notify_receiver: Receiver<AggregationEvent>,
     receiver: SplitStream<WebSocket>,
     sender: SplitSink<WebSocket, Message>,
@@ -292,6 +318,15 @@ pub struct Subscriber<S> {
     connection_deadline: Instant,
     exit: watch::Receiver<bool>,
     responded_to_ping: bool,
+}
+
+impl<S> Drop for Subscriber<S> {
+    fn drop(&mut self) {
+        self.metrics
+            .stream_active_connections
+            .get_or_create(&stream_protocol_label("ws"))
+            .dec();
+    }
 }
 
 impl<S> Subscriber<S>
@@ -308,6 +343,8 @@ where
         token_suffix: String,
         state: Arc<S>,
         ws_state: Arc<WsState>,
+        metrics: Arc<super::metrics_middleware::ApiMetrics>,
+        disconnect_slow_consumers: bool,
         notify_receiver: Receiver<AggregationEvent>,
         receiver: SplitStream<WebSocket>,
         sender: SplitSink<WebSocket, Message>,
@@ -319,6 +356,8 @@ where
             closed: false,
             state,
             ws_state,
+            metrics,
+            disconnect_slow_consumers,
             notify_receiver,
             receiver,
             sender,
@@ -330,11 +369,27 @@ where
         }
     }
 
+    fn record_slow_consumer_disconnect(&self) {
+        self.metrics
+            .stream_slow_consumer_disconnects
+            .get_or_create(&stream_protocol_label("ws"))
+            .inc();
+    }
+
     #[tracing::instrument(skip(self))]
     pub async fn run(&mut self) {
         while !self.closed {
             if let Err(e) = self.handle_next().await {
-                tracing::debug!(subscriber = self.id, error = ?e, "Error Handling Subscriber Message.");
+                if self.disconnect_slow_consumers && is_write_buffer_full(&e) {
+                    tracing::info!(
+                        subscriber = self.id,
+                        ip = ?self.ip_addr,
+                        "Slow consumer disconnected (WebSocket write buffer full)."
+                    );
+                    self.record_slow_consumer_disconnect();
+                } else {
+                    tracing::debug!(subscriber = self.id, error = ?e, "Error Handling Subscriber Message.");
+                }
                 break;
             }
         }
@@ -693,5 +748,29 @@ where
             .await?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use {
+        super::*,
+        anyhow::anyhow,
+        tokio_tungstenite::tungstenite::Message as TungsteniteMessage,
+    };
+
+    #[test]
+    fn detects_write_buffer_full_error() {
+        let err = anyhow!(WsError::WriteBufferFull(TungsteniteMessage::Text(
+            "test".into()
+        )));
+        assert!(is_write_buffer_full(&err));
+    }
+
+    #[test]
+    fn ignores_unrelated_errors() {
+        let err = anyhow!("some other error");
+        assert!(!is_write_buffer_full(&err));
     }
 }

--- a/apps/hermes/server/src/api/ws.rs
+++ b/apps/hermes/server/src/api/ws.rs
@@ -754,11 +754,7 @@ where
 #[cfg(test)]
 #[allow(clippy::unwrap_used, reason = "tests")]
 mod tests {
-    use {
-        super::*,
-        anyhow::anyhow,
-        tokio_tungstenite::tungstenite::Message as TungsteniteMessage,
-    };
+    use {super::*, anyhow::anyhow, tokio_tungstenite::tungstenite::Message as TungsteniteMessage};
 
     #[test]
     fn detects_write_buffer_full_error() {

--- a/apps/hermes/server/src/api/ws.rs
+++ b/apps/hermes/server/src/api/ws.rs
@@ -46,7 +46,7 @@ use {
         sync::{broadcast::Receiver, watch},
         time::Instant,
     },
-    tokio_tungstenite::tungstenite::Error as WsError,
+    tungstenite::Error as WsError,
 };
 
 const PING_INTERVAL_DURATION: Duration = Duration::from_secs(30);
@@ -754,12 +754,20 @@ where
 #[cfg(test)]
 #[allow(clippy::unwrap_used, reason = "tests")]
 mod tests {
-    use {super::*, anyhow::anyhow, tokio_tungstenite::tungstenite::Message as TungsteniteMessage};
+    use {super::*, anyhow::anyhow, tungstenite::Message as TungsteniteMessage};
 
     #[test]
     fn detects_write_buffer_full_error() {
         let err = anyhow!(WsError::WriteBufferFull(TungsteniteMessage::Text(
             "test".into()
+        )));
+        assert!(is_write_buffer_full(&err));
+    }
+
+    #[test]
+    fn detects_write_buffer_full_error_through_axum_error() {
+        let err = anyhow!(axum::Error::new(WsError::WriteBufferFull(
+            TungsteniteMessage::Text("test".into()),
         )));
         assert!(is_write_buffer_full(&err));
     }

--- a/apps/hermes/server/src/config/rpc.rs
+++ b/apps/hermes/server/src/config/rpc.rs
@@ -2,6 +2,7 @@ use {clap::Args, ipnet::IpNet, std::net::SocketAddr};
 
 const DEFAULT_RPC_LISTEN_ADDR: &str = "127.0.0.1:33999";
 const DEFAULT_RPC_REQUESTER_IP_HEADER_NAME: &str = "X-Forwarded-For";
+const DEFAULT_RPC_WS_MAX_WRITE_BUFFER_BYTES: &str = "2097152";
 
 #[derive(Args, Clone, Debug)]
 #[command(next_help_heading = "RPC Options")]
@@ -24,4 +25,17 @@ pub struct Options {
     #[arg(default_value = DEFAULT_RPC_REQUESTER_IP_HEADER_NAME)]
     #[arg(env = "RPC_REQUESTER_IP_HEADER_NAME")]
     pub requester_ip_header_name: String,
+
+    /// When true, disconnect WebSocket and SSE clients that cannot keep up with price updates.
+    #[arg(long = "rpc-disconnect-slow-consumers")]
+    #[arg(default_value = "true")]
+    #[arg(env = "RPC_DISCONNECT_SLOW_CONSUMERS")]
+    pub disconnect_slow_consumers: bool,
+
+    /// Maximum WebSocket write buffer size in bytes. Only enforced when
+    /// `disconnect_slow_consumers` is enabled.
+    #[arg(long = "rpc-ws-max-write-buffer-bytes")]
+    #[arg(default_value = DEFAULT_RPC_WS_MAX_WRITE_BUFFER_BYTES)]
+    #[arg(env = "RPC_WS_MAX_WRITE_BUFFER_BYTES")]
+    pub ws_max_write_buffer_bytes: usize,
 }

--- a/apps/hermes/server/src/config/rpc.rs
+++ b/apps/hermes/server/src/config/rpc.rs
@@ -29,6 +29,7 @@ pub struct Options {
     /// When true, disconnect WebSocket and SSE clients that cannot keep up with price updates.
     #[arg(long = "rpc-disconnect-slow-consumers")]
     #[arg(default_value = "true")]
+    #[arg(action = clap::ArgAction::Set)]
     #[arg(env = "RPC_DISCONNECT_SLOW_CONSUMERS")]
     pub disconnect_slow_consumers: bool,
 

--- a/apps/hermes/server/src/network/wormhole.rs
+++ b/apps/hermes/server/src/network/wormhole.rs
@@ -84,6 +84,7 @@ pub struct GuardianSetData {
 #[allow(
     clippy::enum_variant_names,
     clippy::allow_attributes_without_reason,
+    dead_code,
     reason = "generated code"
 )]
 mod proto {


### PR DESCRIPTION
## Summary
- Add configurable slow-consumer protection for Hermes streaming endpoints via `RPC_DISCONNECT_SLOW_CONSUMERS` (default: true) and `RPC_WS_MAX_WRITE_BUFFER_BYTES` (default: 2 MiB).
- Cap WebSocket write buffers when enabled and disconnect clients on `WriteBufferFull` instead of allowing tungstenite's unlimited outbound buffer to grow under TCP backpressure.
- Disconnect lagging SSE clients with a terminal error event when broadcast lag is detected, instead of keeping connections open for up to 24h.
- Add streaming observability metrics: active connections, slow-consumer disconnects, and SSE broadcast lag events.

## Test plan
- [x] `cargo test` in `apps/hermes/server` (38 tests pass)
- [ ] Manual: connect WS client, subscribe, throttle reads → connection closes and `stream_slow_consumer_disconnects_total{protocol="ws"}` increments
- [ ] Manual: connect SSE client, throttle reads while slots update → stream ends with `Slow consumer: disconnected` and `stream_slow_consumer_disconnects_total{protocol="sse"}` increments
- [ ] Manual: run with `RPC_DISCONNECT_SLOW_CONSUMERS=false` and confirm legacy behavior (WS unlimited buffer, SSE continues after lag errors)
- [ ] Prod canary: watch `stream_active_connections`, `stream_slow_consumer_disconnects_total`, and pod memory after deploy


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->