### PR TITLE
docs: add direct Solana target link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Within this monorepo you will find the following subprojects:
 
 ## Target Chains
 
-> [target_chains](./target_chains/)
+> [target_chains](./target_chains/) ([Solana](./target_chains/solana/))
 
 This directory contains on-chain contracts and SDKs for all of the various
 blockchain runtimes that Pyth supports. Each subdirectory corresponds to a


### PR DESCRIPTION
## Summary
- Adds a direct Solana target-chain link next to the top-level `target_chains` link in the root README.
- Points readers at the existing `target_chains/solana/` directory instead of the stale `/targets/solana/README.md` path reported in the issue.

Fixes #3651.

## Verification
- Confirmed the stale GitHub URL returns `404`:
  `https://github.com/pyth-network/pyth-crosschain/blob/main/targets/solana/README.md`
- Confirmed the replacement GitHub URL returns `200`:
  `https://github.com/pyth-network/pyth-crosschain/blob/main/target_chains/solana/README.md`
- Confirmed local README links resolve:
  - `./target_chains/`
  - `./target_chains/solana/`
- Ran `git diff --check`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->