### PR TITLE
fix(pythnet_sdk): fix example compile error and bump actions/checkout to v4

### DIFF
--- a/.github/workflows/ci-pythnet-sdk.yml
+++ b/.github/workflows/ci-pythnet-sdk.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         working-directory: pythnet/pythnet_sdk
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Format check
         run: cargo fmt --all -- --check

--- a/pythnet/pythnet_sdk/examples/generate_pyth_data.rs
+++ b/pythnet/pythnet_sdk/examples/generate_pyth_data.rs
@@ -113,7 +113,8 @@ fn main() {
         for i in 0..10_000u32 {
             let (accumulator_account, _) = Pubkey::find_program_address(
                 &[b"AccumulatorState", &PYTH_PID, &i.to_be_bytes()],
-                &solana_sdk::system_program::id(),
+                // System Program ID is the zero pubkey.
+                &Pubkey::default(),
             );
             file.write_all(format!("{accumulator_account}\n").as_bytes())
                 .unwrap();


### PR DESCRIPTION
## Summary
- Replace `solana_sdk::system_program::id()` with `Pubkey::default()` in `generate_pyth_data` example to fix compile error with solana-sdk v4 (system_program module was moved out)
- Bump `actions/checkout` from `@v2` to `@v4` in `ci-pythnet-sdk.yml`

## Details
The System Program ID is the well-known all-zeros pubkey (`11111111111111111111111111111111`), so `Pubkey::default()` preserves the exact same behavior without requiring additional dependencies.

All acceptance criteria verified locally:
- `cargo clippy -p pythnet-sdk --all-targets -- --deny warnings` passes
- `cargo fmt --all -- --check` passes
- `cargo test -p pythnet-sdk` passes (23 passed)

Resolves [[i-qdzpxbqu]]