### PR TITLE
feat(price-pusher): migrate EVM pusher to EIP-1559 gas with legacy fallback

### DIFF
--- a/apps/price_pusher/src/common.ts
+++ b/apps/price_pusher/src/common.ts
@@ -1,4 +1,8 @@
+export type GasParams =
+  | { type: "eip1559"; maxFeePerGas: number; maxPriorityFeePerGas: number }
+  | { type: "legacy"; gasPrice: number };
+
 export type PushAttempt = {
   nonce: number;
-  gasPrice: number;
+  gas: GasParams;
 };

--- a/apps/price_pusher/src/evm/command.ts
+++ b/apps/price_pusher/src/evm/command.ts
@@ -49,6 +49,14 @@ export default {
       required: false,
       type: "number",
     } as Options,
+    legacy: {
+      default: false,
+      description:
+        "Use legacy (type-0) transactions with gasPrice instead of EIP-1559 (type-2). " +
+        "Enable this for chains that don't support EIP-1559.",
+      required: false,
+      type: "boolean",
+    } as Options,
     "override-gas-price-multiplier": {
       default: 1.1,
       description:
@@ -113,6 +121,7 @@ export default {
       overrideGasPriceMultiplierCap,
       gasLimit,
       gasPrice,
+      legacy,
       updateFeeMultiplier,
       logLevel,
       controllerLogLevel,
@@ -187,6 +196,7 @@ export default {
       logger.child({ module: "CustomGasStation" }),
       customGasStation,
       txSpeed,
+      legacy,
     );
     const evmPusher = new EvmPricePusher(
       hermesClient,
@@ -196,6 +206,7 @@ export default {
       overrideGasPriceMultiplier,
       overrideGasPriceMultiplierCap,
       updateFeeMultiplier,
+      legacy,
       gasLimit,
       gasStation,
       gasPrice,

--- a/apps/price_pusher/src/evm/custom-gas-station.ts
+++ b/apps/price_pusher/src/evm/custom-gas-station.ts
@@ -9,7 +9,14 @@ import { parseGwei } from "viem";
 import type { CustomGasChainId, TxSpeed } from "../utils.js";
 import { customGasChainIds, txSpeeds, verifyValidOption } from "../utils.js";
 
-type chainMethods = Record<CustomGasChainId, () => Promise<bigint | undefined>>;
+export type CustomGasResult =
+  | { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }
+  | { gasPrice: bigint };
+
+type chainMethods = Record<
+  CustomGasChainId,
+  () => Promise<CustomGasResult | undefined>
+>;
 
 export class CustomGasStation {
   private chain: CustomGasChainId;
@@ -18,23 +25,38 @@ export class CustomGasStation {
     137: this.fetchMaticMainnetGasPrice.bind(this),
   };
   private logger: Logger;
-  constructor(logger: Logger, chain: number, speed: string) {
+  private legacy: boolean;
+  constructor(logger: Logger, chain: number, speed: string, legacy: boolean) {
     this.logger = logger;
     this.speed = verifyValidOption(speed, txSpeeds);
     this.chain = verifyValidOption(chain, customGasChainIds);
+    this.legacy = legacy;
   }
 
-  async getCustomGasPrice() {
+  async getCustomGasPrice(): Promise<CustomGasResult | undefined> {
     return this.chainMethods[this.chain]();
   }
 
-  private async fetchMaticMainnetGasPrice() {
+  private async fetchMaticMainnetGasPrice(): Promise<
+    CustomGasResult | undefined
+  > {
     try {
       const res = await fetch("https://gasstation.polygon.technology/v2");
       // TODO: improve the typing specificity here
       const jsonRes = (await res.json()) as any;
-      const gasPrice = jsonRes[this.speed].maxFee;
-      return parseGwei(gasPrice.toFixed(2));
+      const speedData = jsonRes[this.speed];
+
+      if (this.legacy) {
+        const gasPrice = speedData.maxFee;
+        return { gasPrice: parseGwei(gasPrice.toFixed(2)) };
+      }
+
+      const maxFee = speedData.maxFee;
+      const maxPriorityFee = speedData.maxPriorityFee;
+      return {
+        maxFeePerGas: parseGwei(maxFee.toFixed(2)),
+        maxPriorityFeePerGas: parseGwei(maxPriorityFee.toFixed(2)),
+      };
     } catch (error) {
       this.logger.error(
         error,
@@ -49,9 +71,10 @@ export function getCustomGasStation(
   logger: Logger,
   customGasStation?: number,
   txSpeed?: string,
+  legacy?: boolean,
 ) {
   if (customGasStation && txSpeed) {
-    return new CustomGasStation(logger, customGasStation, txSpeed);
+    return new CustomGasStation(logger, customGasStation, txSpeed, !!legacy);
   }
   return;
 }

--- a/apps/price_pusher/src/evm/evm.ts
+++ b/apps/price_pusher/src/evm/evm.ts
@@ -20,7 +20,7 @@ import {
   TransactionExecutionError,
 } from "viem";
 
-import type { PushAttempt } from "../common.js";
+import type { GasParams, PushAttempt } from "../common.js";
 import type { IPricePusher, PriceInfo, PriceItem } from "../interface.js";
 import { ChainPriceListener } from "../interface.js";
 import type { DurationInSeconds } from "../utils.js";
@@ -132,10 +132,116 @@ export class EvmPricePusher implements IPricePusher {
     private overrideGasPriceMultiplier: number,
     private overrideGasPriceMultiplierCap: number,
     private updateFeeMultiplier: number,
+    private legacy: boolean,
     private gasLimit?: number,
     private customGasStation?: CustomGasStation,
-    private gasPrice?: number,
+    private gasPriceOverride?: number,
   ) {}
+
+  private async getGasParams(): Promise<GasParams> {
+    if (this.customGasStation) {
+      const custom = await this.customGasStation.getCustomGasPrice();
+      if (custom) {
+        if ("gasPrice" in custom) {
+          return { type: "legacy", gasPrice: Number(custom.gasPrice) };
+        }
+        return {
+          type: "eip1559",
+          maxFeePerGas: Number(custom.maxFeePerGas),
+          maxPriorityFeePerGas: Number(custom.maxPriorityFeePerGas),
+        };
+      }
+    }
+
+    if (this.legacy) {
+      const gasPrice = await this.client.getGasPrice();
+      return { type: "legacy", gasPrice: Number(gasPrice) };
+    }
+
+    const fees = await this.client.estimateFeesPerGas();
+    return {
+      type: "eip1559",
+      maxFeePerGas: Number(fees.maxFeePerGas),
+      maxPriorityFeePerGas: Number(fees.maxPriorityFeePerGas),
+    };
+  }
+
+  private applyStaticOverride(gas: GasParams): GasParams {
+    if (this.gasPriceOverride === undefined) return gas;
+
+    if (gas.type === "legacy") {
+      return { type: "legacy", gasPrice: this.gasPriceOverride };
+    }
+
+    // In EIP-1559 mode, use the override as maxFeePerGas and keep fetched priority fee
+    return {
+      type: "eip1559",
+      maxFeePerGas: this.gasPriceOverride,
+      maxPriorityFeePerGas: gas.maxPriorityFeePerGas,
+    };
+  }
+
+  private escalateGas(gas: GasParams, multiplier: number): GasParams {
+    if (gas.type === "legacy") {
+      return { type: "legacy", gasPrice: gas.gasPrice * multiplier };
+    }
+    return {
+      type: "eip1559",
+      maxFeePerGas: gas.maxFeePerGas * multiplier,
+      maxPriorityFeePerGas: gas.maxPriorityFeePerGas * multiplier,
+    };
+  }
+
+  private capGas(escalated: GasParams, base: GasParams): GasParams {
+    if (escalated.type === "legacy" && base.type === "legacy") {
+      return {
+        type: "legacy",
+        gasPrice: Math.min(
+          escalated.gasPrice,
+          base.gasPrice * this.overrideGasPriceMultiplierCap,
+        ),
+      };
+    }
+    if (escalated.type === "eip1559" && base.type === "eip1559") {
+      return {
+        type: "eip1559",
+        maxFeePerGas: Math.min(
+          escalated.maxFeePerGas,
+          base.maxFeePerGas * this.overrideGasPriceMultiplierCap,
+        ),
+        maxPriorityFeePerGas: Math.min(
+          escalated.maxPriorityFeePerGas,
+          base.maxPriorityFeePerGas * this.overrideGasPriceMultiplierCap,
+        ),
+      };
+    }
+    // Mismatched types shouldn't happen, return escalated as-is
+    return escalated;
+  }
+
+  private gasIsHigherThan(a: GasParams, b: GasParams): boolean {
+    if (a.type === "legacy" && b.type === "legacy") {
+      return a.gasPrice > b.gasPrice;
+    }
+    if (a.type === "eip1559" && b.type === "eip1559") {
+      return a.maxFeePerGas > b.maxFeePerGas;
+    }
+    return false;
+  }
+
+  private gasToTxParams(
+    gas: GasParams,
+  ):
+    | { gasPrice: bigint }
+    | { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint } {
+    if (gas.type === "legacy") {
+      return { gasPrice: BigInt(Math.ceil(gas.gasPrice)) };
+    }
+    return {
+      maxFeePerGas: BigInt(Math.ceil(gas.maxFeePerGas)),
+      maxPriorityFeePerGas: BigInt(Math.ceil(gas.maxPriorityFeePerGas)),
+    };
+  }
 
   // The pubTimes are passed here to use the values that triggered the push.
   // This is an optimization to avoid getting a newer value (as an update comes)
@@ -180,16 +286,7 @@ export class EvmPricePusher implements IPricePusher {
       throw error;
     }
 
-    // Gas price in networks with transaction type eip1559 represents the
-    // addition of baseFee and priorityFee required to land the transaction. We
-    // are using this to remain compatible with the networks that doesn't
-    // support this transaction type.
-    let gasPrice =
-      this.gasPrice ??
-      Number(
-        await (this.customGasStation?.getCustomGasPrice() ??
-          this.client.getGasPrice()),
-      );
+    let gas = this.applyStaticOverride(await this.getGasParams());
 
     // Try to re-use the same nonce and increase the gas if the last tx is not landed yet.
     this.pusherAddress ??= this.client.account.address;
@@ -199,30 +296,27 @@ export class EvmPricePusher implements IPricePusher {
         address: this.pusherAddress,
       })) - 1;
 
-    let gasPriceToOverride = undefined;
-
     if (this.lastPushAttempt !== undefined) {
       if (this.lastPushAttempt.nonce <= lastExecutedNonce) {
         this.lastPushAttempt = undefined;
       } else {
-        gasPriceToOverride =
-          this.lastPushAttempt.gasPrice * this.overrideGasPriceMultiplier;
+        const escalated = this.escalateGas(
+          this.lastPushAttempt.gas,
+          this.overrideGasPriceMultiplier,
+        );
+        if (this.gasIsHigherThan(escalated, gas)) {
+          gas = this.capGas(escalated, gas);
+        }
       }
-    }
-
-    if (
-      gasPriceToOverride !== undefined &&
-      gasPriceToOverride > Number(gasPrice)
-    ) {
-      gasPrice = Math.min(
-        gasPriceToOverride,
-        gasPrice * this.overrideGasPriceMultiplierCap,
-      );
     }
 
     const txNonce = lastExecutedNonce + 1;
 
-    this.logger.debug(`Using gas price: ${gasPrice} and nonce: ${txNonce}`);
+    const gasLogInfo =
+      gas.type === "eip1559"
+        ? `maxFeePerGas: ${gas.maxFeePerGas}, maxPriorityFeePerGas: ${gas.maxPriorityFeePerGas}`
+        : `gasPrice: ${gas.gasPrice}`;
+    this.logger.debug(`Using ${gasLogInfo} and nonce: ${txNonce}`);
 
     const pubTimesToPushParam = pubTimesToPush.map(BigInt);
 
@@ -230,7 +324,7 @@ export class EvmPricePusher implements IPricePusher {
 
     // Update lastAttempt
     this.lastPushAttempt = {
-      gasPrice: gasPrice,
+      gas,
       nonce: txNonce,
     };
 
@@ -243,7 +337,7 @@ export class EvmPricePusher implements IPricePusher {
               this.gasLimit === undefined
                 ? undefined
                 : BigInt(Math.ceil(this.gasLimit)),
-            gasPrice: BigInt(Math.ceil(gasPrice)),
+            ...this.gasToTxParams(gas),
             nonce: txNonce,
             value: updateFee,
           },


### PR DESCRIPTION
Migrates the EVM price pusher from deprecated legacy gasPrice transactions to EIP-1559 (type-2) transactions, with a --legacy CLI flag for chains that don't support EIP-1559.

## Changes

- **common.ts**: Added `GasParams` discriminated union type (`eip1559` | `legacy`) and updated `PushAttempt` to use it.
- **evm.ts**: Refactored gas handling into helper methods (`getGasParams`, `applyStaticOverride`, `escalateGas`, `capGas`, `gasToTxParams`) that work with both EIP-1559 and legacy params. Default path uses `estimateFeesPerGas()`.
- **command.ts**: Added `--legacy` boolean CLI flag (default `false`), passed through to `EvmPricePusher`.
- **custom-gas-station.ts**: Returns structured `CustomGasResult` with `maxFeePerGas`/`maxPriorityFeePerGas` in EIP-1559 mode, or `gasPrice` in legacy mode. Polygon gas station now returns both fee fields.

## Testing
- TypeScript compiles cleanly (`pnpm turbo build` passes)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->