### PR TITLE
docs(pro): add Stellar consumer integration guide and contract address

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/contract-addresses.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/contract-addresses.mdx
@@ -39,6 +39,12 @@ For Sui, both the package ID and the shared state object ID are relevant. Integr
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Cardano Mainnet | <CopyAddress address="c935c937d0deda8975142c7b77aeef8f8cd48791e89a8ca7a0edc154" url="https://cexplorer.io/policy/c935c937d0deda8975142c7b77aeef8f8cd48791e89a8ca7a0edc154" /> |
 
+## Stellar
+
+| Network         | Contract Address                                                                                                                                                                                            |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Stellar Testnet | <CopyAddress address="CCE62RN3NUTNMD2SQ2EGWRJ6XHL7RUYQBNCEK7LVGFRLPCW7U7FGACM5" url="https://stellar.expert/explorer/testnet/contract/CCE62RN3NUTNMD2SQ2EGWRJ6XHL7RUYQBNCEK7LVGFRLPCW7U7FGACM5" /> |
+
 ## EVM Mainnets
 
 <LazerTable isMainnet={true} />

--- a/apps/developer-hub/content/docs/price-feeds/pro/contract-addresses.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/contract-addresses.mdx
@@ -43,7 +43,7 @@ For Sui, both the package ID and the shared state object ID are relevant. Integr
 
 | Network         | Contract Address                                                                                                                                                                                            |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Stellar Testnet | <CopyAddress address="CCE62RN3NUTNMD2SQ2EGWRJ6XHL7RUYQBNCEK7LVGFRLPCW7U7FGACM5" url="https://stellar.expert/explorer/testnet/contract/CCE62RN3NUTNMD2SQ2EGWRJ6XHL7RUYQBNCEK7LVGFRLPCW7U7FGACM5" /> |
+| Stellar Testnet | <CopyAddress address="CD2KMDOR274ZVPVVSDIBWNBLGAXJOHKJBQGNWYQHF3O6H767UOYJJYJZ" url="https://stellar.expert/explorer/testnet/contract/CD2KMDOR274ZVPVVSDIBWNBLGAXJOHKJBQGNWYQHF3O6H767UOYJJYJZ" /> |
 
 ## EVM Mainnets
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/index.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/index.mdx
@@ -6,12 +6,13 @@ slug: /price-feeds/pro/integrate-as-consumer
 
 The following guides demonstrate how to integrate and verify prices as a consumer on blockchain.
 
-Pyth Pro price updates can be verified on Solana, Fogo, EVM chains, Sui, and Cardano. Please consult the following guides to get started:
+Pyth Pro price updates can be verified on Solana, Fogo, EVM chains, Sui, Cardano, and Stellar. Please consult the following guides to get started:
 
 - [Solana and Fogo](/price-feeds/pro/integrate-as-consumer/svm)
 - [EVM](/price-feeds/pro/integrate-as-consumer/evm)
 - [Sui](/price-feeds/pro/integrate-as-consumer/sui)
 - [Cardano](/price-feeds/pro/integrate-as-consumer/cardano)
+- [Stellar](/price-feeds/pro/integrate-as-consumer/stellar)
 
 Pyth Pro price updates can also be used in off-chain applications. See the
 [subscribe to prices guide](/price-feeds/pro/subscribe-to-prices) and the [Terms of Service](https://www.dourolabs.xyz/Subscription-Terms.pdf) for more information.

--- a/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/meta.json
+++ b/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/meta.json
@@ -4,7 +4,8 @@
     "[in SVM programs](/price-feeds/pro/integrate-as-consumer/svm)",
     "[in EVM contracts](/price-feeds/pro/integrate-as-consumer/evm)",
     "[in Sui contracts](/price-feeds/pro/integrate-as-consumer/sui)",
-    "[in Cardano contracts](/price-feeds/pro/integrate-as-consumer/cardano)"
+    "[in Cardano contracts](/price-feeds/pro/integrate-as-consumer/cardano)",
+    "[in Stellar contracts](/price-feeds/pro/integrate-as-consumer/stellar)"
   ],
   "defaultOpen": false
 }

