### PR TITLE
feat(crosschain): add Stellar Lazer contract support to contract_manager

### DIFF
--- a/contract_manager/README.md
+++ b/contract_manager/README.md
@@ -10,49 +10,35 @@ It has the following structure:
 
 # Main Entities
 
-Contract Manager has base classes which you can use to interact with the following entities:
+Contract Manager has base classes which you can use to interact with the
+entities below. Most have a chain-specific implementation per supported ecosystem
+(EVM/Cosmos/Aptos/Sui/Iota/Near/Fuel/Starknet/Ton/Stellar), and every instance is
+loaded from `store` by the `DefaultStore`.
 
-- Chain
-- PythContract
-- WormholeContract
+- **Chain** (`Chain`) — a blockchain network the tooling can target; holds RPC/network config and builds and submits transactions and governance payloads.
+- **Price feed contract** (`PriceFeedContract`) — the core Pyth contract that receives price updates and is configured through governance.
+- **Wormhole contract** (`WormholeContract`) — the Wormhole core bridge contract used to verify and submit governance VAAs.
+- **Lazer contract** (`EvmLazerContract` / `SuiLazerContract` / `StellarLazerContract`) — the Pyth Lazer verifier, which checks signed Lazer price updates and holds the trusted signer set.
+- **Executor contract** (`EvmExecutorContract` / `StellarExecutorContract`) — the governance executor that verifies a Pyth governance VAA and dispatches the decoded action to its target contract (or upgrades itself).
+- **Entropy contract** (`EvmEntropyContract`) — the Pyth Entropy contract serving on-chain secure randomness requests.
+- **Pulse contract** (`EvmPulseContract`) — the Pyth Pulse contract for scheduled, on-demand price-update callbacks.
+- **Token** (`Token`) — a native/gas token used to pay fees on a chain.
+- **Vault** (`Vault`) — the Solana multisig governance vault used to propose and execute governance messages.
 
-Each of these entities has a specialized class for each supported chain (EVM/Cosmos/Aptos/Sui/Stellar).
+## Lazer on Stellar
 
-# Lazer on Stellar
+Lazer on Stellar (Soroban) splits the verifier (`StellarLazerContract`) and the
+governance executor (`StellarExecutorContract`) across two contracts, mirroring
+the EVM `EvmLazerContract` / `EvmExecutorContract` split. Governance enters
+through the executor's `execute_governance_action`, which dispatches the decoded
+action to the verifier. Stellar uses a dedicated governance module
+(`MODULE_STELLAR_EXECUTOR = 4`) and dedicated Pyth receiver chain ids
+(`stellar_testnet` / `stellar_mainnet`); see
+`generate_stellar_lazer_update_trusted_signer_proposal.ts` for the proposal flow.
 
-Pyth Lazer on Stellar (Soroban) is split across two contracts (see
-`pyth-network/pyth-lazer` `contracts/stellar`), each with its own class in
-`src/core/contracts/stellar.ts` — mirroring the EVM split between
-`EvmLazerContract` and `EvmExecutorContract`:
-
-- `StellarLazerContract` — the **verifier** (`pyth-lazer-stellar`) verifies signed
-  price updates and holds the trusted signer set, and
-- `StellarExecutorContract` — the **executor** (`wormhole-executor-stellar`)
-  verifies Wormhole governance VAAs and dispatches the decoded action to the
-  verifier (or upgrades itself).
-
-Governance always enters through the executor: a Pyth governance VAA carrying a
-PTGM (Pyth Target Governance Message) is submitted to the executor's
-`execute_governance_action`, which invokes the named function on the verifier. The
-verifier's payload builders resolve the authorized executor from the verifier's
-on-chain state, the same way `EvmLazerContract` resolves its owning executor.
-
-Because Soroban addresses are variable-length strkeys and arguments are
-XDR-encoded, Stellar uses a dedicated governance module
-(`MODULE_STELLAR_EXECUTOR = 4` in `xc-admin-common`) rather than the Lazer module
-(3), so its `Call` / `UpgradeExecutor` action codes never collide with the Sui /
-Cardano Lazer actions. A logical action such as "update trusted signer" is encoded
-as `Call(target = verifier, fn = "update_trusted_signer", args = ScVec([pubkey,
-expiresAt]))`. See `generate_stellar_lazer_update_trusted_signer_proposal.ts`.
-
-The PTGM target chain id is a dedicated Pyth receiver id (`stellar_testnet` /
-`stellar_mainnet`), **not** Wormhole's canonical Stellar id (which collides with
-`base`). The deployed executor must be initialized with the matching `chain_id`.
-
-> **Note:** only the **testnet** verifier is registered today. The testnet
-> executor address in `store/contracts/StellarExecutorContracts.json` is a
-> placeholder and must be replaced once the executor is deployed; mainnet is not
-> yet deployed.
+> **Note:** only the **testnet** verifier is registered today. The executor entry
+> in `store/contracts/StellarExecutorContracts.json` is a placeholder until the
+> executor is deployed; mainnet is not yet deployed.
 
 # Docs
 

--- a/contract_manager/README.md
+++ b/contract_manager/README.md
@@ -16,7 +16,39 @@ Contract Manager has base classes which you can use to interact with the followi
 - PythContract
 - WormholeContract
 
-Each of these entities has a specialized class for each supported chain (EVM/Cosmos/Aptos/Sui).
+Each of these entities has a specialized class for each supported chain (EVM/Cosmos/Aptos/Sui/Stellar).
+
+# Lazer on Stellar
+
+Pyth Lazer on Stellar (Soroban) is split across two contracts (see
+`pyth-network/pyth-lazer` `contracts/stellar`):
+
+- the **verifier** (`pyth-lazer-stellar`) verifies signed price updates and holds
+  the trusted signer set, and
+- the **executor** (`wormhole-executor-stellar`) verifies Wormhole governance
+  VAAs and dispatches the decoded action to the verifier (or upgrades itself).
+
+`StellarLazerContract` (`src/core/contracts/stellar.ts`) wires both contract ids
+together. Governance always enters through the executor: a Pyth governance VAA
+carrying a PTGM (Pyth Target Governance Message) is submitted to
+`execute_governance_action`, which invokes the named function on the verifier.
+
+Because Soroban addresses are variable-length strkeys and arguments are
+XDR-encoded, Stellar uses a dedicated governance module
+(`MODULE_STELLAR_EXECUTOR = 4` in `xc-admin-common`) rather than the Lazer module
+(3), so its `Call` / `UpgradeExecutor` action codes never collide with the Sui /
+Cardano Lazer actions. A logical action such as "update trusted signer" is encoded
+as `Call(target = verifier, fn = "update_trusted_signer", args = ScVec([pubkey,
+expiresAt]))`. See `generate_stellar_lazer_update_trusted_signer_proposal.ts`.
+
+The PTGM target chain id is a dedicated Pyth receiver id (`stellar_testnet` /
+`stellar_mainnet`), **not** Wormhole's canonical Stellar id (which collides with
+`base`). The deployed executor must be initialized with the matching `chain_id`.
+
+> **Note:** only the **testnet** verifier is registered today. The testnet
+> executor address in `store/contracts/StellarLazerContracts.json` is a
+> placeholder and must be replaced once the executor is deployed; mainnet is not
+> yet deployed.
 
 # Docs
 

--- a/contract_manager/README.md
+++ b/contract_manager/README.md
@@ -25,21 +25,6 @@ loaded from `store` by the `DefaultStore`.
 - **Token** (`Token`) — a native/gas token used to pay fees on a chain.
 - **Vault** (`Vault`) — the Solana multisig governance vault used to propose and execute governance messages.
 
-## Lazer on Stellar
-
-Lazer on Stellar (Soroban) splits the verifier (`StellarLazerContract`) and the
-governance executor (`StellarExecutorContract`) across two contracts, mirroring
-the EVM `EvmLazerContract` / `EvmExecutorContract` split. Governance enters
-through the executor's `execute_governance_action`, which dispatches the decoded
-action to the verifier. Stellar uses a dedicated governance module
-(`MODULE_STELLAR_EXECUTOR = 4`) and dedicated Pyth receiver chain ids
-(`stellar_testnet` / `stellar_mainnet`); see
-`generate_stellar_lazer_update_trusted_signer_proposal.ts` for the proposal flow.
-
-> **Note:** only the **testnet** verifier is registered today. The executor entry
-> in `store/contracts/StellarExecutorContracts.json` is a placeholder until the
-> executor is deployed; mainnet is not yet deployed.
-
 # Docs
 
 You can generate the docs by running `pnpm exec typedoc src/index.ts` from this directory. Open the docs by opening `docs/index.html` in your browser.

--- a/contract_manager/README.md
+++ b/contract_manager/README.md
@@ -21,17 +21,21 @@ Each of these entities has a specialized class for each supported chain (EVM/Cos
 # Lazer on Stellar
 
 Pyth Lazer on Stellar (Soroban) is split across two contracts (see
-`pyth-network/pyth-lazer` `contracts/stellar`):
+`pyth-network/pyth-lazer` `contracts/stellar`), each with its own class in
+`src/core/contracts/stellar.ts` — mirroring the EVM split between
+`EvmLazerContract` and `EvmExecutorContract`:
 
-- the **verifier** (`pyth-lazer-stellar`) verifies signed price updates and holds
-  the trusted signer set, and
-- the **executor** (`wormhole-executor-stellar`) verifies Wormhole governance
-  VAAs and dispatches the decoded action to the verifier (or upgrades itself).
+- `StellarLazerContract` — the **verifier** (`pyth-lazer-stellar`) verifies signed
+  price updates and holds the trusted signer set, and
+- `StellarExecutorContract` — the **executor** (`wormhole-executor-stellar`)
+  verifies Wormhole governance VAAs and dispatches the decoded action to the
+  verifier (or upgrades itself).
 
-`StellarLazerContract` (`src/core/contracts/stellar.ts`) wires both contract ids
-together. Governance always enters through the executor: a Pyth governance VAA
-carrying a PTGM (Pyth Target Governance Message) is submitted to
-`execute_governance_action`, which invokes the named function on the verifier.
+Governance always enters through the executor: a Pyth governance VAA carrying a
+PTGM (Pyth Target Governance Message) is submitted to the executor's
+`execute_governance_action`, which invokes the named function on the verifier. The
+verifier's payload builders resolve the authorized executor from the verifier's
+on-chain state, the same way `EvmLazerContract` resolves its owning executor.
 
 Because Soroban addresses are variable-length strkeys and arguments are
 XDR-encoded, Stellar uses a dedicated governance module
@@ -46,7 +50,7 @@ The PTGM target chain id is a dedicated Pyth receiver id (`stellar_testnet` /
 `base`). The deployed executor must be initialized with the matching `chain_id`.
 
 > **Note:** only the **testnet** verifier is registered today. The testnet
-> executor address in `store/contracts/StellarLazerContracts.json` is a
+> executor address in `store/contracts/StellarExecutorContracts.json` is a
 > placeholder and must be replaced once the executor is deployed; mainnet is not
 > yet deployed.
 

--- a/contract_manager/package.json
+++ b/contract_manager/package.json
@@ -293,6 +293,16 @@
         "types": "./dist/cjs/utils/exec-file-async.d.ts"
       }
     },
