### PR TITLE
fix(crosschain): register Stellar executor governance module id (4) in canonical registries

### DIFF
--- a/governance/xc_admin/packages/xc_admin_common/src/governance_payload/PythGovernanceAction.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/governance_payload/PythGovernanceAction.ts
@@ -181,11 +181,17 @@ export const MODULE_EXECUTOR = 0;
 export const MODULE_TARGET = 1;
 export const MODULE_EVM_EXECUTOR = 2;
 export const MODULE_LAZER = 3;
+// The Stellar wormhole executor (in pyth-network/pyth-lazer) has its own module
+// so its generic-dispatch actions do not collide with the Lazer module's fixed
+// actions. Reserved here so the id is not reused; the action payloads are wired
+// up alongside the Stellar contract-manager integration.
+export const MODULE_STELLAR_EXECUTOR = 4;
 export const MODULES = [
   MODULE_EXECUTOR,
   MODULE_TARGET,
   MODULE_EVM_EXECUTOR,
   MODULE_LAZER,
+  MODULE_STELLAR_EXECUTOR,
 ];
 
 export type PythGovernanceAction = {

--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
@@ -22,7 +22,11 @@ contract PythGovernanceInstructions {
         Target, // 1
         EvmExecutor, // 2
         // The stacks target chain contract has custom governance instructions and needs its own module.
-        StacksTarget // 3
+        StacksTarget, // 3
+        // The Stellar wormhole executor (in pyth-network/pyth-lazer) has its own
+        // module so its generic-dispatch actions do not collide with another
+        // module's fixed actions. Reserved here so the id is not reused.
+        StellarExecutor // 4
     }
 
     GovernanceModule constant MODULE = GovernanceModule.Target;


### PR DESCRIPTION
Reserves governance **module id `4` = Stellar wormhole executor** in pyth-crosschain's two canonical module registries, so the id the Stellar executor already uses on the wire (assigned in pyth-lazer — see [[p-avkbedqh]] / [[i-xgzdqaaa]]) cannot be accidentally reused by another module.

This is a small, additive, **id-reservation-only** change spun out of [[i-xgzdqaaa]] — distinct from the contract-manager wiring in [[i-wtmljxan]].

## Changes

1. `target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol` — add `StellarExecutor // 4` to the `GovernanceModule` enum. Required (not cosmetic): `GovernanceModule(modNumber)` casts a u8 to the enum, and a Solidity 0.8 out-of-range enum cast reverts, so a module-byte-4 message can only parse if the enum has a slot at index 4.
2. `governance/xc_admin/packages/xc_admin_common/src/governance_payload/PythGovernanceAction.ts` — add `MODULE_STELLAR_EXECUTOR = 4` and include it in `MODULES`.

## Out of scope (per issue)
- Stellar **action** payload classes (belong with [[i-wtmljxan]]).
- Reconciling the pre-existing id-3 `StacksTarget` vs `MODULE_LAZER` inconsistency.

## Checks
- `pnpm turbo run build --filter=@pythnetwork/xc-admin-common`: green (14/14 tasks).
- Biome lint on the changed TS file: clean (the 2 `useSortedKeys` suppression warnings pre-exist on `main`, unrelated to this change).
- `git merge-tree origin/main HEAD`: no conflicts.