### PR TITLE
Bump hydra CLI to v0.31.0 in Dockerfile.metis

### DIFF
--- a/Dockerfile.metis
+++ b/Dockerfile.metis
@@ -56,7 +56,7 @@ RUN curl -fsSL https://downloads.1password.com/linux/keys/1password.asc \
 RUN op --version
 
 # Install hydra CLI binary
-RUN curl -fsSL https://github.com/dourolabs/metis-releases/releases/download/v0.28.0/hydra-x86_64-unknown-linux-gnu \
+RUN curl -fsSL https://github.com/dourolabs/metis-releases/releases/download/v0.31.0/hydra-x86_64-unknown-linux-gnu \
       -o /usr/local/bin/hydra \
     && chmod +x /usr/local/bin/hydra
 


### PR DESCRIPTION
Bumps the pinned hydra CLI URL in `Dockerfile.metis` from v0.28.0 to v0.31.0 so the rebuilt pyth-crosschain worker image ships the current CLI release.

Resolves [[i-hnvhrskn]].