### PR TITLE
Bump hydra to v0.24.1 in Dockerfile.metis

### DIFF
--- a/Dockerfile.metis
+++ b/Dockerfile.metis
@@ -56,7 +56,7 @@ RUN curl -fsSL https://downloads.1password.com/linux/keys/1password.asc \
 RUN op --version
 
 # Install hydra CLI binary
-RUN curl -fsSL https://github.com/dourolabs/metis-releases/releases/download/v0.22.0/hydra-x86_64-unknown-linux-gnu \
+RUN curl -fsSL https://github.com/dourolabs/metis-releases/releases/download/v0.24.1/hydra-x86_64-unknown-linux-gnu \
       -o /usr/local/bin/hydra \
     && chmod +x /usr/local/bin/hydra
 


### PR DESCRIPTION
Bumps the pinned hydra CLI release from v0.22.0 to v0.24.1 in `Dockerfile.metis`. After this PR merges, CI rebuilds the `pyth-crosschain-metis:latest` image so the new hydra version flows to every session that runs in this repo.

Resolves [[i-vtsjbtiv]].
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->