### PR TITLE
docs(developer-hub): document Pro-compatible Core sponsored feeds

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/abstract-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/abstract-mainnet.json
@@ -2,31 +2,35 @@
   "feeds": [
     {
       "alias": "WETH/USD",
+      "confidence_ratio": 100,
       "id": "9d4294bbcd1174d6f2003ec365831e64cc31d9f6f15a2b85399db8d5000960f6",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "USDT/USD",
+      "confidence_ratio": 100,
       "id": "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "USDC/USD",
+      "confidence_ratio": 100,
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "PENGU/USD",
+      "confidence_ratio": 100,
       "id": "bed3097008b9b5e3c93bec20be79cb43986b85a996475589351a21e67bae9b61",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/arbitrum-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/arbitrum-mainnet.json
@@ -2,10 +2,11 @@
   "feeds": [
     {
       "alias": "HLP0/USDC.RR",
+      "confidence_ratio": 100,
       "id": "aa388e24e74d5dd12145f74fad3180266f78ed08c0a2f47c60583fdb612587ba",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/avalanche-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/avalanche-mainnet.json
@@ -2,10 +2,11 @@
   "feeds": [
     {
       "alias": "HLP0/USDC.RR",
+      "confidence_ratio": 100,
       "id": "aa388e24e74d5dd12145f74fad3180266f78ed08c0a2f47c60583fdb612587ba",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/base-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/base-mainnet.json
@@ -2,52 +2,59 @@
   "feeds": [
     {
       "alias": "USDC/USD",
+      "confidence_ratio": 100,
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "ETH/USD",
+      "confidence_ratio": 100,
       "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "WETH/USD",
+      "confidence_ratio": 100,
       "id": "9d4294bbcd1174d6f2003ec365831e64cc31d9f6f15a2b85399db8d5000960f6",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "CBETH/USD",
+      "confidence_ratio": 100,
       "id": "15ecddd26d49e1a8f1de9376ebebc03916ede873447c1255d2d5891b92ce5717",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "WSTETH/USD",
+      "confidence_ratio": 100,
       "id": "6df640f3b8963d8f8358f791f352b8364513f6ab1cca5ed3f1f7b5448980e784",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "SUI/USD",
+      "confidence_ratio": 100,
       "id": "23d7315113f5b1d3ba7a83604c44b94d79f4fd69af77f804fc7f920a6dc65744",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "XRP/USD",
+      "confidence_ratio": 100,
       "id": "ec5d399846a9209f3fe5881d70aae9268c94339ff9817e8d18ff19fa05eea1c8",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/berachain-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/berachain-mainnet.json
@@ -2,66 +2,75 @@
   "feeds": [
     {
       "alias": "BERA/USD",
+      "confidence_ratio": 100,
       "id": "962088abcfdbdb6e30db2e340c8cf887d9efb311b1f2f17b155a63dbb6d40265",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "BTC/USD",
+      "confidence_ratio": 100,
       "id": "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "ETH/USD",
+      "confidence_ratio": 100,
       "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "USDC/USD",
+      "confidence_ratio": 100,
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "USDT/USD",
+      "confidence_ratio": 100,
       "id": "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "PYUSD/USD",
+      "confidence_ratio": 100,
       "id": "c1da1b73d7f01e7ddd54b3766cf7fcd644395ad14f70aa706ec5384c59e76692",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "SUSDE/USDE.RR",
+      "confidence_ratio": 100,
       "id": "271c64ce459937abf721d42552035713b6c58f80eeceab716a624607fda4b10f",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "HONEY/USD",
+      "confidence_ratio": 100,
       "id": "f67b033925d73d43ba4401e00308d9b0f26ab4fbd1250e8b5407b9eaade7e1f4",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "HONEY/USD.RR",
+      "confidence_ratio": 100,
       "id": "8bb3695875f9c33594097b0e0a1daa881aa81290088f0eac3a07b700fc7612ba",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/ethereum-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/ethereum-mainnet.json
@@ -2,31 +2,35 @@
   "feeds": [
     {
       "alias": "USDC/USD",
+      "confidence_ratio": 100,
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
-      "time_difference": 3600,
       "price_deviation": 2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "LINEA/USD",
+      "confidence_ratio": 100,
       "id": "49e50653755fbf8018ab65a07be2f208ac8c4bdfc43200934304ca17ee663cab",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "BOLD/USD",
+      "confidence_ratio": 100,
       "id": "d6134dbb0427240f901e3e596d6e63f7d85088f96cd4cd4ae2f89c0819b5d623",
-      "time_difference": 3600,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "SPYX/USD",
+      "confidence_ratio": 100,
       "id": "2817b78438c769357182c04346fddaad1178c82f4048828fe0997c3c64624e14",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/hyperevm-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/hyperevm-mainnet.json
@@ -2,304 +2,347 @@
   "feeds": [
     {
       "alias": "BTC/USD",
+      "confidence_ratio": 100,
       "id": "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "ETH/USD",
+      "confidence_ratio": 100,
       "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "USDC/USD",
+      "confidence_ratio": 100,
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "USDT/USD",
+      "confidence_ratio": 100,
       "id": "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "HYPE/USD",
+      "confidence_ratio": 100,
       "id": "4279e31cc369bbcc2faf022b382b080e32a8e689ff20fbc530d2a603eb6cd98b",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "WSTETH/USD",
+      "confidence_ratio": 100,
       "id": "6df640f3b8963d8f8358f791f352b8364513f6ab1cca5ed3f1f7b5448980e784",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "WSTETH/STETH.RR",
+      "confidence_ratio": 100,
       "id": "f59ead01ed0faba85332a1e2feae8ddb14a1c94ebac259f1c982c92fc7ce333e",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "USH/USD",
+      "confidence_ratio": 100,
       "id": "eaa30c1ef2d9f4fde45d6e699bfda5187b3de200ea4cbab25d676b260ab728c1",
-      "time_difference": 3600,
       "price_deviation": 2,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "WBTC/USD",
+      "confidence_ratio": 100,
       "id": "c9d8b075a5c69303365ae23633d4e085199bf5c520a3b90fed1322a0342ffc33",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "WETH/USD",
+      "confidence_ratio": 100,
       "id": "9d4294bbcd1174d6f2003ec365831e64cc31d9f6f15a2b85399db8d5000960f6",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "USDE/USD",
+      "confidence_ratio": 100,
       "id": "6ec879b1e9963de5ee97e9c8710b742d6228252a5e2ca12d4ae81d7fe5ee8c5d",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "SUSDE/USD",
+      "confidence_ratio": 100,
       "id": "ca3ba9a619a4b3755c10ac7d5e760275aa95e9823d38a84fedd416856cdba37c",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "SUSDE/USDE.RR",
+      "confidence_ratio": 100,
       "id": "271c64ce459937abf721d42552035713b6c58f80eeceab716a624607fda4b10f",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "WSTHYPE/STHYPE.RR",
+      "confidence_ratio": 100,
       "id": "1a78b5829a99f1d2897917dae2a02266c0210535a995a2e9d0692613bbc89e27",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "LHYPE/USD",
+      "confidence_ratio": 100,
       "id": "9e3cadc2a8a0ebfd765b34d5ee5de77a4add3114672fc0b8d3ad09ac56940069",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "FHYPE/HYPE.RR",
+      "confidence_ratio": 100,
       "id": "8f749681c078ce4ef65cd220994f25735b80264fca4386dd57b31eacf7e4610b",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "USDXL/USD",
+      "confidence_ratio": 100,
       "id": "e10593860e9ee1c204e4f9569e877502f098dd1a4d84cc5bad06f23f77dcbfe2",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "MHYPE/HYPE.RR",
+      "confidence_ratio": 100,
       "id": "e35aebd2d35795acaa2b0e59f3b498510e8ef334986d151d1502adb9e26234f7",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "FEUSD/USD",
+      "confidence_ratio": 100,
       "id": "7f2e9a7365eb634c543e9ca72683a9cf778cdc16ee5b8bca73abe6d08c1410d5",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "MHYPE/USD",
+      "confidence_ratio": 100,
       "id": "a7fb4cdafed5130e8731b8da7c9208881f24e9b671bb92438b1fbf361d578112",
-      "time_difference": 3600,
       "price_deviation": 2,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "STHYPE/USD",
+      "confidence_ratio": 100,
       "id": "068cd0617cbdd1dda615ed2b5ab4fe07d2e9f46347f5e785484844aa10d22dc5",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "UETH/USD",
+      "confidence_ratio": 100,
       "id": "08c73e187b45ecb2ab8375b975865d3c4a225fef1ccc7f326ad6eec66a24567a",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "UBTC/USD",
+      "confidence_ratio": 100,
       "id": "42bfb26778f3504a9f359a92c731f77d0c24aed9b7745276e3ad0c2d840b74c2",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "CMETH/METH.RR",
+      "confidence_ratio": 100,
       "id": "cef5ad3be493afef85e77267cb0c07d048f3d54055409a34782996607e48cf0a",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "METH/ETH.RR",
+      "confidence_ratio": 100,
       "id": "ee279eeb2fec830e3f535ad4d6524eb35eb1c6890cb1afc0b64554d08c88727e",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "USOL/USD",
+      "confidence_ratio": 100,
       "id": "974c7a77dbace44d229be17fc176975e06404b004476aeaff37641818cb0c55a",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "XAU/USD",
+      "confidence_ratio": 100,
       "id": "765d2ba906dbc32ca17cc11f5310a89e9ee1f6420508c63861f2f8ba4ee34bb2",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "USDHL/USD",
+      "confidence_ratio": 100,
       "id": "1497fb795ae65533d36d147b1b88c8b7226866a201589904c13acd314f694799",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "UFART/USD",
+      "confidence_ratio": 100,
       "id": "a210f55ff119d315002b5dc4f763b4e4114197028e45d6aca16498ab1433fb6d",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "HWHLP/USDC",
+      "confidence_ratio": 100,
       "id": "d136d4fd8d5f41c42339bcaf79954cfc2d50a33b129a990f8a2087d73cadade9",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "WHLP/USDC",
+      "confidence_ratio": 100,
       "id": "b94c49af07479932872c63126f6bdee78140be7a953435e3815c8e1b204a0a04",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "STLOOP/LOOP",
+      "confidence_ratio": 100,
       "id": "1d99073631da1f959284bae0be4d027cfd41c98f4b6a95d20ccf4208a3a4b1f1",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "HLP0/USDC.RR",
+      "confidence_ratio": 100,
       "id": "aa388e24e74d5dd12145f74fad3180266f78ed08c0a2f47c60583fdb612587ba",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "KHYPE/HYPE.RR",
+      "confidence_ratio": 100,
       "id": "983b7cabc6fab548e15a5b05500da9b99c1682107b3e2ff289344116c10ac02c",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "KHYPE/USD",
+      "confidence_ratio": 100,
       "id": "2837a61ae8165c018b0e406ac32b1527270e57b81f0069260afbef71b9cf8ffe",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "HAHYPE/HYPE.RR",
+      "confidence_ratio": 100,
       "id": "19aec77cb70be18c66df7afd33da651d7b376fd26f7c06f2e8b77536c820a281",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "APE/USD",
+      "confidence_ratio": 100,
       "id": "15add95022ae13563a11992e727c91bdb6b55bc183d9d747436c80a483d8c864",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "USDH/USD",
+      "confidence_ratio": 100,
       "id": "f364e785775b4cb2f159ea823f8b5b9b669a4c221a3f845e518ba0e09611c553",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "USDT0/USD",
+      "confidence_ratio": 100,
       "id": "cfc1303ea9f083b1b4f99e1369fb9d2611f3230d5ea33a6abf2f86071c089fdc",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "USDN/USD",
+      "confidence_ratio": 100,
       "id": "ee8e0a7de474035b5cbc1a5f762a74d654e5006b25bfe18f390cc5a3915b88ac",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "HWUSD/USDC.RR",
+      "confidence_ratio": 100,
       "id": "90730ebbd6d0e9b9fe41d099e31b06f5465a2164e468d77126b78e3017f19fa2",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "USDG/USD",
+      "confidence_ratio": 100,
       "id": "daa58c6a3ce7d4b9c46c32a6e646012c17c4a2b24c08dd8c5e476118b855a7da",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "THBILL/USDC.RR",
+      "confidence_ratio": 100,
       "id": "5b1bc5a579deba54dbaa9bc1c5b2e2b3f116d8d5ec27fbb3b9dc140a78e9f1e2",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/linea-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/linea-mainnet.json
@@ -2,10 +2,11 @@
   "feeds": [
     {
       "alias": "LINEA/USD",
+      "confidence_ratio": 100,
       "id": "49e50653755fbf8018ab65a07be2f208ac8c4bdfc43200934304ca17ee663cab",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/monad-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/monad-mainnet.json
@@ -2,423 +2,483 @@
   "feeds": [
     {
       "alias": "BTC/USD",
+      "confidence_ratio": 100,
       "id": "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
-      "time_difference": 3600,
       "price_deviation": 0.1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "ETH/USD",
+      "confidence_ratio": 100,
       "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
-      "time_difference": 3600,
       "price_deviation": 0.1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "MON/USD",
+      "confidence_ratio": 100,
       "id": "31491744e2dbf6df7fcf4ac0820d18a609b49076d45066d3568424e62f686cd1",
-      "time_difference": 3600,
       "price_deviation": 0.1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "SOL/USD",
+      "confidence_ratio": 100,
       "id": "ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d",
-      "time_difference": 3600,
       "price_deviation": 0.1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "USDC/USD",
+      "confidence_ratio": 100,
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "USDT/USD",
+      "confidence_ratio": 100,
       "id": "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "WBTC/USD",
+      "confidence_ratio": 100,
       "id": "c9d8b075a5c69303365ae23633d4e085199bf5c520a3b90fed1322a0342ffc33",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "WETH/USD",
+      "confidence_ratio": 100,
       "id": "9d4294bbcd1174d6f2003ec365831e64cc31d9f6f15a2b85399db8d5000960f6",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "WSTETH/USD",
+      "confidence_ratio": 100,
       "id": "6df640f3b8963d8f8358f791f352b8364513f6ab1cca5ed3f1f7b5448980e784",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "WSTETH/STETH.RR",
+      "confidence_ratio": 100,
       "id": "f59ead01ed0faba85332a1e2feae8ddb14a1c94ebac259f1c982c92fc7ce333e",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "STETH/ETH.RR",
+      "confidence_ratio": 100,
       "id": "cf40822c7635ddbde64c831982c65b3b37247f139e8e53078d1602e886badd2f",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "SUI/USD",
+      "confidence_ratio": 100,
       "id": "23d7315113f5b1d3ba7a83604c44b94d79f4fd69af77f804fc7f920a6dc65744",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "HYPE/USD",
+      "confidence_ratio": 100,
       "id": "4279e31cc369bbcc2faf022b382b080e32a8e689ff20fbc530d2a603eb6cd98b",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "SUSDE/USD",
+      "confidence_ratio": 100,
       "id": "ca3ba9a619a4b3755c10ac7d5e760275aa95e9823d38a84fedd416856cdba37c",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "SUSDE/USDE.RR",
+      "confidence_ratio": 100,
       "id": "271c64ce459937abf721d42552035713b6c58f80eeceab716a624607fda4b10f",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "USDE/USD",
+      "confidence_ratio": 100,
       "id": "6ec879b1e9963de5ee97e9c8710b742d6228252a5e2ca12d4ae81d7fe5ee8c5d",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "USDY/USD",
+      "confidence_ratio": 100,
       "id": "e393449f6aff8a4b6d3e1165a7c9ebec103685f3b41e60db4277b5b6d10e7326",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "PYUSD/USD",
+      "confidence_ratio": 100,
       "id": "c1da1b73d7f01e7ddd54b3766cf7fcd644395ad14f70aa706ec5384c59e76692",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "DAI/USD",
+      "confidence_ratio": 100,
       "id": "b0948a5e5313200c632b51bb5ca32f6de0d36e9950a942d19751e833f70dabfd",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "USDS/USD",
+      "confidence_ratio": 100,
       "id": "77f0971af11cc8bac224917275c1bf55f2319ed5c654a1ca955c82fa2d297ea1",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "SUSDS/USDS.RR",
+      "confidence_ratio": 100,
       "id": "6968a8641208463d17ae3b9cfa0e4841a7aa7a5d54122b9f692b84fe9ce3409f",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "FDUSD/USD",
+      "confidence_ratio": 100,
       "id": "ccdc1a08923e2e4f4b1e6ea89de6acbc5fe1948e9706f5604b8cb50bc1ed3979",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "LBTC/USD",
+      "confidence_ratio": 100,
       "id": "8f257aab6e7698bb92b15511915e593d6f8eae914452f781874754b03d0c612b",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "SOLVBTC/USD",
+      "confidence_ratio": 100,
       "id": "f253cf87dc7d5ed5aa14cba5a6e79aee8bcfaef885a0e1b807035a0bbecc36fa",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "CBBTC/USD",
+      "confidence_ratio": 100,
       "id": "2817d7bfe5c64b8ea956e9a26f573ef64e72e4d7891f2d6af9bcc93f7aff9a97",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "WEETH/USD",
+      "confidence_ratio": 100,
       "id": "9ee4e7c60b940440a261eb54b6d8149c23b580ed7da3139f7f08f4ea29dad395",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "RSETH/USD",
+      "confidence_ratio": 100,
       "id": "0caec284d34d836ca325cf7b3256c078c597bc052fbd3c0283d52b581d68d71f",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "EZETH/USD",
+      "confidence_ratio": 100,
       "id": "06c217a791f5c4f988b36629af4cb88fad827b2485400a358f3b02886b54de92",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "WEETH/EETH.RR",
+      "confidence_ratio": 100,
       "id": "343558e79f587e098c321218ecb34d031ba709ab3e84133126f3c98511b91f64",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "RSETH/ETH.RR",
+      "confidence_ratio": 100,
       "id": "56e9b5eb08e62dd4b445f29e4ec7d3b3d49617d64f2d331d36a2101d4904e3c4",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "XAU/USD",
+      "confidence_ratio": 100,
       "id": "765d2ba906dbc32ca17cc11f5310a89e9ee1f6420508c63861f2f8ba4ee34bb2",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "XAG/USD",
+      "confidence_ratio": 100,
       "id": "f2fb02c32b055c805e7238d628e5e9dadef274376114eb1f012337cabe93871e",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "XRP/USD",
+      "confidence_ratio": 100,
       "id": "ec5d399846a9209f3fe5881d70aae9268c94339ff9817e8d18ff19fa05eea1c8",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "BNB/USD",
+      "confidence_ratio": 100,
       "id": "2f95862b045670cd22bee3114c39763a4a08beeb663b145d283c31d7d1101c4f",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "ADA/USD",
+      "confidence_ratio": 100,
       "id": "2a01deaec9e51a579277b34b122399984d0bbf57e2458a7e42fecd2829867a0d",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "APT/USD",
+      "confidence_ratio": 100,
       "id": "03ae4db29ed4ae33d323568895aa00337e658e348b37509f5372ae51f0af00d5",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "SEI/USD",
+      "confidence_ratio": 100,
       "id": "53614f1cb0c031d4af66c04cb9c756234adad0e1cee85303795091499a4084eb",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "AVAX/USD",
+      "confidence_ratio": 100,
       "id": "93da3352f9f1d105fdfe4971cfa80e9dd777bfc5d0f683ebb6e1294b92137bb7",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "TIA/USD",
+      "confidence_ratio": 100,
       "id": "09f7c1d7dfbb7df2b8fe3d3d87ee94a2259d212da4f30c1f0540d066dfa44723",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "POL/USD",
+      "confidence_ratio": 100,
       "id": "ffd11c5a1cfd42f80afb2df4d9f264c15f956d68153335374ec10722edd70472",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "BERA/USD",
+      "confidence_ratio": 100,
       "id": "962088abcfdbdb6e30db2e340c8cf887d9efb311b1f2f17b155a63dbb6d40265",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "S/USD",
+      "confidence_ratio": 100,
       "id": "f490b178d0c85683b7a0f2388b40af2e6f7c90cbe0f96b31f315f08d0e5a2d6d",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "DOGE/USD",
+      "confidence_ratio": 100,
       "id": "dcef50dd0a4cd2dcc17e45df1676dcb336a11a61c69df7a0299b0150c672d25c",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "OP/USD",
+      "confidence_ratio": 100,
       "id": "385f64d993f7b77d8182ed5003d97c60aa3361f3cecfe711544d2d59165e9bdf",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "ARB/USD",
+      "confidence_ratio": 100,
       "id": "3fa4252848f9f0a1480be62745a4629d9eb1322aebab8a791e344b3b9c1adcf5",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "EBTC/USD",
+      "confidence_ratio": 100,
       "id": "be3dd0cf4a168f82e4912952b24420211ad52641b7365d49866d59e20c948288",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "STONE/ETH.RR",
+      "confidence_ratio": 100,
       "id": "7a508a94c9276cbc60d04e1a8cf839d20d835bb869a74487dfffa8f1bfd1ce42",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "ETHX/ETH.RR",
+      "confidence_ratio": 100,
       "id": "1b8eb073e2a900cdf1f6ee37ddab4869a4400499ec6e52f3e268a93f46c55429",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "PYTH/USD",
+      "confidence_ratio": 100,
       "id": "0bbf28e9a841a1cc788f6a361b17ca072d0ea3098a1e5df1c3922d06719579ff",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "CAKE/USD",
+      "confidence_ratio": 100,
       "id": "2356af9529a1064d41e32d617e2ce1dca5733afa901daba9e2b68dee5d53ecf9",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "LINK/USD",
+      "confidence_ratio": 100,
       "id": "8ac0c70fff57e9aefdf5edf44b51d62c2d433653cbb2cf5cc06bb115af04d221",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "UNI/USD",
+      "confidence_ratio": 100,
       "id": "78d185a741d07edb3412b09008b7c5cfb9bbbd7d568bf00ba737b456ba171501",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "AAVE/USD",
+      "confidence_ratio": 100,
       "id": "2b9ab1e972a281585084148ba1389800799bd4be63b957507db1349314e47445",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "RED/USD",
+      "confidence_ratio": 100,
       "id": "0bb28b82f08477fadbf9607fc8408ff61ca129fae40adc7a8d2ab8945f97ee74",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "W/USD",
+      "confidence_ratio": 100,
       "id": "eff7446475e218517566ea99e72a4abec2e1bd8498b43b7d8331e29dcb059389",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "AXL/USD",
+      "confidence_ratio": 100,
       "id": "60144b1d5c9e9851732ad1d9760e3485ef80be39b984f6bf60f82b28a2b7f126",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "ZRO/USD",
+      "confidence_ratio": 100,
       "id": "3bd860bea28bf982fa06bcf358118064bb114086cc03993bd76197eaab0b8018",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "STG/USD",
+      "confidence_ratio": 100,
       "id": "008546b175392b878c5c7ff0b6327b1cb12669be012fc2935c09a16fc8f6c58f",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "AUSD/USD",
+      "confidence_ratio": 100,
       "id": "d9912df360b5b7f21a122f15bdd5e27f62ce5e72bd316c291f7c86620e07fb2a",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "SMON/MON.RR",
+      "confidence_ratio": 100,
       "id": "7fbf66b9b4e8b0e5723fc7001b00848c7d25225982ab33f6a5d111fdbf528001",
-      "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/optimism-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/optimism-mainnet.json
@@ -2,38 +2,43 @@
   "feeds": [
     {
       "alias": "SETHFI/ETHFI.RR",
+      "confidence_ratio": 100,
       "id": "6d5216dab65051b9242a6ec458ea917e6a8f2cd122eebc25d8ab00dbe703612a",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "ETHFI/USD",
+      "confidence_ratio": 100,
       "id": "b27578a9654246cb0a2950842b92330e9ace141c52b63829cc72d5c45a5a595a",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "BEHYPE/HYPE.RR",
+      "confidence_ratio": 100,
       "id": "0f150eddafc98344c37f6ebe90fe303c12136436baf242f3c5ab412dbf91312c",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "HYPE/USD",
+      "confidence_ratio": 100,
       "id": "4279e31cc369bbcc2faf022b382b080e32a8e689ff20fbc530d2a603eb6cd98b",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "EURC/USD",
+      "confidence_ratio": 100,
       "id": "76fa85158bf14ede77087fe3ae472f66213f6ea2f5b411cb2de472794990fa5c",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/soneium-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/soneium-mainnet.json
@@ -2,52 +2,59 @@
   "feeds": [
     {
       "alias": "ASTR/USD",
+      "confidence_ratio": 100,
       "id": "89b814de1eb2afd3d3b498d296fca3a873e644bafb587e84d181a01edd682853",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "BTC/USD",
+      "confidence_ratio": 100,
       "id": "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "ETH/USD",
+      "confidence_ratio": 100,
       "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "SOLVBTC/BTC.RR",
+      "confidence_ratio": 100,
       "id": "c55e7d4d6caae221f6244d0879532230cfc436b102742a8870c92d7d88a67d95",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "USDC/USD",
+      "confidence_ratio": 100,
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "USDT/USD",
+      "confidence_ratio": 100,
       "id": "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "WSTETH/USD",
+      "confidence_ratio": 100,
       "id": "6df640f3b8963d8f8358f791f352b8364513f6ab1cca5ed3f1f7b5448980e784",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/sonic-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/sonic-mainnet.json
@@ -2,80 +2,91 @@
   "feeds": [
     {
       "alias": "USDC/USD",
+      "confidence_ratio": 100,
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "ETH/USD",
+      "confidence_ratio": 100,
       "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "WETH/USD",
+      "confidence_ratio": 100,
       "id": "9d4294bbcd1174d6f2003ec365831e64cc31d9f6f15a2b85399db8d5000960f6",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "WBTC/USD",
+      "confidence_ratio": 100,
       "id": "c9d8b075a5c69303365ae23633d4e085199bf5c520a3b90fed1322a0342ffc33",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "BTC/USD",
+      "confidence_ratio": 100,
       "id": "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "USDT/USD",
+      "confidence_ratio": 100,
       "id": "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "S/USD",
+      "confidence_ratio": 100,
       "id": "f490b178d0c85683b7a0f2388b40af2e6f7c90cbe0f96b31f315f08d0e5a2d6d",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 3600
     },
     {
       "alias": "STS/S.RR",
+      "confidence_ratio": 100,
       "id": "3b14bd355f182fa3a3feeea6824228e1f71e7c221a37bc91e8307280aee6a803",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "ANON/USD",
+      "confidence_ratio": 100,
       "id": "7a36855b8a4a6efd701ed82688694bbf67602de9faae509ae28f91065013cb82",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "STS/USD",
+      "confidence_ratio": 100,
       "id": "19f463beb47cb398cf2e2c8037f1d0073583cf18209c91a636f051d755ce0662",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     },
     {
       "alias": "HLP0/USDC.RR",
+      "confidence_ratio": 100,
       "id": "aa388e24e74d5dd12145f74fad3180266f78ed08c0a2f47c60583fdb612587ba",
-      "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 3600
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json
@@ -2,255 +2,291 @@
   "feeds": [
     {
       "alias": "AFSUI/USD",
+      "confidence_ratio": 100,
       "id": "17cd845b16e874485b2684f8b8d1517d744105dbb904eec30222717f4bc9ee0d",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 10
     },
     {
       "alias": "AUSD/USD",
+      "confidence_ratio": 100,
       "id": "d9912df360b5b7f21a122f15bdd5e27f62ce5e72bd316c291f7c86620e07fb2a",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 10
     },
     {
       "alias": "BLUE/USD",
+      "confidence_ratio": 100,
       "id": "04cfeb7b143eb9c48e9b074125c1a3447b85f59c31164dc20c1beaa6f21f2b6b",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 10
     },
     {
       "alias": "BNB/USD",
+      "confidence_ratio": 100,
       "id": "2f95862b045670cd22bee3114c39763a4a08beeb663b145d283c31d7d1101c4f",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 10
     },
     {
       "alias": "BTC/USD",
+      "confidence_ratio": 100,
       "id": "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 10
     },
     {
       "alias": "BUCK/USD",
+      "confidence_ratio": 100,
       "id": "fdf28a46570252b25fd31cb257973f865afc5ca2f320439e45d95e0394bc7382",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 10
     },
     {
       "alias": "CETUS/USD",
+      "confidence_ratio": 100,
       "id": "e5b274b2611143df055d6e7cd8d93fe1961716bcd4dca1cad87a83bc1e78c1ef",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 10
     },
     {
       "alias": "DEEP/USD",
+      "confidence_ratio": 100,
       "id": "29bdd5248234e33bd93d3b81100b5fa32eaa5997843847e2c2cb16d7c6d9f7ff",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 10
     },
     {
       "alias": "DMC/USD",
+      "confidence_ratio": 100,
       "id": "8abfa63ae82ca2fbc271861375e497166d8792580fb7c2ffcf014d2a131433f0",
-      "time_difference": 10,
       "price_deviation": 3,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 10
     },
     {
       "alias": "DOGE/USD",
+      "confidence_ratio": 100,
       "id": "dcef50dd0a4cd2dcc17e45df1676dcb336a11a61c69df7a0299b0150c672d25c",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 10
     },
     {
       "alias": "ETH/USD",
+      "confidence_ratio": 100,
       "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 10
     },
     {
       "alias": "FDUSD/USD",
+      "confidence_ratio": 100,
       "id": "ccdc1a08923e2e4f4b1e6ea89de6acbc5fe1948e9706f5604b8cb50bc1ed3979",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 10
     },
     {
       "alias": "HAEDAL/USD",
+      "confidence_ratio": 100,
       "id": "e67d98cc1fbd94f569d5ba6c3c3c759eb3ffc5d2b28e64538a53ae13efad8fd1",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 10
     },
     {
       "alias": "HASUI/USD",
+      "confidence_ratio": 100,
       "id": "6120ffcf96395c70aa77e72dcb900bf9d40dccab228efca59a17b90ce423d5e8",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 10
     },
     {
       "alias": "HIPPO/USD",
+      "confidence_ratio": 100,
       "id": "f2c5249856da2fbe0221e163b3fed678dd6f76515ab933292dfb4f15a1de8f8c",
-      "time_difference": 10,
       "price_deviation": 3,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 10
     },
     {
       "alias": "IKA/USD",
+      "confidence_ratio": 100,
       "id": "2b529621fa6e2c8429f623ba705572aa64175d7768365ef829df6a12c9f365f4",
-      "time_difference": 10,
       "price_deviation": 3,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 10
     },
     {
       "alias": "LBTC/USD",
+      "confidence_ratio": 100,
       "id": "8f257aab6e7698bb92b15511915e593d6f8eae914452f781874754b03d0c612b",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 10
     },
     {
       "alias": "MUSD/USD",
+      "confidence_ratio": 100,
       "id": "2ee09cdb656959379b9262f89de5ff3d4dfed0dd34c072b3e22518496a65249c",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 10
     },
     {
       "alias": "NAVX/USD",
+      "confidence_ratio": 100,
       "id": "88250f854c019ef4f88a5c073d52a18bb1c6ac437033f5932cd017d24917ab46",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 10
     },
     {
       "alias": "NS/USD",
+      "confidence_ratio": 100,
       "id": "bb5ff26e47a3a6cc7ec2fce1db996c2a145300edc5acaabe43bf9ff7c5dd5d32",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 10
     },
     {
       "alias": "SCA/USD",
+      "confidence_ratio": 100,
       "id": "7e17f0ac105abe9214deb9944c30264f5986bf292869c6bd8e8da3ccd92d79bc",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 10
     },
     {
       "alias": "SEND/USD",
+      "confidence_ratio": 100,
       "id": "7d19b607c945f7edf3a444289c86f7b58dcd8b18df82deadf925074807c99b59",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 10
     },
     {
       "alias": "SOL/USD",
+      "confidence_ratio": 100,
       "id": "ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 10
     },
     {
       "alias": "STSUI/USD",
+      "confidence_ratio": 100,
       "id": "0b3eae8cb6e221e7388a435290e0f2211172563f94769077b7f4c4c6a11eea76",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 10
     },
     {
       "alias": "SUI/USD",
+      "confidence_ratio": 100,
       "id": "23d7315113f5b1d3ba7a83604c44b94d79f4fd69af77f804fc7f920a6dc65744",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 10
     },
     {
       "alias": "SUIUSDE/USD",
+      "confidence_ratio": 100,
       "id": "8cead549d0e770dea8fdf5e018a85d59585265cf8bff16ba83962fc7996dbb7f",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 10
     },
     {
       "alias": "TRX/USD",
+      "confidence_ratio": 100,
       "id": "67aed5a24fdad045475e7195c98a98aea119c763f272d4523f5bac93a4f33c2b",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 10
     },
     {
       "alias": "USDC/USD",
+      "confidence_ratio": 100,
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 10
     },
     {
       "alias": "USDT/USD",
+      "confidence_ratio": 100,
       "id": "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 10
     },
     {
       "alias": "USDSUI/USD",
+      "confidence_ratio": 100,
       "id": "d510fcdb3a63f35d3bb118d5db3afc5815a3f13bc55d48abb893b63f0315902a",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 10
     },
     {
       "alias": "USDY/USD",
+      "confidence_ratio": 100,
       "id": "e393449f6aff8a4b6d3e1165a7c9ebec103685f3b41e60db4277b5b6d10e7326",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 10
     },
     {
       "alias": "VSUI/USD",
+      "confidence_ratio": 100,
       "id": "57ff7100a282e4af0c91154679c5dae2e5dcacb93fd467ea9cb7e58afdcfde27",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 10
     },
     {
       "alias": "WAL/USD",
+      "confidence_ratio": 100,
       "id": "eba0732395fae9dec4bae12e52760b35fc1c5671e2da8b449c9af4efe5d54341",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 10
     },
     {
       "alias": "XAUM/USD.RR",
+      "confidence_ratio": 100,
       "id": "d7db067954e28f51a96fd50c6d51775094025ced2d60af61ec9803e553471c88",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 10
     },
     {
       "alias": "UP/USD",
+      "confidence_ratio": 100,
       "id": "c591a547856b091560b120ee14b165a84ca58eca23b2ab635df641340bde1f10",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 10
     },
     {
       "alias": "XRP/USD",
+      "confidence_ratio": 100,
       "id": "ec5d399846a9209f3fe5881d70aae9268c94339ff9817e8d18ff19fa05eea1c8",
-      "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 10
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json
@@ -1,380 +1,427 @@
 {
   "feeds": [
     {
-      "alias": "SOL/USD",
       "account_address": "7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE",
+      "alias": "SOL/USD",
+      "confidence_ratio": 100,
       "id": "ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "MSOL/USD",
       "account_address": "5CKzb9j4ChgLUt8Gfm5CNGLN6khXKiqMbnGAW4cgXgxK",
+      "alias": "MSOL/USD",
+      "confidence_ratio": 100,
       "id": "c2289a6a43d2ce91c6f55caec370f4acc38a2ed477f58813334c6d03749ff2a4",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "BSOL/USD",
       "account_address": "5cN76Xm2Dtx9MnrQqBDeZZRsWruTTcw37UruznAdSvvE",
+      "alias": "BSOL/USD",
+      "confidence_ratio": 100,
       "id": "89875379e70f8fbadc17aef315adf3a8d5d160b811435537e03c97e8aac97d9c",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "SSOL/SOL",
       "account_address": "2doCYXwYNt2FhzfCdgpW4YAwczvdzB27xtJkzQd5Kre2",
+      "alias": "SSOL/SOL",
+      "confidence_ratio": 100,
       "id": "add6499a420f809bbebc0b22fbf68acb8c119023897f6ea801688e0d6e391af4",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 60
     },
     {
-      "alias": "BONK/USD",
       "account_address": "DBE3N8uNjhKPRHfANdwGvCZghWXyLPdqdSbEW2XFwBiX",
+      "alias": "BONK/USD",
+      "confidence_ratio": 100,
       "id": "72b021217ca3fe68922a19aaf990109cb9d84e9ad004b4d2025ad6f529314419",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "W/USD",
       "account_address": "BEMsCSQEGi2kwPA4mKnGjxnreijhMki7L4eeb96ypzF9",
+      "alias": "W/USD",
+      "confidence_ratio": 100,
       "id": "eff7446475e218517566ea99e72a4abec2e1bd8498b43b7d8331e29dcb059389",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "MEW/USD",
       "account_address": "EF6U755BdHMXim8RBw6XSC6Yk6XaouTKpwcBZ7QkcanB",
+      "alias": "MEW/USD",
+      "confidence_ratio": 100,
       "id": "514aed52ca5294177f20187ae883cec4a018619772ddce41efcc36a6448f5d5d",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "USDC/USD",
       "account_address": "Dpw1EAVrSB1ibxiDQyTAW6Zip3J4Btk2x4SgApQCeFbX",
+      "alias": "USDC/USD",
+      "confidence_ratio": 100,
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "BTC/USD",
       "account_address": "4cSM2e6rvbGQUFiJbqytoVMi5GgghSMr8LwVrT9VPSPo",
+      "alias": "BTC/USD",
+      "confidence_ratio": 100,
       "id": "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "USDT/USD",
       "account_address": "HT2PLQBcG5EiCcNSaMHAjSgd9F98ecpATbk4Sk5oYuM",
+      "alias": "USDT/USD",
+      "confidence_ratio": 100,
       "id": "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "JUP/USD",
       "account_address": "7dbob1psH1iZBS7qPsm3Kwbf5DzSXK8Jyg31CTgTnxH5",
+      "alias": "JUP/USD",
+      "confidence_ratio": 100,
       "id": "0a0408d619e9380abad35060f9192039ed5042fa6f82301d0e48bb52be830996",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "ETH/USD",
       "account_address": "42amVS4KgzR9rA28tkVYqVXjq9Qa8dcZQMbH5EYFX6XC",
+      "alias": "ETH/USD",
+      "confidence_ratio": 100,
       "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "PYTH/USD",
       "account_address": "8vjchtMuJNY4oFQdTi8yCe6mhCaNBFaUbktT482TpLPS",
+      "alias": "PYTH/USD",
+      "confidence_ratio": 100,
       "id": "0bbf28e9a841a1cc788f6a361b17ca072d0ea3098a1e5df1c3922d06719579ff",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "HNT/USD",
       "account_address": "4DdmDswskDxXGpwHrXUfn2CNUm9rt21ac79GHNTN3J33",
+      "alias": "HNT/USD",
+      "confidence_ratio": 100,
       "id": "649fdd7ec08e8e2a20f425729854e90293dcbe2376abc47197a14da6ff339756",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "ORCA/USD",
       "account_address": "4CBshVeNBEXz24GZpoj8SrqP5L7VGG3qjGd6tCST1pND",
+      "alias": "ORCA/USD",
+      "confidence_ratio": 100,
       "id": "37505261e557e251290b8c8899453064e8d760ed5c65a779726f2490980da74c",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "SAMO/USD",
       "account_address": "2eUVzcYccqXzsDU1iBuatUaDCbRKBjegEaPPeChzfocG",
+      "alias": "SAMO/USD",
+      "confidence_ratio": 100,
       "id": "49601625e1a342c1f90c3fe6a03ae0251991a1d76e480d2741524c29037be28a",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 60
     },
     {
-      "alias": "WIF/USD",
       "account_address": "6B23K3tkb51vLZA14jcEQVCA1pfHptzEHFA93V5dYwbT",
+      "alias": "WIF/USD",
+      "confidence_ratio": 100,
       "id": "4ca4beeca86f0d164160323817a4e42b10010a724c2217c6ee41b54cd4cc61fc",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "INF/USD",
       "account_address": "Ceg5oePJv1a6RR541qKeQaTepvERA3i8SvyueX9tT8Sq",
+      "alias": "INF/USD",
+      "confidence_ratio": 100,
       "id": "f51570985c642c49c2d6e50156390fdba80bb6d5f7fa389d2f012ced4f7d208f",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "MNDE/USD",
       "account_address": "GHKcxocPyzSjy7tWApQjKRkDNuVXd4Kk624zhuaR7xhC",
+      "alias": "MNDE/USD",
+      "confidence_ratio": 100,
       "id": "3607bf4d7b78666bd3736c7aacaf2fd2bc56caa8667d3224971ebe3c0623292a",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 60
     },
     {
-      "alias": "NEON/USD",
       "account_address": "F2VfCymdNQiCa8Vyg5E7BwEv9UPwfm8cVN6eqQLqXiGo",
+      "alias": "NEON/USD",
+      "confidence_ratio": 100,
       "id": "d82183dd487bef3208a227bb25d748930db58862c5121198e723ed0976eb92b7",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 60
     },
     {
-      "alias": "JLP/USD",
       "account_address": "2TTGSRSezqFzeLUH8JwRUbtN66XLLaymfYsWRTMjfiMw",
+      "alias": "JLP/USD",
+      "confidence_ratio": 100,
       "id": "c811abc82b4bad1f9bd711a2773ccaa935b03ecef974236942cec5e0eb845a3a",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "WBTC/USD",
       "account_address": "9gNX5vguzarZZPjTnE1hWze3s6UsZ7dsU3UnAmKPnMHG",
+      "alias": "WBTC/USD",
+      "confidence_ratio": 100,
       "id": "c9d8b075a5c69303365ae23633d4e085199bf5c520a3b90fed1322a0342ffc33",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "PENGU/USD",
       "account_address": "27zzC5wXCeZeuJ3h9uAJzV5tGn6r5Tzo98S1ZceYKEb8",
+      "alias": "PENGU/USD",
+      "confidence_ratio": 100,
       "id": "bed3097008b9b5e3c93bec20be79cb43986b85a996475589351a21e67bae9b61",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "TRUMP/USD",
       "account_address": "9vNb2tQoZ8bB4vzMbQLWViGwNaDJVtct13AGgno1wazp",
+      "alias": "TRUMP/USD",
+      "confidence_ratio": 100,
       "id": "879551021853eec7a7dc827578e8e69da7e4fa8148339aa0d3d5296405be4b1a",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "FARTCOIN/USD",
       "account_address": "2t8eUbYKjidMs3uSeYM9jXM9uudYZwGkSeTB4TKjmvnC",
+      "alias": "FARTCOIN/USD",
+      "confidence_ratio": 100,
       "id": "58cd29ef0e714c5affc44f269b2c1899a52da4169d7acc147b9da692e6953608",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "ACRED/USD",
       "account_address": "6gyQ2TKvvV1JB5oWDobndv6BLRWcJzeBNk9PLQ5uPQms",
+      "alias": "ACRED/USD",
+      "confidence_ratio": 100,
       "id": "40ac3329933a6b5b65cf31496018c5764ac0567316146f7d0de00095886b480d",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "PUMP/USD",
       "account_address": "HMm3GPbdnqGwbkTnUUqCFsH8AMHDdEC3Lg8gcPD3HJSH",
+      "alias": "PUMP/USD",
+      "confidence_ratio": 100,
       "id": "7a01fca212788bba7c5bf8c9efd576a8a722f070d2c17596ff7bb609b8d5c3b9",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "JUPSOL/SOL.RR",
       "account_address": "D7UqeBmCEmhGXGYfi2y9RfoCa7t1Xw5iZLBeYZ3sxFSe",
+      "alias": "JUPSOL/SOL.RR",
+      "confidence_ratio": 100,
       "id": "f8d8d6b6c866c8b2624fb5b679ae846738725e5fc887fa8e927c8d8645018a2b",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 60
     },
     {
-      "alias": "NAV.USTB/USD",
       "account_address": "EqggHKbjePzmXAX6MW3EsgjiJ4mhkbb8j5s5KfGs1gLq",
+      "alias": "NAV.USTB/USD",
+      "confidence_ratio": 100,
       "id": "dea78edd10cd7ae4524cc1744216788746306623bc3553014eeab6062860795d",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "NAV.USCC/USD",
       "account_address": "823Y4cV7XH2TzkB9NdHfTRoCKLrqXv8EgQP5nzEG43Hp",
+      "alias": "NAV.USCC/USD",
+      "confidence_ratio": 100,
       "id": "5d73a5953dc86c4773adc778c30e8a6dfc94c5c3a74d7ebb56dd5e70350f044a",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "ZBTC/USD",
       "account_address": "7qFJxM2GefbY2td7cXb6bmXmwVqkeF7kYjaypgZWLBng",
+      "alias": "ZBTC/USD",
+      "confidence_ratio": 100,
       "id": "3d824c7f7c26ed1c85421ecec8c754e6b52d66a4e45de20a9c9ea91de8b396f9",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "LBTC/USD",
       "account_address": "HENev4WeM2VhJ2b9tFCQsWdHGU6fTvgW68MsvBeYpxYn",
+      "alias": "LBTC/USD",
+      "confidence_ratio": 100,
       "id": "8f257aab6e7698bb92b15511915e593d6f8eae914452f781874754b03d0c612b",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "INF/SOL",
       "account_address": "4MbCk4vH47K2gHee6nTg62KScpGu2bV3YDeTZtpQm3ro",
+      "alias": "INF/SOL",
+      "confidence_ratio": 100,
       "id": "49e50653755fbf8018ab65a07be2f208ac8c4bdfc43200934304ca17ee663cab",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "INDEX.FORD/USD",
       "account_address": "GUq4JEVMgC5AmZpKxjh1aJsabB9X7mBwPavKSsnz11DS",
+      "alias": "INDEX.FORD/USD",
+      "confidence_ratio": 100,
       "id": "84d8c84bfbe6f71af527493f9aaee09950ee3e09c8460b2b781ce65ea341c10a",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 60
     },
     {
-      "alias": "INDEX.GLXY/USD",
       "account_address": "84NBovYcdtTdbb9vw9U7YeGPssTuCxcAMexw3PWDzWhR",
+      "alias": "INDEX.GLXY/USD",
+      "confidence_ratio": 100,
       "id": "c59735498fa594a63e36382c12656e4313a7269ea1a1ed8fa583008e277f9cdb",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 60
     },
     {
-      "alias": "SYRUPUSDC/USDC.RR",
       "account_address": "GWdwWDhYFUc8ZD6uCTtEAAwx97V1ZCsxPWGL7vhSha6w",
+      "alias": "SYRUPUSDC/USDC.RR",
+      "confidence_ratio": 100,
       "id": "2ad31d1c4a85fbf2156ce57fab4104124c5ef76a6386375ecfc8da1ed5ce1486",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "ORE/USD",
       "account_address": "GYYQ8gbX4Tndc4WMJ9jSjZTePTvbmgRRxByt54ZQYqvZ",
+      "alias": "ORE/USD",
+      "confidence_ratio": 100,
       "id": "142b804c658e14ff60886783e46e5a51bdf398b4871d9d8f7c28aa1585cad504",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 60
     },
     {
-      "alias": "NOPAL/USD.RR",
       "account_address": "3GDZNVfeYJupHxj65tyCC44HW5NHPTycBihFrCEcDTBj",
+      "alias": "NOPAL/USD.RR",
+      "confidence_ratio": 100,
       "id": "8858dfaa8998ff44681aa145a8aa5b7772979b1d044a1bbf3cf5d971168baa85",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 60
     },
     {
-      "alias": "NTBILL/USD.RR",
       "account_address": "FrJxRfRkaktSWrEPsBaJhx7fdofPZZsuNHoh4E9YxZjn",
+      "alias": "NTBILL/USD.RR",
+      "confidence_ratio": 100,
       "id": "f03015f29e6c90d5fe62da7d1a13c912c8bf7523d90c981387f82ee0c83332bd",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 60
     },
     {
-      "alias": "NBASIS/USD.RR",
       "account_address": "Cv7ZRaS7vezPHVfYBYqUvaXBqh9VABbC1JDczCHzAd3j",
+      "alias": "NBASIS/USD.RR",
+      "confidence_ratio": 100,
       "id": "fd9397e6dfc968ff8eaa652c6e4b7dfdeb6fdc940afe90c23ca5acfa45d408e1",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 60
     },
     {
-      "alias": "NWISDOM/USD.RR",
       "account_address": "CTwo3uNzA3Pj1aJRN77Xi7icfq9Q53JWTfppUrEYHfhC",
+      "alias": "NWISDOM/USD.RR",
+      "confidence_ratio": 100,
       "id": "384986c9655ec6887dbd7f7430d864992f872db2c77ba5781a26b78dad277adc",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 60
     },
     {
-      "alias": "NALPHA/USD.RR",
       "account_address": "DihTptVgZNyfxN5ya1V5XThRJHhzZ4V2RAPpwvNXkxUK",
+      "alias": "NALPHA/USD.RR",
+      "confidence_ratio": 100,
       "id": "57d1e11bea1316c2f7263a39c2780685691585aae34eff39300f5db564501b17",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 60
     },
     {
-      "alias": "NFALCON/USD.RR",
       "account_address": "6MKpWqGCLcwURBGKaCQiGem1hQVUsSixymRZcPvfnhRC",
+      "alias": "NFALCON/USD.RR",
+      "confidence_ratio": 100,
       "id": "323647322045edff1a0928dca6628169a57afdea43a5f0d948115e3dcae9c1fb",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 60
     },
     {
-      "alias": "CASH/RD.RR",
       "account_address": "7ELVkNXhZLJGdwPGps8sEBgs583TewjZoRzgf9Zdp5T8",
+      "alias": "CASH/RD.RR",
+      "confidence_ratio": 100,
       "id": "64c74ffd61574170cfaee65c54c8810adcf83f6c31f3c256d9a290dcbf4ff1a9",
-      "time_difference": 30,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 30
     },
     {
-      "alias": "CASH/USD",
       "account_address": "F23Xi7VQw1pdre26VmuKnjRcDcrhpqGtHkGdKdSdbM8w",
+      "alias": "CASH/USD",
+      "confidence_ratio": 100,
       "id": "df3320ef0f4617337b8dbb924f2aaa4f9db08f522a5435b44f9066c1ac4c7f95",
-      "time_difference": 30,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": true,
+      "time_difference": 30
     },
     {
-      "alias": "PST/USDC.RR",
       "account_address": "CBGwQddTeYn3KdvxGWtU95fqCcavzHK9XPFBLENDF5JR",
+      "alias": "PST/USDC.RR",
+      "confidence_ratio": 100,
       "id": "675e36f84a6be779ed793c71eb5c03151e1866c125767f46933626e0610af84d",
-      "time_difference": 240,
       "price_deviation": 0.05,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 240
     },
     {
-      "alias": "JUPUSD/USD",
       "account_address": "AqSwMCZYnEdnGoFCSLtWVnWf4xyCJuePcztmYWq8SBwp",
+      "alias": "JUPUSD/USD",
+      "confidence_ratio": 100,
       "id": "8ed858a2214e892c9371694fb6c8a9037b6ed4052c4edf209f8cb988484e81d9",
-      "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "pro_available": false,
+      "time_difference": 60
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/evm.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/evm.mdx
@@ -5,6 +5,7 @@ slug: /price-feeds/core/push-feeds/evm
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
+import Link from "next/link";
 import { SponsoredFeedsTable } from "../../../../../src/components/SponsoredFeedsTable";
 import abstractMainnet from "./data/evm/abstract-mainnet.json";
 import arbitrumMainnet from "./data/evm/arbitrum-mainnet.json";
@@ -37,6 +38,10 @@ The following EVM chains have push feeds:
 <Callout type="info" title="Request Additional Feeds">
   If you would like to see additional feeds on this list, please fill in this
   [form](https://tally.so/r/nGz2jj) to signal your interest.
+</Callout>
+
+<Callout type="info" title="Pro-compatible Core upgrade">
+  EVM chains are part of the <Link href="/price-feeds/core/upgrade">Pyth Core upgrade</Link> on July 31, 2026. The sponsored feeds and update parameters below carry over to the Pro-compatible scheduler. Feeds tagged <strong>Coming soon (Pro)</strong> are skipped by the scheduler until they are added to Pyth Pro — see the <Link href="/price-feeds/core/push-feeds#sponsored-feeds-and-the-pro-compatible-core-upgrade">push-feeds overview</Link> for details.
 </Callout>
 
 ## Abstract Mainnet

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/index.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/index.mdx
@@ -39,6 +39,12 @@ The feeds can vary by network. Please see the relevant section below for the net
   changes.
 </Callout>
 
+## Sponsored feeds and the Pro-compatible Core upgrade
+
+After the <Link href="/price-feeds/core/upgrade">Pyth Core upgrade</Link> on **July 31, 2026**, sponsored push feeds keep the same feed list and per-feed update parameters (heartbeat and price deviation) shown on the per-network pages below. The Pro-compatible scheduler publishes them from the upgraded data path.
+
+Some feeds are not yet available in Pyth Pro. The Pro-compatible scheduler **skips those feeds** until they are added to Pyth Pro. Feeds in that state are tagged **"Coming soon (Pro)"** on the per-network tables. See <Link href="/price-feeds/core/upgrade/preparing">preparing for the upgrade</Link> for the full migration checklist (EVM, Solana, and Sui).
+
 <Callout type="warning">
   DISCLAIMER: While the Pyth Data Association strives to deliver timely updates,
   these push feeds may occasionally experience delays in updates caused by chain

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/solana.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/solana.mdx
@@ -5,12 +5,17 @@ slug: /price-feeds/core/push-feeds/solana
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
+import Link from "next/link";
 import { SponsoredFeedsTable } from "../../../../../src/components/SponsoredFeedsTable";
 import solanaMainnet from "./data/svm/solana-mainnet.json";
 
 <Callout type="info" title="Request Additional Feeds">
   If you would like to see additional feeds on this list, please fill in this
   [form](https://tally.so/r/nGz2jj) to signal your interest.
+</Callout>
+
+<Callout type="info" title="Pro-compatible Core upgrade">
+  Solana is part of the <Link href="/price-feeds/core/upgrade">Pyth Core upgrade</Link> on July 31, 2026. The sponsored feeds and update parameters below carry over to the Pro-compatible scheduler. Feeds tagged <strong>Coming soon (Pro)</strong> are skipped by the scheduler until they are added to Pyth Pro — see the <Link href="/price-feeds/core/push-feeds#sponsored-feeds-and-the-pro-compatible-core-upgrade">push-feeds overview</Link> for details.
 </Callout>
 
 ## Solana Mainnet

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/sui.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/sui.mdx
@@ -5,12 +5,17 @@ slug: /price-feeds/core/push-feeds/sui
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
+import Link from "next/link";
 import { SponsoredFeedsTable } from "../../../../../src/components/SponsoredFeedsTable";
 import suiMainnet from "./data/sui/sui-mainnet.json";
 
 <Callout type="info" title="Request Additional Feeds">
   If you would like to see additional feeds on this list, please fill in this
   [form](https://tally.so/r/nGz2jj) to signal your interest.
+</Callout>
+
+<Callout type="info" title="Pro-compatible Core upgrade">
+  Sui is part of the <Link href="/price-feeds/core/upgrade">Pyth Core upgrade</Link> on July 31, 2026. The sponsored feeds and update parameters below carry over to the Pro-compatible scheduler. Feeds tagged <strong>Coming soon (Pro)</strong> are skipped by the scheduler until they are added to Pyth Pro — see the <Link href="/price-feeds/core/push-feeds#sponsored-feeds-and-the-pro-compatible-core-upgrade">push-feeds overview</Link> for details.
 </Callout>
 
 ## Sui Mainnet

--- a/apps/developer-hub/src/components/SponsoredFeedsTable/index.module.scss
+++ b/apps/developer-hub/src/components/SponsoredFeedsTable/index.module.scss
@@ -61,8 +61,32 @@
   background-color: theme.pallette-color("orange", 500);
 }
 
+.statusDotComingSoon {
+  background-color: theme.pallette-color("gray", 500);
+}
+
 .nameLabel {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+
   @include theme.text("base", "medium");
+}
+
+.nameLabelComingSoon {
+  color: theme.pallette-color("gray", 500);
+}
+
+.comingSoonBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.5rem;
+  border: 1px solid theme.pallette-color("gray", 600);
+  border-radius: theme.border-radius("full");
+  color: theme.pallette-color("gray", 500);
+
+  @include theme.text("xs", "medium");
 }
 
 .updateParams {

--- a/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
+++ b/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
@@ -17,6 +17,7 @@ type SponsoredFeed = {
   time_difference: number;
   price_deviation: number;
   confidence_ratio: number;
+  pro_available?: boolean;
 };
 
 type SponsoredFeedsTableProps = {
@@ -39,15 +40,15 @@ const formatTimeDifference = (
 ): { value: number; unit: string } => {
   if (seconds >= 3600) {
     const hours = Math.floor(seconds / 3600);
-    return { value: hours, unit: hours === 1 ? "hour" : "hours" };
+    return { unit: hours === 1 ? "hour" : "hours", value: hours };
   }
 
   if (seconds >= 60) {
     const minutes = Math.floor(seconds / 60);
-    return { value: minutes, unit: minutes === 1 ? "minute" : "minutes" };
+    return { unit: minutes === 1 ? "minute" : "minutes", value: minutes };
   }
 
-  return { value: seconds, unit: seconds === 1 ? "second" : "seconds" };
+  return { unit: seconds === 1 ? "second" : "seconds", value: seconds };
 };
 
 const formatUpdateParams = (feed: SponsoredFeed): string => {
@@ -108,41 +109,46 @@ export const SponsoredFeedsTable = ({
   const hasAccountAddress =
     !hideAccountAddress && feeds.some((feed) => !!feed.account_address);
 
+  const comingSoonCount = feeds.filter(
+    (feed) => feed.pro_available === false,
+  ).length;
+  const showProAvailability = comingSoonCount > 0;
+
   const columns = useMemo(
     () => [
       {
-        id: "name",
-        name: "Name",
-        isRowHeader: true,
         alignment: "left" as const,
+        id: "name",
+        isRowHeader: true,
+        name: "Name",
       },
       ...(hasAccountAddress
         ? [
             {
+              alignment: "left" as const,
               id: "accountAddress",
               name: "Account Address",
-              alignment: "left" as const,
             },
           ]
         : []),
       ...(showUpgradedAccountAddress
         ? [
             {
+              alignment: "left" as const,
               id: "upgradedAccountAddress",
               name: "Upgraded Account Address",
-              alignment: "left" as const,
             },
           ]
         : []),
       {
+        alignment: "left" as const,
         id: "priceFeedId",
         name: "Price Feed Id",
-        alignment: "left" as const,
       },
       {
+        alignment: "left" as const,
         id: "updateParameters",
         name: "Update Parameters",
-        alignment: "left" as const,
       },
     ],
     [hasAccountAddress, showUpgradedAccountAddress],
@@ -153,6 +159,7 @@ export const SponsoredFeedsTable = ({
       feeds.map((feed) => {
         const formattedParams = formatUpdateParams(feed);
         const isDefault = formattedParams === defaultParams;
+        const isComingSoon = feed.pro_available === false;
 
         const rowData: {
           name: ReactNode;
@@ -161,12 +168,26 @@ export const SponsoredFeedsTable = ({
           accountAddress: ReactNode | undefined;
           upgradedAccountAddress: ReactNode | undefined;
         } = {
-          name: <span className={styles.nameLabel}>{feed.alias}</span>,
+          accountAddress: undefined,
+          name: (
+            <span
+              className={clsx(
+                styles.nameLabel,
+                isComingSoon && styles.nameLabelComingSoon,
+              )}
+            >
+              {feed.alias}
+              {isComingSoon ? (
+                <span className={styles.comingSoonBadge}>
+                  Coming soon (Pro)
+                </span>
+              ) : undefined}
+            </span>
+          ),
           priceFeedId: (
             <CopyButton text={feed.id}>{truncateHex(feed.id)}</CopyButton>
           ),
           updateParameters: <UpdateParams feed={feed} isDefault={isDefault} />,
-          accountAddress: undefined,
           upgradedAccountAddress: undefined,
         };
 
@@ -192,8 +213,8 @@ export const SponsoredFeedsTable = ({
         }
 
         return {
-          id: feed.id,
           data: rowData,
+          id: feed.id,
         };
       }),
     [feeds, defaultParams, hasAccountAddress, showUpgradedAccountAddress],
@@ -231,7 +252,7 @@ export const SponsoredFeedsTable = ({
           {paramEntries
             .filter(([params]) => params !== defaultParams)
             .map(([params, count]) => (
-              <div key={params} className={styles.summaryItem}>
+              <div className={styles.summaryItem} key={params}>
                 <span
                   className={clsx(styles.statusDot, styles.statusDotException)}
                 />
@@ -240,15 +261,25 @@ export const SponsoredFeedsTable = ({
                 <span className={styles.summaryCount}>({count})</span>
               </div>
             ))}
+          {showProAvailability ? (
+            <div className={styles.summaryItem}>
+              <span
+                className={clsx(styles.statusDot, styles.statusDotComingSoon)}
+              />
+              <span className={styles.summaryLabel}>Coming soon (Pro):</span>
+              <span>skipped by the Pro-compatible scheduler</span>
+              <span className={styles.summaryCount}>({comingSoonCount})</span>
+            </div>
+          ) : undefined}
         </div>
 
         <Table
-          label="Sponsored Feeds"
-          fill
+          className={clsx("not-prose", styles.table)}
           columns={columns}
+          fill
+          label="Sponsored Feeds"
           rows={rows}
           stickyHeader="top"
-          className={clsx("not-prose", styles.table)}
         />
       </div>
     </div>


### PR DESCRIPTION
Issue: [[i-bdivhafa]] (parent: [[i-drqxmnrx]])

## Summary

Documents that the **Pyth Core Pro-compatible upgrade (July 31, 2026)** preserves the existing sponsored push-feed list and per-feed update parameters for EVM, Solana, and Sui, and that the new scheduler skips feeds not yet available in Pyth Pro.

- Adds a "Sponsored feeds and the Pro-compatible Core upgrade" section to `push-feeds/index.mdx` cross-linking `/price-feeds/core/upgrade` and `/price-feeds/core/upgrade/preparing`.
- Adds a one-callout nudge on `sui.mdx`, `solana.mdx`, and `evm.mdx` pointing back to the index section.
- Extends each sponsored-feed JSON for the upgrading chains with an optional `pro_available` boolean computed against a live snapshot of `https://pyth.dourolabs.app/v1/symbols` (true iff a `state == "stable"` entry has matching `hermes_id`).
- Extends `SponsoredFeedsTable` to render a **"Coming soon (Pro)"** badge on rows where `pro_available === false` and adds a matching summary-bar legend item. The badge and legend only appear when at least one feed on the table carries the field — Aptos/Movement/Fogo tables render unchanged.

## Pro availability snapshot

Cross-referenced against `https://pyth.dourolabs.app/v1/symbols` taken during implementation:

- Sui mainnet: 19 of 36 feeds Coming soon
- Solana mainnet: 16 of 47 feeds Coming soon
- EVM mainnets (across all 12 files): EVM rollup-only / long-tail feeds flagged per chain (e.g. Monad 15/60, HyperEVM 29/43)

No build-time fetch is wired up; manual refresh is acceptable per the issue scope — automation can come in a follow-up.

## Note on the large diff

Once these JSON files became "changed" relative to `origin/main`, biome's `useSortedKeys` assist (enabled in `biome.json`) rejected the existing key order. The pre-PR gate (`./scripts/biome-ci` in CI mode) forces a global key sort on every touched feed entry, which inflates the diff. The semantic change per entry is just the added `pro_available` field; everything else is alphabetical re-ordering.

## Test plan

- [x] `pnpm turbo run build --filter=@pythnetwork/developer-hub` — passes (build is the implicit dependency of `test:types`).
- [x] `pnpm turbo run test:types --filter=@pythnetwork/developer-hub` — passes.
- [x] `pnpm turbo run test:lint:stylelint --filter=@pythnetwork/developer-hub` — passes.
- [x] `biome ci --changed` on the changed files — passes (only the changed files are flagged, and they're clean after `--write`).
- [ ] Visual smoke check on `/price-feeds/core/push-feeds/sui` once deployed: badge renders for "Coming soon" feeds, summary bar shows the legend entry, column alignment unchanged.