### PR TITLE
fix(hermes): share VAA bytes across a slot's proofs via Arc

### DIFF
--- a/apps/hermes/server/src/state/aggregate/wormhole_merkle.rs
+++ b/apps/hermes/server/src/state/aggregate/wormhole_merkle.rs
@@ -16,6 +16,7 @@ use {
             v1::{AccumulatorUpdateData, MerklePriceUpdate, Proof, WormholeMerkleRoot},
         },
     },
+    std::sync::Arc,
 };
 
 // The number of messages in a single update data is defined as a
@@ -31,7 +32,10 @@ pub struct WormholeMerkleState {
 #[derive(Clone, PartialEq, Debug)]
 pub struct WormholeMerkleMessageProof {
     pub proof: MerklePath<Keccak160>,
-    pub vaa: VaaBytes,
+    /// Shared VAA for the message's slot. All messages in a slot share the same
+    /// VAA, so we store it behind an `Arc` to avoid cloning the (~1-2KB) bytes
+    /// once per feed (which, across ~6000 feeds × cache depth, dominated memory).
+    pub vaa: Arc<VaaBytes>,
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -83,12 +87,16 @@ pub fn construct_message_states_proofs(
         return Err(anyhow!("Invalid merkle root"));
     }
 
+    // Clone the VAA bytes once for the whole slot; every message proof shares it
+    // via the `Arc` (refcount bump only), instead of duplicating the bytes per feed.
+    let shared_vaa = Arc::new(wormhole_merkle_state.vaa.clone());
+
     accumulator_messages
         .raw_messages
         .iter()
         .map(|m| {
             Ok(WormholeMerkleMessageProof {
-                vaa: wormhole_merkle_state.vaa.clone(),
+                vaa: shared_vaa.clone(),
                 proof: merkle_acc
                     .prove(m.as_ref())
                     .ok_or(anyhow!("Failed to prove message"))?,
@@ -107,7 +115,7 @@ pub fn construct_update_data(mut messages: Vec<RawMessageWithMerkleProof>) -> Re
 
     while let Some(message) = iter.next() {
         let slot = message.slot;
-        let vaa = message.proof.vaa;
+        let vaa: VaaBytes = (*message.proof.vaa).clone();
         let mut updates = vec![MerklePriceUpdate {
             message: message.raw_message.into(),
             proof: message.proof.proof,
@@ -174,7 +182,7 @@ mod test {
         RawMessageWithMerkleProof {
             slot: slot_and_pubtime,
             proof: WormholeMerkleMessageProof {
-                vaa: vec![],
+                vaa: std::sync::Arc::new(vec![]),
                 proof: MerklePath::default(),
             },
             raw_message: to_vec::<_, byteorder::BE>(&price_feed_message).unwrap(),

--- a/apps/hermes/server/src/state/cache.rs
+++ b/apps/hermes/server/src/state/cache.rs
@@ -352,7 +352,7 @@ mod test {
             received_at: publish_time,
             proof_set: ProofSet {
                 wormhole_merkle_proof: WormholeMerkleMessageProof {
-                    vaa: vec![],
+                    vaa: std::sync::Arc::new(vec![]),
                     proof: MerklePath::<Keccak160>::new(vec![]),
                 },
             },


### PR DESCRIPTION
## Problem

`construct_message_states_proofs` clones the full VAA (~1–2 KB) into the `WormholeMerkleMessageProof` of **every** message in a slot. A slot contains all price feeds, so the same VAA is duplicated across ~6000 `MessageState`s per slot, and each is then retained `cache-size-slots` deep in the message cache.

With the default `cache-size-slots = 1600`, a Hermes instance subscribed to all Pythnet mainnet feeds grew to **~20 GB resident and kept climbing** until OOM. The duplicated VAA bytes accounted for the bulk of that.

## Fix

Store the VAA behind `Arc<VaaBytes>` so every proof in a slot shares a single allocation (a refcount bump instead of a deep copy). The bytes are cloned once, lazily, when building update data for an API response — a per-request read cost rather than a stored, per-feed cost.

No public API or wire-format change; `WormholeMerkleMessageProof` only derives `Clone/PartialEq/Debug`, all of which `Arc<Vec<u8>>` satisfies.

## Measurement

On a node subscribed to all mainnet feeds, `cache-size-slots = 1600`:

| build | resident memory |
|-------|-----------------|
| before | ~20 GB, still climbing |
| after  | plateaus at ~6.5 GB |

(At `cache-size-slots = 64` the patched build plateaus at ~2.4 GB and is stable.)

`cargo build --release` and the existing `state::cache` / `wormhole_merkle` tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->