### PR TITLE
feat(price_pusher): add EIP-1559 gas model to EVM pusher

### DIFF
--- a/apps/price_pusher/README.md
+++ b/apps/price_pusher/README.md
@@ -104,7 +104,18 @@ pnpm run start evm --endpoint wss://example-rpc.com \
     [--override-gas-price-multiplier 1.1] \
     [--override-gas-price-multiplier-cap 5] \
     [--gas-limit 1000000] \
+    [--gas-pricing-strategy eip1559] \
+    [--base-fee-multiplier 1.2] \
+    [--priority-fee-multiplier 1] \
     [--gas-price 160000000]
+
+# The EVM pusher prices transactions with the `eip1559` strategy by default. It
+# computes `maxFeePerGas` from the chain base fee (padded by `--base-fee-multiplier`
+# to leave headroom for the base fee growing between blocks) plus an estimated
+# priority fee (scaled by `--priority-fee-multiplier`). This avoids the deprecated
+# `eth_gasPrice` RPC, which some RPCs mishandle. For chains that do not support
+# EIP-1559 transactions, pass `--gas-pricing-strategy legacy`, which falls back to
+# the single `gasPrice` model and where `--gas-price` / `--custom-gas-station` apply.
 
 # For Injective
 pnpm run start injective --grpc-endpoint https://grpc-endpoint.com \

--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -89,6 +89,10 @@
       "default": "./dist/evm/evm.cjs",
       "types": "./dist/evm/evm.d.ts"
     },
+    "./evm/gas-price": {
+      "default": "./dist/evm/gas-price.cjs",
+      "types": "./dist/evm/gas-price.d.ts"
+    },
     "./evm/pyth-abi": {
       "default": "./dist/evm/pyth-abi.cjs",
       "types": "./dist/evm/pyth-abi.d.ts"
@@ -215,9 +219,10 @@
     "dev": "ts-node src/index.ts",
     "prepublishOnly": "pnpm run build",
     "start": "node dist/index.cjs",
-    "test:types": "tsc"
+    "test:types": "tsc",
+    "test:unit": "test-unit"
   },
   "type": "module",
   "types": "./dist/index.d.ts",
-  "version": "10.5.0"
+  "version": "10.6.0"
 }

--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -224,5 +224,5 @@
   },
   "type": "module",
   "types": "./dist/index.d.ts",
-  "version": "10.6.0"
+  "version": "11.0.0"
 }

--- a/apps/price_pusher/src/common.ts
+++ b/apps/price_pusher/src/common.ts
@@ -1,6 +1,0 @@
-import type { GasPrice } from "./evm/gas-price.js";
-
-export type PushAttempt = {
-  nonce: number;
-  gasPrice: GasPrice;
-};

--- a/apps/price_pusher/src/common.ts
+++ b/apps/price_pusher/src/common.ts
@@ -1,4 +1,6 @@
+import type { GasPrice } from "./evm/gas-price.js";
+
 export type PushAttempt = {
   nonce: number;
-  gasPrice: number;
+  gasPrice: GasPrice;
 };