+    "./utils/sleep": {
+      "import": {
+        "default": "./dist/esm/utils/sleep.mjs",
+        "types": "./dist/esm/utils/sleep.d.ts"
+      },
+      "require": {
+        "default": "./dist/cjs/utils/sleep.cjs",
+        "types": "./dist/cjs/utils/sleep.d.ts"
+      }
+    },
     "./utils/utils": {
       "import": {
         "default": "./dist/esm/utils/utils.mjs",

--- a/contract_manager/package.json
+++ b/contract_manager/package.json
@@ -26,6 +26,7 @@
     "@pythnetwork/xc-admin-common": "workspace:*",
     "@solana/web3.js": "^1.73.0",
     "@sqds/mesh": "^1.0.6",
+    "@stellar/stellar-sdk": "catalog:",
     "@ton/blueprint": "^0.22.0",
     "@ton/core": "^0.59.0",
     "@ton/crypto": "^3.3.0",
@@ -167,6 +168,16 @@
       "require": {
         "default": "./dist/cjs/core/contracts/starknet.cjs",
         "types": "./dist/cjs/core/contracts/starknet.d.ts"
+      }
+    },
+    "./core/contracts/stellar": {
+      "import": {
+        "default": "./dist/esm/core/contracts/stellar.mjs",
+        "types": "./dist/esm/core/contracts/stellar.d.ts"
+      },
+      "require": {
+        "default": "./dist/cjs/core/contracts/stellar.cjs",
+        "types": "./dist/cjs/core/contracts/stellar.d.ts"
       }
     },
     "./core/contracts/sui": {

--- a/contract_manager/scripts/generate_stellar_lazer_update_trusted_signer_proposal.ts
+++ b/contract_manager/scripts/generate_stellar_lazer_update_trusted_signer_proposal.ts
@@ -66,7 +66,7 @@ async function main() {
   }
 
   console.log(`Generating payload for contract ${contract.getId()}`);
-  const payload = contract.generateUpdateTrustedSignerPayload(
+  const payload = await contract.generateUpdateTrustedSignerPayload(
     argv["trusted-signer"],
     BigInt(argv["expires-at"]),
   );

--- a/contract_manager/scripts/generate_stellar_lazer_update_trusted_signer_proposal.ts
+++ b/contract_manager/scripts/generate_stellar_lazer_update_trusted_signer_proposal.ts
@@ -1,0 +1,83 @@
+/** biome-ignore-all lint/suspicious/noConsole: this is a CLI script */
+/* eslint-disable @typescript-eslint/no-floating-promises */
+/* eslint-disable unicorn/prefer-top-level-await */
+
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+import { StellarLazerContract } from "../src/core/contracts";
+import { loadHotWallet } from "../src/node/utils/governance";
+import { DefaultStore } from "../src/node/utils/store";
+
+const parser = yargs(hideBin(process.argv))
+  .usage("Usage: $0 --contract <id> --trusted-signer <hex33> --expires-at <ts>")
+  .options({
+    contract: {
+      demandOption: true,
+      desc: "Stellar Lazer contract id (e.g. stellar_testnet_C...)",
+      type: "string",
+    },
+    "expires-at": {
+      demandOption: true,
+      desc: "Expiration timestamp (unix seconds) for the trusted signer; 0 removes it",
+      type: "number",
+    },
+    "ops-key-path": {
+      demandOption: true,
+      desc: "Path to the ops key file",
+      type: "string",
+    },
+    "trusted-signer": {
+      demandOption: true,
+      desc: "33-byte compressed secp256k1 signer key, hex without 0x",
+      type: "string",
+    },
+    vault: {
+      default: "mainnet-beta_FVQyHcooAtThJ83XFrNnv74BcinbRH3bRmfFamAHBfuj",
+      desc: "Vault ID",
+      type: "string",
+    },
+  });
+
+async function main() {
+  const argv = await parser.argv;
+
+  if (argv["expires-at"] !== 0 && argv["expires-at"] < Date.now() / 1000) {
+    throw new Error(
+      "Expiration timestamp must be in the future (or 0 to remove)",
+    );
+  }
+  if (argv["trusted-signer"] === "") {
+    throw new Error("Trusted signer key cannot be empty");
+  }
+  const vault = DefaultStore.vaults[argv.vault];
+  if (!vault) {
+    throw new Error(`Vault with ID '${argv.vault}' does not exist.`);
+  }
+
+  const contract = DefaultStore.lazer_contracts[argv.contract];
+  if (!contract) {
+    throw new Error(`Contract with ID '${argv.contract}' does not exist.`);
+  }
+  if (!(contract instanceof StellarLazerContract)) {
+    throw new TypeError(
+      `ID '${argv.contract}' is not a Stellar Lazer contract.`,
+    );
+  }
+
+  console.log(`Generating payload for contract ${contract.getId()}`);
+  const payload = contract.generateUpdateTrustedSignerPayload(
+    argv["trusted-signer"],
+    BigInt(argv["expires-at"]),
+  );
+
+  console.log("Using vault at for proposal", vault.getId());
+  const wallet = await loadHotWallet(argv["ops-key-path"]);
+  console.log("Using wallet", wallet.publicKey.toBase58());
+  // eslint-disable-next-line @typescript-eslint/await-thenable, @typescript-eslint/no-confusing-void-expression
+  await vault.connect(wallet);
+  const proposal = await vault.proposeWormholeMessage([payload]);
+  console.log("Proposal address", proposal.address.toBase58());
+}
+
+main();

--- a/contract_manager/scripts/latency_entropy.ts
+++ b/contract_manager/scripts/latency_entropy.ts
@@ -8,6 +8,7 @@ import { hideBin } from "yargs/helpers";
 import { toPrivateKey } from "../src/core/base";
 import { EvmChain } from "../src/core/chains";
 import { DefaultStore } from "../src/node/utils/store";
+import { sleep } from "../src/utils/sleep";
 import { COMMON_DEPLOY_OPTIONS, findEntropyContract } from "./common";
 
 const parser = yargs(hideBin(process.argv))
@@ -64,7 +65,7 @@ async function main() {
       console.log("Reveal tx hash:", revealResponse.transactionHash);
       break;
     }
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    await sleep(300);
   }
 }
 

--- a/contract_manager/scripts/latency_entropy_with_callback.ts
+++ b/contract_manager/scripts/latency_entropy_with_callback.ts
@@ -10,6 +10,7 @@ import { toPrivateKey } from "../src/core/base";
 import { EvmChain } from "../src/core/chains";
 import type { EvmEntropyContract } from "../src/core/contracts";
 import { DefaultStore } from "../src/node/utils/store";
+import { sleep } from "../src/utils/sleep";
 import { COMMON_DEPLOY_OPTIONS, findEntropyContract } from "./common";
 
 const parser = yargs(hideBin(process.argv))
@@ -65,7 +66,7 @@ async function testLatency(
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   while (true) {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await sleep(1000);
     const currentBlock = await web3.eth.getBlockNumber();
 
     if (fromBlock > currentBlock) {

--- a/contract_manager/scripts/send_message_to_wormhole.ts
+++ b/contract_manager/scripts/send_message_to_wormhole.ts
@@ -4,6 +4,7 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
 import { loadHotWallet, WormholeEmitter } from "../src/node/utils/governance";
+import { sleep } from "../src/utils/sleep";
 
 const parser = yargs(hideBin(process.argv))
   .usage(
@@ -44,7 +45,7 @@ async function main() {
     }`,
   );
   console.log(`Sleeping for 5 seconds to allow the message to be processed...`);
-  await new Promise((resolve) => setTimeout(resolve, 5000));
+  await sleep(5000);
   console.log(
     `Fetching VAA for message ${submittedMessage.emitter.toBase58()}, Sequence Number: ${
       submittedMessage.sequenceNumber

--- a/contract_manager/scripts/update_all_pricefeeds.ts
+++ b/contract_manager/scripts/update_all_pricefeeds.ts
@@ -8,6 +8,7 @@ import { hideBin } from "yargs/helpers";
 
 import { toPrivateKey } from "../src/core/base";
 import { DefaultStore } from "../src/node/utils/store";
+import { sleep } from "../src/utils/sleep";
 
 const parser = yargs(hideBin(process.argv))
   .usage("Update the set of price feeds in a network. Usage: $0")
@@ -81,7 +82,7 @@ async function main() {
       ),
     );
     // Wait for 2 seconds to avoid rate limiting and nonce collision
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await sleep(2000);
   }
 }
 

--- a/contract_manager/src/core/chains.ts
+++ b/contract_manager/src/core/chains.ts
@@ -49,6 +49,11 @@ import {
   LAMPORTS_PER_SOL,
   PublicKey,
 } from "@solana/web3.js";
+import {
+  Horizon as StellarHorizon,
+  Keypair as StellarKeypair,
+  rpc as stellarRpc,
+} from "@stellar/stellar-sdk";
 import { keyPairFromSeed } from "@ton/crypto";
 import type { ContractProvider, OpenedContract, Sender } from "@ton/ton";
 import { Address, TonClient, WalletContractV4 } from "@ton/ton";
@@ -1638,5 +1643,93 @@ export class NearChain extends Chain {
     };
     const nearConnection = await nearAPI.connect(connectionConfig);
     return await nearConnection.account(accountId);
+  }
+}
+
+export class StellarChain extends Chain {
+  static override type = "StellarChain";
+
+  /**
+   * @param rpcUrl - Soroban RPC endpoint (e.g. https://soroban-testnet.stellar.org)
+   * @param networkPassphrase - Stellar network passphrase, e.g.
+   *   "Test SDF Network ; September 2015" for testnet
+   * @param horizonUrl - Horizon endpoint, used only to read account balances
+   */
+  constructor(
+    id: string,
+    mainnet: boolean,
+    wormholeChainName: string,
+    nativeToken: TokenId | undefined,
+    public rpcUrl: string,
+    public networkPassphrase: string,
+    public horizonUrl: string,
+  ) {
+    super(id, mainnet, wormholeChainName, nativeToken);
+  }
+
+  static fromJson(parsed: ChainConfig): StellarChain {
+    if (parsed.type !== StellarChain.type) throw new Error("Invalid type");
+    return new StellarChain(
+      parsed.id,
+      parsed.mainnet,
+      parsed.wormholeChainName ?? "",
+      parsed.nativeToken,
+      parsed.rpcUrl ?? "",
+      parsed.networkPassphrase ?? "",
+      parsed.horizonUrl ?? "",
+    );
+  }
+
+  toJson(): KeyValueConfig {
+    return {
+      horizonUrl: this.horizonUrl,
+      id: this.id,
+      mainnet: this.mainnet,
+      networkPassphrase: this.networkPassphrase,
+      rpcUrl: this.rpcUrl,
+      type: StellarChain.type,
+      wormholeChainName: this.wormholeChainName,
+    };
+  }
+
+  getType(): string {
+    return StellarChain.type;
+  }
+
+  getProvider(): stellarRpc.Server {
+    return new stellarRpc.Server(this.rpcUrl, {
+      allowHttp: this.rpcUrl.startsWith("http://"),
+    });
+  }
+
+  /**
+   * Stellar contract upgrades are governance actions dispatched through the
+   * wormhole executor, which needs the executor and target contract ids. Build
+   * them with the StellarLazerContract methods instead (it holds both ids).
+   */
+  generateGovernanceUpgradePayload(): Buffer {
+    throw new Error(
+      "Use StellarLazerContract.generateUpgradeVerifierPayload / " +
+        "generateUpgradeExecutorPayload — Stellar upgrades require contract ids.",
+    );
+  }
+
+  getAccountAddress(privateKey: PrivateKey): Promise<string> {
+    const keypair = StellarKeypair.fromRawEd25519Seed(
+      Buffer.from(privateKey, "hex"),
+    );
+    return Promise.resolve(keypair.publicKey());
+  }
+
+  async getAccountBalance(privateKey: PrivateKey): Promise<number> {
+    const address = await this.getAccountAddress(privateKey);
+    const server = new StellarHorizon.Server(this.horizonUrl, {
+      allowHttp: this.horizonUrl.startsWith("http://"),
+    });
+    const account = await server.loadAccount(address);
+    const native = account.balances.find(
+      (balance) => balance.asset_type === "native",
+    );
+    return native ? Number(native.balance) : 0;
   }
 }

--- a/contract_manager/src/core/chains.ts
+++ b/contract_manager/src/core/chains.ts
@@ -1705,12 +1705,13 @@ export class StellarChain extends Chain {
   /**
    * Stellar contract upgrades are governance actions dispatched through the
    * wormhole executor, which needs the executor and target contract ids. Build
-   * them with the StellarLazerContract methods instead (it holds both ids).
+   * them with the per-contract methods instead.
    */
   generateGovernanceUpgradePayload(): Buffer {
     throw new Error(
       "Use StellarLazerContract.generateUpgradeVerifierPayload / " +
-        "generateUpgradeExecutorPayload — Stellar upgrades require contract ids.",
+        "StellarExecutorContract.generateUpgradeExecutorPayload — Stellar " +
+        "upgrades require contract ids.",
     );
   }
 

--- a/contract_manager/src/core/contracts/index.ts
+++ b/contract_manager/src/core/contracts/index.ts
@@ -4,6 +4,7 @@ export * from "./evm";
 export * from "./evm_abis";
 export * from "./fuel";
 export * from "./iota";
+export * from "./stellar";
 export * from "./sui";
 export * from "./ton";
 export * from "./wormhole";

--- a/contract_manager/src/core/contracts/stellar.ts
+++ b/contract_manager/src/core/contracts/stellar.ts
@@ -13,6 +13,7 @@ import {
   xdr,
 } from "@stellar/stellar-sdk";
 
+import { sleep } from "../../utils/sleep";
 import type { PrivateKey, TxResult } from "../base";
 import { Storable } from "../base";
 import type { Chain } from "../chains";
@@ -348,8 +349,4 @@ async function readInstanceStorage(
     }
   }
   return undefined;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/contract_manager/src/core/contracts/stellar.ts
+++ b/contract_manager/src/core/contracts/stellar.ts
@@ -1,0 +1,308 @@
+import {
+  CallStellarExecutor,
+  UpgradeStellarExecutor,
+} from "@pythnetwork/xc-admin-common";
+import {
+  BASE_FEE,
+  Contract,
+  nativeToScVal,
+  Keypair as StellarKeypair,
+  scValToNative,
+  rpc as stellarRpc,
+  TransactionBuilder,
+  xdr,
+} from "@stellar/stellar-sdk";
+
+import type { PrivateKey, TxResult } from "../base";
+import { Storable } from "../base";
+import type { Chain } from "../chains";
+import { StellarChain } from "../chains";
+
+/**
+ * Lazer on Stellar is split across two Soroban contracts (see
+ * `pyth-network/pyth-lazer` `contracts/stellar`):
+ *
+ * - the **verifier** (`pyth-lazer-stellar`) verifies signed price updates and
+ *   stores the trusted signer set, and
+ * - the **executor** (`wormhole-executor-stellar`) verifies Wormhole governance
+ *   VAAs and dispatches the decoded PTGM action to the verifier (or upgrades
+ *   itself).
+ *
+ * Governance always enters through the executor: a Pyth governance VAA carrying
+ * a PTGM `Call` is submitted to `execute_governance_action`, which invokes the
+ * named function on the verifier. This class wires both contract ids together
+ * and builds the matching PTGM payloads.
+ */
+export class StellarLazerContract extends Storable {
+  static type = "StellarLazerContract";
+
+  /**
+   * @param chain - the Stellar chain this contract is deployed on
+   * @param verifierAddress - Soroban contract id of the `pyth-lazer-stellar`
+   *   verifier
+   * @param executorAddress - Soroban contract id of the
+   *   `wormhole-executor-stellar` governance executor
+   */
+  constructor(
+    public readonly chain: StellarChain,
+    public readonly verifierAddress: string,
+    public readonly executorAddress: string,
+  ) {
+    super();
+  }
+
+  getId(): string {
+    return `${this.chain.getId()}_${this.verifierAddress}`;
+  }
+
+  getType(): string {
+    return StellarLazerContract.type;
+  }
+
+  getChain(): StellarChain {
+    return this.chain;
+  }
+
+  toJson() {
+    return {
+      chain: this.chain.getId(),
+      executorAddress: this.executorAddress,
+      type: StellarLazerContract.type,
+      verifierAddress: this.verifierAddress,
+    };
+  }
+
+  static fromJson(
+    chain: Chain,
+    parsed: {
+      type: string;
+      verifierAddress: string;
+      executorAddress: string;
+    },
+  ): StellarLazerContract {
+    if (parsed.type !== StellarLazerContract.type) {
+      throw new Error("Invalid type");
+    }
+    if (!(chain instanceof StellarChain)) {
+      throw new Error(`Wrong chain type ${chain}`);
+    }
+    return new StellarLazerContract(
+      chain,
+      parsed.verifierAddress,
+      parsed.executorAddress,
+    );
+  }
+
+  /**
+   * Build the PTGM payload that updates (or, with `expiresAt = 0n`, removes) a
+   * trusted Lazer signer on the verifier. Encoded as a generic executor `Call`
+   * to `update_trusted_signer(pubkey: BytesN<33>, expires_at: u64)`.
+   *
+   * @param publicKey - 33-byte compressed secp256k1 signer key, hex without 0x
+   * @param expiresAt - expiry timestamp in unix seconds (0 removes the signer)
+   */
+  generateUpdateTrustedSignerPayload(
+    publicKey: string,
+    expiresAt: bigint,
+  ): Buffer {
+    const pubkey = Buffer.from(publicKey, "hex");
+    if (pubkey.length !== 33) {
+      throw new Error(
+        `Trusted signer key must be 33 bytes, got ${pubkey.length}`,
+      );
+    }
+    const args = encodeScVecArgs([
+      xdr.ScVal.scvBytes(pubkey),
+      nativeToScVal(expiresAt, { type: "u64" }),
+    ]);
+    return new CallStellarExecutor(
+      this.chain.wormholeChainName,
+      this.executorAddress,
+      this.verifierAddress,
+      "update_trusted_signer",
+      args,
+    ).encode();
+  }
+
+  /**
+   * Build the PTGM payload that upgrades the verifier contract WASM. Encoded as
+   * a generic executor `Call` to `upgrade(new_wasm_hash: BytesN<32>)`.
+   *
+   * @param wasmHash - 32-byte WASM hash of the new verifier, hex without 0x
+   */
+  generateUpgradeVerifierPayload(wasmHash: string): Buffer {
+    const hash = Buffer.from(wasmHash, "hex");
+    if (hash.length !== 32) {
+      throw new Error(`WASM hash must be 32 bytes, got ${hash.length}`);
+    }
+    const args = encodeScVecArgs([xdr.ScVal.scvBytes(hash)]);
+    return new CallStellarExecutor(
+      this.chain.wormholeChainName,
+      this.executorAddress,
+      this.verifierAddress,
+      "upgrade",
+      args,
+    ).encode();
+  }
+
+  /**
+   * Build the PTGM payload that self-upgrades the executor contract WASM.
+   *
+   * @param wasmDigest - 32-byte WASM digest of the new executor, hex without 0x
+   */
+  generateUpgradeExecutorPayload(wasmDigest: string): Buffer {
+    return new UpgradeStellarExecutor(
+      this.chain.wormholeChainName,
+      this.executorAddress,
+      Buffer.from(wasmDigest, "hex"),
+    ).encode();
+  }
+
+  /**
+   * Submit a signed governance VAA to the executor's `execute_governance_action`
+   * entry point and return the resulting transaction hash.
+   *
+   * @param senderPrivateKey - 32-byte ed25519 seed of the submitting account,
+   *   hex without 0x. The submitter only pays fees; authority comes from the
+   *   guardian-signed VAA, not the sender.
+   * @param vaa - the signed Wormhole governance VAA wrapping the PTGM payload
+   */
+  async executeGovernanceAction(
+    senderPrivateKey: PrivateKey,
+    vaa: Buffer,
+  ): Promise<TxResult> {
+    const server = this.chain.getProvider();
+    const keypair = StellarKeypair.fromRawEd25519Seed(
+      Buffer.from(senderPrivateKey, "hex"),
+    );
+    const account = await server.getAccount(keypair.publicKey());
+    const executor = new Contract(this.executorAddress);
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.chain.networkPassphrase,
+    })
+      .addOperation(
+        executor.call("execute_governance_action", xdr.ScVal.scvBytes(vaa)),
+      )
+      .setTimeout(30)
+      .build();
+
+    const prepared = await server.prepareTransaction(tx);
+    prepared.sign(keypair);
+
+    const sent = await server.sendTransaction(prepared);
+    if (sent.status === "ERROR") {
+      throw new Error(
+        `Failed to submit governance transaction: ${JSON.stringify(sent.errorResult)}`,
+      );
+    }
+
+    let result = await server.getTransaction(sent.hash);
+    while (result.status === stellarRpc.Api.GetTransactionStatus.NOT_FOUND) {
+      await sleep(1000);
+      result = await server.getTransaction(sent.hash);
+    }
+
+    if (result.status !== stellarRpc.Api.GetTransactionStatus.SUCCESS) {
+      throw new Error(`Governance transaction ${sent.hash} failed`);
+    }
+
+    return { id: sent.hash, info: result };
+  }
+
+  /**
+   * Read the executor address authorized for governance on the verifier. Should
+   * match {@link executorAddress}; a mismatch means the registry is stale.
+   */
+  async getExecutor(): Promise<string> {
+    const value = await this.readInstanceStorage(
+      this.verifierAddress,
+      "Executor",
+    );
+    if (!value) {
+      throw new Error("Verifier has no executor set (not initialized)");
+    }
+    return scValToNative(value) as string;
+  }
+
+  /**
+   * Read the expiry timestamp (unix seconds) of a trusted signer, or `undefined`
+   * if the signer is not currently trusted.
+   *
+   * The verifier keys trusted signers individually by public key and exposes no
+   * enumeration, so callers must supply the key of interest — there is no
+   * on-chain "list all signers" to mirror.
+   *
+   * @param publicKey - 33-byte compressed secp256k1 key, hex without 0x
+   */
+  async getTrustedSignerExpiry(publicKey: string): Promise<bigint | undefined> {
+    const server = this.chain.getProvider();
+    const key = xdr.ScVal.scvVec([
+      xdr.ScVal.scvSymbol("TrustedSigner"),
+      xdr.ScVal.scvBytes(Buffer.from(publicKey, "hex")),
+    ]);
+    try {
+      const entry = await server.getContractData(
+        this.verifierAddress,
+        key,
+        stellarRpc.Durability.Persistent,
+      );
+      return BigInt(
+        scValToNative(entry.val.contractData().val()) as number | bigint,
+      );
+    } catch {
+      // getContractData throws when the entry does not exist.
+      return undefined;
+    }
+  }
+
+  /**
+   * Read the executor's current Wormhole guardian set index.
+   */
+  async getCurrentGuardianSetIndex(): Promise<number> {
+    const value = await this.readInstanceStorage(
+      this.executorAddress,
+      "GuardianSetIndex",
+    );
+    if (!value) {
+      throw new Error("Executor has no guardian set index (not initialized)");
+    }
+    return Number(scValToNative(value) as number | bigint);
+  }
+
+  /**
+   * Read a single entry from a contract's instance storage. Instance storage is
+   * bundled inside the contract instance ledger entry (not stored as separate
+   * ledger entries), so the whole instance is fetched and its storage map is
+   * scanned for `keySymbol`.
+   */
+  private async readInstanceStorage(
+    contractId: string,
+    keySymbol: string,
+  ): Promise<xdr.ScVal | undefined> {
+    const server = this.chain.getProvider();
+    const entry = await server.getContractData(
+      contractId,
+      xdr.ScVal.scvLedgerKeyContractInstance(),
+      stellarRpc.Durability.Persistent,
+    );
+    const storage = entry.val.contractData().val().instance().storage() ?? [];
+    for (const item of storage) {
+      const key = scValToNative(item.key()) as unknown;
+      if (Array.isArray(key) && key[0] === keySymbol) {
+        return item.val();
+      }
+    }
+    return undefined;
+  }
+}
+
+/** XDR-encode an argument vector as the `ScVec` the executor's `Call` expects. */
+function encodeScVecArgs(args: xdr.ScVal[]): Buffer {
+  return xdr.ScVal.scvVec(args).toXDR();
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/contract_manager/src/core/contracts/stellar.ts
+++ b/contract_manager/src/core/contracts/stellar.ts
@@ -19,66 +19,63 @@ import type { Chain } from "../chains";
 import { StellarChain } from "../chains";
 
 /**
- * Lazer on Stellar is split across two Soroban contracts (see
- * `pyth-network/pyth-lazer` `contracts/stellar`):
+ * Lazer on Stellar (Soroban) is split across two contracts (see
+ * `pyth-network/pyth-lazer` `contracts/stellar`), each represented by its own
+ * `Storable` type here, mirroring the EVM split between {@link EvmLazerContract}
+ * and {@link EvmExecutorContract}:
  *
- * - the **verifier** (`pyth-lazer-stellar`) verifies signed price updates and
- *   stores the trusted signer set, and
- * - the **executor** (`wormhole-executor-stellar`) verifies Wormhole governance
- *   VAAs and dispatches the decoded PTGM action to the verifier (or upgrades
- *   itself).
+ * - {@link StellarLazerContract} — the **verifier** (`pyth-lazer-stellar`), which
+ *   verifies signed price updates and stores the trusted signer set.
+ * - {@link StellarExecutorContract} — the **executor**
+ *   (`wormhole-executor-stellar`), which verifies Wormhole governance VAAs and
+ *   dispatches the decoded PTGM action to the verifier (or upgrades itself).
  *
- * Governance always enters through the executor: a Pyth governance VAA carrying
- * a PTGM `Call` is submitted to `execute_governance_action`, which invokes the
- * named function on the verifier. This class wires both contract ids together
- * and builds the matching PTGM payloads.
+ * Governance always enters through the executor: a Pyth governance VAA carrying a
+ * PTGM `Call` is submitted to `execute_governance_action`, which invokes the
+ * named function on the verifier.
+ */
+
+/**
+ * The Lazer **verifier** (`pyth-lazer-stellar`).
+ *
+ * Governance does not enter the verifier directly — the verifier's payload
+ * builders frame each action as an executor `Call` and resolve the authorized
+ * executor from the verifier's on-chain state, the same way
+ * {@link EvmLazerContract} resolves its owning executor.
  */
 export class StellarLazerContract extends Storable {
   static type = "StellarLazerContract";
 
   /**
    * @param chain - the Stellar chain this contract is deployed on
-   * @param verifierAddress - Soroban contract id of the `pyth-lazer-stellar`
-   *   verifier
-   * @param executorAddress - Soroban contract id of the
-   *   `wormhole-executor-stellar` governance executor
+   * @param address - Soroban contract id of the `pyth-lazer-stellar` verifier
    */
   constructor(
     public readonly chain: StellarChain,
-    public readonly verifierAddress: string,
-    public readonly executorAddress: string,
+    public readonly address: string,
   ) {
     super();
   }
 
   getId(): string {
-    return `${this.chain.getId()}_${this.verifierAddress}`;
+    return `${this.chain.getId()}_${this.address}`;
   }
 
   getType(): string {
     return StellarLazerContract.type;
   }
 
-  getChain(): StellarChain {
-    return this.chain;
-  }
-
   toJson() {
     return {
+      address: this.address,
       chain: this.chain.getId(),
-      executorAddress: this.executorAddress,
       type: StellarLazerContract.type,
-      verifierAddress: this.verifierAddress,
     };
   }
 
   static fromJson(
     chain: Chain,
-    parsed: {
-      type: string;
-      verifierAddress: string;
-      executorAddress: string;
-    },
+    parsed: { type: string; address: string },
   ): StellarLazerContract {
     if (parsed.type !== StellarLazerContract.type) {
       throw new Error("Invalid type");
@@ -86,11 +83,7 @@ export class StellarLazerContract extends Storable {
     if (!(chain instanceof StellarChain)) {
       throw new Error(`Wrong chain type ${chain}`);
     }
-    return new StellarLazerContract(
-      chain,
-      parsed.verifierAddress,
-      parsed.executorAddress,
-    );
+    return new StellarLazerContract(chain, parsed.address);
   }
 
   /**
@@ -101,10 +94,10 @@ export class StellarLazerContract extends Storable {
    * @param publicKey - 33-byte compressed secp256k1 signer key, hex without 0x
    * @param expiresAt - expiry timestamp in unix seconds (0 removes the signer)
    */
-  generateUpdateTrustedSignerPayload(
+  async generateUpdateTrustedSignerPayload(
     publicKey: string,
     expiresAt: bigint,
-  ): Buffer {
+  ): Promise<Buffer> {
     const pubkey = Buffer.from(publicKey, "hex");
     if (pubkey.length !== 33) {
       throw new Error(
@@ -117,8 +110,8 @@ export class StellarLazerContract extends Storable {
     ]);
     return new CallStellarExecutor(
       this.chain.wormholeChainName,
-      this.executorAddress,
-      this.verifierAddress,
+      await this.getExecutor(),
+      this.address,
       "update_trusted_signer",
       args,
     ).encode();
@@ -130,7 +123,7 @@ export class StellarLazerContract extends Storable {
    *
    * @param wasmHash - 32-byte WASM hash of the new verifier, hex without 0x
    */
-  generateUpgradeVerifierPayload(wasmHash: string): Buffer {
+  async generateUpgradeVerifierPayload(wasmHash: string): Promise<Buffer> {
     const hash = Buffer.from(wasmHash, "hex");
     if (hash.length !== 32) {
       throw new Error(`WASM hash must be 32 bytes, got ${hash.length}`);
@@ -138,11 +131,109 @@ export class StellarLazerContract extends Storable {
     const args = encodeScVecArgs([xdr.ScVal.scvBytes(hash)]);
     return new CallStellarExecutor(
       this.chain.wormholeChainName,
-      this.executorAddress,
-      this.verifierAddress,
+      await this.getExecutor(),
+      this.address,
       "upgrade",
       args,
     ).encode();
+  }
+
+  /**
+   * Read the executor address authorized for governance on the verifier. This is
+   * the executor that {@link StellarExecutorContract} wraps; a mismatch with the
+   * registered executor means the registry is stale.
+   */
+  async getExecutor(): Promise<string> {
+    const value = await readInstanceStorage(
+      this.chain,
+      this.address,
+      "Executor",
+    );
+    if (!value) {
+      throw new Error("Verifier has no executor set (not initialized)");
+    }
+    return scValToNative(value) as string;
+  }
+
+  /**
+   * Read the expiry timestamp (unix seconds) of a trusted signer, or `undefined`
+   * if the signer is not currently trusted.
+   *
+   * The verifier keys trusted signers individually by public key and exposes no
+   * enumeration, so callers must supply the key of interest — there is no
+   * on-chain "list all signers" to mirror.
+   *
+   * @param publicKey - 33-byte compressed secp256k1 key, hex without 0x
+   */
+  async getTrustedSignerExpiry(publicKey: string): Promise<bigint | undefined> {
+    const server = this.chain.getProvider();
+    const key = xdr.ScVal.scvVec([
+      xdr.ScVal.scvSymbol("TrustedSigner"),
+      xdr.ScVal.scvBytes(Buffer.from(publicKey, "hex")),
+    ]);
+    try {
+      const entry = await server.getContractData(
+        this.address,
+        key,
+        stellarRpc.Durability.Persistent,
+      );
+      return BigInt(
+        scValToNative(entry.val.contractData().val()) as number | bigint,
+      );
+    } catch {
+      // getContractData throws when the entry does not exist.
+      return undefined;
+    }
+  }
+}
+
+/**
+ * The Wormhole governance **executor** (`wormhole-executor-stellar`). It verifies
+ * Pyth governance VAAs and dispatches the decoded PTGM action to the verifier, or
+ * upgrades itself. Mirrors {@link EvmExecutorContract}.
+ */
+export class StellarExecutorContract extends Storable {
+  static type = "StellarExecutorContract";
+
+  /**
+   * @param chain - the Stellar chain this contract is deployed on
+   * @param address - Soroban contract id of the `wormhole-executor-stellar`
+   *   governance executor
+   */
+  constructor(
+    public readonly chain: StellarChain,
+    public readonly address: string,
+  ) {
+    super();
+  }
+
+  getId(): string {
+    return `${this.chain.getId()}_${this.address}`;
+  }
+
+  getType(): string {
+    return StellarExecutorContract.type;
+  }
+
+  toJson() {
+    return {
+      address: this.address,
+      chain: this.chain.getId(),
+      type: StellarExecutorContract.type,
+    };
+  }
+
+  static fromJson(
+    chain: Chain,
+    parsed: { type: string; address: string },
+  ): StellarExecutorContract {
+    if (parsed.type !== StellarExecutorContract.type) {
+      throw new Error("Invalid type");
+    }
+    if (!(chain instanceof StellarChain)) {
+      throw new Error(`Wrong chain type ${chain}`);
+    }
+    return new StellarExecutorContract(chain, parsed.address);
   }
 
   /**
@@ -153,7 +244,7 @@ export class StellarLazerContract extends Storable {
   generateUpgradeExecutorPayload(wasmDigest: string): Buffer {
     return new UpgradeStellarExecutor(
       this.chain.wormholeChainName,
-      this.executorAddress,
+      this.address,
       Buffer.from(wasmDigest, "hex"),
     ).encode();
   }
@@ -176,7 +267,7 @@ export class StellarLazerContract extends Storable {
       Buffer.from(senderPrivateKey, "hex"),
     );
     const account = await server.getAccount(keypair.publicKey());
-    const executor = new Contract(this.executorAddress);
+    const executor = new Contract(this.address);
 
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
@@ -212,57 +303,12 @@ export class StellarLazerContract extends Storable {
   }
 
   /**
-   * Read the executor address authorized for governance on the verifier. Should
-   * match {@link executorAddress}; a mismatch means the registry is stale.
-   */
-  async getExecutor(): Promise<string> {
-    const value = await this.readInstanceStorage(
-      this.verifierAddress,
-      "Executor",
-    );
-    if (!value) {
-      throw new Error("Verifier has no executor set (not initialized)");
-    }
-    return scValToNative(value) as string;
-  }
-
-  /**
-   * Read the expiry timestamp (unix seconds) of a trusted signer, or `undefined`
-   * if the signer is not currently trusted.
-   *
-   * The verifier keys trusted signers individually by public key and exposes no
-   * enumeration, so callers must supply the key of interest — there is no
-   * on-chain "list all signers" to mirror.
-   *
-   * @param publicKey - 33-byte compressed secp256k1 key, hex without 0x
-   */
-  async getTrustedSignerExpiry(publicKey: string): Promise<bigint | undefined> {
-    const server = this.chain.getProvider();
-    const key = xdr.ScVal.scvVec([
-      xdr.ScVal.scvSymbol("TrustedSigner"),
-      xdr.ScVal.scvBytes(Buffer.from(publicKey, "hex")),
-    ]);
-    try {
-      const entry = await server.getContractData(
-        this.verifierAddress,
-        key,
-        stellarRpc.Durability.Persistent,
-      );
-      return BigInt(
-        scValToNative(entry.val.contractData().val()) as number | bigint,
-      );
-    } catch {
-      // getContractData throws when the entry does not exist.
-      return undefined;
-    }
-  }
-
-  /**
    * Read the executor's current Wormhole guardian set index.
    */
   async getCurrentGuardianSetIndex(): Promise<number> {
-    const value = await this.readInstanceStorage(
-      this.executorAddress,
+    const value = await readInstanceStorage(
+      this.chain,
+      this.address,
       "GuardianSetIndex",
     );
     if (!value) {
@@ -270,37 +316,38 @@ export class StellarLazerContract extends Storable {
     }
     return Number(scValToNative(value) as number | bigint);
   }
-
-  /**
-   * Read a single entry from a contract's instance storage. Instance storage is
-   * bundled inside the contract instance ledger entry (not stored as separate
-   * ledger entries), so the whole instance is fetched and its storage map is
-   * scanned for `keySymbol`.
-   */
-  private async readInstanceStorage(
-    contractId: string,
-    keySymbol: string,
-  ): Promise<xdr.ScVal | undefined> {
-    const server = this.chain.getProvider();
-    const entry = await server.getContractData(
-      contractId,
-      xdr.ScVal.scvLedgerKeyContractInstance(),
-      stellarRpc.Durability.Persistent,
-    );
-    const storage = entry.val.contractData().val().instance().storage() ?? [];
-    for (const item of storage) {
-      const key = scValToNative(item.key()) as unknown;
-      if (Array.isArray(key) && key[0] === keySymbol) {
-        return item.val();
-      }
-    }
-    return undefined;
-  }
 }
 
 /** XDR-encode an argument vector as the `ScVec` the executor's `Call` expects. */
 function encodeScVecArgs(args: xdr.ScVal[]): Buffer {
   return xdr.ScVal.scvVec(args).toXDR();
+}
+
+/**
+ * Read a single entry from a contract's instance storage. Instance storage is
+ * bundled inside the contract instance ledger entry (not stored as separate
+ * ledger entries), so the whole instance is fetched and its storage map is
+ * scanned for `keySymbol`.
+ */
+async function readInstanceStorage(
+  chain: StellarChain,
+  contractId: string,
+  keySymbol: string,
+): Promise<xdr.ScVal | undefined> {
+  const server = chain.getProvider();
+  const entry = await server.getContractData(
+    contractId,
+    xdr.ScVal.scvLedgerKeyContractInstance(),
+    stellarRpc.Durability.Persistent,
+  );
+  const storage = entry.val.contractData().val().instance().storage() ?? [];
+  for (const item of storage) {
+    const key = scValToNative(item.key()) as unknown;
+    if (Array.isArray(key) && key[0] === keySymbol) {
+      return item.val();
+    }
+  }
+  return undefined;
 }
 
 function sleep(ms: number): Promise<void> {

--- a/contract_manager/src/core/contracts/wormhole.ts
+++ b/contract_manager/src/core/contracts/wormhole.ts
@@ -1,3 +1,4 @@
+import { sleep } from "../../utils/sleep";
 import type { PrivateKey, TxResult } from "../base";
 import { Storable } from "../base";
 import type { Chain } from "../chains";
@@ -56,7 +57,7 @@ export abstract class WormholeContract extends Storable {
       console.log(`Submitted upgrade VAA ${i} with tx id ${result.id}`);
       // make sure the upgrade is complete before continuing
       while ((await this.getCurrentGuardianSetIndex()) <= i) {
-        await new Promise((resolve) => setTimeout(resolve, 5000));
+        await sleep(5000);
       }
     }
   }

--- a/contract_manager/src/node/utils/governance.ts
+++ b/contract_manager/src/node/utils/governance.ts
@@ -39,6 +39,7 @@ import bs58 from "bs58";
 
 import type { KeyValueConfig } from "../../core/base.js";
 import { Storable } from "../../core/base.js";
+import { sleep } from "../../utils/sleep.js";
 
 // TODO: this should be migrated to @wormhole-foundation/dsk
 // as such, we cannot publish an ESM variant of the contract_manager
@@ -131,7 +132,7 @@ export class SubmittedWormholeMessage {
         }`,
       );
       if (response.status === 404) {
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        await sleep(1000);
         continue;
       }
       const { vaaBytes } = (await response.json()) as {

--- a/contract_manager/src/node/utils/store.ts
+++ b/contract_manager/src/node/utils/store.ts
@@ -22,6 +22,7 @@ import {
   IotaChain,
   NearChain,
   StarknetChain,
+  StellarChain,
   SuiChain,
   SvmChain,
   TonChain,
@@ -41,6 +42,7 @@ import {
   FuelWormholeContract,
   IotaPriceFeedContract,
   IotaWormholeContract,
+  StellarLazerContract,
   SuiLazerContract,
   SuiPriceFeedContract,
   SuiWormholeContract,
@@ -68,8 +70,10 @@ export class Store {
   public wormhole_contracts: Record<string, WormholeContract> = {};
   public tokens: Record<string, Token> = {};
   public vaults: Record<string, Vault> = {};
-  public lazer_contracts: Record<string, EvmLazerContract | SuiLazerContract> =
-    {};
+  public lazer_contracts: Record<
+    string,
+    EvmLazerContract | SuiLazerContract | StellarLazerContract
+  > = {};
 
   constructor(public path: string) {
     this.loadAllChains();
@@ -115,6 +119,7 @@ export class Store {
       [SuiChain.type]: SuiChain,
       [IotaChain.type]: IotaChain,
       [SvmChain.type]: SvmChain,
+      [StellarChain.type]: StellarChain,
     };
 
     for (const jsonFile of this.getJsonFiles(`${this.path}/chains/`)) {
@@ -204,6 +209,7 @@ export class Store {
       [IotaWormholeContract.type]: IotaWormholeContract,
       [EvmLazerContract.type]: EvmLazerContract,
       [SuiLazerContract.type]: SuiLazerContract,
+      [StellarLazerContract.type]: StellarLazerContract,
     };
     for (const jsonFile of this.getJsonFiles(`${this.path}/contracts/`)) {
       const parsedArray = JSON.parse(readFileSync(jsonFile, "utf8"));
@@ -234,7 +240,8 @@ export class Store {
           this.executor_contracts[chainContract.getId()] = chainContract;
         } else if (
           chainContract instanceof EvmLazerContract ||
-          chainContract instanceof SuiLazerContract
+          chainContract instanceof SuiLazerContract ||
+          chainContract instanceof StellarLazerContract
         ) {
           this.lazer_contracts[chainContract.getId()] = chainContract;
         } else {

--- a/contract_manager/src/node/utils/store.ts
+++ b/contract_manager/src/node/utils/store.ts
@@ -42,6 +42,7 @@ import {
   FuelWormholeContract,
   IotaPriceFeedContract,
   IotaWormholeContract,
+  StellarExecutorContract,
   StellarLazerContract,
   SuiLazerContract,
   SuiPriceFeedContract,
@@ -64,7 +65,10 @@ import { Vault } from "./governance";
 export class Store {
   public chains: Record<string, Chain> = { global: new GlobalChain() };
   public contracts: Record<string, PriceFeedContract> = {};
-  public executor_contracts: Record<string, EvmExecutorContract> = {};
+  public executor_contracts: Record<
+    string,
+    EvmExecutorContract | StellarExecutorContract
+  > = {};
   public entropy_contracts: Record<string, EvmEntropyContract> = {};
   public pulse_contracts: Record<string, EvmPulseContract> = {};
   public wormhole_contracts: Record<string, WormholeContract> = {};
@@ -210,6 +214,7 @@ export class Store {
       [EvmLazerContract.type]: EvmLazerContract,
       [SuiLazerContract.type]: SuiLazerContract,
       [StellarLazerContract.type]: StellarLazerContract,
+      [StellarExecutorContract.type]: StellarExecutorContract,
     };
     for (const jsonFile of this.getJsonFiles(`${this.path}/contracts/`)) {
       const parsedArray = JSON.parse(readFileSync(jsonFile, "utf8"));
@@ -236,7 +241,10 @@ export class Store {
           this.entropy_contracts[chainContract.getId()] = chainContract;
         } else if (chainContract instanceof WormholeContract) {
           this.wormhole_contracts[chainContract.getId()] = chainContract;
-        } else if (chainContract instanceof EvmExecutorContract) {
+        } else if (
+          chainContract instanceof EvmExecutorContract ||
+          chainContract instanceof StellarExecutorContract
+        ) {
           this.executor_contracts[chainContract.getId()] = chainContract;
         } else if (
           chainContract instanceof EvmLazerContract ||

--- a/contract_manager/src/store/chains/StellarChains.json
+++ b/contract_manager/src/store/chains/StellarChains.json
@@ -1,0 +1,11 @@
+[
+  {
+    "horizonUrl": "https://horizon-testnet.stellar.org",
+    "id": "stellar_testnet",
+    "mainnet": false,
+    "networkPassphrase": "Test SDF Network ; September 2015",
+    "rpcUrl": "https://soroban-testnet.stellar.org",
+    "type": "StellarChain",
+    "wormholeChainName": "stellar_testnet"
+  }
+]

--- a/contract_manager/src/store/contracts/StellarExecutorContracts.json
+++ b/contract_manager/src/store/contracts/StellarExecutorContracts.json
@@ -1,0 +1,7 @@
+[
+  {
+    "address": "PLACEHOLDER_EXECUTOR_TESTNET_NOT_YET_DEPLOYED",
+    "chain": "stellar_testnet",
+    "type": "StellarExecutorContract"
+  }
+]

--- a/contract_manager/src/store/contracts/StellarLazerContracts.json
+++ b/contract_manager/src/store/contracts/StellarLazerContracts.json
@@ -1,8 +1,7 @@
 [
   {
+    "address": "CCE62RN3NUTNMD2SQ2EGWRJ6XHL7RUYQBNCEK7LVGFRLPCW7U7FGACM5",
     "chain": "stellar_testnet",
-    "executorAddress": "PLACEHOLDER_EXECUTOR_TESTNET_NOT_YET_DEPLOYED",
-    "type": "StellarLazerContract",
-    "verifierAddress": "CCE62RN3NUTNMD2SQ2EGWRJ6XHL7RUYQBNCEK7LVGFRLPCW7U7FGACM5"
+    "type": "StellarLazerContract"
   }
 ]

--- a/contract_manager/src/store/contracts/StellarLazerContracts.json
+++ b/contract_manager/src/store/contracts/StellarLazerContracts.json
@@ -1,0 +1,8 @@
+[
+  {
+    "chain": "stellar_testnet",
+    "executorAddress": "PLACEHOLDER_EXECUTOR_TESTNET_NOT_YET_DEPLOYED",
+    "type": "StellarLazerContract",
+    "verifierAddress": "CCE62RN3NUTNMD2SQ2EGWRJ6XHL7RUYQBNCEK7LVGFRLPCW7U7FGACM5"
+  }
+]

--- a/contract_manager/src/utils/sleep.ts
+++ b/contract_manager/src/utils/sleep.ts
@@ -1,0 +1,4 @@
+/** Resolve after `ms` milliseconds. */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/governance/xc_admin/packages/xc_admin_common/package.json
+++ b/governance/xc_admin/packages/xc_admin_common/package.json
@@ -229,6 +229,16 @@
         "types": "./dist/cjs/governance_payload/SetWormholeAddress.d.ts"
       }
     },
+    "./governance_payload/StellarExecutorAction": {
+      "import": {
+        "default": "./dist/esm/governance_payload/StellarExecutorAction.mjs",
+        "types": "./dist/esm/governance_payload/StellarExecutorAction.d.ts"
+      },
+      "require": {
+        "default": "./dist/cjs/governance_payload/StellarExecutorAction.cjs",
+        "types": "./dist/cjs/governance_payload/StellarExecutorAction.d.ts"
+      }
+    },
     "./governance_payload/UpdateTrustedSigner": {
       "import": {
         "default": "./dist/esm/governance_payload/UpdateTrustedSigner.mjs",

--- a/governance/xc_admin/packages/xc_admin_common/src/__tests__/StellarExecutorAction.test.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/__tests__/StellarExecutorAction.test.ts
@@ -1,0 +1,130 @@
+import { toChainId } from "../chains";
+import {
+  CallStellarExecutor,
+  decodeGovernancePayload,
+  MAGIC_NUMBER,
+  MODULE_STELLAR_EXECUTOR,
+  PythGovernanceHeader,
+  StellarExecutorAction,
+  UpgradeStellarExecutor,
+} from "../governance_payload";
+
+// A 56-character Soroban contract id (testnet Lazer verifier).
+const VERIFIER = "CCE62RN3NUTNMD2SQ2EGWRJ6XHL7RUYQBNCEK7LVGFRLPCW7U7FGACM5";
+const EXECUTOR = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+
+function expectHeader(buffer: Buffer, action: number) {
+  // Magic "PTGM" is MAGIC_NUMBER serialized little-endian (u32).
+  expect(buffer.readUInt32LE(0)).toBe(MAGIC_NUMBER);
+  expect(buffer.subarray(0, 4).toString("utf8")).toBe("PTGM");
+  expect(buffer[4]).toBe(MODULE_STELLAR_EXECUTOR);
+  expect(buffer[5]).toBe(action);
+  expect(buffer.readUInt16BE(6)).toBe(toChainId("stellar_testnet"));
+}
+
+describe("StellarExecutorAction", () => {
+  test("Call encodes the header, length-prefixed addresses, function and args", () => {
+    // ScVec([BytesN<33>, u64]) for update_trusted_signer — the exact XDR is
+    // produced by the Stellar SDK in the contract manager; here we only assert
+    // the framing wraps whatever args buffer it is given.
+    const argsXdr = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
+    const action = new CallStellarExecutor(
+      "stellar_testnet",
+      EXECUTOR,
+      VERIFIER,
+      "update_trusted_signer",
+      argsXdr,
+    );
+    const buffer = action.encode();
+
+    expectHeader(buffer, StellarExecutorAction.Call);
+
+    let offset = PythGovernanceHeader.span;
+    expect(buffer[offset]).toBe(EXECUTOR.length);
+    offset += 1;
+    expect(buffer.subarray(offset, offset + EXECUTOR.length).toString()).toBe(
+      EXECUTOR,
+    );
+    offset += EXECUTOR.length;
+    expect(buffer[offset]).toBe(VERIFIER.length);
+    offset += 1;
+    expect(buffer.subarray(offset, offset + VERIFIER.length).toString()).toBe(
+      VERIFIER,
+    );
+    offset += VERIFIER.length;
+    expect(buffer[offset]).toBe("update_trusted_signer".length);
+    offset += 1 + "update_trusted_signer".length;
+    expect(buffer.subarray(offset)).toEqual(argsXdr);
+  });
+
+  test("Call round-trips through decode", () => {
+    const argsXdr = Buffer.from([9, 9, 9]);
+    const original = new CallStellarExecutor(
+      "stellar_testnet",
+      EXECUTOR,
+      VERIFIER,
+      "ping",
+      argsXdr,
+    );
+    const decoded = CallStellarExecutor.decode(original.encode());
+    expect(decoded).toBeDefined();
+    expect(decoded?.targetChainId).toBe("stellar_testnet");
+    expect(decoded?.executor).toBe(EXECUTOR);
+    expect(decoded?.targetContract).toBe(VERIFIER);
+    expect(decoded?.functionName).toBe("ping");
+    expect(decoded?.argsXdr).toEqual(argsXdr);
+  });
+
+  test("decodeGovernancePayload resolves a Stellar Call", () => {
+    const action = new CallStellarExecutor(
+      "stellar_testnet",
+      EXECUTOR,
+      VERIFIER,
+      "ping",
+      Buffer.alloc(0),
+    );
+    const decoded = decodeGovernancePayload(action.encode());
+    expect(decoded).toBeInstanceOf(CallStellarExecutor);
+  });
+
+  test("Call rejects an over-long function name", () => {
+    const action = new CallStellarExecutor(
+      "stellar_testnet",
+      EXECUTOR,
+      VERIFIER,
+      "a".repeat(33),
+      Buffer.alloc(0),
+    );
+    expect(() => action.encode()).toThrow();
+  });
+
+  test("UpgradeExecutor round-trips and targets the executor itself", () => {
+    const wasmDigest = Buffer.alloc(32, 0xab);
+    const original = new UpgradeStellarExecutor(
+      "stellar_testnet",
+      EXECUTOR,
+      wasmDigest,
+    );
+    const buffer = original.encode();
+    expectHeader(buffer, StellarExecutorAction.UpgradeExecutor);
+
+    const decoded = UpgradeStellarExecutor.decode(buffer);
+    expect(decoded).toBeDefined();
+    expect(decoded?.executor).toBe(EXECUTOR);
+    expect(decoded?.wasmDigest).toEqual(wasmDigest);
+    expect(decodeGovernancePayload(buffer)).toBeInstanceOf(
+      UpgradeStellarExecutor,
+    );
+  });
+
+  test("UpgradeExecutor rejects a wrong-length digest", () => {
+    expect(
+      () =>
+        new UpgradeStellarExecutor(
+          "stellar_testnet",
+          EXECUTOR,
+          Buffer.alloc(31),
+        ),
+    ).toThrow();
+  });
+});

--- a/governance/xc_admin/packages/xc_admin_common/src/chains.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/chains.ts
@@ -130,6 +130,12 @@ export const RECEIVER_CHAINS = {
   cardano_mainnet: 60097,
   cardano_preprod: 60098,
   cardano_preview: 60099,
+  // Stellar (Soroban) Lazer deployment. The Stellar wormhole executor is
+  // initialized with this id as its `chain_id`; PTGM messages target it exactly
+  // (the executor rejects the wildcard 0). A dedicated Pyth receiver id is used
+  // rather than Wormhole's canonical Stellar id, which collides with `base`
+  // (30) — matching the precedent set by Sui (`iota_sui_*`) and Cardano.
+  stellar_mainnet: 60100,
 
   // Testnets as a separate chain ids (to use stable data sources and governance for them)
   injective_testnet: 60013,
@@ -276,6 +282,7 @@ export const RECEIVER_CHAINS = {
   celo_sepolia_testnet: 50137,
   arc_testnet: 50138,
   tempo_testnet: 50139,
+  stellar_testnet: 50140,
 };
 
 // If there is any overlapping value the receiver chain will replace the wormhole

--- a/governance/xc_admin/packages/xc_admin_common/src/governance_payload/PythGovernanceAction.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/governance_payload/PythGovernanceAction.ts
@@ -35,6 +35,17 @@ export const LazerAction = {
   UpgradeCardanoWithdrawScript: 3,
 } as const;
 
+// Actions for the Stellar wormhole executor (MODULE_STELLAR_EXECUTOR). The
+// executor is a generic dispatcher: `Call` invokes an arbitrary function on a
+// target Soroban contract, and `UpgradeExecutor` swaps the executor's own WASM.
+// These live in their own module (4) rather than the Lazer module (3) so the
+// codes do not collide with `UpgradeSuiLazerContract`/`UpdateTrustedSigner`.
+// biome-ignore assist/source/useSortedKeys: ordered by ID
+export const StellarExecutorAction = {
+  UpgradeExecutor: 0,
+  Call: 1,
+} as const;
+
 /** Helper to get the ActionName from a (moduleId, actionId) tuple*/
 export function toActionName(
   deserialized: Readonly<{ moduleId: number; actionId: number }>,
@@ -80,6 +91,13 @@ export function toActionName(
       case 3:
         return "UpgradeCardanoWithdrawScript";
     }
+  } else if (deserialized.moduleId == MODULE_STELLAR_EXECUTOR) {
+    switch (deserialized.actionId) {
+      case 0:
+        return "UpgradeExecutor";
+      case 1:
+        return "Call";
+    }
   }
   return undefined;
 }
@@ -88,7 +106,8 @@ export declare type ActionName =
   | keyof typeof ExecutorAction
   | keyof typeof TargetAction
   | keyof typeof EvmExecutorAction
-  | keyof typeof LazerAction;
+  | keyof typeof LazerAction
+  | keyof typeof StellarExecutorAction;
 
 /** Governance header that should be in every Pyth crosschain governance message*/
 export class PythGovernanceHeader {
@@ -157,6 +176,12 @@ export class PythGovernanceHeader {
     } else if (this.action in EvmExecutorAction) {
       module = MODULE_EVM_EXECUTOR;
       action = EvmExecutorAction[this.action as keyof typeof EvmExecutorAction];
+    } else if (this.action in StellarExecutorAction) {
+      module = MODULE_STELLAR_EXECUTOR;
+      action =
+        StellarExecutorAction[
+          this.action as keyof typeof StellarExecutorAction
+        ];
     } else {
       module = MODULE_LAZER;
       action = LazerAction[this.action as keyof typeof LazerAction];
@@ -183,8 +208,7 @@ export const MODULE_EVM_EXECUTOR = 2;
 export const MODULE_LAZER = 3;
 // The Stellar wormhole executor (in pyth-network/pyth-lazer) has its own module
 // so its generic-dispatch actions do not collide with the Lazer module's fixed
-// actions. Reserved here so the id is not reused; the action payloads are wired
-// up alongside the Stellar contract-manager integration.
+// actions. Its action payloads are defined in StellarExecutorAction.ts.
 export const MODULE_STELLAR_EXECUTOR = 4;
 export const MODULES = [
   MODULE_EXECUTOR,

--- a/governance/xc_admin/packages/xc_admin_common/src/governance_payload/StellarExecutorAction.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/governance_payload/StellarExecutorAction.ts
@@ -1,0 +1,181 @@
+import type { ChainName } from "../chains";
+import { safeBufferConcat } from "../utils/buffer";
+import {
+  PythGovernanceActionImpl,
+  PythGovernanceHeader,
+} from "./PythGovernanceAction";
+
+// Soroban `Symbol` maximum length, in bytes. Mirrors `MAX_SYMBOL_LEN` in the
+// Stellar executor's `governance.rs`.
+const MAX_SYMBOL_LEN = 32;
+
+// Stellar addresses are variable-length strkey strings (e.g. a 56-character
+// contract id starting with `C`). The executor reads them with
+// `Address::from_string_bytes`, so each address is serialized as its raw strkey
+// *string* bytes, length-prefixed with a single byte — not the decoded 32-byte
+// key. See `wormhole-executor-stellar/src/governance.rs`.
+function encodeLengthPrefixed(value: Buffer): Buffer {
+  if (value.length === 0 || value.length > 0xff) {
+    throw new Error(
+      `Length-prefixed field must be 1..=255 bytes, got ${value.length}`,
+    );
+  }
+  return safeBufferConcat([Buffer.from([value.length]), value]);
+}
+
+// Read a `[u8 len][len bytes]` field starting at `offset`; returns the bytes and
+// the offset just past them.
+function decodeLengthPrefixed(
+  data: Buffer,
+  offset: number,
+): { value: Buffer; offset: number } {
+  if (offset >= data.length) {
+    throw new Error("Truncated length-prefixed field");
+  }
+  const len = data.readUInt8(offset);
+  const start = offset + 1;
+  const end = start + len;
+  if (len === 0 || end > data.length) {
+    throw new Error("Truncated length-prefixed field");
+  }
+  return { offset: end, value: data.subarray(start, end) };
+}
+
+/**
+ * Generic governance call dispatched by the Stellar wormhole executor
+ * (`MODULE_STELLAR_EXECUTOR`, action `Call`).
+ *
+ * Wire format (after the 8-byte governance header):
+ * ```text
+ * [1 byte]  executor strkey length
+ * [N bytes] executor strkey (must equal the deployed executor contract id)
+ * [1 byte]  target strkey length
+ * [M bytes] target strkey (contract the executor invokes)
+ * [1 byte]  function name length (1..=32, valid Soroban Symbol)
+ * [F bytes] function name (UTF-8)
+ * [rest]    XDR-encoded ScVec of call arguments
+ * ```
+ *
+ * `argsXdr` is the XDR serialization of the argument vector that the target
+ * function expects — produced with the Stellar SDK in the contract manager,
+ * since this package is intentionally free of Soroban SDK dependencies. For
+ * example, "update trusted signer" is expressed as
+ * `Call(target = verifier, functionName = "update_trusted_signer",
+ * argsXdr = ScVec([pubkey: BytesN<33>, expiresAt: u64]))`.
+ */
+export class CallStellarExecutor extends PythGovernanceActionImpl {
+  constructor(
+    targetChainId: ChainName,
+    readonly executor: string,
+    readonly targetContract: string,
+    readonly functionName: string,
+    readonly argsXdr: Buffer,
+  ) {
+    super(targetChainId, "Call");
+  }
+
+  static decode(data: Buffer): CallStellarExecutor | undefined {
+    const header = PythGovernanceHeader.decode(data);
+    if (!header || header.action !== "Call") return undefined;
+
+    try {
+      let offset = PythGovernanceHeader.span;
+      const executor = decodeLengthPrefixed(data, offset);
+      offset = executor.offset;
+      const target = decodeLengthPrefixed(data, offset);
+      offset = target.offset;
+      const fn = decodeLengthPrefixed(data, offset);
+      offset = fn.offset;
+      const argsXdr = data.subarray(offset);
+
+      return new CallStellarExecutor(
+        header.targetChainId,
+        executor.value.toString("utf8"),
+        target.value.toString("utf8"),
+        fn.value.toString("utf8"),
+        argsXdr,
+      );
+    } catch {
+      return undefined;
+    }
+  }
+
+  encode(): Buffer {
+    const functionName = Buffer.from(this.functionName, "utf8");
+    if (functionName.length === 0 || functionName.length > MAX_SYMBOL_LEN) {
+      throw new Error(
+        `Function name must be 1..=${MAX_SYMBOL_LEN} bytes, got ${functionName.length}`,
+      );
+    }
+    return safeBufferConcat([
+      this.header().encode(),
+      encodeLengthPrefixed(Buffer.from(this.executor, "utf8")),
+      encodeLengthPrefixed(Buffer.from(this.targetContract, "utf8")),
+      encodeLengthPrefixed(functionName),
+      this.argsXdr,
+    ]);
+  }
+}
+
+/**
+ * Self-upgrade of the Stellar wormhole executor
+ * (`MODULE_STELLAR_EXECUTOR`, action `UpgradeExecutor`).
+ *
+ * Wire format (after the 8-byte governance header):
+ * ```text
+ * [1 byte]  executor strkey length
+ * [N bytes] executor strkey
+ * [1 byte]  target strkey length
+ * [M bytes] target strkey (must equal the executor — self-upgrade)
+ * [32 bytes] new WASM digest
+ * ```
+ */
+export class UpgradeStellarExecutor extends PythGovernanceActionImpl {
+  readonly wasmDigest: Buffer;
+
+  constructor(
+    targetChainId: ChainName,
+    readonly executor: string,
+    wasmDigest: Buffer,
+  ) {
+    super(targetChainId, "UpgradeExecutor");
+    if (wasmDigest.length !== 32) {
+      throw new Error(`WASM digest must be 32 bytes, got ${wasmDigest.length}`);
+    }
+    this.wasmDigest = wasmDigest;
+  }
+
+  static decode(data: Buffer): UpgradeStellarExecutor | undefined {
+    const header = PythGovernanceHeader.decode(data);
+    if (!header || header.action !== "UpgradeExecutor") return undefined;
+
+    try {
+      let offset = PythGovernanceHeader.span;
+      const executor = decodeLengthPrefixed(data, offset);
+      offset = executor.offset;
+      const target = decodeLengthPrefixed(data, offset);
+      offset = target.offset;
+      const wasmDigest = data.subarray(offset);
+      if (wasmDigest.length !== 32) return undefined;
+
+      return new UpgradeStellarExecutor(
+        header.targetChainId,
+        executor.value.toString("utf8"),
+        Buffer.from(wasmDigest),
+      );
+    } catch {
+      return undefined;
+    }
+  }
+
+  encode(): Buffer {
+    const executor = Buffer.from(this.executor, "utf8");
+    return safeBufferConcat([
+      this.header().encode(),
+      encodeLengthPrefixed(executor),
+      // Self-upgrade: the target contract is the executor itself.
+      encodeLengthPrefixed(executor),
+      this.wasmDigest,
+    ]);
+  }
+}

--- a/governance/xc_admin/packages/xc_admin_common/src/governance_payload/index.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/governance_payload/index.ts
@@ -15,6 +15,10 @@ import {
   StarknetSetWormholeAddress,
 } from "./SetWormholeAddress";
 import {
+  CallStellarExecutor,
+  UpgradeStellarExecutor,
+} from "./StellarExecutorAction";
+import {
   UpdateTrustedSigner256Bit,
   UpdateTrustedSigner264Bit,
 } from "./UpdateTrustedSigner";
@@ -102,6 +106,10 @@ export function decodeGovernancePayload(
         return undefined;
       }
     }
+    case "Call":
+      return CallStellarExecutor.decode(data);
+    case "UpgradeExecutor":
+      return UpgradeStellarExecutor.decode(data);
     default:
       return undefined;
   }
@@ -117,6 +125,7 @@ export * from "./SetFee";
 export * from "./SetTransactionFee";
 export * from "./SetValidPeriod";
 export * from "./SetWormholeAddress";
+export * from "./StellarExecutorAction";
 export * from "./UpdateTrustedSigner";
 export * from "./UpgradeContract";
 export * from "./UpgradeLazerContract";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ catalogs:
     '@solana/web3.js':
       specifier: ^1.98.0
       version: 1.98.0
+    '@stellar/stellar-sdk':
+      specifier: ^13.3.0
+      version: 13.3.0
     '@storybook/addon-styling-webpack':
       specifier: ^3.0.0
       version: 3.0.0
@@ -1438,6 +1441,9 @@ importers:
       '@sqds/mesh':
         specifier: ^1.0.6
         version: 1.0.6(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@stellar/stellar-sdk':
+        specifier: 'catalog:'
+        version: 13.3.0
       '@ton/blueprint':
         specifier: ^0.22.0
         version: 0.22.0(patch_hash=87640a947e37634630debe8c6d3959cc24098499df6ba20cefbaec73c56e81fe)(@swc/core@1.15.10)(@ton/core@0.59.1(@ton/crypto@3.3.0))(@ton/crypto@3.3.0)(@ton/ton@15.2.1(@ton/core@0.59.1(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@types/node@22.14.0)(encoding@0.1.13)(typescript@5.9.3)
@@ -11023,6 +11029,18 @@ packages:
   '@starknet-io/types-js@0.7.10':
     resolution: {integrity: sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==}
 
+  '@stellar/js-xdr@3.1.2':
+    resolution: {integrity: sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==}
+
+  '@stellar/stellar-base@13.1.0':
+    resolution: {integrity: sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==}
+    engines: {node: '>=18.0.0'}
+    deprecated: This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.
+
+  '@stellar/stellar-sdk@13.3.0':
+    resolution: {integrity: sha512-8+GHcZLp+mdin8gSjcgfb/Lb6sSMYRX6Nf/0LcSJxvjLQR0XHpjGzOiRbYb2jSXo51EnA6kAV5j+4Pzh5OUKUg==}
+    engines: {node: '>=18.0.0'}
+
   '@storybook/addon-styling-webpack@3.0.0':
     resolution: {integrity: sha512-6iI7wGf/tEt5awB8NYAWU+I/hI7PwOdoaNb5V8Z+GkhEko4nZFpXfp8jz2nMblAnx9Jsl95LfIaH9Spa0JksuQ==}
     peerDependencies:
@@ -13341,6 +13359,25 @@ packages:
   balanced-match@2.0.0:
     resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==}
 
+  bare-addon-resolve@1.10.0:
+    resolution: {integrity: sha512-sSd0jieRJlDaODOzj0oe0RjFVC1QI0ZIjGIdPkbrTXsdVVtENg14c+lHHAhHwmWCZ2nQlMhy8jA3Y5LYPc/isA==}
+    peerDependencies:
+      bare-url: '*'
+    peerDependenciesMeta:
+      bare-url:
+        optional: true
+
+  bare-module-resolve@1.12.2:
+    resolution: {integrity: sha512-j+hiD5k99qec4KjJvYsI67q5AOBifmy9JG3oeMVxTmvrhn2sIdp8StrUvZu4YNgwTpO+NhniQG16N1ETDe1k5w==}
+    peerDependencies:
+      bare-url: '*'
+    peerDependenciesMeta:
+      bare-url:
+        optional: true
+
+  bare-semver@1.1.0:
+    resolution: {integrity: sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==}
+
   base-64@1.0.0:
     resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
 
@@ -13357,6 +13394,10 @@ packages:
 
   base-x@5.0.1:
     resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
+
+  base32.js@0.1.0:
+    resolution: {integrity: sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==}
+    engines: {node: '>=0.12.0'}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -13410,6 +13451,9 @@ packages:
 
   bignumber.js@9.1.2:
     resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -15798,6 +15842,9 @@ packages:
       picomatch:
         optional: true
 
+  feaxios@0.0.23:
+    resolution: {integrity: sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==}
+
   fetch-cookie@3.0.1:
     resolution: {integrity: sha512-ZGXe8Y5Z/1FWqQ9q/CrJhkUD73DyBU9VF0hBQmEO/wPHe4A9PKTjplFDLeFX8aOsYypZUcX5Ji/eByn3VCVO3Q==}
 
@@ -17055,6 +17102,10 @@ packages:
   is-retry-allowed@2.2.0:
     resolution: {integrity: sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==}
     engines: {node: '>=10'}
+
+  is-retry-allowed@3.0.0:
+    resolution: {integrity: sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==}
+    engines: {node: '>=12'}
 
   is-root@2.1.0:
     resolution: {integrity: sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==}
@@ -20290,6 +20341,10 @@ packages:
   requestidlecallback@0.3.0:
     resolution: {integrity: sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==}
 
+  require-addon@1.2.0:
+    resolution: {integrity: sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==}
+    engines: {bare: '>=1.10.0'}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -20853,6 +20908,9 @@ packages:
   socks@2.8.4:
     resolution: {integrity: sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sodium-native@4.3.3:
+    resolution: {integrity: sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==}
 
   solc@0.8.26:
     resolution: {integrity: sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==}
@@ -35988,6 +36046,35 @@ snapshots:
 
   '@starknet-io/types-js@0.7.10': {}
 
+  '@stellar/js-xdr@3.1.2': {}
+
+  '@stellar/stellar-base@13.1.0':
+    dependencies:
+      '@stellar/js-xdr': 3.1.2
+      base32.js: 0.1.0
+      bignumber.js: 9.3.1
+      buffer: 6.0.3
+      sha.js: 2.4.11
+      tweetnacl: 1.0.3
+    optionalDependencies:
+      sodium-native: 4.3.3
+    transitivePeerDependencies:
+      - bare-url
+
+  '@stellar/stellar-sdk@13.3.0':
+    dependencies:
+      '@stellar/stellar-base': 13.1.0
+      axios: 1.8.4(debug@4.4.3)
+      bignumber.js: 9.3.1
+      eventsource: 2.0.2
+      feaxios: 0.0.23
+      randombytes: 2.1.0
+      toml: 3.0.0
+      urijs: 1.19.11
+    transitivePeerDependencies:
+      - bare-url
+      - debug
+
   '@storybook/addon-styling-webpack@3.0.0(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.5.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(utf-8-validate@6.0.3))(webpack@5.98.0(@swc/core@1.15.10))':
     dependencies:
       storybook: 10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.5.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(utf-8-validate@6.0.3)
@@ -39809,6 +39896,20 @@ snapshots:
 
   balanced-match@2.0.0: {}
 
+  bare-addon-resolve@1.10.0:
+    dependencies:
+      bare-module-resolve: 1.12.2
+      bare-semver: 1.1.0
+    optional: true
+
+  bare-module-resolve@1.12.2:
+    dependencies:
+      bare-semver: 1.1.0
+    optional: true
+
+  bare-semver@1.1.0:
+    optional: true
+
   base-64@1.0.0:
     optional: true
 
@@ -39823,6 +39924,8 @@ snapshots:
   base-x@4.0.1: {}
 
   base-x@5.0.1: {}
+
+  base32.js@0.1.0: {}
 
   base64-js@1.5.1: {}
 
@@ -39866,6 +39969,8 @@ snapshots:
   bignumber.js@7.2.1: {}
 
   bignumber.js@9.1.2: {}
+
+  bignumber.js@9.3.1: {}
 
   binary-extensions@2.3.0: {}
 
@@ -42969,6 +43074,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  feaxios@0.0.23:
+    dependencies:
+      is-retry-allowed: 3.0.0
+
   fetch-cookie@3.0.1:
     dependencies:
       set-cookie-parser: 2.7.1
@@ -44648,6 +44757,8 @@ snapshots:
       hasown: 2.0.2
 
   is-retry-allowed@2.2.0: {}
+
+  is-retry-allowed@3.0.0: {}
 
   is-root@2.1.0: {}
 
@@ -49551,6 +49662,13 @@ snapshots:
 
   requestidlecallback@0.3.0: {}
 
+  require-addon@1.2.0:
+    dependencies:
+      bare-addon-resolve: 1.10.0
+    transitivePeerDependencies:
+      - bare-url
+    optional: true
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -50371,6 +50489,13 @@ snapshots:
     dependencies:
       ip-address: 9.0.5
       smart-buffer: 4.2.0
+
+  sodium-native@4.3.3:
+    dependencies:
+      require-addon: 1.2.0
+    transitivePeerDependencies:
+      - bare-url
+    optional: true
 
   solc@0.8.26(debug@4.4.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,6 +68,7 @@ catalog:
   "@solana/wallet-adapter-react-ui": ^0.9.36
   "@solana/wallet-adapter-wallets": ^0.19.33
   "@solana/web3.js": ^1.98.0
+  "@stellar/stellar-sdk": ^13.3.0
   "@storybook/addon-styling-webpack": ^3.0.0
   "@storybook/addon-themes": ^10.1.11
   "@storybook/nextjs": ^10.1.11


### PR DESCRIPTION
Adds Stellar (Soroban) Lazer support to the cross-chain `contract_manager`, following the existing per-chain Lazer pattern (Sui/EVM/Cardano). Resolves [[i-wtmljxan]].

Unblocked by the governance-vocabulary validation gate [[i-zjawcplo]] (audit-trail [[d-hthzpvy]]); the Stellar action-code reassignment it required landed in [[i-xgzdqaaa]]. Security context: [[d-cdzwwku]].

## Design decisions

**Separate verifier and executor contract types.** Per human-iteration feedback, the on-chain contracts are modeled as two distinct `Storable` types — `StellarLazerContract` (the `pyth-lazer-stellar` verifier) and `StellarExecutorContract` (the `wormhole-executor-stellar` governance executor) — mirroring the EVM split between `EvmLazerContract` and `EvmExecutorContract`. Each carries a single `address`, is registered in its own store file (`StellarLazerContracts.json` / `StellarExecutorContracts.json`), and the executor loads into `Store.executor_contracts` alongside `EvmExecutorContract`. The verifier's payload builders resolve the authorized executor from the verifier's on-chain state (`getExecutor()`), exactly as `EvmLazerContract` resolves its owning executor via `getOwner()`.

**Dedicated governance module (4), not Lazer module (3).** The validation gate found Stellar's executor reuses module-3 action codes `0`/`1` with incompatible payloads. The resolution (landed in [[i-xgzdqaaa]]) moved the Stellar executor to its own module `MODULE_STELLAR_EXECUTOR = 4` (mirroring Solana executor=0, EVM executor=2), so `Call`/`UpgradeExecutor` never collide with `UpgradeSuiLazerContract`/`UpdateTrustedSigner`. This makes the "disambiguate decode by target chain" concern moot.

**Dedicated Pyth receiver chain ids.** Wormhole's canonical chain id 30 maps to `base` in this repo, so a stellar→30 mapping would clobber `base` in `toChainName`. Instead Stellar gets dedicated Pyth receiver ids `stellar_testnet` (50140) / `stellar_mainnet` (60100), exactly as Sui (`iota_sui_*`) and Cardano do. **The deployed executor must be initialized with the matching `chain_id`** (the pyth-lazer README's `--chain_id 30` example must be updated to 50140 for testnet).

**Serializer placement.** The length-prefixed-strkey + XDR-`ScVec` framing lives in `xc-admin-common` (`StellarExecutorAction.ts`) alongside the other governance actions and is unit-tested there. The Soroban-specific XDR argument encoding lives in `contract_manager` (which depends on `@stellar/stellar-sdk`), keeping `xc-admin-common` free of Soroban SDK deps.

## Changes

**`xc-admin-common`**
- `chains.ts`: `stellar_testnet` (50140), `stellar_mainnet` (60100).
- `PythGovernanceAction.ts`: `StellarExecutorAction` (`UpgradeExecutor=0`, `Call=1`); wired into header encode + `toActionName` + `ActionName`.
- `StellarExecutorAction.ts`: `CallStellarExecutor` / `UpgradeStellarExecutor` serializer + decoder, mirroring `wormhole-executor-stellar/src/governance.rs`.
- `index.ts`: decode wiring + exports.
- Unit tests (`__tests__/StellarExecutorAction.test.ts`): encode framing, decode round-trip, `decodeGovernancePayload` resolution, error cases.

**`contract_manager`**
- `StellarChain` (`core/chains.ts`): Soroban RPC provider, account address/balance.
- `StellarLazerContract` (`core/contracts/stellar.ts`): the verifier. PTGM payload builders `generateUpdateTrustedSignerPayload` / `generateUpgradeVerifierPayload` (both resolve the executor on-chain via `getExecutor()`); getters `getExecutor`, `getTrustedSignerExpiry(pubkey)`. (The verifier keys signers individually with no enumeration, so there is no on-chain "list all signers" to mirror — callers query a specific key.)
- `StellarExecutorContract` (`core/contracts/stellar.ts`): the executor. `generateUpgradeExecutorPayload`, `executeGovernanceAction(senderPrivateKey, vaa)`, `getCurrentGuardianSetIndex`.
- Store wiring + `StellarChains.json` / `StellarLazerContracts.json` / `StellarExecutorContracts.json` testnet entries.
- `generate_stellar_lazer_update_trusted_signer_proposal.ts` + README section.
- Adds `@stellar/stellar-sdk` to the catalog + contract_manager.

## Verification

- `pnpm turbo run build` (typecheck) green for `xc-admin-common` + `contract-manager`.
- `pnpm turbo run test:unit` green — 13 suites / 29 tests (6 new Stellar tests).
- `biome ci --changed` clean on all changed files.
- Registry self-check: `DefaultStore` loads `stellar_testnet`, the Stellar Lazer verifier, and the Stellar executor.
- Rebased onto current `origin/main`; `git merge-tree origin/main HEAD`: no conflicts.

## Known limitations

- **No live smoke test.** A testnet deploy/attach + governance-VAA round-trip cannot run in CI (no testnet creds/network, and the testnet executor is not yet deployed). The verifier testnet id is real (`CCE6…`); the executor address in `StellarExecutorContracts.json` is a **placeholder** to be replaced once deployed. Mainnet is not yet deployed (see [[i-rzpskiav]] follow-ups).
- The `Call` args XDR uses the canonical Soroban `ScVal::Vec` encoding produced by `@stellar/stellar-sdk` (`scvVec`), matching `Vec::<Val>::from_xdr` in the executor; this is the one part not exercised by an on-chain test here.