### PR TITLE
fix(apps/hip-3-pusher): Change Stale Logs to INFO

### DIFF
--- a/apps/hip-3-pusher/pyproject.toml
+++ b/apps/hip-3-pusher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hip-3-pusher"
-version = "0.3.1"
+version = "0.3.2"
 description = "Hyperliquid HIP-3 market oracle pusher"
 readme = "README.md"
 requires-python = "==3.13.*"

--- a/apps/hip-3-pusher/src/pusher/price_state.py
+++ b/apps/hip-3-pusher/src/pusher/price_state.py
@@ -305,7 +305,7 @@ class PriceState:
         time_diff = update.time_diff(now)
         if time_diff >= self.stale_price_threshold_seconds:
             self._record_unavailable(source.source_name, "stale")
-            logger.debug(
+            logger.info(
                 "source {} id {} is stale by {} seconds",
                 source.source_name,
                 source.source_id,
@@ -371,7 +371,7 @@ class PriceState:
         time_diff = mid_price_update.time_diff(time.time())
         if time_diff >= self.stale_price_threshold_seconds:
             self._record_unavailable(self.HL_MID, "stale")
-            logger.debug("mid price for {} is stale by {} seconds", symbol, time_diff)
+            logger.info("mid price for {} is stale by {} seconds", symbol, time_diff)
             return None
 
         return (float(oracle_price) + float(mid_price_update.price)) / 2.0
@@ -425,7 +425,7 @@ class PriceState:
         time_diff = oracle_update.time_diff(now)
         if time_diff >= self.stale_price_threshold_seconds:
             self._record_unavailable(oracle_source.source_name, "stale")
-            logger.debug(
+            logger.info(
                 "source {} id {} is stale by {} seconds",
                 oracle_source.source_name,
                 oracle_source.source_id,

--- a/apps/hip-3-pusher/uv.lock
+++ b/apps/hip-3-pusher/uv.lock
@@ -381,7 +381,7 @@ wheels = [
 
 [[package]]
 name = "hip-3-pusher"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

Bump staleness logs to INFO

## Rationale

Need to know which asset is stale for debugging

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->