--- a/apps/price_pusher/src/evm/__tests__/gas-price.test.ts
+++ b/apps/price_pusher/src/evm/__tests__/gas-price.test.ts
@@ -1,0 +1,240 @@
+import type { Logger } from "pino";
+
+import type { CustomGasStation } from "../custom-gas-station.js";
+import type { GasPrice } from "../gas-price.js";
+import {
+  describeGasPrice,
+  gasPriceToTxParams,
+  getGasPrice,
+  maxGasPrice,
+  minGasPrice,
+  scaleGasPrice,
+} from "../gas-price.js";
+import type { SuperWalletClient } from "../super-wallet.js";
+
+const logger = {
+  debug: () => {
+    /* no-op */
+  },
+} as unknown as Logger;
+
+// Build a minimal client stub exposing only the methods getGasPrice uses.
+const makeClient = (overrides: Record<string, unknown>): SuperWalletClient =>
+  overrides as unknown as SuperWalletClient;
+
+describe("getGasPrice (legacy strategy)", () => {
+  const baseConfig = {
+    baseFeeMultiplier: 1.2,
+    priorityFeeMultiplier: 1,
+    strategy: "legacy" as const,
+  };
+
+  it("uses the explicit gasPrice override when provided", async () => {
+    const client = makeClient({
+      getGasPrice: () => Promise.resolve(999n),
+    });
+
+    const result = await getGasPrice(
+      client,
+      { ...baseConfig, gasPrice: 1234 },
+      logger,
+    );
+
+    expect(result).toStrictEqual({ gasPrice: 1234n, strategy: "legacy" });
+  });
+
+  it("prefers the custom gas station over the RPC gas price", async () => {
+    const client = makeClient({
+      getGasPrice: () => Promise.resolve(999n),
+    });
+    const customGasStation = {
+      getCustomGasPrice: () => Promise.resolve(500n),
+    } as unknown as CustomGasStation;
+
+    const result = await getGasPrice(
+      client,
+      { ...baseConfig, customGasStation },
+      logger,
+    );
+
+    expect(result).toStrictEqual({ gasPrice: 500n, strategy: "legacy" });
+  });
+
+  it("falls back to the RPC gas price", async () => {
+    const client = makeClient({
+      getGasPrice: () => Promise.resolve(777n),
+    });
+
+    const result = await getGasPrice(client, baseConfig, logger);
+
+    expect(result).toStrictEqual({ gasPrice: 777n, strategy: "legacy" });
+  });
+});
+
+describe("getGasPrice (eip1559 strategy)", () => {
+  it("computes maxFeePerGas from the padded base fee plus the scaled priority fee", async () => {
+    const client = makeClient({
+      estimateMaxPriorityFeePerGas: () => Promise.resolve(10n),
+      getBlock: () => Promise.resolve({ baseFeePerGas: 100n }),
+    });
+
+    const result = await getGasPrice(
+      client,
+      {
+        baseFeeMultiplier: 1.5,
+        priorityFeeMultiplier: 2,
+        strategy: "eip1559",
+      },
+      logger,
+    );
+
+    // priorityFee = 10 * 2 = 20; maxFee = 100 * 1.5 + 20 = 170
+    expect(result).toStrictEqual({
+      maxFeePerGas: 170n,
+      maxPriorityFeePerGas: 20n,
+      strategy: "eip1559",
+    });
+  });
+
+  it("throws a clear error when the chain has no base fee", async () => {
+    const client = makeClient({
+      estimateMaxPriorityFeePerGas: () => Promise.resolve(10n),
+      // eslint-disable-next-line unicorn/no-null
+      getBlock: () => Promise.resolve({ baseFeePerGas: null }),
+    });
+
+    await expect(
+      getGasPrice(
+        client,
+        {
+          baseFeeMultiplier: 1.2,
+          priorityFeeMultiplier: 1,
+          strategy: "eip1559",
+        },
+        logger,
+      ),
+    ).rejects.toThrow(/legacy/);
+  });
+});
+
+describe("scaleGasPrice", () => {
+  it("scales the single fee in legacy mode", () => {
+    const scaled = scaleGasPrice({ gasPrice: 100n, strategy: "legacy" }, 1.1);
+    expect(scaled).toStrictEqual({ gasPrice: 110n, strategy: "legacy" });
+  });
+
+  it("scales both fee components in eip1559 mode", () => {
+    const scaled = scaleGasPrice(
+      { maxFeePerGas: 200n, maxPriorityFeePerGas: 20n, strategy: "eip1559" },
+      1.5,
+    );
+    expect(scaled).toStrictEqual({
+      maxFeePerGas: 300n,
+      maxPriorityFeePerGas: 30n,
+      strategy: "eip1559",
+    });
+  });
+});
+
+describe("maxGasPrice / minGasPrice", () => {
+  const low: GasPrice = { gasPrice: 100n, strategy: "legacy" };
+  const high: GasPrice = { gasPrice: 200n, strategy: "legacy" };
+
+  it("max picks the higher bid", () => {
+    expect(maxGasPrice(low, high)).toBe(high);
+  });
+
+  it("min picks the lower bid", () => {
+    expect(minGasPrice(low, high)).toBe(low);
+  });
+
+  it("compares eip1559 prices by maxFeePerGas", () => {
+    const a: GasPrice = {
+      maxFeePerGas: 300n,
+      maxPriorityFeePerGas: 5n,
+      strategy: "eip1559",
+    };
+    const b: GasPrice = {
+      maxFeePerGas: 250n,
+      maxPriorityFeePerGas: 50n,
+      strategy: "eip1559",
+    };
+    expect(maxGasPrice(a, b)).toBe(a);
+    expect(minGasPrice(a, b)).toBe(b);
+  });
+});
+
+describe("override + cap composition (as used by the pusher)", () => {
+  // Mirrors the escalation logic in evm.ts: bump the last attempt by the
+  // override multiplier, but cap it relative to the fresh gas price.
+  const escalate = (
+    fresh: GasPrice,
+    lastAttempt: GasPrice,
+    multiplier: number,
+    cap: number,
+  ): GasPrice =>
+    minGasPrice(
+      maxGasPrice(scaleGasPrice(lastAttempt, multiplier), fresh),
+      scaleGasPrice(fresh, cap),
+    );
+
+  it("keeps the fresh price when the override is not higher", () => {
+    const fresh: GasPrice = { gasPrice: 200n, strategy: "legacy" };
+    const lastAttempt: GasPrice = { gasPrice: 100n, strategy: "legacy" };
+    // override = 100 * 1.1 = 110 < 200 -> keep fresh
+    expect(escalate(fresh, lastAttempt, 1.1, 5)).toStrictEqual(fresh);
+  });
+
+  it("bumps to the escalated override when it exceeds the fresh price", () => {
+    const fresh: GasPrice = { gasPrice: 100n, strategy: "legacy" };
+    const lastAttempt: GasPrice = { gasPrice: 200n, strategy: "legacy" };
+    // override = 200 * 1.1 = 220; cap = 100 * 5 = 500 -> 220
+    expect(escalate(fresh, lastAttempt, 1.1, 5)).toStrictEqual({
+      gasPrice: 220n,
+      strategy: "legacy",
+    });
+  });
+
+  it("caps the override at fresh * cap", () => {
+    const fresh: GasPrice = { gasPrice: 100n, strategy: "legacy" };
+    const lastAttempt: GasPrice = { gasPrice: 1000n, strategy: "legacy" };
+    // override = 1000 * 2 = 2000; cap = 100 * 3 = 300 -> 300
+    expect(escalate(fresh, lastAttempt, 2, 3)).toStrictEqual({
+      gasPrice: 300n,
+      strategy: "legacy",
+    });
+  });
+});
+
+describe("gasPriceToTxParams", () => {
+  it("emits gasPrice for legacy", () => {
+    expect(
+      gasPriceToTxParams({ gasPrice: 100n, strategy: "legacy" }),
+    ).toStrictEqual({ gasPrice: 100n });
+  });
+
+  it("emits maxFeePerGas and maxPriorityFeePerGas for eip1559", () => {
+    expect(
+      gasPriceToTxParams({
+        maxFeePerGas: 200n,
+        maxPriorityFeePerGas: 20n,
+        strategy: "eip1559",
+      }),
+    ).toStrictEqual({ maxFeePerGas: 200n, maxPriorityFeePerGas: 20n });
+  });
+});
+
+describe("describeGasPrice", () => {
+  it("describes legacy and eip1559 prices", () => {
+    expect(describeGasPrice({ gasPrice: 100n, strategy: "legacy" })).toBe(
+      "gasPrice=100",
+    );
+    expect(
+      describeGasPrice({
+        maxFeePerGas: 200n,
+        maxPriorityFeePerGas: 20n,
+        strategy: "eip1559",
+      }),
+    ).toBe("maxFeePerGas=200 maxPriorityFeePerGas=20");
+  });
+});

