### PR TITLE
fix(fortuna): fix clippy warnings and bump checkout action to v4

### DIFF
--- a/.github/workflows/ci-fortuna.yml
+++ b/.github/workflows/ci-fortuna.yml
@@ -15,7 +15,7 @@ jobs:
       run:
         working-directory: apps/fortuna
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Format check
         run: cargo fmt --all -- --check

--- a/apps/fortuna/src/command/run.rs
+++ b/apps/fortuna/src/command/run.rs
@@ -12,7 +12,7 @@ use {
     anyhow::{anyhow, Error, Result},
     axum::Router,
     ethers::types::Address,
-    prometheus_client::{encoding::EncodeLabelSet, registry::Registry},
+    prometheus_client::registry::Registry,
     std::{collections::HashMap, net::SocketAddr, sync::Arc},
     tokio::{
         spawn,
@@ -331,9 +331,4 @@ async fn setup_chain_state(
         confirmed_block_status: chain_config.confirmed_block_status,
     };
     Ok(state)
-}
-
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
-pub struct ChainLabel {
-    pub chain_id: String,
 }

--- a/apps/fortuna/src/history.rs
+++ b/apps/fortuna/src/history.rs
@@ -3,7 +3,7 @@ use {
     anyhow::Result,
     chrono::DateTime,
     ethers::{
-        core::utils::hex::ToHex,
+        core::utils::hex::ToHexExt,
         prelude::TxHash,
         types::{Address, Bytes, U256},
         utils::keccak256,
@@ -417,7 +417,7 @@ impl History {
         }
     }
 
-    pub fn query(&self) -> RequestQueryBuilder {
+    pub fn query(&self) -> RequestQueryBuilder<'_> {
         RequestQueryBuilder::new(&self.pool)
     }
 }
@@ -770,10 +770,7 @@ mod test {
 
         let logs = history
             .query()
-            .search(format!(
-                "0x{}",
-                status.request_tx_hash.encode_hex::<String>()
-            ))
+            .search(format!("0x{}", status.request_tx_hash.encode_hex()))
             .unwrap()
             .execute()
             .await
@@ -782,7 +779,7 @@ mod test {
 
         let logs = history
             .query()
-            .search(status.request_tx_hash.encode_hex::<String>().to_uppercase())
+            .search(status.request_tx_hash.encode_hex().to_uppercase())
             .unwrap()
             .execute()
             .await
@@ -793,7 +790,7 @@ mod test {
             .query()
             .search(format!(
                 "0x{}",
-                status.request_tx_hash.encode_hex::<String>().to_uppercase()
+                status.request_tx_hash.encode_hex().to_uppercase()
             ))
             .unwrap()
             .execute()
@@ -822,7 +819,7 @@ mod test {
 
         let logs = history
             .query()
-            .search(format!("0x{}", reveal_tx_hash.encode_hex::<String>()))
+            .search(format!("0x{}", reveal_tx_hash.encode_hex()))
             .unwrap()
             .execute()
             .await
@@ -831,7 +828,7 @@ mod test {
 
         let logs = history
             .query()
-            .search(reveal_tx_hash.encode_hex::<String>().to_uppercase())
+            .search(reveal_tx_hash.encode_hex().to_uppercase())
             .unwrap()
             .execute()
             .await
@@ -840,10 +837,7 @@ mod test {
 
         let logs = history
             .query()
-            .search(format!(
-                "0x{}",
-                reveal_tx_hash.encode_hex::<String>().to_uppercase()
-            ))
+            .search(format!("0x{}", reveal_tx_hash.encode_hex().to_uppercase()))
             .unwrap()
             .execute()
             .await
@@ -872,7 +866,7 @@ mod test {
 
         let logs = history
             .query()
-            .search(format!("0x{}", status.sender.encode_hex::<String>()))
+            .search(format!("0x{}", status.sender.encode_hex()))
             .unwrap()
             .network_id(status.network_id)
             .execute()
@@ -882,7 +876,7 @@ mod test {
 
         let logs = history
             .query()
-            .search(status.sender.encode_hex::<String>().to_uppercase())
+            .search(status.sender.encode_hex().to_uppercase())
             .unwrap()
             .network_id(status.network_id)
             .execute()
@@ -892,10 +886,7 @@ mod test {
 
         let logs = history
             .query()
-            .search(format!(
-                "0x{}",
-                status.sender.encode_hex::<String>().to_uppercase()
-            ))
+            .search(format!("0x{}", status.sender.encode_hex().to_uppercase()))
             .unwrap()
             .network_id(status.network_id)
             .execute()


### PR DESCRIPTION
## Summary

Fixes all Clippy warnings blocking the `Check Fortuna` CI workflow on `main` (Rust 1.89) and bumps the deprecated `actions/checkout@v2` to `@v4`.

### Changes

- **`apps/fortuna/src/history.rs`**: Replaced deprecated `ToHex` import with `ToHexExt`, removed `::<String>()` turbofish from `encode_hex` calls (new trait returns `String` directly), added explicit `<'_>` lifetime on `query()` return type per `mismatched_lifetime_syntaxes` lint.
- **`apps/fortuna/src/command/run.rs`**: Deleted unused `ChainLabel` struct (orphaned dead code — no references found anywhere in the workspace) and removed its now-unused `EncodeLabelSet` import.
- **`.github/workflows/ci-fortuna.yml`**: Bumped `actions/checkout@v2` → `@v4` (scoped to this workflow only).

### ChainLabel disposition

Deleted. A workspace-wide grep confirmed zero references outside the struct definition itself. The struct was orphaned after a prior metrics refactor.

### Verification

- `cargo clippy -p fortuna --all-targets -- --deny warnings` exits 0
- `cargo fmt --all -- --check` exits 0
- No behavioral changes — all diffs are mechanical refactors + a YAML version bump
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->