### PR TITLE
fix(ci): bump turbo workflow actions to fix cache breakage

### DIFF
--- a/.github/workflows/ci-turbo-build.yml
+++ b/.github/workflows/ci-turbo-build.yml
@@ -20,9 +20,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: "package.json"
       # Libusb is a build requirement for the node-hid package and so pnpm
@@ -35,13 +35,13 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: v0.3.0
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: true
       - name: Install Forge dependencies
         run: cd target_chains/ethereum/contracts && pnpm run install-forge-deps
       - name: Cache for Turbo
-        uses: rharkor/caching-for-turbo@v1.5
+        uses: rharkor/caching-for-turbo@v2.3.12
       - name: Build
         run: pnpm run turbo build

--- a/.github/workflows/ci-turbo-build.yml
+++ b/.github/workflows/ci-turbo-build.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version-file: "package.json"
+          package-manager-cache: false
       # Libusb is a build requirement for the node-hid package and so pnpm
       # install will fail if this isn't in the build environment and if a
       # precompiled binary isn't found.

--- a/.github/workflows/ci-turbo-test.yml
+++ b/.github/workflows/ci-turbo-test.yml
@@ -20,9 +20,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: "package.json"
       # Libusb is a build requirement for the node-hid package and so pnpm
@@ -35,13 +35,13 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: v0.3.0
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: true
       - name: Install Forge dependencies
         run: cd target_chains/ethereum/contracts && pnpm run install-forge-deps
       - name: Cache for Turbo
-        uses: rharkor/caching-for-turbo@v1.5
+        uses: rharkor/caching-for-turbo@v2.3.12
       - name: Test
         run: pnpm turbo test

--- a/.github/workflows/ci-turbo-test.yml
+++ b/.github/workflows/ci-turbo-test.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version-file: "package.json"
+          package-manager-cache: false
       # Libusb is a build requirement for the node-hid package and so pnpm
       # install will fail if this isn't in the build environment and if a
       # precompiled binary isn't found.


### PR DESCRIPTION
## Summary

Fixes broken `rharkor/caching-for-turbo@v1.5` (cache API 400 + `readBody` TypeError); also clears Node-20 deprecation warnings on three sibling actions.

Bumps applied in both `ci-turbo-test.yml` and `ci-turbo-build.yml`:

- `rharkor/caching-for-turbo@v1.5` → `@v2.3.12`
- `actions/checkout@v4` → `@v5`
- `actions/setup-node@v4` → `@v5`
- `pnpm/action-setup@v4` → `@v6`

Additionally, `package-manager-cache: false` was added to the `setup-node` step in both files. This is needed because `actions/setup-node@v5` defaults `package-manager-cache` to `true`, which tries to locate the `pnpm` executable — but `pnpm/action-setup` runs later in the workflow. Without this, the step errors with "Unable to locate executable file: pnpm."

No other changes — no step reordering, no other workflow files touched.

## Test plan

- [ ] `Turbo test` CI job passes green on this PR
- [ ] `Turbo build` CI job passes green on this PR
- [ ] No new deprecation warnings from bumped actions

Resolves [[i-ulmsumii]]