### PR TITLE
fix(cosmwasm): add explicit lifetimes to state helpers and bump checkout to v4

### DIFF
--- a/.github/workflows/ci-cosmwasm-contract.yml
+++ b/.github/workflows/ci-cosmwasm-contract.yml
@@ -20,7 +20,7 @@ jobs:
       run:
         working-directory: target_chains/cosmwasm/contracts/pyth
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Format check
         run: cargo fmt --all -- --check

--- a/target_chains/cosmwasm/contracts/pyth/src/state.rs
+++ b/target_chains/cosmwasm/contracts/pyth/src/state.rs
@@ -47,19 +47,19 @@ pub struct ConfigInfo {
     pub fee: Coin,
 }
 
-pub fn config(storage: &mut dyn Storage) -> Singleton<ConfigInfo> {
+pub fn config<'a>(storage: &'a mut dyn Storage) -> Singleton<'a, ConfigInfo> {
     singleton(storage, CONFIG_KEY)
 }
 
-pub fn config_read(storage: &dyn Storage) -> ReadonlySingleton<ConfigInfo> {
+pub fn config_read<'a>(storage: &'a dyn Storage) -> ReadonlySingleton<'a, ConfigInfo> {
     singleton_read(storage, CONFIG_KEY)
 }
 
-pub fn price_feed_bucket(storage: &mut dyn Storage) -> Bucket<PriceFeed> {
+pub fn price_feed_bucket<'a>(storage: &'a mut dyn Storage) -> Bucket<'a, PriceFeed> {
     bucket(storage, PRICE_FEED_KEY)
 }
 
-pub fn price_feed_read_bucket(storage: &dyn Storage) -> ReadonlyBucket<PriceFeed> {
+pub fn price_feed_read_bucket<'a>(storage: &'a dyn Storage) -> ReadonlyBucket<'a, PriceFeed> {
     bucket_read(storage, PRICE_FEED_KEY)
 }
 


### PR DESCRIPTION
## Summary

Fixes [[i-ukxcqqyy]]: restores green status to the `Test CosmWasm Contract` CI workflow by:

- Adding explicit `'a` lifetimes to the four storage helper functions in `target_chains/cosmwasm/contracts/pyth/src/state.rs` (`config`, `config_read`, `price_feed_bucket`, `price_feed_read_bucket`) to resolve rustc 1.89's `mismatched_lifetime_syntaxes` lint warnings that fail `cargo clippy --all-targets -- --deny warnings`.
- Bumping `actions/checkout@v2` → `actions/checkout@v4` in `.github/workflows/ci-cosmwasm-contract.yml`.

No new `#[allow(...)]` attributes or `unsafe` blocks introduced.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->