### PR TITLE
fix(starknet): fix Check Starknet Tools CI by clearing RUSTFLAGS for scarb

### DIFF
--- a/.github/workflows/ci-starknet-tools.yml
+++ b/.github/workflows/ci-starknet-tools.yml
@@ -13,7 +13,7 @@ jobs:
       run:
         working-directory: target_chains/starknet/tools/test_vaas
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install Scarb
         uses: software-mansion/setup-scarb@v1
@@ -34,7 +34,7 @@ jobs:
       - name: Check test data
         run: |
           . ~/.config/.starkli/env && cargo run --bin generate_test_data > ../../contracts/data.cairo
-          cd ../../contracts && scarb fmt data.cairo
+          cd ../../contracts && RUSTFLAGS="" scarb fmt data.cairo
           if ! diff ./tests/data.cairo data.cairo; then
             >&2 echo "Re-run generate_test_data to update data.cairo"
             exit 1

--- a/target_chains/starknet/tools/test_vaas/src/bin/generate_test_data.rs
+++ b/target_chains/starknet/tools/test_vaas/src/bin/generate_test_data.rs
@@ -336,13 +336,18 @@ fn main() {
     );
 
     let contracts_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../contracts");
-    let status = Command::new("scarb")
+    let output = Command::new("scarb")
         .arg("build")
         .current_dir(&contracts_dir)
+        .env_remove("RUSTFLAGS")
         .output()
-        .unwrap()
-        .status;
-    assert!(status.success(), "scarb failed with {status:?}");
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "scarb failed with {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     let upgrade_hashes = [
         ("fake1", get_class_hash("fake_upgrade1", &contracts_dir)),


### PR DESCRIPTION
## Summary

Fixes the `Check Starknet Tools` CI workflow, which has been failing on every push to `main` since 2026-04-30 (80+ consecutive failures).

### Failing step and error

**Step:** `Check test data`  
**Last lines of log from run 26649940487:**
```
Running generate_test_data
thread 'main' panicked at generate_test_data.rs:345:5:
scarb failed with ExitStatus(unix_wait_status(256))
Process completed with exit code 101.
```

### Root cause

`RUSTFLAGS=-D warnings` (set by `setup-rust-toolchain`) leaks into `scarb build` and `scarb fmt`. Scarb internally compiles `snforge_scarb_plugin v0.38.3` from Rust source. Under Rust 1.89.0, newly promoted warnings in the plugin dependencies become hard errors.

The workflow broke on the exact commit that bumped `rust-toolchain.toml` from 1.88.0 to 1.89.0 (last green = 6a6daf6dac48 at 1.88.0, first red = d24a0d83df48 at 1.89.0).

### Changes

1. `generate_test_data.rs`: Clear RUSTFLAGS via `.env_remove("RUSTFLAGS")` when spawning `scarb build`. Also improved panic message to include stderr.
2. `ci-starknet-tools.yml`: Clear RUSTFLAGS before `scarb fmt`.
3. `ci-starknet-tools.yml`: Bump `actions/checkout@v3` to `@v4`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->