### PR TITLE
fix(price_pusher): detect "replacement transaction underpriced" across RPC error classes

### DIFF
--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -224,5 +224,5 @@
   },
   "type": "module",
   "types": "./dist/index.d.ts",
-  "version": "11.0.0"
+  "version": "11.0.1"
 }

--- a/apps/price_pusher/src/evm/evm.ts
+++ b/apps/price_pusher/src/evm/evm.ts
@@ -16,7 +16,6 @@ import {
   ContractFunctionRevertedError,
   FeeCapTooLowError,
   InsufficientFundsError,
-  InternalRpcError,
   TransactionExecutionError,
 } from "viem";
 
@@ -40,6 +39,19 @@ type PushAttempt = {
   nonce: number;
   gasPrice: GasPrice;
 };
+
+// Some RPC providers surface the same underlying failure through different viem
+// error classes. For example "replacement transaction underpriced" comes back as
+// an `InternalRpcError` (code -32000) on most chains, but Soneium/Alchemy returns
+// it as an `InvalidInputRpcError` (code -32602, "Missing or invalid parameters").
+// Matching on the error text across the whole cause chain (rather than on a
+// specific class) keeps the detection robust across providers.
+const errorChainIncludes = (error: BaseError, needle: string): boolean =>
+  error.walk(
+    (e) =>
+      (e instanceof BaseError && e.details.includes(needle)) ||
+      (e instanceof Error && e.message.includes(needle)),
+  ) !== null;
 
 export class EvmPriceListener extends ChainPriceListener {
   constructor(
@@ -300,11 +312,7 @@ export class EvmPricePusher implements IPricePusher {
 
         if (
           error.walk((e) => e instanceof FeeCapTooLowError) ||
-          error.walk(
-            (e) =>
-              e instanceof InternalRpcError &&
-              e.details.includes("replacement transaction underpriced"),
-          )
+          errorChainIncludes(error, "replacement transaction underpriced")
         ) {
           this.logger.warn(
             "The gas price of the transaction is too low or there is an existing transaction with higher gas with the same nonce. " +


### PR DESCRIPTION
## Summary

The EVM price pusher has a dedicated handler that quietly skips a push (and escalates the gas on the next attempt) when a same-nonce replacement is rejected as **"replacement transaction underpriced"**. That handler gated on `e instanceof InternalRpcError && e.details.includes("replacement transaction underpriced")`, which only matches the standard Geth encoding (JSON-RPC `-32000`).

Some RPC providers encode the same mempool rejection differently. **Soneium via Alchemy** returns it as an `InvalidInputRpcError` (`-32602`, `"Missing or invalid parameters"`) with the real reason demoted to the `details` string. The class-based check missed that, so the error fell through to the generic `ContractFunctionExecutionError` branch and produced a noisy multi-page `warn` dump instead of the intended one-line skip.

This is purely an **error-classification** fix — the escalation/retry logic is unchanged and already correct (the failed attempt is saved to `lastPushAttempt` before submission, so the next push escalates from it).

## What this fixes

Observed in production on `soneium-mainnet`:

```
... ContractFunctionExecutionError: Missing or invalid parameters.
... Details: replacement transaction underpriced
"The contract function execution failed in simulation. ... Skipping this push."
```

After this change the same situation hits the intended handler and logs the concise:

> "The gas price of the transaction is too low or there is an existing transaction with higher gas with the same nonce. The price will be increased in the next push. Skipping this push. ..."

## Changes

- Add `errorChainIncludes(error, needle)` helper that walks the viem error cause chain and matches on the error **text** (`.details` / `.message`) rather than a specific error class.
- Use it to detect `"replacement transaction underpriced"` regardless of which viem RPC error class the provider wraps it in.
- Remove the now-unused `InternalRpcError` import.
- Bump `@pythnetwork/price-pusher` to `11.0.1`.

## Test plan

- [x] `tsc` clean for `evm.ts` (pre-existing monorepo dep errors in other chains' files are unrelated).
- Behavior verified against the captured Soneium/Alchemy error payload: the `-32602` "Missing or invalid parameters" + `details: replacement transaction underpriced` now matches the dedicated handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->