--- a/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/stellar.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/stellar.mdx
@@ -41,36 +41,7 @@ client.subscribe({
   <Step>
   ### Verify price updates from your Soroban contract
 
-Pyth Pro provides a Soroban contract deployed on Stellar that verifies signed Lazer updates. Your own Soroban contract calls it via cross-contract invocation:
-
-```rust copy
-use pyth_lazer_stellar_sdk::PythLazerClient;
-use soroban_sdk::{contract, contractimpl, Address, Bytes, Env};
-
-#[contract]
-pub struct ExampleConsumer;
-
-#[contractimpl]
-impl ExampleConsumer {
-    /// Receives a signed Lazer update, asks `pyth-lazer-stellar` to verify it,
-    /// and returns the verified payload bytes.
-    pub fn update_price(env: Env, lazer: Address, update: Bytes) -> Bytes {
-        let lazer = PythLazerClient::new(&env, &lazer);
-        lazer.verify_update(&update)
-    }
-}
-```
-
-<Callout type="warning">
-  Always call `verify_update` from inside your own contract — don't trust verified bytes passed in by the off-chain caller.
-  The cross-contract call is what gives your contract a trust boundary against an unsigned update.
-</Callout>
-
-  </Step>
-  <Step>
-  ### Consume the verified payload
-
-The [Pyth Lazer Stellar SDK](https://crates.io/crates/pyth-lazer-stellar-sdk) exposes the verified payload as a typed `Update` value. Add it to your contract's `Cargo.toml`:
+Pyth Pro provides a Soroban contract deployed on Stellar that verifies signed Lazer updates. The [Pyth Lazer Stellar SDK](https://crates.io/crates/pyth-lazer-stellar-sdk) exposes a typed `PythLazerClient` that cross-contract-calls the verifier and returns the parsed update in one call. Add it to your contract's `Cargo.toml`:
 
 ```toml copy
 [dependencies]
@@ -78,17 +49,51 @@ soroban-sdk = "22"
 pyth-lazer-stellar-sdk = "0.2"
 ```
 
-Parse the payload and read the feeds you need:
+Then verify from inside your own contract:
 
 ```rust copy
-use pyth_lazer_stellar_sdk::{parse_payload, PythLazerClient};
+use pyth_lazer_stellar_sdk::{ParseError, PythLazerClient, VerifiedPayload};
+use soroban_sdk::{contract, contractimpl, Address, Bytes, Env};
+
+#[contract]
+pub struct ExampleConsumer;
+
+#[contractimpl]
+impl ExampleConsumer {
+    /// Receives a signed Lazer update and asks `pyth-lazer-stellar` to verify
+    /// it. Returns a typed `VerifiedPayload` (which derefs to the parsed
+    /// `Update`); traps if the signature is bad, returns `ParseError` if the
+    /// verified payload bytes are malformed.
+    pub fn update_price(env: Env, lazer: Address, payload: Bytes) -> Result<(), ParseError> {
+        let update: VerifiedPayload =
+            PythLazerClient::new(&env, &lazer).verify_update(&payload)?;
+        // `update.feeds`, `update.timestamp`, `update.channel` are accessible
+        // via deref — use them in the next step.
+        Ok(())
+    }
+}
+```
+
+<Callout type="warning">
+  Always call `verify_update` from inside your own contract — don't trust a parsed update passed in by the off-chain caller.
+  The cross-contract call is what gives your contract a trust boundary against an unsigned update.
+</Callout>
+
+  </Step>
+  <Step>
+  ### Consume the verified payload
+
+Pick the feed you care about and read its fields off the verified `Update`:
+
+```rust copy
+use pyth_lazer_stellar_sdk::{ParseError, PythLazerClient};
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, Env};
 
 #[contracttype]
 #[derive(Clone)]
 pub struct StoredPrice {
     pub price: i64,
-    pub exponent: i16,
+    pub exponent: i32,
     pub timestamp_us: u64,
 }
 
@@ -97,31 +102,27 @@ pub struct ExampleConsumer;
 
 #[contractimpl]
 impl ExampleConsumer {
-    pub fn update_price(env: Env, lazer: Address, update: Bytes) -> StoredPrice {
-        // 1. Verify the signed update via cross-contract call.
-        let lazer = PythLazerClient::new(&env, &lazer);
-        let verified_payload = lazer.verify_update(&update);
+    pub fn update_price(env: Env, lazer: Address, payload: Bytes) -> Result<StoredPrice, ParseError> {
+        // Verify + parse in one call.
+        let update = PythLazerClient::new(&env, &lazer).verify_update(&payload)?;
 
-        // 2. Parse the verified payload into a typed Update.
-        let parsed = parse_payload(&verified_payload).expect("invalid payload");
-
-        // 3. Find the feed you care about (BTC/USD, feed_id = 1) and read its fields.
-        let feed = parsed
+        // BTC/USD is feed_id = 1; pick the feed you care about.
+        let feed = update
             .feeds
             .iter()
             .find(|f| f.feed_id == 1)
             .expect("BTC/USD feed missing");
 
-        StoredPrice {
+        Ok(StoredPrice {
             price: feed.price.expect("price missing"),
-            exponent: feed.exponent.expect("exponent missing"),
-            timestamp_us: parsed.timestamp,
-        }
+            exponent: i32::from(feed.exponent.expect("exponent missing")),
+            timestamp_us: feed.feed_update_timestamp.expect("feed timestamp missing"),
+        })
     }
 }
 ```
 
-Feed properties that are not requested in the subscription return `None`. Signed integer properties (`price`, `best_bid_price`, `best_ask_price`, `confidence`, `funding_rate`, `ema_price`, `ema_confidence`) are decoded as `Option<i64>`. See the [Pyth Pro payload reference](/price-feeds/pro/payload-reference) for the complete wire format.
+Feed properties that are not requested in the subscription return `None`. Signed integer properties (`price`, `best_bid_price`, `best_ask_price`, `confidence`, `funding_rate`, `ema_price`, `ema_confidence`) are decoded as `Option<i64>`. Per-feed `feed_update_timestamp` (microseconds since epoch) is the right field for freshness checks; the top-level `update.timestamp` is the payload-level timestamp. See the [Pyth Pro payload reference](/price-feeds/pro/payload-reference) for the complete wire format.
 
 <Callout type="info">
   Submit the transaction from your off-chain client using

--- a/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/stellar.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/stellar.mdx
@@ -30,7 +30,7 @@ client.subscribe({
   type: "subscribe",
   subscriptionId: 1,
   priceFeedIds: [1, 2], // BTC/USD, ETH/USD
-  properties: ["price", "bestBidPrice", "bestAskPrice", "exponent"],
+  properties: ["price", "bestBidPrice", "bestAskPrice", "exponent", "feedUpdateTimestamp"],
   formats: ["leEcdsa"], // Required for Stellar
   channel: "fixed_rate@200ms",
   jsonBinaryEncoding: "hex",
@@ -41,9 +41,19 @@ client.subscribe({
   <Step>
   ### Verify price updates from your Soroban contract
 
-Pyth Pro provides a Soroban contract deployed on Stellar that verifies signed Lazer updates. The [Pyth Lazer Stellar SDK](https://crates.io/crates/pyth-lazer-stellar-sdk) exposes a typed `PythLazerClient` that cross-contract-calls the verifier and returns the parsed update in one call. Add it to your contract's `Cargo.toml`:
+Pyth Pro provides a Soroban contract deployed on Stellar that verifies signed Lazer updates. The [Pyth Lazer Stellar SDK](https://crates.io/crates/pyth-lazer-stellar-sdk) exposes a typed `PythLazerClient` that cross-contract-calls the verifier and returns the parsed update in one call.
+
+Scaffold a new Soroban contract with `stellar contract init <name>`, then replace the contract crate's `Cargo.toml` and `src/lib.rs` with the snippets below. Pin `soroban-sdk` to the major the SDK targets — bumping to a newer `soroban-sdk` (e.g. the `stellar contract init` default) will fail to build against the published SDK.
 
 ```toml copy
+[package]
+name = "example-consumer"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
 [dependencies]
 soroban-sdk = "22"
 pyth-lazer-stellar-sdk = "0.2"
@@ -52,6 +62,8 @@ pyth-lazer-stellar-sdk = "0.2"
 Then verify from inside your own contract:
 
 ```rust copy
+#![no_std]
+
 use pyth_lazer_stellar_sdk::{ParseError, PythLazerClient, VerifiedPayload};
 use soroban_sdk::{contract, contractimpl, Address, Bytes, Env};
 
@@ -86,6 +98,8 @@ impl ExampleConsumer {
 Pick the feed you care about and read its fields off the verified `Update`:
 
 ```rust copy
+#![no_std]
+
 use pyth_lazer_stellar_sdk::{ParseError, PythLazerClient};
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, Env};
 
@@ -122,7 +136,7 @@ impl ExampleConsumer {
 }
 ```
 
-Feed properties that are not requested in the subscription return `None`. Signed integer properties (`price`, `best_bid_price`, `best_ask_price`, `confidence`, `funding_rate`, `ema_price`, `ema_confidence`) are decoded as `Option<i64>`. Per-feed `feed_update_timestamp` (microseconds since epoch) is the right field for freshness checks; the top-level `update.timestamp` is the payload-level timestamp. See the [Pyth Pro payload reference](/price-feeds/pro/payload-reference) for the complete wire format.
+Every property your contract reads must be requested in the Step 1 subscription — feed properties not in the subscription decode to `None`, so an unguarded `.expect(...)` will trap on-chain. Signed integer properties (`price`, `best_bid_price`, `best_ask_price`, `confidence`, `funding_rate`, `ema_price`, `ema_confidence`) are decoded as `Option<i64>`. Per-feed `feed_update_timestamp` (microseconds since epoch, requested as `feedUpdateTimestamp`) is the right field for freshness checks; the top-level `update.timestamp` is the payload-level timestamp. See the [Pyth Pro payload reference](/price-feeds/pro/payload-reference) for the complete wire format.
 
 <Callout type="info">
   Submit the transaction from your off-chain client using
@@ -146,4 +160,4 @@ Pyth Pro supports a wide range of price feeds. Consult the [Price Feed IDs](/pri
 
 ### Rust SDK
 
-The user-facing Rust SDK [`pyth-lazer-stellar-sdk`](https://crates.io/crates/pyth-lazer-stellar-sdk) exposes the typed `Update` and `Feed` types plus the `parse_payload` helper shown above. API reference on [docs.rs](https://docs.rs/pyth-lazer-stellar-sdk).
+The user-facing Rust SDK [`pyth-lazer-stellar-sdk`](https://crates.io/crates/pyth-lazer-stellar-sdk) exposes the typed `Update` and `Feed` types, the `verify_update` helper used above, and a standalone `parse_payload` helper for already-verified bytes. API reference on [docs.rs](https://docs.rs/pyth-lazer-stellar-sdk).

--- a/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/stellar.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/stellar.mdx
@@ -43,7 +43,7 @@ client.subscribe({
 
 Pyth Pro provides a Soroban contract deployed on Stellar that verifies signed Lazer updates. The [Pyth Lazer Stellar SDK](https://crates.io/crates/pyth-lazer-stellar-sdk) exposes a typed `PythLazerClient` that cross-contract-calls the verifier and returns the parsed update in one call.
 
-Scaffold a new Soroban contract with `stellar contract init <name>`, then replace the contract crate's `Cargo.toml` and `src/lib.rs` with the snippets below. Pin `soroban-sdk` to the major the SDK targets — bumping to a newer `soroban-sdk` (e.g. the `stellar contract init` default) will fail to build against the published SDK.
+Scaffold a new Soroban contract with `stellar contract init <name>`, then replace the contract crate's `Cargo.toml` and `src/lib.rs` with the snippets below.
 
 ```toml copy
 [package]
@@ -55,8 +55,8 @@ edition = "2021"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-soroban-sdk = "22"
-pyth-lazer-stellar-sdk = "0.2"
+soroban-sdk = "26"
+pyth-lazer-stellar-sdk = "0.3"
 ```
 
 Then verify from inside your own contract:

--- a/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/stellar.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/stellar.mdx
@@ -1,0 +1,150 @@
+---
+title: Consume Data on Stellar
+description: Consume and verify Pyth Pro price updates in Stellar Soroban smart contracts
+slug: /price-feeds/pro/integrate-as-consumer/stellar
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+import { Step, Steps } from "fumadocs-ui/components/steps";
+
+This guide is intended to serve users who want to consume prices from Pyth Pro on **Stellar** (via [Soroban](https://soroban.stellar.org/) smart contracts).
+
+Integrating with Pyth Pro in Soroban smart contracts as a consumer is a three-step process:
+
+1. **Subscribe** to Pyth Pro to receive signed price updates off-chain.
+2. **Verify** price updates by cross-contract calling `pyth-lazer-stellar`'s `verify_update` from your own Soroban contract.
+3. **Consume** the verified payload using the Pyth Lazer Stellar SDK crate.
+
+<Steps>
+  <Step>
+  ### Subscribe to Pyth Pro to receive Price Updates
+
+Pyth Pro provides a websocket endpoint to receive price updates and a [TypeScript SDK](https://www.npmjs.com/package/@pythnetwork/pyth-lazer-sdk) to subscribe to it.
+
+Consult [How to subscribe to prices](/price-feeds/pro/subscribe-to-prices) for a complete step-by-step guide.
+
+When subscribing, request the `leEcdsa` format which is compatible with Soroban's host-side secp256k1 signature verification:
+
+```typescript copy
+client.subscribe({
+  type: "subscribe",
+  subscriptionId: 1,
+  priceFeedIds: [1, 2], // BTC/USD, ETH/USD
+  properties: ["price", "bestBidPrice", "bestAskPrice", "exponent"],
+  formats: ["leEcdsa"], // Required for Stellar
+  channel: "fixed_rate@200ms",
+  jsonBinaryEncoding: "hex",
+});
+```
+
+  </Step>
+  <Step>
+  ### Verify price updates from your Soroban contract
+
+Pyth Pro provides a [Soroban contract](https://github.com/pyth-network/pyth-lazer/tree/main/contracts/stellar) deployed on Stellar that verifies signed Lazer updates. Your own Soroban contract calls it via cross-contract invocation:
+
+```rust copy
+use pyth_lazer_stellar_sdk::PythLazerClient;
+use soroban_sdk::{contract, contractimpl, Address, Bytes, Env};
+
+#[contract]
+pub struct ExampleConsumer;
+
+#[contractimpl]
+impl ExampleConsumer {
+    /// Receives a signed Lazer update, asks `pyth-lazer-stellar` to verify it,
+    /// and returns the verified payload bytes.
+    pub fn update_price(env: Env, lazer: Address, update: Bytes) -> Bytes {
+        let lazer = PythLazerClient::new(&env, &lazer);
+        lazer.verify_update(&update)
+    }
+}
+```
+
+<Callout type="warning">
+  Always call `verify_update` from inside your own contract — don't trust verified bytes passed in by the off-chain caller.
+  The cross-contract call is what gives your contract a trust boundary against an unsigned update.
+</Callout>
+
+  </Step>
+  <Step>
+  ### Consume the verified payload
+
+The Pyth Lazer Stellar SDK exposes the verified payload as a typed `Update` value. Add it to your contract's `Cargo.toml`:
+
+```toml copy
+[dependencies]
+soroban-sdk = "22"
+pyth-lazer-stellar-sdk = "0.1"
+```
+
+Parse the payload and read the feeds you need:
+
+```rust copy
+use pyth_lazer_stellar_sdk::{parse_payload, PythLazerClient};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, Env};
+
+#[contracttype]
+#[derive(Clone)]
+pub struct StoredPrice {
+    pub price: i64,
+    pub exponent: i16,
+    pub timestamp_us: u64,
+}
+
+#[contract]
+pub struct ExampleConsumer;
+
+#[contractimpl]
+impl ExampleConsumer {
+    pub fn update_price(env: Env, lazer: Address, update: Bytes) -> StoredPrice {
+        // 1. Verify the signed update via cross-contract call.
+        let lazer = PythLazerClient::new(&env, &lazer);
+        let verified_payload = lazer.verify_update(&update);
+
+        // 2. Parse the verified payload into a typed Update.
+        let parsed = parse_payload(&verified_payload).expect("invalid payload");
+
+        // 3. Find the feed you care about (BTC/USD, feed_id = 1) and read its fields.
+        let feed = parsed
+            .feeds
+            .iter()
+            .find(|f| f.feed_id == 1)
+            .expect("BTC/USD feed missing");
+
+        StoredPrice {
+            price: feed.price.expect("price missing"),
+            exponent: feed.exponent.expect("exponent missing"),
+            timestamp_us: parsed.timestamp,
+        }
+    }
+}
+```
+
+Feed properties that are not requested in the subscription return `None`. Signed integer properties (`price`, `best_bid_price`, `best_ask_price`, `confidence`, `funding_rate`, `ema_price`, `ema_confidence`) are decoded as `Option<i64>`. See the [Pyth Pro payload reference](/price-feeds/pro/payload-reference) for the complete wire format.
+
+<Callout type="info">
+  Submit the transaction from your off-chain client using
+  [`@stellar/stellar-sdk`](https://www.npmjs.com/package/@stellar/stellar-sdk),
+  passing the binary update bytes as the `update` argument to
+  `ExampleConsumer::update_price` (and the deployed
+  [`pyth-lazer-stellar` contract id](/price-feeds/pro/contract-addresses#stellar)
+  as `lazer`).
+</Callout>
+
+  </Step>
+</Steps>
+
+## Additional Resources
+
+You may find these additional resources helpful for consuming prices from Pyth Pro in Stellar Soroban smart contracts.
+
+### Price Feed IDs
+
+Pyth Pro supports a wide range of price feeds. Consult the [Price Feed IDs](/price-feeds/pro/price-feed-ids) page for a complete list of supported price feeds.
+
+### Contract Sources
+
+The Stellar Soroban contract implementation lives in [`contracts/stellar`](https://github.com/pyth-network/pyth-lazer/tree/main/contracts/stellar) in the `pyth-network/pyth-lazer` repository.
+
+The user-facing Rust SDK ([`pyth-lazer-stellar-sdk`](https://github.com/pyth-network/pyth-lazer/tree/main/contracts/stellar/sdk/rust)) exposes the typed `Update` and `Feed` types plus the `parse_payload` helper shown above.

--- a/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/stellar.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/stellar.mdx
@@ -41,7 +41,7 @@ client.subscribe({
   <Step>
   ### Verify price updates from your Soroban contract
 
-Pyth Pro provides a [Soroban contract](https://github.com/pyth-network/pyth-lazer/tree/main/contracts/stellar) deployed on Stellar that verifies signed Lazer updates. Your own Soroban contract calls it via cross-contract invocation:
+Pyth Pro provides a Soroban contract deployed on Stellar that verifies signed Lazer updates. Your own Soroban contract calls it via cross-contract invocation:
 
 ```rust copy
 use pyth_lazer_stellar_sdk::PythLazerClient;
@@ -70,12 +70,12 @@ impl ExampleConsumer {
   <Step>
   ### Consume the verified payload
 
-The Pyth Lazer Stellar SDK exposes the verified payload as a typed `Update` value. Add it to your contract's `Cargo.toml`:
+The [Pyth Lazer Stellar SDK](https://crates.io/crates/pyth-lazer-stellar-sdk) exposes the verified payload as a typed `Update` value. Add it to your contract's `Cargo.toml`:
 
 ```toml copy
 [dependencies]
 soroban-sdk = "22"
-pyth-lazer-stellar-sdk = "0.1"
+pyth-lazer-stellar-sdk = "0.2"
 ```
 
 Parse the payload and read the feeds you need:
@@ -143,8 +143,6 @@ You may find these additional resources helpful for consuming prices from Pyth P
 
 Pyth Pro supports a wide range of price feeds. Consult the [Price Feed IDs](/price-feeds/pro/price-feed-ids) page for a complete list of supported price feeds.
 
-### Contract Sources
+### Rust SDK
 
-The Stellar Soroban contract implementation lives in [`contracts/stellar`](https://github.com/pyth-network/pyth-lazer/tree/main/contracts/stellar) in the `pyth-network/pyth-lazer` repository.
-
-The user-facing Rust SDK ([`pyth-lazer-stellar-sdk`](https://github.com/pyth-network/pyth-lazer/tree/main/contracts/stellar/sdk/rust)) exposes the typed `Update` and `Feed` types plus the `parse_payload` helper shown above.
+The user-facing Rust SDK [`pyth-lazer-stellar-sdk`](https://crates.io/crates/pyth-lazer-stellar-sdk) exposes the typed `Update` and `Feed` types plus the `parse_payload` helper shown above. API reference on [docs.rs](https://docs.rs/pyth-lazer-stellar-sdk).

--- a/apps/developer-hub/src/app/llms-price-feeds-pro.txt/route.ts
+++ b/apps/developer-hub/src/app/llms-price-feeds-pro.txt/route.ts
@@ -248,8 +248,6 @@ For complete documentation, fetch any page as plain markdown:
 - https://docs.pyth.network/price-feeds/pro/mcp-skills.mdx — MCP skills catalog (price alerts, portfolio tracking, FX conversion, etc.)
 \`
 
-
-
 `;
 
 export function GET() {

--- a/apps/developer-hub/src/app/llms-price-feeds-pro.txt/route.ts
+++ b/apps/developer-hub/src/app/llms-price-feeds-pro.txt/route.ts
@@ -171,7 +171,7 @@ Pyth Pro also provides an MCP server so agents can discover feeds and fetch pric
 - pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT
 
 ### Stellar
-- Soroban Devnet: soroxysjdBk2fHxUx3zR5wba6FT6Po9nF5Tdzc5gnPx
+- Soroban Devnet: sor2xysjdBk2fHxUx3zR5wba6FT6Po9nF5Tdzc5gnPx
 
 Full list: https://docs.pyth.network/price-feeds/pro/contract-addresses
 
@@ -247,6 +247,8 @@ For complete documentation, fetch any page as plain markdown:
 - https://docs.pyth.network/price-feeds/pro/mcp.mdx — MCP server overview
 - https://docs.pyth.network/price-feeds/pro/mcp-skills.mdx — MCP skills catalog (price alerts, portfolio tracking, FX conversion, etc.)
 \`
+
+
 
 `;
 

--- a/apps/developer-hub/src/app/llms-price-feeds-pro.txt/route.ts
+++ b/apps/developer-hub/src/app/llms-price-feeds-pro.txt/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 
 export const revalidate = false;
 
-const CONTENT = `# Pyth Pro — Quick Start
+const CONTENT = `\`# Pyth Pro — Quick Start
 
 > Enterprise-grade, ultra-low latency WebSocket price streaming for professional trading applications.
 > This file contains a curated quick-start. For full docs, fetch individual pages below.
@@ -11,7 +11,7 @@ const CONTENT = `# Pyth Pro — Quick Start
 
 Pyth Pro (formerly Lazer) is a subscription-based price streaming service designed for high-frequency trading, MEV strategies, and latency-sensitive applications. It delivers real-time market data via WebSocket with configurable update channels.
 
-Unlike Pyth Core (pull-based oracle for DeFi), Pyth Pro provides direct WebSocket streaming optimized for speed. Data can optionally be verified on-chain using signed payloads on EVM and Solana.
+Unlike Pyth Core (pull-based oracle for DeFi), Pyth Pro provides direct WebSocket streaming optimized for speed. Data can optionally be verified on-chain using signed payloads on EVM, Solana, and Stellar.
 
 Access requires an API token from an authorized Pyth Data Distributor. Apply at https://pyth.network/pro.
 
@@ -33,6 +33,7 @@ Access requires an API token from an authorized Pyth Data Distributor. Apply at 
 **Binary Formats**: Payloads can include signed data for on-chain verification:
 - \`evm\` — ECDSA signatures for EVM chains
 - \`solana\` — Ed25519 signatures for Solana/Fogo
+- \`stellar\` — Stellar signatures for Soroban contracts
 - \`leUnsigned\` — No signature (offline/testing only)
 
 ## Integration Code
@@ -169,6 +170,9 @@ Pyth Pro also provides an MCP server so agents can discover feeds and fetch pric
 ### Fogo
 - pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT
 
+### Stellar
+- Soroban Devnet: soroxysjdBk2fHxUx3zR5wba6FT6Po9nF5Tdzc5gnPx
+
 Full list: https://docs.pyth.network/price-feeds/pro/contract-addresses
 
 ## Common Patterns
@@ -237,10 +241,13 @@ For complete documentation, fetch any page as plain markdown:
 - https://docs.pyth.network/price-feeds/pro/api/history.mdx — History API and OHLC data
 - https://docs.pyth.network/price-feeds/pro/integrate-as-consumer/evm.mdx — EVM on-chain verification
 - https://docs.pyth.network/price-feeds/pro/integrate-as-consumer/svm.mdx — Solana/Fogo on-chain verification
+- https://docs.pyth.network/price-feeds/pro/integrate-as-consumer/stellar.mdx — Stellar on-chain verification
 - https://docs.pyth.network/price-feeds/pro/contract-addresses.mdx — Deployment addresses
 - https://docs.pyth.network/price-feeds/pro/price-feed-ids.mdx — Available price feeds
 - https://docs.pyth.network/price-feeds/pro/mcp.mdx — MCP server overview
 - https://docs.pyth.network/price-feeds/pro/mcp-skills.mdx — MCP skills catalog (price alerts, portfolio tracking, FX conversion, etc.)
+\`
+
 `;
 
 export function GET() {

--- a/apps/developer-hub/src/data/llm-token-counts.json
+++ b/apps/developer-hub/src/data/llm-token-counts.json
@@ -11,9 +11,9 @@
       "tokens": 2312
     },
     "/llms-price-feeds-pro.txt": {
-      "bytes": 10139,
-      "hash": "sha256:9ba763c0493126a1bb57ac80516c574f5385895439948419ca286fba9c2208c7",
-      "tokens": 2587
+      "bytes": 10397,
+      "hash": "sha256:086e47c60c261e91d4758f1dc752cab85ff7a7f2a9634105bbd83947ce29b7ec",
+      "tokens": 2674
     },
     "/llms-price-feeds.txt": {
       "bytes": 3117,
@@ -36,7 +36,7 @@
       "tokens": 2890
     }
   },
-  "generated_at": "2026-05-21T21:22:40.360Z",
+  "generated_at": "2026-06-18T16:00:16.545Z",
   "tokenizer": "cl100k_base",
   "tokenizer_note": "Token counts are approximate. Actual counts vary by model."
 }

--- a/apps/developer-hub/src/data/llm-token-counts.json
+++ b/apps/developer-hub/src/data/llm-token-counts.json
@@ -11,9 +11,9 @@
       "tokens": 2312
     },
     "/llms-price-feeds-pro.txt": {
-      "bytes": 10397,
-      "hash": "sha256:086e47c60c261e91d4758f1dc752cab85ff7a7f2a9634105bbd83947ce29b7ec",
-      "tokens": 2674
+      "bytes": 10399,
+      "hash": "sha256:9fb5df63fe08f8b66d70b9fe035fde6f772cb76a762608e763480099de9d6c05",
+      "tokens": 2676
     },
     "/llms-price-feeds.txt": {
       "bytes": 3117,
@@ -36,7 +36,7 @@
       "tokens": 2890
     }
   },
-  "generated_at": "2026-06-18T16:00:16.545Z",
+  "generated_at": "2026-06-29T21:42:00.547Z",
   "tokenizer": "cl100k_base",
   "tokenizer_note": "Token counts are approximate. Actual counts vary by model."
 }

--- a/apps/developer-hub/src/data/llm-token-counts.json
+++ b/apps/developer-hub/src/data/llm-token-counts.json
@@ -11,9 +11,9 @@
       "tokens": 2312
     },
     "/llms-price-feeds-pro.txt": {
-      "bytes": 10399,
-      "hash": "sha256:9fb5df63fe08f8b66d70b9fe035fde6f772cb76a762608e763480099de9d6c05",
-      "tokens": 2676
+      "bytes": 10397,
+      "hash": "sha256:a54d1f7b74136fd1ae9d39153a95d79b36593cb64a8b48d2299c5cd968b5bc26",
+      "tokens": 2675
     },
     "/llms-price-feeds.txt": {
       "bytes": 3117,
@@ -36,7 +36,7 @@
       "tokens": 2890
     }
   },
-  "generated_at": "2026-06-29T21:42:00.547Z",
+  "generated_at": "2026-06-29T22:09:59.105Z",
   "tokenizer": "cl100k_base",
   "tokenizer_note": "Token counts are approximate. Actual counts vary by model."
 }


### PR DESCRIPTION
**Stellar consumer guide** — adds the new chain to `pro/integrate-as-consumer/{meta.json,index.mdx}` and ships `stellar.mdx`; appends a `## Stellar` row to `contract-addresses.mdx` (testnet only — mainnet pending deploy).

Out-of-band sequencing — all upstream gates now resolved:

- pyth-lazer-stellar-sdk **0.3.0** published to crates.io (soroban-sdk 26.1.0, wasm32v1-none) via [[i-pyrpcdab]] / [[p-fssmjczh]] + tag push [[i-qdktxgmn]]. Step 2 dep example uses the new pin.
- verify_update returns Result<VerifiedPayload, ParseError> (one-call verify+parse, landed via audit fix I-1 [[i-jevqydpg]]). Guide reflects the one-call helper.
- Stellar testnet redeployed under canonical Pyth-DAO governance per [[i-jssmgwwe]] / [[i-lvjjokbo]]. Verifier id CD2KMDOR274ZVPVVSDIBWNBLGAXJOHKJBQGNWYQHF3O6H767UOYJJYJZ recorded in contract-addresses.mdx. (Verifier itself stays on soroban-sdk 22 — cross-version cross-contract ABI verified in [[p-fssmjczh]] via local host test.)
- End-to-end docs validation [[i-mbjnzklc]] — a fresh-user run built a Soroban contract from this guide verbatim, deployed it to testnet, and fed it a real signed Lazer update. The on-chain verify_update path works (BTC/USD $59,425.27 returned). Four friction points found; all addressed.

Friction-point fixes applied:

- **BLOCKING — verbatim flow trapped.** Step 1 omitted feedUpdateTimestamp from the subscription, but Step 3 .expect()s it on the per-feed Option. Added the property to Step 1 and sharpened the Step 3 prose so the property-selection requirement is impossible to miss.
- **MEDIUM — soroban-sdk version-pin gotcha** (the prior interim warning). Resolved at the SDK level: 0.3.0 targets soroban-sdk 26 + wasm32v1-none, matching the `stellar contract init` default. Snippet now uses `soroban-sdk = "26"` / `pyth-lazer-stellar-sdk = "0.3"`; the prior warning sentence dropped.
- **MINOR — parse_payload "shown above"** at the bottom mislabeled the in-guide helper. verify_update is what's shown; parse_payload is a separate helper for already-verified bytes. Reworded.
- **MINOR — snippet scaffolding gap.** Cargo.toml snippet completed with [package] + [lib] crate-type; Rust snippets gained #![no_std]; added a one-line `stellar contract init` scaffolding pointer.

Out of scope (deferred to follow-ups):

- **Filling Step 3's off-chain example gap** (the section ends at "submit the transaction from your off-chain client using `@stellar/stellar-sdk`"). Validator's notes — leEcdsa arrives as type: "json" with bytes in msg.value.leEcdsa.data; @stellar/stellar-sdk v15+ exposes rpc.Server not SorobanRpc.Server — captured for follow-up.
- **Mainnet contract-id row** (when mainnet deploy lands).
- **pyth-examples/lazer/stellar bump to 0.3** tracked separately as [[i-zwfldyou]].