### PR TITLE
docs: remove deprecated Resolv push feeds (Base / Ethereum / Arbitrum / HyperEVM / Solana)

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/arbitrum-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/arbitrum-mainnet.json
@@ -6,27 +6,6 @@
       "time_difference": 3600,
       "price_deviation": 1,
       "confidence_ratio": 100
-    },
-    {
-      "alias": "USR/USD.RR",
-      "id": "512a79cc65f49531f0bbb72956353e79ecdc1e4a6e5241847196c1f9a11d8a52",
-      "time_difference": 21600,
-      "price_deviation": 0.5,
-      "confidence_ratio": 100
-    },
-    {
-      "alias": "WSTUSR/USR.RR",
-      "id": "b74c2bc175c2dab850ce5a5451608501c293fe8410cb4aba7449dd1c355ab706",
-      "time_difference": 21600,
-      "price_deviation": 0.5,
-      "confidence_ratio": 100
-    },
-    {
-      "alias": "RLP/USD.RR",
-      "id": "796bcb684fdfbba2b071c165251511ab61f08c8949afd9e05665a26f69d9a839",
-      "time_difference": 21600,
-      "price_deviation": 0.5,
-      "confidence_ratio": 100
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/base-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/base-mainnet.json
@@ -48,41 +48,6 @@
       "time_difference": 3600,
       "price_deviation": 1,
       "confidence_ratio": 100
-    },
-    {
-      "alias": "USR/USD",
-      "id": "10b013adec14c0fe839ca0fe54cec9e4d0b6c1585ac6d7e70010dac015e57f9c",
-      "time_difference": 3600,
-      "price_deviation": 1,
-      "confidence_ratio": 100
-    },
-    {
-      "alias": "USR/USD.RR",
-      "id": "512a79cc65f49531f0bbb72956353e79ecdc1e4a6e5241847196c1f9a11d8a52",
-      "time_difference": 3600,
-      "price_deviation": 1,
-      "confidence_ratio": 100
-    },
-    {
-      "alias": "RLP/USD",
-      "id": "7265d5cf8ee0e7b5266f75ff19c42c5b7697a9756c9304aa78b6be4fbb8d823d",
-      "time_difference": 3600,
-      "price_deviation": 1,
-      "confidence_ratio": 100
-    },
-    {
-      "alias": "RLP/USD.RR",
-      "id": "796bcb684fdfbba2b071c165251511ab61f08c8949afd9e05665a26f69d9a839",
-      "time_difference": 3600,
-      "price_deviation": 1,
-      "confidence_ratio": 100
-    },
-    {
-      "alias": "WSTUSR/USR.RR",
-      "id": "b74c2bc175c2dab850ce5a5451608501c293fe8410cb4aba7449dd1c355ab706",
-      "time_difference": 3600,
-      "price_deviation": 1,
-      "confidence_ratio": 100
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/ethereum-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/ethereum-mainnet.json
@@ -8,20 +8,6 @@
       "confidence_ratio": 100
     },
     {
-      "alias": "USR/USD",
-      "id": "10b013adec14c0fe839ca0fe54cec9e4d0b6c1585ac6d7e70010dac015e57f9c",
-      "time_difference": 3600,
-      "price_deviation": 2,
-      "confidence_ratio": 100
-    },
-    {
-      "alias": "WSTUSR/USR",
-      "id": "b74c2bc175c2dab850ce5a5451608501c293fe8410cb4aba7449dd1c355ab706",
-      "time_difference": 3600,
-      "price_deviation": 2,
-      "confidence_ratio": 100
-    },
-    {
       "alias": "LINEA/USD",
       "id": "49e50653755fbf8018ab65a07be2f208ac8c4bdfc43200934304ca17ee663cab",
       "time_difference": 3600,

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/hyperevm-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/hyperevm-mainnet.json
@@ -176,13 +176,6 @@
       "confidence_ratio": 100
     },
     {
-      "alias": "USR/USD.RR",
-      "id": "512a79cc65f49531f0bbb72956353e79ecdc1e4a6e5241847196c1f9a11d8a52",
-      "time_difference": 3600,
-      "price_deviation": 1,
-      "confidence_ratio": 100
-    },
-    {
       "alias": "USOL/USD",
       "id": "974c7a77dbace44d229be17fc176975e06404b004476aeaff37641818cb0c55a",
       "time_difference": 3600,
@@ -241,20 +234,6 @@
     {
       "alias": "KHYPE/HYPE.RR",
       "id": "983b7cabc6fab548e15a5b05500da9b99c1682107b3e2ff289344116c10ac02c",
-      "time_difference": 3600,
-      "price_deviation": 1,
-      "confidence_ratio": 100
-    },
-    {
-      "alias": "WSTUSR/USR.RR",
-      "id": "b74c2bc175c2dab850ce5a5451608501c293fe8410cb4aba7449dd1c355ab706",
-      "time_difference": 3600,
-      "price_deviation": 1,
-      "confidence_ratio": 100
-    },
-    {
-      "alias": "RLP/USD.RR",
-      "id": "796bcb684fdfbba2b071c165251511ab61f08c8949afd9e05665a26f69d9a839",
       "time_difference": 3600,
       "price_deviation": 1,
       "confidence_ratio": 100

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json
@@ -375,14 +375,6 @@
       "time_difference": 60,
       "price_deviation": 0.5,
       "confidence_ratio": 100
-    },
-    {
-      "alias": "WSTUSR/USR.RR",
-      "account_address": "4iG7tnQXmhPfUHxn7F54T6g3j3UZEFyYcoD6PWeF1YVF",
-      "id": "b74c2bc175c2dab850ce5a5451608501c293fe8410cb4aba7449dd1c355ab706",
-      "time_difference": 540,
-      "price_deviation": 0.001,
-      "confidence_ratio": 100
     }
   ]
 }


### PR DESCRIPTION
## Summary

Stop pushing the 14 Resolv-related push feeds announced for deprecation on 2026-05-31 ([dev-forum post](https://dev-forum.pyth.network/t/deprecation-of-some-resolv-pyth-push-feeds-on-base-ethereum-arbitrum-hyperevm-and-solana-may-31st-2026/783)).

Per-chain removals (alias):

- **base-mainnet**: USR/USD, USR/USD.RR, RLP/USD, RLP/USD.RR, WSTUSR/USR.RR
- **ethereum-mainnet**: USR/USD, WSTUSR/USR
- **arbitrum-mainnet**: USR/USD.RR, WSTUSR/USR.RR, RLP/USD.RR
- **hyperevm-mainnet**: USR/USD.RR, WSTUSR/USR.RR, RLP/USD.RR
- **solana-mainnet**: WSTUSR/USR.RR

Follows the same JSON-only pattern as the prior Monad (e9a21904f, [[p-fzljbvil]] style) and Sonic (21fd0af47) deprecation PRs. A repo-wide grep confirms the five deprecated feed IDs (10b013ad…, 512a79cc…, 7265d5cf…, 796bcb68…, b74c2bc1…) appear in no other source files, so no SDK / contract / pusher-service changes are needed.

Resolves [[i-fatqruyj]].

## Test plan

- [x] All 5 modified JSON files parse with \`jq\` and the schema is unchanged (\`{ "feeds": [...] }\`).
- [x] Repo-wide grep for the 5 deprecated feed IDs returns no matches.
- [ ] Developer-hub build (\`pnpm turbo build --filter=@pythnetwork/developer-hub\`) renders the affected chain pages without runtime errors (CI).