--- a/apps/price_pusher/src/evm/__tests__/gas-price.test.ts
+++ b/apps/price_pusher/src/evm/__tests__/gas-price.test.ts
@@ -4,10 +4,9 @@ import type { CustomGasStation } from "../custom-gas-station.js";
 import type { GasPrice } from "../gas-price.js";
 import {
   describeGasPrice,
+  escalateGasPrice,
   gasPriceToTxParams,
   getGasPrice,
-  maxGasPrice,
-  minGasPrice,
   scaleGasPrice,
 } from "../gas-price.js";
 import type { SuperWalletClient } from "../super-wallet.js";
@@ -136,47 +135,16 @@ describe("scaleGasPrice", () => {
   });
 });
 
-describe("maxGasPrice / minGasPrice", () => {
-  const low: GasPrice = { gasPrice: 100n, strategy: "legacy" };
-  const high: GasPrice = { gasPrice: 200n, strategy: "legacy" };
-
-  it("max picks the higher bid", () => {
-    expect(maxGasPrice(low, high)).toBe(high);
-  });
-
-  it("min picks the lower bid", () => {
-    expect(minGasPrice(low, high)).toBe(low);
-  });
-
-  it("compares eip1559 prices by maxFeePerGas", () => {
-    const a: GasPrice = {
-      maxFeePerGas: 300n,
-      maxPriorityFeePerGas: 5n,
-      strategy: "eip1559",
-    };
-    const b: GasPrice = {
-      maxFeePerGas: 250n,
-      maxPriorityFeePerGas: 50n,
-      strategy: "eip1559",
-    };
-    expect(maxGasPrice(a, b)).toBe(a);
-    expect(minGasPrice(a, b)).toBe(b);
-  });
-});
-
-describe("override + cap composition (as used by the pusher)", () => {
-  // Mirrors the escalation logic in evm.ts: bump the last attempt by the
-  // override multiplier, but cap it relative to the fresh gas price.
+describe("escalateGasPrice (override a stuck tx, as used by the pusher)", () => {
+  // The pusher escalates the last attempt by the override multiplier before
+  // calling escalateGasPrice with the fresh price and the cap.
   const escalate = (
     fresh: GasPrice,
     lastAttempt: GasPrice,
     multiplier: number,
     cap: number,
   ): GasPrice =>
-    minGasPrice(
-      maxGasPrice(scaleGasPrice(lastAttempt, multiplier), fresh),
-      scaleGasPrice(fresh, cap),
-    );
+    escalateGasPrice(fresh, scaleGasPrice(lastAttempt, multiplier), cap);
 
   it("keeps the fresh price when the override is not higher", () => {
     const fresh: GasPrice = { gasPrice: 200n, strategy: "legacy" };
@@ -202,6 +170,50 @@ describe("override + cap composition (as used by the pusher)", () => {
     expect(escalate(fresh, lastAttempt, 2, 3)).toStrictEqual({
       gasPrice: 300n,
       strategy: "legacy",
+    });
+  });
+
+  it("escalates maxPriorityFeePerGas independently so the replacement is accepted", () => {
+    // Regression test: base fee rose but the tip dropped. Selecting purely by
+    // maxFeePerGas would pick the fresh price and leave the tip below the stuck
+    // tx's, which nodes reject as an underpriced replacement.
+    const fresh: GasPrice = {
+      maxFeePerGas: 200n,
+      maxPriorityFeePerGas: 10n,
+      strategy: "eip1559",
+    };
+    const lastAttempt: GasPrice = {
+      maxFeePerGas: 150n,
+      maxPriorityFeePerGas: 50n,
+      strategy: "eip1559",
+    };
+    // override = {165, 55}. Per component: maxFee = max(165,200)=200;
+    // priority = max(55,10)=55. Both exceed the stuck tx, so the replacement
+    // is accepted. Cap (5x) does not bind.
+    expect(escalate(fresh, lastAttempt, 1.1, 5)).toStrictEqual({
+      maxFeePerGas: 200n,
+      maxPriorityFeePerGas: 55n,
+      strategy: "eip1559",
+    });
+  });
+
+  it("caps total spend via maxFeePerGas and bounds the tip by it", () => {
+    const fresh: GasPrice = {
+      maxFeePerGas: 100n,
+      maxPriorityFeePerGas: 10n,
+      strategy: "eip1559",
+    };
+    const lastAttempt: GasPrice = {
+      maxFeePerGas: 1000n,
+      maxPriorityFeePerGas: 1000n,
+      strategy: "eip1559",
+    };
+    // override = {2000, 2000}; maxFeePerGas capped at 100 * 3 = 300; the tip is
+    // bounded by the capped maxFeePerGas (priority <= maxFee), so it lands at 300.
+    expect(escalate(fresh, lastAttempt, 2, 3)).toStrictEqual({
+      maxFeePerGas: 300n,
+      maxPriorityFeePerGas: 300n,
+      strategy: "eip1559",
     });
   });
 });

--- a/apps/price_pusher/src/evm/command.ts
+++ b/apps/price_pusher/src/evm/command.ts
@@ -23,6 +23,15 @@ import { createClient } from "./super-wallet.js";
 
 export default {
   builder: {
+    "base-fee-multiplier": {
+      default: 1.2,
+      description:
+        "[eip1559 strategy only] Multiplier applied to the chain base fee when computing " +
+        "maxFeePerGas. Values above 1 leave headroom for the base fee to grow between blocks. " +
+        "Default to 1.2",
+      required: false,
+      type: "number",
+    } as Options,
     "custom-gas-station": {
       description:
         "If using a custom gas station, chainId of custom gas station to use",
@@ -45,9 +54,20 @@ export default {
       type: "number",
     } as Options,
     "gas-price": {
-      description: "Override the gas price that would be received from the RPC",
+      description:
+        "[legacy strategy only] Override the gas price (in wei) that would be received from the RPC",
       required: false,
       type: "number",
+    } as Options,
+    "gas-pricing-strategy": {
+      choices: ["eip1559", "legacy"],
+      default: "eip1559",
+      description:
+        "How to price transactions. 'eip1559' (default and recommended) sources the " +
+        "gas from the chain base fee and a priority fee, which is more robust as it " +
+        "avoids the deprecated eth_gasPrice RPC. Use 'legacy' for chains that do not " +
+        "support eip1559 transactions.",
+      required: false,
     } as Options,
     "override-gas-price-multiplier": {
       default: 1.1,
@@ -64,6 +84,14 @@ export default {
       description:
         "Maximum gas price multiplier to use in override compared to the RPC returned " +
         "gas price. Default to 5",
+      required: false,
+      type: "number",
+    } as Options,
+    "priority-fee-multiplier": {
+      default: 1,
+      description:
+        "[eip1559 strategy only] Multiplier applied to the priority fee (tip) estimated from " +
+        "the RPC. Default to 1",
       required: false,
       type: "number",
     } as Options,
@@ -112,7 +140,10 @@ export default {
       overrideGasPriceMultiplier,
       overrideGasPriceMultiplierCap,
       gasLimit,
+      gasPricingStrategy,
       gasPrice,
+      baseFeeMultiplier,
+      priorityFeeMultiplier,
       updateFeeMultiplier,
       logLevel,
       controllerLogLevel,
@@ -188,6 +219,23 @@ export default {
       customGasStation,
       txSpeed,
     );
+
+    if (gasPricingStrategy === "eip1559" && (gasStation || gasPrice)) {
+      logger.warn(
+        "`--custom-gas-station`/`--tx-speed` and `--gas-price` only apply to the 'legacy' " +
+          "gas pricing strategy and will be ignored. Use `--base-fee-multiplier` and " +
+          "`--priority-fee-multiplier` to tune the 'eip1559' strategy.",
+      );
+    }
+
+    const gasPriceConfig = {
+      baseFeeMultiplier,
+      customGasStation: gasStation,
+      gasPrice,
+      priorityFeeMultiplier,
+      strategy: gasPricingStrategy,
+    };
+
     const evmPusher = new EvmPricePusher(
       hermesClient,
       client,
@@ -196,9 +244,8 @@ export default {
       overrideGasPriceMultiplier,
       overrideGasPriceMultiplierCap,
       updateFeeMultiplier,
+      gasPriceConfig,
       gasLimit,
-      gasStation,
-      gasPrice,
     );
 
     const controller = new Controller(

--- a/apps/price_pusher/src/evm/evm.ts
+++ b/apps/price_pusher/src/evm/evm.ts
@@ -20,12 +20,11 @@ import {
   TransactionExecutionError,
 } from "viem";
 
-import type { PushAttempt } from "../common.js";
 import type { IPricePusher, PriceInfo, PriceItem } from "../interface.js";
 import { ChainPriceListener } from "../interface.js";
 import type { DurationInSeconds } from "../utils.js";
 import { addLeading0x, assertDefined, removeLeading0x } from "../utils.js";
-import type { GasPriceConfig } from "./gas-price.js";
+import type { GasPrice, GasPriceConfig } from "./gas-price.js";
 import {
   describeGasPrice,
   escalateGasPrice,
@@ -36,6 +35,11 @@ import {
 import type { PythAbi } from "./pyth-abi.js";
 import type { PythContract } from "./pyth-contract.js";
 import type { SuperWalletClient } from "./super-wallet.js";
+
+type PushAttempt = {
+  nonce: number;
+  gasPrice: GasPrice;
+};
 
 export class EvmPriceListener extends ChainPriceListener {
   constructor(

--- a/apps/price_pusher/src/evm/evm.ts
+++ b/apps/price_pusher/src/evm/evm.ts
@@ -28,10 +28,9 @@ import { addLeading0x, assertDefined, removeLeading0x } from "../utils.js";
 import type { GasPriceConfig } from "./gas-price.js";
 import {
   describeGasPrice,
+  escalateGasPrice,
   gasPriceToTxParams,
   getGasPrice,
-  maxGasPrice,
-  minGasPrice,
   scaleGasPrice,
 } from "./gas-price.js";
 import type { PythAbi } from "./pyth-abi.js";
@@ -219,11 +218,12 @@ export class EvmPricePusher implements IPricePusher {
     }
 
     if (gasPriceToOverride !== undefined) {
-      // Bump the gas price to override the stuck transaction, but cap the bump
-      // relative to the fresh gas price returned by the RPC.
-      gasPrice = minGasPrice(
-        maxGasPrice(gasPriceToOverride, gasPrice),
-        scaleGasPrice(gasPrice, this.overrideGasPriceMultiplierCap),
+      // Bump every fee component to override the stuck transaction, capping the
+      // bump relative to the fresh gas price returned by the RPC.
+      gasPrice = escalateGasPrice(
+        gasPrice,
+        gasPriceToOverride,
+        this.overrideGasPriceMultiplierCap,
       );
     }
 

--- a/apps/price_pusher/src/evm/evm.ts
+++ b/apps/price_pusher/src/evm/evm.ts
@@ -25,7 +25,15 @@ import type { IPricePusher, PriceInfo, PriceItem } from "../interface.js";
 import { ChainPriceListener } from "../interface.js";
 import type { DurationInSeconds } from "../utils.js";
 import { addLeading0x, assertDefined, removeLeading0x } from "../utils.js";
-import type { CustomGasStation } from "./custom-gas-station";
+import type { GasPriceConfig } from "./gas-price.js";
+import {
+  describeGasPrice,
+  gasPriceToTxParams,
+  getGasPrice,
+  maxGasPrice,
+  minGasPrice,
+  scaleGasPrice,
+} from "./gas-price.js";
 import type { PythAbi } from "./pyth-abi.js";
 import type { PythContract } from "./pyth-contract.js";
 import type { SuperWalletClient } from "./super-wallet.js";
@@ -132,9 +140,8 @@ export class EvmPricePusher implements IPricePusher {
     private overrideGasPriceMultiplier: number,
     private overrideGasPriceMultiplierCap: number,
     private updateFeeMultiplier: number,
+    private gasPriceConfig: GasPriceConfig,
     private gasLimit?: number,
-    private customGasStation?: CustomGasStation,
-    private gasPrice?: number,
   ) {}
 
   // The pubTimes are passed here to use the values that triggered the push.
@@ -180,16 +187,15 @@ export class EvmPricePusher implements IPricePusher {
       throw error;
     }
 
-    // Gas price in networks with transaction type eip1559 represents the
-    // addition of baseFee and priorityFee required to land the transaction. We
-    // are using this to remain compatible with the networks that doesn't
-    // support this transaction type.
-    let gasPrice =
-      this.gasPrice ??
-      Number(
-        await (this.customGasStation?.getCustomGasPrice() ??
-          this.client.getGasPrice()),
-      );
+    // Fetch a fresh gas price. With the eip1559 strategy this is sourced from
+    // the chain base fee and priority fee (avoiding the deprecated eth_gasPrice
+    // RPC); with the legacy strategy it falls back to the single gasPrice model
+    // for chains that don't support eip1559 transactions.
+    let gasPrice = await getGasPrice(
+      this.client,
+      this.gasPriceConfig,
+      this.logger,
+    );
 
     // Try to re-use the same nonce and increase the gas if the last tx is not landed yet.
     this.pusherAddress ??= this.client.account.address;
@@ -205,24 +211,27 @@ export class EvmPricePusher implements IPricePusher {
       if (this.lastPushAttempt.nonce <= lastExecutedNonce) {
         this.lastPushAttempt = undefined;
       } else {
-        gasPriceToOverride =
-          this.lastPushAttempt.gasPrice * this.overrideGasPriceMultiplier;
+        gasPriceToOverride = scaleGasPrice(
+          this.lastPushAttempt.gasPrice,
+          this.overrideGasPriceMultiplier,
+        );
       }
     }
 
-    if (
-      gasPriceToOverride !== undefined &&
-      gasPriceToOverride > Number(gasPrice)
-    ) {
-      gasPrice = Math.min(
-        gasPriceToOverride,
-        gasPrice * this.overrideGasPriceMultiplierCap,
+    if (gasPriceToOverride !== undefined) {
+      // Bump the gas price to override the stuck transaction, but cap the bump
+      // relative to the fresh gas price returned by the RPC.
+      gasPrice = minGasPrice(
+        maxGasPrice(gasPriceToOverride, gasPrice),
+        scaleGasPrice(gasPrice, this.overrideGasPriceMultiplierCap),
       );
     }
 
     const txNonce = lastExecutedNonce + 1;
 
-    this.logger.debug(`Using gas price: ${gasPrice} and nonce: ${txNonce}`);
+    this.logger.debug(
+      `Using ${describeGasPrice(gasPrice)} and nonce: ${txNonce}`,
+    );
 
     const pubTimesToPushParam = pubTimesToPush.map(BigInt);
 
@@ -243,7 +252,7 @@ export class EvmPricePusher implements IPricePusher {
               this.gasLimit === undefined
                 ? undefined
                 : BigInt(Math.ceil(this.gasLimit)),
-            gasPrice: BigInt(Math.ceil(gasPrice)),
+            ...gasPriceToTxParams(gasPrice),
             nonce: txNonce,
             value: updateFee,
           },

--- a/apps/price_pusher/src/evm/gas-price.ts
+++ b/apps/price_pusher/src/evm/gas-price.ts
@@ -93,18 +93,63 @@ export const scaleGasPrice = (gasPrice: GasPrice, factor: number): GasPrice => {
   };
 };
 
-// The scalar that represents how much we are bidding to land the transaction.
-// Used to compare two gas prices when deciding whether to override.
-export const gasPriceBid = (gasPrice: GasPrice): bigint =>
-  gasPrice.strategy === "legacy" ? gasPrice.gasPrice : gasPrice.maxFeePerGas;
+// Combine a freshly-fetched gas price with the (already escalated) gas price of
+// a stuck transaction so the stuck transaction can be replaced.
+//
+// For legacy, the single gasPrice is raised to at least the escalated value and
+// bounded at the fresh value scaled by `cap`.
+//
+// For eip1559, nodes (e.g. Geth) require *both* maxFeePerGas and
+// maxPriorityFeePerGas to increase (typically by >=10%) for a replacement to be
+// accepted, so the priority fee must be escalated independently rather than
+// only bumping the larger maxFeePerGas. We cap the total spend via maxFeePerGas
+// (fresh maxFeePerGas scaled by `cap`) and raise the tip enough to outbid the
+// stuck tx, bounding it only by that capped maxFeePerGas — bounding the tip by
+// the fresh tip scaled by `cap` would stall escalation whenever the market tip
+// drops, leaving the replacement underpriced.
+export const escalateGasPrice = (
+  fresh: GasPrice,
+  escalated: GasPrice,
+  cap: number,
+): GasPrice => {
+  // The strategy is fixed for the lifetime of the pusher, so fresh and escalated
+  // always share it. The guards keep the discriminated union narrow.
+  if (fresh.strategy === "legacy" && escalated.strategy === "legacy") {
+    return {
+      gasPrice: capComponent(fresh.gasPrice, escalated.gasPrice, cap),
+      strategy: "legacy",
+    };
+  }
+  if (fresh.strategy === "eip1559" && escalated.strategy === "eip1559") {
+    // Cap the total spend via maxFeePerGas. The priority fee (tip) only needs
+    // to be raised enough to outbid the stuck tx; it is bounded by the capped
+    // maxFeePerGas (the EIP-1559 invariant priority <= maxFee), NOT by the fresh
+    // tip scaled by `cap` — when the market tip drops, that would stop the tip
+    // from escalating and leave the replacement underpriced.
+    const maxFeePerGas = capComponent(
+      fresh.maxFeePerGas,
+      escalated.maxFeePerGas,
+      cap,
+    );
+    const bumpedPriority = maxBigInt(
+      escalated.maxPriorityFeePerGas,
+      fresh.maxPriorityFeePerGas,
+    );
+    return {
+      maxFeePerGas,
+      maxPriorityFeePerGas: minBigInt(bumpedPriority, maxFeePerGas),
+      strategy: "eip1559",
+    };
+  }
+  return fresh;
+};
 
-// Pick the gas price with the higher bid (used to override a stuck tx).
-export const maxGasPrice = (a: GasPrice, b: GasPrice): GasPrice =>
-  gasPriceBid(a) >= gasPriceBid(b) ? a : b;
+// Raise `fresh` to at least `escalated`, but never above `fresh * cap`.
+const capComponent = (fresh: bigint, escalated: bigint, cap: number): bigint =>
+  minBigInt(maxBigInt(escalated, fresh), scaleBigInt(fresh, cap));
 
-// Pick the gas price with the lower bid (used to cap an override).
-export const minGasPrice = (a: GasPrice, b: GasPrice): GasPrice =>
-  gasPriceBid(a) <= gasPriceBid(b) ? a : b;
+const maxBigInt = (a: bigint, b: bigint): bigint => (a > b ? a : b);
+const minBigInt = (a: bigint, b: bigint): bigint => (a < b ? a : b);
 
 // Convert to the fee fields understood by viem's transaction methods.
 export const gasPriceToTxParams = (gasPrice: GasPrice) =>

--- a/apps/price_pusher/src/evm/gas-price.ts
+++ b/apps/price_pusher/src/evm/gas-price.ts
@@ -1,0 +1,128 @@
+import type { Logger } from "pino";
+
+import type { CustomGasStation } from "./custom-gas-station.js";
+import type { SuperWalletClient } from "./super-wallet.js";
+
+export const gasPriceStrategies = ["eip1559", "legacy"] as const;
+export type GasPriceStrategy = (typeof gasPriceStrategies)[number];
+
+// A gas price is represented differently depending on the transaction type.
+//
+// - `eip1559`: The recommended model. The fee is split into the network base
+//   fee (handled by the chain) and a priority fee (tip) paid to the proposer.
+//   We send `maxFeePerGas` (the cap we are willing to pay including base fee)
+//   and `maxPriorityFeePerGas` (the tip). This avoids relying on the
+//   `eth_gasPrice` RPC which is deprecated and mishandled by some RPCs.
+// - `legacy`: The deprecated single `gasPrice` model. Kept for chains that do
+//   not support EIP-1559 transactions.
+export type GasPrice =
+  | { strategy: "legacy"; gasPrice: bigint }
+  | { strategy: "eip1559"; maxFeePerGas: bigint; maxPriorityFeePerGas: bigint };
+
+export type GasPriceConfig = {
+  strategy: GasPriceStrategy;
+  // eip1559: multiplier applied to the chain base fee to leave headroom for
+  // base fee increases between blocks (mirrors the base fee surge in Fortuna).
+  baseFeeMultiplier: number;
+  // eip1559: multiplier applied to the estimated priority fee (tip).
+  priorityFeeMultiplier: number;
+  // legacy: override the gas price returned by the RPC (in wei).
+  gasPrice?: number | undefined;
+  // legacy: optional chain-specific gas station to source the gas price from.
+  customGasStation?: CustomGasStation | undefined;
+};
+
+// Fetch a fresh gas price from the chain (or config overrides).
+export const getGasPrice = async (
+  client: SuperWalletClient,
+  config: GasPriceConfig,
+  logger: Logger,
+): Promise<GasPrice> => {
+  if (config.strategy === "legacy") {
+    const gasPrice =
+      config.gasPrice !== undefined
+        ? BigInt(Math.ceil(config.gasPrice))
+        : // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          (await config.customGasStation?.getCustomGasPrice()) ||
+          (await client.getGasPrice());
+    return { gasPrice, strategy: "legacy" };
+  }
+
+  // Source the fee from the chain base fee and an estimated priority fee
+  // instead of the deprecated eth_gasPrice RPC (which some RPCs mishandle).
+  // We pad the base fee to leave headroom for increases between blocks and
+  // apply a multiplier to the priority fee, mirroring the gas model in Fortuna.
+  const block = await client.getBlock({ blockTag: "latest" });
+  if (block.baseFeePerGas == null) {
+    throw new Error(
+      "The chain does not report a base fee per gas, so it does not support " +
+        "eip1559 transactions. Re-run with `--gas-pricing-strategy legacy`.",
+    );
+  }
+
+  const priorityFee = scaleBigInt(
+    await client.estimateMaxPriorityFeePerGas(),
+    config.priorityFeeMultiplier,
+  );
+  const maxFeePerGas =
+    scaleBigInt(block.baseFeePerGas, config.baseFeeMultiplier) + priorityFee;
+
+  logger.debug(
+    `Estimated baseFeePerGas=${block.baseFeePerGas} priorityFee=${priorityFee}`,
+  );
+
+  return {
+    maxFeePerGas,
+    maxPriorityFeePerGas: priorityFee,
+    strategy: "eip1559",
+  };
+};
+
+// Multiply every fee component by `factor` (used to bump a stuck transaction).
+export const scaleGasPrice = (gasPrice: GasPrice, factor: number): GasPrice => {
+  if (gasPrice.strategy === "legacy") {
+    return {
+      gasPrice: scaleBigInt(gasPrice.gasPrice, factor),
+      strategy: "legacy",
+    };
+  }
+  return {
+    maxFeePerGas: scaleBigInt(gasPrice.maxFeePerGas, factor),
+    maxPriorityFeePerGas: scaleBigInt(gasPrice.maxPriorityFeePerGas, factor),
+    strategy: "eip1559",
+  };
+};
+
+// The scalar that represents how much we are bidding to land the transaction.
+// Used to compare two gas prices when deciding whether to override.
+export const gasPriceBid = (gasPrice: GasPrice): bigint =>
+  gasPrice.strategy === "legacy" ? gasPrice.gasPrice : gasPrice.maxFeePerGas;
+
+// Pick the gas price with the higher bid (used to override a stuck tx).
+export const maxGasPrice = (a: GasPrice, b: GasPrice): GasPrice =>
+  gasPriceBid(a) >= gasPriceBid(b) ? a : b;
+
+// Pick the gas price with the lower bid (used to cap an override).
+export const minGasPrice = (a: GasPrice, b: GasPrice): GasPrice =>
+  gasPriceBid(a) <= gasPriceBid(b) ? a : b;
+
+// Convert to the fee fields understood by viem's transaction methods.
+export const gasPriceToTxParams = (gasPrice: GasPrice) =>
+  gasPrice.strategy === "legacy"
+    ? { gasPrice: gasPrice.gasPrice }
+    : {
+        maxFeePerGas: gasPrice.maxFeePerGas,
+        maxPriorityFeePerGas: gasPrice.maxPriorityFeePerGas,
+      };
+
+export const describeGasPrice = (gasPrice: GasPrice): string =>
+  gasPrice.strategy === "legacy"
+    ? `gasPrice=${gasPrice.gasPrice}`
+    : `maxFeePerGas=${gasPrice.maxFeePerGas} maxPriorityFeePerGas=${gasPrice.maxPriorityFeePerGas}`;
+
+// Scale a bigint by a floating point factor using fixed-point arithmetic to
+// avoid precision loss on large wei values.
+const SCALE_PRECISION = 1_000_000_000n;
+const scaleBigInt = (value: bigint, factor: number): bigint =>
+  (value * BigInt(Math.round(factor * Number(SCALE_PRECISION)))) /
+  SCALE_PRECISION;


### PR DESCRIPTION
## Problem

The EVM price pusher prices transactions using the deprecated single `gasPrice` (legacy) model, sourced from the `eth_gasPrice` RPC. That RPC is long-deprecated and some RPCs mishandle it in corner cases, causing transactions to be mispriced or stuck.

## Change

Adopt the gas model that [Fortuna](../tree/main/apps/fortuna) uses, which works well in production:

- **Default to an `eip1559` strategy** that computes `maxFeePerGas` from:
  - the chain **base fee** (read from the latest block, padded by `--base-fee-multiplier` to leave headroom for the base fee growing between blocks — mirrors Fortuna's "base fee surge"), plus
  - an **estimated priority fee** (via `eth_maxPriorityFeePerGas`, scaled by `--priority-fee-multiplier`).

  This avoids the deprecated `eth_gasPrice` RPC entirely.
- **Keep a `legacy` strategy** (`--gas-pricing-strategy legacy`) for chains that don't support EIP-1559 transactions. This preserves the previous `--gas-price` override and custom gas station behaviour.

The existing stuck-transaction fee escalation (override multiplier + cap) is generalized to operate on both strategies via a small `GasPrice` abstraction in the new `evm/gas-price.ts` module.

### New CLI options
| Option | Default | Applies to |
| --- | --- | --- |
| `--gas-pricing-strategy eip1559\|legacy` | `eip1559` | both |
| `--base-fee-multiplier` | `1.2` | eip1559 |
| `--priority-fee-multiplier` | `1` | eip1559 |
| `--gas-price`, `--custom-gas-station` | — | legacy (unchanged) |

### Behaviour change
This flips the default transaction type from legacy to EIP-1559 for all EVM chains (the intent — moving off `eth_gasPrice`). Operators on non-EIP-1559 chains must add `--gas-pricing-strategy legacy`; the pusher throws a clear, actionable error pointing to that flag if it detects a chain that reports no base fee.

## Testing
- New unit tests in `src/evm/__tests__/gas-price.test.ts` cover both strategies, the base-fee/priority-fee computation, the no-base-fee error path, and the override+cap escalation composition (16 tests).
- `pnpm test:unit`, `tsc`, and `biome check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->