### PR TITLE
fix(starknet): clear RUSTFLAGS for snforge/scarb in contract CI

### DIFF
--- a/.github/workflows/ci-starknet-contract.yml
+++ b/.github/workflows/ci-starknet-contract.yml
@@ -30,11 +30,14 @@ jobs:
         # it doesn't build with more recent Rust versions
         run: cargo +1.85.0 install starknet-devnet --locked --version $(awk '/starknet-devnet/{print $2}' .tool-versions)
       - name: Check formatting
-        run: scarb fmt --check
+        # Clear RUSTFLAGS (-D warnings from setup-rust-toolchain) so it doesn't
+        # leak into the snforge_scarb_plugin build, where newer Rust lints get
+        # promoted to errors.
+        run: RUSTFLAGS="" scarb fmt --check
       - name: Run tests
-        run: snforge test
+        run: RUSTFLAGS="" snforge test
       - name: Build contracts
-        run: scarb build
+        run: RUSTFLAGS="" scarb build
       - name: Check ABI files
         run: |
           cat target/dev/pyth_pyth.contract_class.json | jq .abi > /tmp/pyth.json


### PR DESCRIPTION
## Problem

The **Starknet contract** workflow started failing on `main` ([run](https://github.com/pyth-network/pyth-crosschain/actions/runs/26746482423)) at the **Run tests** step:

```
error: hiding a lifetime that's elided elsewhere is confusing
  --> src/args.rs:79:43
  = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
error: could not compile `snforge_scarb_plugin` (lib) due to 2 previous errors
```

`actions-rust-lang/setup-rust-toolchain@v1` exports `RUSTFLAGS=-D warnings`, which leaks into `snforge test`, `scarb fmt`, and `scarb build`. Those commands internally compile the third-party `snforge_scarb_plugin` from Rust source, and under the newer Rust toolchain the `mismatched-lifetime-syntaxes` lint is promoted to a hard error — failing the step with exit code 2. The failure is unrelated to the change that triggered the run.

## Fix

Clear `RUSTFLAGS` when invoking `scarb fmt`, `snforge test`, and `scarb build`. This mirrors the fix already applied to `ci-starknet-tools.yml` in #3778.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->