### PR TITLE
ci(starknet): pass --locked to cargo install + bump deprecated actions

### DIFF
--- a/.github/workflows/ci-starknet-contract.yml
+++ b/.github/workflows/ci-starknet-contract.yml
@@ -14,13 +14,13 @@ jobs:
       run:
         working-directory: target_chains/starknet/contracts/
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Install Scarb
         uses: software-mansion/setup-scarb@v1
         with:
           tool-versions: target_chains/starknet/contracts/.tool-versions
       - name: Install Starknet Foundry
-        uses: foundry-rs/setup-snfoundry@v3
+        uses: foundry-rs/setup-snfoundry@v6
         with:
           tool-versions: target_chains/starknet/contracts/.tool-versions
       - name: Install Starkli
@@ -28,7 +28,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install Devnet
         # it doesn't build with more recent Rust versions
-        run: cargo +1.85.0 install starknet-devnet --version $(awk '/starknet-devnet/{print $2}' .tool-versions)
+        run: cargo +1.85.0 install starknet-devnet --locked --version $(awk '/starknet-devnet/{print $2}' .tool-versions)
       - name: Check formatting
         run: scarb fmt --check
       - name: Run tests


### PR DESCRIPTION
## Summary

Fixes the broken `Starknet contract` CI workflow by making three changes to `.github/workflows/ci-starknet-contract.yml`:

1. **Add `--locked` to `cargo install starknet-devnet`** — the workflow pins Rust 1.85.0 but without `--locked`, transitive deps re-resolve and `time-macros@0.2.27` (requiring rustc ≥ 1.88) breaks the build. `--locked` uses the published `Cargo.lock` from starknet-devnet 0.4.0.
2. **Bump `actions/checkout@v3` → `@v5`** — v3 is deprecated (Node 20).
3. **Bump `foundry-rs/setup-snfoundry@v3` → `@v6`** — latest stable; `tool-versions` input is still supported.

Resolves [[i-jfitlqmn]].
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->