### PR TITLE
fix(sui): disable set_governance_data_source as stopgap for replay bug

### DIFF
--- a/target_chains/sui/contracts/sources/governance/set_governance_data_source.move
+++ b/target_chains/sui/contracts/sources/governance/set_governance_data_source.move
@@ -1,36 +1,71 @@
 module pyth::set_governance_data_source {
-    use pyth::deserialize;
-    use pyth::data_source;
-    use pyth::state::{Self, State, LatestOnly};
-
-    use wormhole::cursor;
-    use wormhole::external_address::{Self, ExternalAddress};
-    use wormhole::bytes32::{Self};
+    use pyth::state::{State, LatestOnly};
 
     friend pyth::governance;
 
-    struct GovernanceDataSource {
-        emitter_chain_id: u64,
-        emitter_address: ExternalAddress,
-        initial_sequence: u64,
-    }
+    /// Governance data source rotation has been disabled as a stopgap fix for a
+    /// replay vulnerability. `WormholeVAAVerificationReceipt` does not bind to
+    /// the data source it was verified against, so an in-PTB rotation (which
+    /// also resets `last_executed_governance_sequence` to the payload-controlled
+    /// `initial_sequence`) lets a sibling receipt verified under the old source
+    /// pass the post-rotation monotonicity check and replay any historical
+    /// SetDataSources / SetFeeRecipient / SetUpdateFee / SetStalePriceThreshold /
+    /// ContractUpgrade VAA against the new governance source.
+    ///
+    /// A proper fix requires binding the data source to the receipt and
+    /// re-checking it at execute time. Under Sui's `compatible` upgrade policy
+    /// that can only ship as an additive V2 receipt + V2 function variants
+    /// (changing the existing struct layout or function signatures is rejected
+    /// by the upgrade verifier). Until that V2 upgrade lands, this function
+    /// aborts so the rotation vector is closed.
+    const E_GOVERNANCE_DATA_SOURCE_ROTATION_DISABLED: u64 = 0;
 
-    public(friend) fun execute(latest_only: &LatestOnly, pyth_state: &mut State, payload: vector<u8>) {
-        let GovernanceDataSource { emitter_chain_id, emitter_address, initial_sequence: initial_sequence } = from_byte_vec(payload);
-        state::set_governance_data_source(latest_only, pyth_state, data_source::new(emitter_chain_id, emitter_address));
-        state::set_last_executed_governance_sequence(latest_only, pyth_state, initial_sequence);
+    public(friend) fun execute(_latest_only: &LatestOnly, _pyth_state: &mut State, _payload: vector<u8>) {
+        abort E_GOVERNANCE_DATA_SOURCE_ROTATION_DISABLED
     }
+}
 
-    fun from_byte_vec(bytes: vector<u8>): GovernanceDataSource {
-        let cursor = cursor::new(bytes);
-        let emitter_chain_id = deserialize::deserialize_u16(&mut cursor);
-        let emitter_address = external_address::new(bytes32::from_bytes(deserialize::deserialize_vector(&mut cursor, 32)));
-        let initial_sequence = deserialize::deserialize_u64(&mut cursor);
-        cursor::destroy_empty(cursor);
-        GovernanceDataSource {
-            emitter_chain_id: (emitter_chain_id as u64),
-            emitter_address,
-            initial_sequence
-        }
+#[test_only]
+module pyth::set_governance_data_source_tests {
+    use sui::test_scenario::{Self};
+    use sui::coin::Self;
+
+    use pyth::pyth_tests::{Self, setup_test, take_wormhole_and_pyth_states};
+
+    // A signed Wormhole VAA carrying a Pyth `SetGovernanceDataSource` governance
+    // action (module=1, action=1, target_chain=21). Signed by the well-known
+    // Wormhole devnet guardian (priv `cfb12303...e113a0` → address
+    // `0xbeFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe`) over governance emitter
+    // chain 1 / address `63278d27...068c385`, sequence 1. Payload rotates the
+    // governance source to chain 26 / address `f346195a...8697b0` with
+    // `initial_sequence = 0`. The exact rotation values don't matter — we only
+    // assert the action aborts before any state update lands.
+    const SET_GOVERNANCE_DATA_SOURCE_VAA: vector<u8> = x"01000000000100101895ce77ebb22ac257a5cf4def92a52cff4ca1409f9375416c2c8f8a887dd65dfc8d34eb87312a1d5eee1ef694f6bbed357dda8ee7070dd9d505589dcc8dd4010000000000000000000163278d271099bfd491951b3e648f08b1c71631e4a53674ad43e8f9f98068c3850000000000000001015054474d01010015001af346195ac02f37d60d4db8ffa6ef74cb1be3550047543a4a9ee9acf4d78697b00000000000000000";
+
+    const DEPLOYER: address = @0x1234;
+    const DEFAULT_BASE_UPDATE_FEE: u64 = 0;
+    const DEFAULT_COIN_TO_MINT: u64 = 0;
+
+    #[test]
+    #[expected_failure(abort_code = pyth::set_governance_data_source::E_GOVERNANCE_DATA_SOURCE_ROTATION_DISABLED)]
+    fun test_set_governance_data_source_aborts() {
+        let (scenario, test_coins, clock) = setup_test(500, 1, x"63278d271099bfd491951b3e648f08b1c71631e4a53674ad43e8f9f98068c385", pyth_tests::data_sources_for_test_vaa(), vector[x"beFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe"], DEFAULT_BASE_UPDATE_FEE, DEFAULT_COIN_TO_MINT);
+        test_scenario::next_tx(&mut scenario, DEPLOYER);
+        let (pyth_state, worm_state) = take_wormhole_and_pyth_states(&scenario);
+
+        let verified_vaa = wormhole::vaa::parse_and_verify(&worm_state, SET_GOVERNANCE_DATA_SOURCE_VAA, &clock);
+
+        let receipt = pyth::governance::verify_vaa(&pyth_state, verified_vaa);
+
+        test_scenario::next_tx(&mut scenario, DEPLOYER);
+
+        // The dispatcher routes this to `set_governance_data_source::execute`,
+        // which now aborts with `E_GOVERNANCE_DATA_SOURCE_ROTATION_DISABLED`.
+        pyth::governance::execute_governance_instruction(&mut pyth_state, receipt);
+
+        // Unreachable; kept so the test compiles with all resources consumed.
+        coin::burn_for_testing(test_coins);
+        pyth_tests::cleanup_worm_state_pyth_state_and_clock(worm_state, pyth_state, clock);
+        test_scenario::end(scenario);
     }
 }


### PR DESCRIPTION
Replace the body of `pyth::set_governance_data_source::execute` on Sui with an unconditional abort so that Pyth governance data source rotation cannot fire. This kills the in-PTB replay attack against Sui Pyth governance ([[i-bouhkykq]] — bug bounty report #79076) without requiring a V2 contract migration.

## Why a stopgap

`WormholeVAAVerificationReceipt` (returned by `pyth::governance::verify_vaa`) carries only `payload`, `digest`, and `sequence` — not the data source the VAA was verified against. An attacker holding any stale, previously-signed governance VAA (`SetDataSources`, `SetUpdateFee`, `SetStalePriceThreshold`, `SetFeeRecipient`, `ContractUpgrade`) can, in a single PTB:

1. `verify_vaa(stale_vaa)` — passes (source = OLD); produces `receipt_old`.
2. `verify_vaa(rotate_vaa)` — passes (source still = OLD); produces `receipt_rotate`.
3. `execute_governance_instruction(receipt_rotate)` — rotates the source to NEW *and* overwrites `last_executed_governance_sequence` with the payload-controlled `initial_sequence`.
4. `execute_governance_instruction(receipt_old)` — slips past the post-rotation monotonicity check and replays the stale VAA against the NEW source.

The architecturally correct fix is to bind the data source to the receipt and re-check it at execute time. Under Sui's `compatible` package upgrade policy, that requires an additive V2 path (new receipt struct + new function variants + abort-deprecate the old ones + SDK migration); a struct-layout or public-signature change is rejected by the upgrade verifier.

Disabling rotation closes the only function call that can trigger step 3 in the chain above, at the cost of making the Sui Pyth governance emitter immutable until a future V2 upgrade ships. The Sui governance source has been stable since deployment, so disabling rotation temporarily is an acceptable trade-off.

## What changed

`target_chains/sui/contracts/sources/governance/set_governance_data_source.move`:

- `execute` now `abort`s with a new `E_GOVERNANCE_DATA_SOURCE_ROTATION_DISABLED` constant. The function signature is byte-identical to the previous version (only parameter names gain a `_` prefix to silence unused-parameter warnings), so the dispatcher in `governance.move` still type-checks and the package upgrade verifier still accepts the change under `compatible`.
- The doc comment above the const explains the replay vector and the V2-upgrade constraint that prevents the proper fix from landing in this patch.
- Removed the now-unused `GovernanceDataSource` struct, the `from_byte_vec` helper, and their imports. Removing private items is allowed under `compatible`. The `public(friend) execute` function MUST stay (removing it would be rejected).
- The `friend pyth::governance;` declaration is preserved.

`governance.move`'s dispatcher is unchanged — it still routes the `SetGovernanceDataSource` action to `set_governance_data_source::execute`; the abort happens in the callee.

## Regression test

Inline `#[test_only] module pyth::set_governance_data_source_tests` following the pattern in the other `set_*.move` files. It verifies a hand-rolled `SetGovernanceDataSource` Wormhole VAA against the Pyth governance source and asserts the subsequent `execute_governance_instruction` aborts with `E_GOVERNANCE_DATA_SOURCE_ROTATION_DISABLED`.

The test VAA is signed by the well-known Wormhole devnet guardian (`0xbeFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe`); the matching `setup_test` call wires that guardian into the initial guardian set. Governance emitter chain/address match `setup_test`'s `governance_emitter` argument (chain 1 / address `63278d27...068c385`). Payload uses Pyth governance action byte `1` (the actual `SetGovernanceDataSource` value from `governance_action.move` — the issue body's reference to "action byte `2`" appears to be a typo; action `2` is `SetDataSources`).

## Out of scope

- `WormholeVAAVerificationReceipt` struct in `governance.move` — layout change is rejected by `compatible`.
- Public function signatures (`verify_vaa`, `execute_governance_instruction`, `authorize_upgrade`, etc.) — signature changes are rejected by `compatible`.
- Off-chain SDKs (`target_chains/sui/sdk`, `target_chains/sui/cli`) — no signature changes, no client work.
- `lazer/contracts/sui` — not vulnerable to this bug class (no governance rotation action exists).

## Local test gate

The repo pins Sui rev `041c5f2b` (Move compiler 1.27.2). The matching `sui` binary is not in the Mysten releases page, and building it from source in this sandbox failed during `librocksdb-sys` (`libclang` is missing and the sandbox has no package manager to install it). The newer pre-built `sui 1.73.1` rejects the project's `Move.toml` outright (`Address 'wormhole' is defined more than once`). CI (`.github/workflows/ci-sui-contract.yml`) installs the pinned `sui` via `cargo +1.79.0 install --git ... --rev 041c5f2b` and runs `sui move test`, which will exercise the gate. The code follows the established conventions of the surrounding `set_*.move` files exactly.