### PR TITLE
fix(ci): add --locked to cargo-stylus install, bump checkout@v5

### DIFF
--- a/.github/workflows/ci-stylus-check-wasm.yml
+++ b/.github/workflows/ci-stylus-check-wasm.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - target_chains/ethereum/sdk/stylus/**
+      - .github/workflows/ci-stylus-check-wasm.yml
   push:
     branches:
       - main
@@ -23,13 +24,13 @@ jobs:
       run:
         working-directory: target_chains/ethereum/sdk/stylus
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
       - name: Install cargo-stylus
-        run: cargo install cargo-stylus@0.5.8
+        run: cargo install --locked cargo-stylus@0.5.8
       - name: Run wasm check
         run: ./scripts/check-wasm.sh


### PR DESCRIPTION
## Summary

Fixes the failing `stylus-check-wasm` CI job by making three targeted changes to `.github/workflows/ci-stylus-check-wasm.yml`:

1. **Add `--locked` to `cargo install cargo-stylus@0.5.8`** — pins transitive deps via the published `Cargo.lock`, preventing `ruint` from resolving to v1.18.0 which requires rustc 1.90
2. **Bump `actions/checkout@v4` → `@v5`** — resolves Node-20 deprecation warning
3. **Add workflow path to `pull_request.paths` trigger** — ensures the CI job runs on PRs that modify only the workflow file

Resolves [[i-izfuufga]].
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->