### PR TITLE
fix(developer-hub): pull change-log data over HTTPS, not git fetch

### DIFF
--- a/apps/developer-hub/docs/changelog-automation.md
+++ b/apps/developer-hub/docs/changelog-automation.md
@@ -14,7 +14,7 @@ stays up to date.
   3. POST the deploy hook  ───────┼────────────────────────────┼──▶ rebuild main
                                   └────────────────────────────┘        │
   main:  code only, no data            build: pull:changelog  ◀─────────┘
-         (data/changelog-diffs/         (git archive from changelog-data)
+         (data/changelog-diffs/         (https tarball of changelog-data)
           is gitignored)                generate:changelog → bundles last 15
                                         → page renders (build-time, SSR)
 ```
@@ -26,6 +26,11 @@ stays up to date.
   hydrates the diffs from `changelog-data` at build, then `generate:changelog`
   bundles the most recent 15 day-files into `generated-data.ts`. No CMS, no
   runtime fetch.
+- **It pulls over HTTPS, not `git fetch`.** The script downloads the
+  `changelog-data` branch tarball from `codeload.github.com` (public repo, no
+  auth). Vercel's build is a shallow, single-branch clone where
+  `git fetch <other-branch>` does not work — using it silently produced a page
+  with zero days.
 - A Vercel **Deploy Hook** is what turns a data push into a fresh deployment
   (a push to `changelog-data` does not auto-deploy).
 

--- a/apps/developer-hub/scripts/pull-changelog-data.sh
+++ b/apps/developer-hub/scripts/pull-changelog-data.sh
@@ -5,29 +5,40 @@
 # committed on main (see .gitignore) — Hermes writes them to `changelog-data`
 # daily, and this step hydrates them at build time.
 #
+# It downloads the branch tarball over plain HTTPS from GitHub (public repo) —
+# NOT `git fetch`. Vercel's build sandbox is a shallow, single-branch clone
+# where `git fetch <other-branch>` does not work; that silently left the page
+# with zero days. codeload needs no auth, no API token, and is not subject to
+# the GitHub API rate limit.
+#
 # On any failure (offline, branch missing, no diffs yet) it leaves whatever is
 # already local and exits 0, so the build never breaks; the page just renders
 # fewer or no days.
 
 set -uo pipefail
 
-ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
-  echo "pull:changelog — not a git repo; skipping."
-  exit 0
-}
+REPO="pyth-network/pyth-crosschain"
+BRANCH="changelog-data"
 DIR="apps/developer-hub/data/changelog-diffs"
+URL="https://codeload.github.com/${REPO}/tar.gz/refs/heads/${BRANCH}"
+
+# Repo root: prefer git, fall back to this script's location (apps/developer-hub/scripts).
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" \
+  || ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
 mkdir -p "$ROOT/$DIR"
 
-if ! git -C "$ROOT" fetch origin changelog-data --depth=1 2>/dev/null; then
-  echo "pull:changelog — could not fetch changelog-data; using local diffs (if any)."
-  exit 0
-fi
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
 
-if git -C "$ROOT" archive FETCH_HEAD -- "$DIR" 2>/dev/null | tar -x -C "$ROOT" 2>/dev/null; then
+if curl -fsSL "$URL" -o "$tmp/cl.tgz" 2>/dev/null \
+  && tar -xzf "$tmp/cl.tgz" -C "$tmp" --strip-components=1 2>/dev/null \
+  && [ -d "$tmp/$DIR" ]; then
+  find "$tmp/$DIR" -name '*.json' -exec cp -f {} "$ROOT/$DIR/" \;
   count="$(find "$ROOT/$DIR" -name '*.json' | wc -l | tr -d ' ')"
-  echo "pull:changelog — pulled ${count} diff file(s) from changelog-data."
+  echo "pull:changelog — pulled change-log diffs from ${BRANCH} (${count} file(s) total)."
 else
-  echo "pull:changelog — changelog-data has no diffs path yet; using local diffs (if any)."
+  echo "pull:changelog — could not fetch ${BRANCH} over https; using local diffs (if any)."
 fi
 
 exit 0


### PR DESCRIPTION
## Problem

The live [Change Log page](https://docs.pyth.network/price-feeds/changelog) renders the empty state ("No transitions yet…", `Invalid Date – Invalid Date`, 0/0/0) even though the `changelog-data` branch holds 16 days of real diffs.

Root cause: `scripts/pull-changelog-data.sh` hydrated the diffs at build time with `git fetch origin changelog-data`. Vercel's build is a **shallow, single-branch clone** where fetching a different branch does not work, so the build bundled zero days. The script's `exit 0`-on-failure design turned that into a silent empty page (worked locally on a full clone, never in Vercel).

## Fix

Pull the `changelog-data` branch tarball over **HTTPS from `codeload.github.com`** (public repo: no auth, no API token, not subject to the GitHub API rate limit) using `curl` + `tar`, instead of `git fetch`. Same graceful fallback to local diffs and `exit 0` so the build never breaks.

## Verification (local, simulating a fresh checkout)

- wiped `data/changelog-diffs/` to 0 files
- `pnpm pull:changelog` -> pulled 16 files over HTTPS, no git
- `pnpm generate:changelog` -> `Wrote 15 day(s) covering 2026-06-05 -> 2026-06-19` with real counts

Merging to `main` triggers a production rebuild, which will populate the page.

## Not included

- The `changelog-data` preview-build noise (every push fans out failing previews across all Vercel projects) is a separate Vercel **Ignored Build Step** setting, handled outside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->