### PR TITLE
fix(developer-hub): remove price feeds from docs search index

### DIFF
--- a/apps/developer-hub/src/app/api/search/route.ts
+++ b/apps/developer-hub/src/app/api/search/route.ts
@@ -1,115 +1,16 @@
 import type { AdvancedIndex } from "fumadocs-core/search/server";
 import { createSearchAPI } from "fumadocs-core/search/server";
-import { z } from "zod";
 
-import { SYMBOLS_API_URL } from "../../../config/pyth-pro-public";
 import { source } from "../../../lib/source";
 
-// Define schemas for type safety
-const hermesSchema = z.array(
-  z.object({
-    id: z.string(),
-    attributes: z.object({ symbol: z.string() }),
-  }),
-);
-
-const lazerSchema = z.array(
-  z.object({
-    symbol: z.string(),
-    name: z.string(),
-    pyth_lazer_id: z.number(),
-    description: z.string(),
-  }),
-);
-
-function toAdvancedIndex(
-  fee: z.infer<typeof hermesSchema>[number],
-): AdvancedIndex {
-  return {
-    title: `${fee.attributes.symbol} (Core)`,
-    description: `Price Feed ID: ${fee.id}`,
-    url: `/price-feeds/core/price-feeds/price-feed-ids?search=${fee.attributes.symbol}`,
-    id: fee.id,
-    tag: "price-feed-core",
-    structuredData: {
-      headings: [],
-      contents: [
-        { heading: "Symbol", content: fee.attributes.symbol },
-        { heading: "ID", content: fee.id },
-      ],
-    },
-  };
-}
-
-async function getHermesFeeds(): Promise<AdvancedIndex[]> {
-  try {
-    const results = await Promise.all(
-      ["https://hermes.pyth.network", "https://hermes-beta.pyth.network"].map(
-        async (url): Promise<AdvancedIndex[]> => {
-          const hermesResult = await fetch(new URL("/v2/price_feeds", url), {
-            next: { revalidate: 3600 },
-          });
-          const parsed = hermesSchema.safeParse(await hermesResult.json());
-          return parsed.success
-            ? parsed.data.map((feed) => toAdvancedIndex(feed))
-            : [];
-        },
-      ),
-    );
-
-    return results.flat();
-  } catch (error: unknown) {
-    throw new Error("Failed to fetch Hermes feeds", { cause: error });
-  }
-}
-
-async function getLazerFeeds(): Promise<AdvancedIndex[]> {
-  try {
-    const res = await fetch(SYMBOLS_API_URL, { next: { revalidate: 3600 } });
-    const parsed = lazerSchema.safeParse(await res.json());
-
-    if (!parsed.success) {
-      return [];
-    }
-
-    return parsed.data.map((feed) => ({
-      title: `${feed.name} (Pro)`,
-      description: `${feed.symbol} - ${feed.description} (ID: ${String(feed.pyth_lazer_id)})`,
-      url: `/price-feeds/pro/price-feed-ids?search=${feed.symbol}`,
-      id: `lazer-${String(feed.pyth_lazer_id)}`,
-      tag: "price-feed-pro",
-      structuredData: {
-        headings: [],
-        contents: [
-          { heading: "Symbol", content: feed.symbol },
-          { heading: "Name", content: feed.name },
-          { heading: "Description", content: feed.description },
-          { heading: "ID", content: String(feed.pyth_lazer_id) },
-        ],
-      },
-    }));
-  } catch (error: unknown) {
-    throw new Error("Failed to fetch Lazer feeds", { cause: error });
-  }
-}
-
 export const { GET } = createSearchAPI("advanced", {
-  indexes: async () => {
-    const staticPages = source.getPages().map((page) => ({
+  indexes: () => {
+    return source.getPages().map((page) => ({
       title: page.data.title,
       description: page.data.description,
       url: page.url,
       id: page.url,
       structuredData: page.data.structuredData,
     })) as AdvancedIndex[];
-
-    // Added these two functions to get the price feeds from the Hermes and Pro APIs
-    const [hermesFeeds, lazerFeeds] = await Promise.all([
-      getHermesFeeds(),
-      getLazerFeeds(),
-    ]);
-
-    // Combine the static pages, Hermes feeds, and Pro feeds
-    return [...staticPages, ...hermesFeeds, ...lazerFeeds];
   },
 });

--- a/apps/developer-hub/turbo.json
+++ b/apps/developer-hub/turbo.json
@@ -18,6 +18,11 @@
         "PLAYGROUND_MAX_STREAM_DURATION_MS",
         "PLAYGROUND_RATE_LIMIT_WINDOW_MS",
         "PLAYGROUND_RATE_LIMIT_MAX_REQUESTS"
+      ],
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**",
+        ".source/**"
       ]
     },
     "fix:lint": {


### PR DESCRIPTION
Parent issue: [[i-wjchrnyb]]

## Summary

`apps/developer-hub/src/app/api/search/route.ts` was fetching ~9,262 price feeds from Hermes mainnet + Hermes beta + Lazer on every cold start and expanding them to ~36k Orama records — ~95% of the global search index. The dedicated `/price-feeds/core/price-feeds/price-feed-ids` and `/price-feeds/pro/price-feed-ids` pages already have their own in-page `SearchInput` (`match-sorter` over the same Hermes/Lazer data), and the global search entries just funneled users to those pages via `?search=` query params — pure redundancy. The `price-feed-core` / `price-feed-pro` tags were consumed nowhere.

## Changes

### 1. `apps/developer-hub/src/app/api/search/route.ts` (primary, scoped change)

- Deleted `getHermesFeeds()`, `getLazerFeeds()`, `toAdvancedIndex()`, `hermesSchema`, `lazerSchema`.
- `indexes` callback now returns only the MDX pages from `source.getPages()`.
- Dropped now-unused imports: `z` from `zod`, `SYMBOLS_API_URL` from `../../../config/pyth-pro-public`.
- Kept the `AdvancedIndex` type import for the static-pages cast (matches what was there before).
- `SYMBOLS_API_URL` itself is intentionally left in `src/config/pyth-pro-public.ts` per the issue's out-of-scope list.
- `PriceFeedIdsCoreTable` / `PriceFeedIdsProTable` untouched — they retain their in-page search and Hermes/Lazer fetches.

### 2. `apps/developer-hub/turbo.json` (rework: CI fix)

Override the inherited `build` `outputs` to add `.source/**` alongside `.next/**`. `next build` (via the `fumadocs-mdx` `createMDX` wrapper in `next.config.js`) generates `apps/developer-hub/.source/server.ts` etc., which `src/lib/source.ts` imports. The previous outputs only listed `.next/**` (inherited from root `turbo.json`), so when CI's turbo cache restored a prior `developer-hub#build` artifact, `.source/` was missing — `test:types` then ran `tsc` and failed with `Cannot find module '../../.source/server'` plus the cascade of `Property 'body' / 'toc' / 'full' / 'structuredData' does not exist on type 'PageData'` errors that prompted the rework (see the prior run https://github.com/pyth-network/pyth-crosschain/actions/runs/27693529743/job/81910556027). Reproduced locally by deleting `apps/developer-hub/.source` after a build and re-running `pnpm exec tsc`: same errors. With `.source/**` in outputs, turbo now restores it from cache alongside `.next/**`, so dependent type-check / lint tasks resolve the generated module reliably.

(The inherited `lib/**` / `dist/**` entries were dropped from the override because developer-hub is a Next.js app and never produces those.)

## Verification

- `grep -rn "price-feed-core\|price-feed-pro" apps/developer-hub/src` → no matches.
- `pnpm turbo run test:types --filter=@pythnetwork/developer-hub` → passes (fresh cache).
- Cleared `apps/developer-hub/.next` and `.source`, re-ran `pnpm turbo run test:types --filter=@pythnetwork/developer-hub` with a populated turbo cache → cache-hit on `build`, `.source/` restored from cache, `test:types` passes.
- `pnpm turbo run test:lint --filter=@pythnetwork/developer-hub` → passes.
- `git merge-tree origin/main HEAD` → clean (no conflicts).

Manual dev-server check could not be performed in this environment (no browser). Vercel's preview deployment for developer-hub succeeded on the prior commit, exercising the production build.