### PR TITLE
add(developer-hub): Pro-compatible status column to EVM/Solana/Sui push-feed tables

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/abstract-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/abstract-mainnet.json
@@ -5,28 +5,32 @@
       "id": "9d4294bbcd1174d6f2003ec365831e64cc31d9f6f15a2b85399db8d5000960f6",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDT/USD",
       "id": "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDC/USD",
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "PENGU/USD",
       "id": "bed3097008b9b5e3c93bec20be79cb43986b85a996475589351a21e67bae9b61",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/arbitrum-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/arbitrum-mainnet.json
@@ -5,7 +5,8 @@
       "id": "aa388e24e74d5dd12145f74fad3180266f78ed08c0a2f47c60583fdb612587ba",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/avalanche-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/avalanche-mainnet.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Avalanche feeds are intentionally pinned to pro_compatible_status \"coming_soon\": Pro-compatible push feeds are not deployed for this chain (no deployment-pro-compatible.yaml). Do NOT auto-derive this field from the Hermes listing for this file. See the JSDoc on ProCompatibleStatus in src/components/SponsoredFeedsTable/index.tsx.",
   "feeds": [
     {
       "alias": "HLP0/USDC.RR",

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/avalanche-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/avalanche-mainnet.json
@@ -5,7 +5,8 @@
       "id": "aa388e24e74d5dd12145f74fad3180266f78ed08c0a2f47c60583fdb612587ba",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/base-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/base-mainnet.json
@@ -5,49 +5,56 @@
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "ETH/USD",
       "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WETH/USD",
       "id": "9d4294bbcd1174d6f2003ec365831e64cc31d9f6f15a2b85399db8d5000960f6",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "CBETH/USD",
       "id": "15ecddd26d49e1a8f1de9376ebebc03916ede873447c1255d2d5891b92ce5717",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "WSTETH/USD",
       "id": "6df640f3b8963d8f8358f791f352b8364513f6ab1cca5ed3f1f7b5448980e784",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SUI/USD",
       "id": "23d7315113f5b1d3ba7a83604c44b94d79f4fd69af77f804fc7f920a6dc65744",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "XRP/USD",
       "id": "ec5d399846a9209f3fe5881d70aae9268c94339ff9817e8d18ff19fa05eea1c8",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/berachain-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/berachain-mainnet.json
@@ -5,63 +5,72 @@
       "id": "962088abcfdbdb6e30db2e340c8cf887d9efb311b1f2f17b155a63dbb6d40265",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "BTC/USD",
       "id": "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "ETH/USD",
       "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDC/USD",
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDT/USD",
       "id": "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "PYUSD/USD",
       "id": "c1da1b73d7f01e7ddd54b3766cf7fcd644395ad14f70aa706ec5384c59e76692",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SUSDE/USDE.RR",
       "id": "271c64ce459937abf721d42552035713b6c58f80eeceab716a624607fda4b10f",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "HONEY/USD",
       "id": "f67b033925d73d43ba4401e00308d9b0f26ab4fbd1250e8b5407b9eaade7e1f4",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "HONEY/USD.RR",
       "id": "8bb3695875f9c33594097b0e0a1daa881aa81290088f0eac3a07b700fc7612ba",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/ethereum-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/ethereum-mainnet.json
@@ -5,28 +5,32 @@
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
       "time_difference": 3600,
       "price_deviation": 2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "LINEA/USD",
       "id": "49e50653755fbf8018ab65a07be2f208ac8c4bdfc43200934304ca17ee663cab",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "BOLD/USD",
       "id": "d6134dbb0427240f901e3e596d6e63f7d85088f96cd4cd4ae2f89c0819b5d623",
       "time_difference": 3600,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "SPYX/USD",
       "id": "2817b78438c769357182c04346fddaad1178c82f4048828fe0997c3c64624e14",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/hyperevm-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/hyperevm-mainnet.json
@@ -5,301 +5,344 @@
       "id": "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "ETH/USD",
       "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDC/USD",
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDT/USD",
       "id": "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "HYPE/USD",
       "id": "4279e31cc369bbcc2faf022b382b080e32a8e689ff20fbc530d2a603eb6cd98b",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WSTETH/USD",
       "id": "6df640f3b8963d8f8358f791f352b8364513f6ab1cca5ed3f1f7b5448980e784",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WSTETH/STETH.RR",
       "id": "f59ead01ed0faba85332a1e2feae8ddb14a1c94ebac259f1c982c92fc7ce333e",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "USH/USD",
       "id": "eaa30c1ef2d9f4fde45d6e699bfda5187b3de200ea4cbab25d676b260ab728c1",
       "time_difference": 3600,
       "price_deviation": 2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "WBTC/USD",
       "id": "c9d8b075a5c69303365ae23633d4e085199bf5c520a3b90fed1322a0342ffc33",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WETH/USD",
       "id": "9d4294bbcd1174d6f2003ec365831e64cc31d9f6f15a2b85399db8d5000960f6",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDE/USD",
       "id": "6ec879b1e9963de5ee97e9c8710b742d6228252a5e2ca12d4ae81d7fe5ee8c5d",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SUSDE/USD",
       "id": "ca3ba9a619a4b3755c10ac7d5e760275aa95e9823d38a84fedd416856cdba37c",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SUSDE/USDE.RR",
       "id": "271c64ce459937abf721d42552035713b6c58f80eeceab716a624607fda4b10f",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "WSTHYPE/STHYPE.RR",
       "id": "1a78b5829a99f1d2897917dae2a02266c0210535a995a2e9d0692613bbc89e27",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "LHYPE/USD",
       "id": "9e3cadc2a8a0ebfd765b34d5ee5de77a4add3114672fc0b8d3ad09ac56940069",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "FHYPE/HYPE.RR",
       "id": "8f749681c078ce4ef65cd220994f25735b80264fca4386dd57b31eacf7e4610b",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "USDXL/USD",
       "id": "e10593860e9ee1c204e4f9569e877502f098dd1a4d84cc5bad06f23f77dcbfe2",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "MHYPE/HYPE.RR",
       "id": "e35aebd2d35795acaa2b0e59f3b498510e8ef334986d151d1502adb9e26234f7",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "FEUSD/USD",
       "id": "7f2e9a7365eb634c543e9ca72683a9cf778cdc16ee5b8bca73abe6d08c1410d5",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "MHYPE/USD",
       "id": "a7fb4cdafed5130e8731b8da7c9208881f24e9b671bb92438b1fbf361d578112",
       "time_difference": 3600,
       "price_deviation": 2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "STHYPE/USD",
       "id": "068cd0617cbdd1dda615ed2b5ab4fe07d2e9f46347f5e785484844aa10d22dc5",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "UETH/USD",
       "id": "08c73e187b45ecb2ab8375b975865d3c4a225fef1ccc7f326ad6eec66a24567a",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "UBTC/USD",
       "id": "42bfb26778f3504a9f359a92c731f77d0c24aed9b7745276e3ad0c2d840b74c2",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "CMETH/METH.RR",
       "id": "cef5ad3be493afef85e77267cb0c07d048f3d54055409a34782996607e48cf0a",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "METH/ETH.RR",
       "id": "ee279eeb2fec830e3f535ad4d6524eb35eb1c6890cb1afc0b64554d08c88727e",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "USOL/USD",
       "id": "974c7a77dbace44d229be17fc176975e06404b004476aeaff37641818cb0c55a",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "XAU/USD",
       "id": "765d2ba906dbc32ca17cc11f5310a89e9ee1f6420508c63861f2f8ba4ee34bb2",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDHL/USD",
       "id": "1497fb795ae65533d36d147b1b88c8b7226866a201589904c13acd314f694799",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "UFART/USD",
       "id": "a210f55ff119d315002b5dc4f763b4e4114197028e45d6aca16498ab1433fb6d",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "HWHLP/USDC",
       "id": "d136d4fd8d5f41c42339bcaf79954cfc2d50a33b129a990f8a2087d73cadade9",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "WHLP/USDC",
       "id": "b94c49af07479932872c63126f6bdee78140be7a953435e3815c8e1b204a0a04",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "STLOOP/LOOP",
       "id": "1d99073631da1f959284bae0be4d027cfd41c98f4b6a95d20ccf4208a3a4b1f1",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "HLP0/USDC.RR",
       "id": "aa388e24e74d5dd12145f74fad3180266f78ed08c0a2f47c60583fdb612587ba",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "KHYPE/HYPE.RR",
       "id": "983b7cabc6fab548e15a5b05500da9b99c1682107b3e2ff289344116c10ac02c",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "KHYPE/USD",
       "id": "2837a61ae8165c018b0e406ac32b1527270e57b81f0069260afbef71b9cf8ffe",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "HAHYPE/HYPE.RR",
       "id": "19aec77cb70be18c66df7afd33da651d7b376fd26f7c06f2e8b77536c820a281",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "APE/USD",
       "id": "15add95022ae13563a11992e727c91bdb6b55bc183d9d747436c80a483d8c864",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDH/USD",
       "id": "f364e785775b4cb2f159ea823f8b5b9b669a4c221a3f845e518ba0e09611c553",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDT0/USD",
       "id": "cfc1303ea9f083b1b4f99e1369fb9d2611f3230d5ea33a6abf2f86071c089fdc",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "USDN/USD",
       "id": "ee8e0a7de474035b5cbc1a5f762a74d654e5006b25bfe18f390cc5a3915b88ac",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "HWUSD/USDC.RR",
       "id": "90730ebbd6d0e9b9fe41d099e31b06f5465a2164e468d77126b78e3017f19fa2",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "USDG/USD",
       "id": "daa58c6a3ce7d4b9c46c32a6e646012c17c4a2b24c08dd8c5e476118b855a7da",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "THBILL/USDC.RR",
       "id": "5b1bc5a579deba54dbaa9bc1c5b2e2b3f116d8d5ec27fbb3b9dc140a78e9f1e2",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/linea-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/linea-mainnet.json
@@ -5,7 +5,8 @@
       "id": "49e50653755fbf8018ab65a07be2f208ac8c4bdfc43200934304ca17ee663cab",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/monad-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/monad-mainnet.json
@@ -5,420 +5,480 @@
       "id": "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
       "time_difference": 3600,
       "price_deviation": 0.1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "ETH/USD",
       "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
       "time_difference": 3600,
       "price_deviation": 0.1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "MON/USD",
       "id": "31491744e2dbf6df7fcf4ac0820d18a609b49076d45066d3568424e62f686cd1",
       "time_difference": 3600,
       "price_deviation": 0.1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SOL/USD",
       "id": "ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d",
       "time_difference": 3600,
       "price_deviation": 0.1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDC/USD",
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDT/USD",
       "id": "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WBTC/USD",
       "id": "c9d8b075a5c69303365ae23633d4e085199bf5c520a3b90fed1322a0342ffc33",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WETH/USD",
       "id": "9d4294bbcd1174d6f2003ec365831e64cc31d9f6f15a2b85399db8d5000960f6",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WSTETH/USD",
       "id": "6df640f3b8963d8f8358f791f352b8364513f6ab1cca5ed3f1f7b5448980e784",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WSTETH/STETH.RR",
       "id": "f59ead01ed0faba85332a1e2feae8ddb14a1c94ebac259f1c982c92fc7ce333e",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "STETH/ETH.RR",
       "id": "cf40822c7635ddbde64c831982c65b3b37247f139e8e53078d1602e886badd2f",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "SUI/USD",
       "id": "23d7315113f5b1d3ba7a83604c44b94d79f4fd69af77f804fc7f920a6dc65744",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "HYPE/USD",
       "id": "4279e31cc369bbcc2faf022b382b080e32a8e689ff20fbc530d2a603eb6cd98b",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SUSDE/USD",
       "id": "ca3ba9a619a4b3755c10ac7d5e760275aa95e9823d38a84fedd416856cdba37c",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SUSDE/USDE.RR",
       "id": "271c64ce459937abf721d42552035713b6c58f80eeceab716a624607fda4b10f",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "USDE/USD",
       "id": "6ec879b1e9963de5ee97e9c8710b742d6228252a5e2ca12d4ae81d7fe5ee8c5d",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDY/USD",
       "id": "e393449f6aff8a4b6d3e1165a7c9ebec103685f3b41e60db4277b5b6d10e7326",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "PYUSD/USD",
       "id": "c1da1b73d7f01e7ddd54b3766cf7fcd644395ad14f70aa706ec5384c59e76692",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "DAI/USD",
       "id": "b0948a5e5313200c632b51bb5ca32f6de0d36e9950a942d19751e833f70dabfd",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDS/USD",
       "id": "77f0971af11cc8bac224917275c1bf55f2319ed5c654a1ca955c82fa2d297ea1",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SUSDS/USDS.RR",
       "id": "6968a8641208463d17ae3b9cfa0e4841a7aa7a5d54122b9f692b84fe9ce3409f",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "FDUSD/USD",
       "id": "ccdc1a08923e2e4f4b1e6ea89de6acbc5fe1948e9706f5604b8cb50bc1ed3979",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "LBTC/USD",
       "id": "8f257aab6e7698bb92b15511915e593d6f8eae914452f781874754b03d0c612b",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SOLVBTC/USD",
       "id": "f253cf87dc7d5ed5aa14cba5a6e79aee8bcfaef885a0e1b807035a0bbecc36fa",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "CBBTC/USD",
       "id": "2817d7bfe5c64b8ea956e9a26f573ef64e72e4d7891f2d6af9bcc93f7aff9a97",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WEETH/USD",
       "id": "9ee4e7c60b940440a261eb54b6d8149c23b580ed7da3139f7f08f4ea29dad395",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "RSETH/USD",
       "id": "0caec284d34d836ca325cf7b3256c078c597bc052fbd3c0283d52b581d68d71f",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "EZETH/USD",
       "id": "06c217a791f5c4f988b36629af4cb88fad827b2485400a358f3b02886b54de92",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "WEETH/EETH.RR",
       "id": "343558e79f587e098c321218ecb34d031ba709ab3e84133126f3c98511b91f64",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "RSETH/ETH.RR",
       "id": "56e9b5eb08e62dd4b445f29e4ec7d3b3d49617d64f2d331d36a2101d4904e3c4",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "XAU/USD",
       "id": "765d2ba906dbc32ca17cc11f5310a89e9ee1f6420508c63861f2f8ba4ee34bb2",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "XAG/USD",
       "id": "f2fb02c32b055c805e7238d628e5e9dadef274376114eb1f012337cabe93871e",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "XRP/USD",
       "id": "ec5d399846a9209f3fe5881d70aae9268c94339ff9817e8d18ff19fa05eea1c8",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "BNB/USD",
       "id": "2f95862b045670cd22bee3114c39763a4a08beeb663b145d283c31d7d1101c4f",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "ADA/USD",
       "id": "2a01deaec9e51a579277b34b122399984d0bbf57e2458a7e42fecd2829867a0d",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "APT/USD",
       "id": "03ae4db29ed4ae33d323568895aa00337e658e348b37509f5372ae51f0af00d5",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SEI/USD",
       "id": "53614f1cb0c031d4af66c04cb9c756234adad0e1cee85303795091499a4084eb",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "AVAX/USD",
       "id": "93da3352f9f1d105fdfe4971cfa80e9dd777bfc5d0f683ebb6e1294b92137bb7",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "TIA/USD",
       "id": "09f7c1d7dfbb7df2b8fe3d3d87ee94a2259d212da4f30c1f0540d066dfa44723",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "POL/USD",
       "id": "ffd11c5a1cfd42f80afb2df4d9f264c15f956d68153335374ec10722edd70472",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "BERA/USD",
       "id": "962088abcfdbdb6e30db2e340c8cf887d9efb311b1f2f17b155a63dbb6d40265",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "S/USD",
       "id": "f490b178d0c85683b7a0f2388b40af2e6f7c90cbe0f96b31f315f08d0e5a2d6d",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "DOGE/USD",
       "id": "dcef50dd0a4cd2dcc17e45df1676dcb336a11a61c69df7a0299b0150c672d25c",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "OP/USD",
       "id": "385f64d993f7b77d8182ed5003d97c60aa3361f3cecfe711544d2d59165e9bdf",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "ARB/USD",
       "id": "3fa4252848f9f0a1480be62745a4629d9eb1322aebab8a791e344b3b9c1adcf5",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "EBTC/USD",
       "id": "be3dd0cf4a168f82e4912952b24420211ad52641b7365d49866d59e20c948288",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "STONE/ETH.RR",
       "id": "7a508a94c9276cbc60d04e1a8cf839d20d835bb869a74487dfffa8f1bfd1ce42",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "ETHX/ETH.RR",
       "id": "1b8eb073e2a900cdf1f6ee37ddab4869a4400499ec6e52f3e268a93f46c55429",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "PYTH/USD",
       "id": "0bbf28e9a841a1cc788f6a361b17ca072d0ea3098a1e5df1c3922d06719579ff",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "CAKE/USD",
       "id": "2356af9529a1064d41e32d617e2ce1dca5733afa901daba9e2b68dee5d53ecf9",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "LINK/USD",
       "id": "8ac0c70fff57e9aefdf5edf44b51d62c2d433653cbb2cf5cc06bb115af04d221",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "UNI/USD",
       "id": "78d185a741d07edb3412b09008b7c5cfb9bbbd7d568bf00ba737b456ba171501",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "AAVE/USD",
       "id": "2b9ab1e972a281585084148ba1389800799bd4be63b957507db1349314e47445",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "RED/USD",
       "id": "0bb28b82f08477fadbf9607fc8408ff61ca129fae40adc7a8d2ab8945f97ee74",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "W/USD",
       "id": "eff7446475e218517566ea99e72a4abec2e1bd8498b43b7d8331e29dcb059389",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "AXL/USD",
       "id": "60144b1d5c9e9851732ad1d9760e3485ef80be39b984f6bf60f82b28a2b7f126",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "ZRO/USD",
       "id": "3bd860bea28bf982fa06bcf358118064bb114086cc03993bd76197eaab0b8018",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "STG/USD",
       "id": "008546b175392b878c5c7ff0b6327b1cb12669be012fc2935c09a16fc8f6c58f",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "AUSD/USD",
       "id": "d9912df360b5b7f21a122f15bdd5e27f62ce5e72bd316c291f7c86620e07fb2a",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SMON/MON.RR",
       "id": "7fbf66b9b4e8b0e5723fc7001b00848c7d25225982ab33f6a5d111fdbf528001",
       "time_difference": 3600,
       "price_deviation": 0.2,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/optimism-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/optimism-mainnet.json
@@ -5,35 +5,40 @@
       "id": "6d5216dab65051b9242a6ec458ea917e6a8f2cd122eebc25d8ab00dbe703612a",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "ETHFI/USD",
       "id": "b27578a9654246cb0a2950842b92330e9ace141c52b63829cc72d5c45a5a595a",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "BEHYPE/HYPE.RR",
       "id": "0f150eddafc98344c37f6ebe90fe303c12136436baf242f3c5ab412dbf91312c",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "HYPE/USD",
       "id": "4279e31cc369bbcc2faf022b382b080e32a8e689ff20fbc530d2a603eb6cd98b",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "EURC/USD",
       "id": "76fa85158bf14ede77087fe3ae472f66213f6ea2f5b411cb2de472794990fa5c",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/soneium-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/soneium-mainnet.json
@@ -5,49 +5,56 @@
       "id": "89b814de1eb2afd3d3b498d296fca3a873e644bafb587e84d181a01edd682853",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "BTC/USD",
       "id": "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "ETH/USD",
       "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SOLVBTC/BTC.RR",
       "id": "c55e7d4d6caae221f6244d0879532230cfc436b102742a8870c92d7d88a67d95",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDC/USD",
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDT/USD",
       "id": "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WSTETH/USD",
       "id": "6df640f3b8963d8f8358f791f352b8364513f6ab1cca5ed3f1f7b5448980e784",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/sonic-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/sonic-mainnet.json
@@ -5,77 +5,88 @@
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "ETH/USD",
       "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WETH/USD",
       "id": "9d4294bbcd1174d6f2003ec365831e64cc31d9f6f15a2b85399db8d5000960f6",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WBTC/USD",
       "id": "c9d8b075a5c69303365ae23633d4e085199bf5c520a3b90fed1322a0342ffc33",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "BTC/USD",
       "id": "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDT/USD",
       "id": "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "S/USD",
       "id": "f490b178d0c85683b7a0f2388b40af2e6f7c90cbe0f96b31f315f08d0e5a2d6d",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "STS/S.RR",
       "id": "3b14bd355f182fa3a3feeea6824228e1f71e7c221a37bc91e8307280aee6a803",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "ANON/USD",
       "id": "7a36855b8a4a6efd701ed82688694bbf67602de9faae509ae28f91065013cb82",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "STS/USD",
       "id": "19f463beb47cb398cf2e2c8037f1d0073583cf18209c91a636f051d755ce0662",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "HLP0/USDC.RR",
       "id": "aa388e24e74d5dd12145f74fad3180266f78ed08c0a2f47c60583fdb612587ba",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json
@@ -5,252 +5,288 @@
       "id": "17cd845b16e874485b2684f8b8d1517d744105dbb904eec30222717f4bc9ee0d",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "AUSD/USD",
       "id": "d9912df360b5b7f21a122f15bdd5e27f62ce5e72bd316c291f7c86620e07fb2a",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "BLUE/USD",
       "id": "04cfeb7b143eb9c48e9b074125c1a3447b85f59c31164dc20c1beaa6f21f2b6b",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "BNB/USD",
       "id": "2f95862b045670cd22bee3114c39763a4a08beeb663b145d283c31d7d1101c4f",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "BTC/USD",
       "id": "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "BUCK/USD",
       "id": "fdf28a46570252b25fd31cb257973f865afc5ca2f320439e45d95e0394bc7382",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "CETUS/USD",
       "id": "e5b274b2611143df055d6e7cd8d93fe1961716bcd4dca1cad87a83bc1e78c1ef",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "DEEP/USD",
       "id": "29bdd5248234e33bd93d3b81100b5fa32eaa5997843847e2c2cb16d7c6d9f7ff",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "DMC/USD",
       "id": "8abfa63ae82ca2fbc271861375e497166d8792580fb7c2ffcf014d2a131433f0",
       "time_difference": 10,
       "price_deviation": 3,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "DOGE/USD",
       "id": "dcef50dd0a4cd2dcc17e45df1676dcb336a11a61c69df7a0299b0150c672d25c",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "ETH/USD",
       "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "FDUSD/USD",
       "id": "ccdc1a08923e2e4f4b1e6ea89de6acbc5fe1948e9706f5604b8cb50bc1ed3979",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "HAEDAL/USD",
       "id": "e67d98cc1fbd94f569d5ba6c3c3c759eb3ffc5d2b28e64538a53ae13efad8fd1",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "HASUI/USD",
       "id": "6120ffcf96395c70aa77e72dcb900bf9d40dccab228efca59a17b90ce423d5e8",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "HIPPO/USD",
       "id": "f2c5249856da2fbe0221e163b3fed678dd6f76515ab933292dfb4f15a1de8f8c",
       "time_difference": 10,
       "price_deviation": 3,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "IKA/USD",
       "id": "2b529621fa6e2c8429f623ba705572aa64175d7768365ef829df6a12c9f365f4",
       "time_difference": 10,
       "price_deviation": 3,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "LBTC/USD",
       "id": "8f257aab6e7698bb92b15511915e593d6f8eae914452f781874754b03d0c612b",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "MUSD/USD",
       "id": "2ee09cdb656959379b9262f89de5ff3d4dfed0dd34c072b3e22518496a65249c",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "NAVX/USD",
       "id": "88250f854c019ef4f88a5c073d52a18bb1c6ac437033f5932cd017d24917ab46",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "NS/USD",
       "id": "bb5ff26e47a3a6cc7ec2fce1db996c2a145300edc5acaabe43bf9ff7c5dd5d32",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "SCA/USD",
       "id": "7e17f0ac105abe9214deb9944c30264f5986bf292869c6bd8e8da3ccd92d79bc",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "SEND/USD",
       "id": "7d19b607c945f7edf3a444289c86f7b58dcd8b18df82deadf925074807c99b59",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "SOL/USD",
       "id": "ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "STSUI/USD",
       "id": "0b3eae8cb6e221e7388a435290e0f2211172563f94769077b7f4c4c6a11eea76",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "SUI/USD",
       "id": "23d7315113f5b1d3ba7a83604c44b94d79f4fd69af77f804fc7f920a6dc65744",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SUIUSDE/USD",
       "id": "8cead549d0e770dea8fdf5e018a85d59585265cf8bff16ba83962fc7996dbb7f",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "TRX/USD",
       "id": "67aed5a24fdad045475e7195c98a98aea119c763f272d4523f5bac93a4f33c2b",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDC/USD",
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDT/USD",
       "id": "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDSUI/USD",
       "id": "d510fcdb3a63f35d3bb118d5db3afc5815a3f13bc55d48abb893b63f0315902a",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDY/USD",
       "id": "e393449f6aff8a4b6d3e1165a7c9ebec103685f3b41e60db4277b5b6d10e7326",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "VSUI/USD",
       "id": "57ff7100a282e4af0c91154679c5dae2e5dcacb93fd467ea9cb7e58afdcfde27",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "WAL/USD",
       "id": "eba0732395fae9dec4bae12e52760b35fc1c5671e2da8b449c9af4efe5d54341",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "XAUM/USD.RR",
       "id": "d7db067954e28f51a96fd50c6d51775094025ced2d60af61ec9803e553471c88",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "UP/USD",
       "id": "c591a547856b091560b120ee14b165a84ca58eca23b2ab635df641340bde1f10",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "XRP/USD",
       "id": "ec5d399846a9209f3fe5881d70aae9268c94339ff9817e8d18ff19fa05eea1c8",
       "time_difference": 10,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json
@@ -291,11 +291,11 @@
     {
       "alias": "INF/SOL",
       "account_address": "4MbCk4vH47K2gHee6nTg62KScpGu2bV3YDeTZtpQm3ro",
-      "id": "49e50653755fbf8018ab65a07be2f208ac8c4bdfc43200934304ca17ee663cab",
+      "id": "3e9961b890c4e77e9009c1a6d81dc556e24a3c190b02d1682c8f545c53b1d4a2",
       "time_difference": 60,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "available"
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "INDEX.FORD/USD",

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json
@@ -289,7 +289,7 @@
       "pro_compatible_status": "available"
     },
     {
-      "alias": "INF/SOL",
+      "alias": "INF/SOL.RR",
       "account_address": "4MbCk4vH47K2gHee6nTg62KScpGu2bV3YDeTZtpQm3ro",
       "id": "3e9961b890c4e77e9009c1a6d81dc556e24a3c190b02d1682c8f545c53b1d4a2",
       "time_difference": 60,

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json
@@ -6,7 +6,8 @@
       "id": "ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "MSOL/USD",
@@ -14,7 +15,8 @@
       "id": "c2289a6a43d2ce91c6f55caec370f4acc38a2ed477f58813334c6d03749ff2a4",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "BSOL/USD",
@@ -22,7 +24,8 @@
       "id": "89875379e70f8fbadc17aef315adf3a8d5d160b811435537e03c97e8aac97d9c",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SSOL/SOL",
@@ -30,7 +33,8 @@
       "id": "add6499a420f809bbebc0b22fbf68acb8c119023897f6ea801688e0d6e391af4",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "BONK/USD",
@@ -38,7 +42,8 @@
       "id": "72b021217ca3fe68922a19aaf990109cb9d84e9ad004b4d2025ad6f529314419",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "W/USD",
@@ -46,7 +51,8 @@
       "id": "eff7446475e218517566ea99e72a4abec2e1bd8498b43b7d8331e29dcb059389",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "MEW/USD",
@@ -54,7 +60,8 @@
       "id": "514aed52ca5294177f20187ae883cec4a018619772ddce41efcc36a6448f5d5d",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDC/USD",
@@ -62,7 +69,8 @@
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "BTC/USD",
@@ -70,7 +78,8 @@
       "id": "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDT/USD",
@@ -78,7 +87,8 @@
       "id": "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "JUP/USD",
@@ -86,7 +96,8 @@
       "id": "0a0408d619e9380abad35060f9192039ed5042fa6f82301d0e48bb52be830996",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "ETH/USD",
@@ -94,7 +105,8 @@
       "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "PYTH/USD",
@@ -102,7 +114,8 @@
       "id": "0bbf28e9a841a1cc788f6a361b17ca072d0ea3098a1e5df1c3922d06719579ff",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "HNT/USD",
@@ -110,7 +123,8 @@
       "id": "649fdd7ec08e8e2a20f425729854e90293dcbe2376abc47197a14da6ff339756",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "ORCA/USD",
@@ -118,7 +132,8 @@
       "id": "37505261e557e251290b8c8899453064e8d760ed5c65a779726f2490980da74c",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SAMO/USD",
@@ -126,7 +141,8 @@
       "id": "49601625e1a342c1f90c3fe6a03ae0251991a1d76e480d2741524c29037be28a",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "WIF/USD",
@@ -134,7 +150,8 @@
       "id": "4ca4beeca86f0d164160323817a4e42b10010a724c2217c6ee41b54cd4cc61fc",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "INF/USD",
@@ -142,7 +159,8 @@
       "id": "f51570985c642c49c2d6e50156390fdba80bb6d5f7fa389d2f012ced4f7d208f",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "MNDE/USD",
@@ -150,7 +168,8 @@
       "id": "3607bf4d7b78666bd3736c7aacaf2fd2bc56caa8667d3224971ebe3c0623292a",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "NEON/USD",
@@ -158,7 +177,8 @@
       "id": "d82183dd487bef3208a227bb25d748930db58862c5121198e723ed0976eb92b7",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "JLP/USD",
@@ -166,7 +186,8 @@
       "id": "c811abc82b4bad1f9bd711a2773ccaa935b03ecef974236942cec5e0eb845a3a",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WBTC/USD",
@@ -174,7 +195,8 @@
       "id": "c9d8b075a5c69303365ae23633d4e085199bf5c520a3b90fed1322a0342ffc33",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "PENGU/USD",
@@ -182,7 +204,8 @@
       "id": "bed3097008b9b5e3c93bec20be79cb43986b85a996475589351a21e67bae9b61",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "TRUMP/USD",
@@ -190,7 +213,8 @@
       "id": "879551021853eec7a7dc827578e8e69da7e4fa8148339aa0d3d5296405be4b1a",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "FARTCOIN/USD",
@@ -198,7 +222,8 @@
       "id": "58cd29ef0e714c5affc44f269b2c1899a52da4169d7acc147b9da692e6953608",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "ACRED/USD",
@@ -206,7 +231,8 @@
       "id": "40ac3329933a6b5b65cf31496018c5764ac0567316146f7d0de00095886b480d",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "PUMP/USD",
@@ -214,7 +240,8 @@
       "id": "7a01fca212788bba7c5bf8c9efd576a8a722f070d2c17596ff7bb609b8d5c3b9",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "JUPSOL/SOL.RR",
@@ -222,7 +249,8 @@
       "id": "f8d8d6b6c866c8b2624fb5b679ae846738725e5fc887fa8e927c8d8645018a2b",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "NAV.USTB/USD",
@@ -230,7 +258,8 @@
       "id": "dea78edd10cd7ae4524cc1744216788746306623bc3553014eeab6062860795d",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "NAV.USCC/USD",
@@ -238,7 +267,8 @@
       "id": "5d73a5953dc86c4773adc778c30e8a6dfc94c5c3a74d7ebb56dd5e70350f044a",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "ZBTC/USD",
@@ -246,7 +276,8 @@
       "id": "3d824c7f7c26ed1c85421ecec8c754e6b52d66a4e45de20a9c9ea91de8b396f9",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "LBTC/USD",
@@ -254,7 +285,8 @@
       "id": "8f257aab6e7698bb92b15511915e593d6f8eae914452f781874754b03d0c612b",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "INF/SOL",
@@ -262,7 +294,8 @@
       "id": "49e50653755fbf8018ab65a07be2f208ac8c4bdfc43200934304ca17ee663cab",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "INDEX.FORD/USD",
@@ -270,7 +303,8 @@
       "id": "84d8c84bfbe6f71af527493f9aaee09950ee3e09c8460b2b781ce65ea341c10a",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "INDEX.GLXY/USD",
@@ -278,7 +312,8 @@
       "id": "c59735498fa594a63e36382c12656e4313a7269ea1a1ed8fa583008e277f9cdb",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "SYRUPUSDC/USDC.RR",
@@ -286,7 +321,8 @@
       "id": "2ad31d1c4a85fbf2156ce57fab4104124c5ef76a6386375ecfc8da1ed5ce1486",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "ORE/USD",
@@ -294,7 +330,8 @@
       "id": "142b804c658e14ff60886783e46e5a51bdf398b4871d9d8f7c28aa1585cad504",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "NOPAL/USD.RR",
@@ -302,7 +339,8 @@
       "id": "8858dfaa8998ff44681aa145a8aa5b7772979b1d044a1bbf3cf5d971168baa85",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "NTBILL/USD.RR",
@@ -310,7 +348,8 @@
       "id": "f03015f29e6c90d5fe62da7d1a13c912c8bf7523d90c981387f82ee0c83332bd",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "NBASIS/USD.RR",
@@ -318,7 +357,8 @@
       "id": "fd9397e6dfc968ff8eaa652c6e4b7dfdeb6fdc940afe90c23ca5acfa45d408e1",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "NWISDOM/USD.RR",
@@ -326,7 +366,8 @@
       "id": "384986c9655ec6887dbd7f7430d864992f872db2c77ba5781a26b78dad277adc",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "NALPHA/USD.RR",
@@ -334,7 +375,8 @@
       "id": "57d1e11bea1316c2f7263a39c2780685691585aae34eff39300f5db564501b17",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "NFALCON/USD.RR",
@@ -342,7 +384,8 @@
       "id": "323647322045edff1a0928dca6628169a57afdea43a5f0d948115e3dcae9c1fb",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "CASH/RD.RR",
@@ -350,7 +393,8 @@
       "id": "64c74ffd61574170cfaee65c54c8810adcf83f6c31f3c256d9a290dcbf4ff1a9",
       "time_difference": 30,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "CASH/USD",
@@ -358,7 +402,8 @@
       "id": "df3320ef0f4617337b8dbb924f2aaa4f9db08f522a5435b44f9066c1ac4c7f95",
       "time_difference": 30,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "PST/USDC.RR",
@@ -366,7 +411,8 @@
       "id": "675e36f84a6be779ed793c71eb5c03151e1866c125767f46933626e0610af84d",
       "time_difference": 240,
       "price_deviation": 0.05,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "JUPUSD/USD",
@@ -374,7 +420,8 @@
       "id": "8ed858a2214e892c9371694fb6c8a9037b6ed4052c4edf209f8cb988484e81d9",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/evm.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/evm.mdx
@@ -44,6 +44,7 @@ The following EVM chains have push feeds:
 <SponsoredFeedsTable
   feeds={abstractMainnet.feeds}
   networkName="Abstract mainnet"
+  showProCompatibleStatus
 />
 
 ## Arbitrum Mainnet
@@ -51,6 +52,7 @@ The following EVM chains have push feeds:
 <SponsoredFeedsTable
   feeds={arbitrumMainnet.feeds}
   networkName="Arbitrum mainnet"
+  showProCompatibleStatus
 />
 
 ## Avalanche Mainnet
@@ -58,17 +60,23 @@ The following EVM chains have push feeds:
 <SponsoredFeedsTable
   feeds={avalancheMainnet.feeds}
   networkName="Avalanche mainnet"
+  showProCompatibleStatus
 />
 
 ## Base Mainnet
 
-<SponsoredFeedsTable feeds={baseMainnet.feeds} networkName="Base mainnet" />
+<SponsoredFeedsTable
+  feeds={baseMainnet.feeds}
+  networkName="Base mainnet"
+  showProCompatibleStatus
+/>
 
 ## Berachain Mainnet
 
 <SponsoredFeedsTable
   feeds={berachainMainnet.feeds}
   networkName="Berachain mainnet"
+  showProCompatibleStatus
 />
 
 ## Ethereum Mainnet
@@ -76,6 +84,7 @@ The following EVM chains have push feeds:
 <SponsoredFeedsTable
   feeds={ethereumMainnet.feeds}
   networkName="Ethereum mainnet"
+  showProCompatibleStatus
 />
 
 ## HyperEVM Mainnet
@@ -83,21 +92,31 @@ The following EVM chains have push feeds:
 <SponsoredFeedsTable
   feeds={hyperevmMainnet.feeds}
   networkName="HyperEVM mainnet"
+  showProCompatibleStatus
 />
 
 ## Linea Mainnet
 
-<SponsoredFeedsTable feeds={lineaMainnet.feeds} networkName="Linea mainnet" />
+<SponsoredFeedsTable
+  feeds={lineaMainnet.feeds}
+  networkName="Linea mainnet"
+  showProCompatibleStatus
+/>
 
 ## Monad Mainnet
 
-<SponsoredFeedsTable feeds={monadMainnet.feeds} networkName="Monad mainnet" />
+<SponsoredFeedsTable
+  feeds={monadMainnet.feeds}
+  networkName="Monad mainnet"
+  showProCompatibleStatus
+/>
 
 ## Optimism Mainnet
 
 <SponsoredFeedsTable
   feeds={optimismMainnet.feeds}
   networkName="Optimism mainnet"
+  showProCompatibleStatus
 />
 
 ## Soneium Mainnet
@@ -105,8 +124,13 @@ The following EVM chains have push feeds:
 <SponsoredFeedsTable
   feeds={soneiumMainnet.feeds}
   networkName="Soneium mainnet"
+  showProCompatibleStatus
 />
 
 ## Sonic Mainnet
 
-<SponsoredFeedsTable feeds={sonicMainnet.feeds} networkName="Sonic mainnet" />
+<SponsoredFeedsTable
+  feeds={sonicMainnet.feeds}
+  networkName="Sonic mainnet"
+  showProCompatibleStatus
+/>

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/solana.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/solana.mdx
@@ -18,6 +18,7 @@ import solanaMainnet from "./data/svm/solana-mainnet.json";
 <SponsoredFeedsTable
   feeds={solanaMainnet.feeds}
   networkName="Solana mainnet and devnet"
+  showProCompatibleStatus
 />
 
 Note: The addresses represent the price feed account for shard 0 of the relevant price feed id.

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/sui.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/sui.mdx
@@ -15,4 +15,8 @@ import suiMainnet from "./data/sui/sui-mainnet.json";
 
 ## Sui Mainnet
 
-<SponsoredFeedsTable feeds={suiMainnet.feeds} networkName="Sui mainnet" />
+<SponsoredFeedsTable
+  feeds={suiMainnet.feeds}
+  networkName="Sui mainnet"
+  showProCompatibleStatus
+/>

--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/index.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/index.mdx
@@ -119,6 +119,8 @@ const client = new HermesClient("https://pyth.dourolabs.app/hermes", {
 Routes and response shapes are unchanged.
 The upgraded endpoint is a drop-in replacement. See the new [Hermes API reference](https://pyth.dourolabs.app/docs/?urls.primaryName=Hermes+API#/) for the full surface.
 
+Per-chain availability: see the **Pro-compatible** column on the [EVM](/price-feeds/core/push-feeds/evm), [Solana](/price-feeds/core/push-feeds/solana), and [Sui](/price-feeds/core/push-feeds/sui) push-feed tables to confirm which feeds are already served by the upgraded Hermes today.
+
 <Callout type="warn">
   **Deploy 1 and 2 in the same release.**
   The upgraded endpoint serves payloads only the upgraded Pyth Core Contract verifies.

--- a/apps/developer-hub/src/components/SponsoredFeedsTable/index.module.scss
+++ b/apps/developer-hub/src/components/SponsoredFeedsTable/index.module.scss
@@ -80,3 +80,14 @@
 .updateParamsException {
   color: theme.pallette-color("orange", 600);
 }
+
+.proCompatibleHeaderLink {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+
+  &:hover,
+  &:focus-visible {
+    color: theme.pallette-color("blue", 500);
+  }
+}

--- a/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
+++ b/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
@@ -1,3 +1,4 @@
+import { Badge } from "@pythnetwork/component-library/Badge";
 import { CopyButton } from "@pythnetwork/component-library/CopyButton";
 import { Table } from "@pythnetwork/component-library/Table";
 import {
@@ -10,6 +11,11 @@ import { useMemo } from "react";
 
 import styles from "./index.module.scss";
 
+const HERMES_API_DOCS_URL =
+  "https://pyth.dourolabs.app/docs/?urls.primaryName=Hermes+API";
+
+type ProCompatibleStatus = "available" | "coming_soon";
+
 type SponsoredFeed = {
   alias: string;
   account_address?: string;
@@ -17,6 +23,7 @@ type SponsoredFeed = {
   time_difference: number;
   price_deviation: number;
   confidence_ratio: number;
+  pro_compatible_status?: ProCompatibleStatus;
 };
 
 type SponsoredFeedsTableProps = {
@@ -24,6 +31,7 @@ type SponsoredFeedsTableProps = {
   networkName: string;
   showUpgradedAccountAddress?: boolean;
   hideAccountAddress?: boolean;
+  showProCompatibleStatus?: boolean;
 };
 
 type UpdateParamsProps = {
@@ -85,11 +93,27 @@ const UpdateParams = ({ feed, isDefault }: UpdateParamsProps) => {
   );
 };
 
+const ProCompatibleStatusBadge = ({
+  status,
+}: {
+  status: ProCompatibleStatus;
+}) =>
+  status === "available" ? (
+    <Badge variant="success" size="xs" style="filled">
+      Available
+    </Badge>
+  ) : (
+    <Badge variant="warning" size="xs" style="filled">
+      Coming soon
+    </Badge>
+  );
+
 export const SponsoredFeedsTable = ({
   feeds,
   networkName,
   showUpgradedAccountAddress = false,
   hideAccountAddress = false,
+  showProCompatibleStatus = false,
 }: SponsoredFeedsTableProps) => {
   const paramCounts: Record<string, number> = {};
   for (const feed of feeds) {
@@ -144,8 +168,26 @@ export const SponsoredFeedsTable = ({
         name: "Update Parameters",
         alignment: "left" as const,
       },
+      ...(showProCompatibleStatus
+        ? [
+            {
+              id: "proCompatibleStatus",
+              name: (
+                <a
+                  href={HERMES_API_DOCS_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={styles.proCompatibleHeaderLink}
+                >
+                  Pro-compatible
+                </a>
+              ),
+              alignment: "left" as const,
+            },
+          ]
+        : []),
     ],
-    [hasAccountAddress, showUpgradedAccountAddress],
+    [hasAccountAddress, showUpgradedAccountAddress, showProCompatibleStatus],
   );
 
   const rows = useMemo(
@@ -160,6 +202,7 @@ export const SponsoredFeedsTable = ({
           updateParameters: ReactNode;
           accountAddress: ReactNode | undefined;
           upgradedAccountAddress: ReactNode | undefined;
+          proCompatibleStatus: ReactNode | undefined;
         } = {
           name: <span className={styles.nameLabel}>{feed.alias}</span>,
           priceFeedId: (
@@ -168,6 +211,7 @@ export const SponsoredFeedsTable = ({
           updateParameters: <UpdateParams feed={feed} isDefault={isDefault} />,
           accountAddress: undefined,
           upgradedAccountAddress: undefined,
+          proCompatibleStatus: undefined,
         };
 
         if (hasAccountAddress) {
@@ -191,12 +235,26 @@ export const SponsoredFeedsTable = ({
           );
         }
 
+        if (showProCompatibleStatus) {
+          rowData.proCompatibleStatus = (
+            <ProCompatibleStatusBadge
+              status={feed.pro_compatible_status ?? "coming_soon"}
+            />
+          );
+        }
+
         return {
           id: feed.id,
           data: rowData,
         };
       }),
-    [feeds, defaultParams, hasAccountAddress, showUpgradedAccountAddress],
+    [
+      feeds,
+      defaultParams,
+      hasAccountAddress,
+      showUpgradedAccountAddress,
+      showProCompatibleStatus,
+    ],
   );
 
   if (feeds.length === 0) {

--- a/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
+++ b/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
@@ -11,9 +11,26 @@ import { useMemo } from "react";
 
 import styles from "./index.module.scss";
 
-const HERMES_API_DOCS_URL =
-  "https://pyth.dourolabs.app/docs/?urls.primaryName=Hermes+API";
+// The Pyth Core upgrade guide explains what "Pro-compatible" means for a feed.
+// The column header and intro copy link here rather than to the raw API spec.
+const PRO_COMPATIBLE_DOCS_URL = "/price-feeds/core/upgrade/preparing";
 
+/**
+ * `pro_compatible_status` is a DERIVED, point-in-time field on the push-feed
+ * data files (content/docs/price-feeds/core/push-feeds/data/{evm,sui,svm}/*.json).
+ * It is not returned by any API; it is computed and committed into the JSON:
+ *
+ *   1. Fetch the Pro-compatible Hermes listing:
+ *      GET https://pyth.dourolabs.app/hermes/v2/price_feeds
+ *   2. For each feed, set "available" if its `id` is present in that listing,
+ *      otherwise "coming_soon".
+ *   3. Avalanche carve-out: every Avalanche feed is pinned to "coming_soon"
+ *      regardless of the listing, because Pro-compatible push feeds are not
+ *      deployed for that chain (no deployment-pro-compatible.yaml). See the
+ *      `_comment` in data/evm/avalanche-mainnet.json.
+ *
+ * Last refreshed 2026-06-23. To refresh, re-run the steps above.
+ */
 type ProCompatibleStatus = "available" | "coming_soon";
 
 type SponsoredFeed = {
@@ -174,9 +191,7 @@ export const SponsoredFeedsTable = ({
               id: "proCompatibleStatus",
               name: (
                 <a
-                  href={HERMES_API_DOCS_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  href={PRO_COMPATIBLE_DOCS_URL}
                   className={styles.proCompatibleHeaderLink}
                 >
                   Pro-compatible
@@ -274,6 +289,15 @@ export const SponsoredFeedsTable = ({
         The price feeds listed below are currently sponsored in{" "}
         <strong>{networkName}</strong>.
       </p>
+      {showProCompatibleStatus && (
+        <p className={styles.introText}>
+          The <strong>Pro-compatible</strong> column shows whether each feed is
+          already served by the upgraded Hermes endpoint for the{" "}
+          <a href={PRO_COMPATIBLE_DOCS_URL}>Pyth Core upgrade</a>. Feeds marked{" "}
+          <strong>Available</strong> are already served by the upgraded Hermes;{" "}
+          <strong>Coming soon</strong> feeds are still being migrated.
+        </p>
+      )}
       <div className={styles.tableWrapper}>
         <div className={styles.summaryBar}>
           {defaultParams ? (


### PR DESCRIPTION
## Summary

Adds a **Pro-compatible** column to the push-feed tables on `/price-feeds/core/push-feeds/{evm,solana,sui}`, showing whether each feed is currently served by the upgraded ("Pro-compatible") Hermes. Feeds get an **Available** badge (green) or **Coming soon** badge (orange). The column header links to the new Hermes API reference. Adds a one-sentence cross-link from the "Move your Hermes calls to the new Hermes endpoint" section of the Pyth Core upgrade guide back to these tables.

## Data source

The per-feed `pro_compatible_status` values were generated by querying the Pro-compatible Hermes listing endpoint:

```
curl https://pyth.dourolabs.app/hermes/v2/price_feeds
```

(The endpoint did not require an `Authorization` header at the time of capture, so no `HERMES_ACCESS_TOKEN` was needed.) The response was a JSON array of 1267 served feeds. For each feed id in the in-scope JSON files, `pro_compatible_status` was set to `"available"` if the id is in that array, else `"coming_soon"`.

**Captured: 2026-06-23.** To refresh, re-run the same `curl` and re-derive the per-file values.

## Avalanche carve-out

Per the issue spec, Avalanche has no `deployment-pro-compatible.yaml` in either `platform-green` or `platform-yellow` — Pro-compatible push feeds are not deployed for that chain. All Avalanche feeds (currently the single `HLP0/USDC.RR` entry) are marked **Coming soon** regardless of whether Hermes serves the id. (As it happens, that id is also absent from the Hermes listing today, so the result coincides with the data-driven value.)

## Per-page counts

| Page | available | coming_soon |
| --- | --- | --- |
| EVM / abstract | 4 | 0 |
| EVM / arbitrum | 0 | 1 |
| EVM / avalanche | 0 | 1 (carve-out) |
| EVM / base | 6 | 1 |
| EVM / berachain | 6 | 3 |
| EVM / ethereum | 3 | 1 |
| EVM / hyperevm | 14 | 29 |
| EVM / linea | 1 | 0 |
| EVM / monad | 45 | 15 |
| EVM / optimism | 5 | 0 |
| EVM / soneium | 7 | 0 |
| EVM / sonic | 7 | 4 |
| Solana | 31 | 16 |
| Sui | 17 | 19 |

Both badge states are visible across the in-scope pages, so the acceptance criterion ("at least one Available and one Coming soon") holds.

## Component changes

- `SponsoredFeedsTable` gains a `showProCompatibleStatus?: boolean` prop (default `false`). The EVM, Solana, and Sui MDX pages pass `showProCompatibleStatus`; the aptos / fogo / movement pages are unchanged and still render without the column.
- `SponsoredFeed` type gains `pro_compatible_status?: "available" | "coming_soon"`. A missing value falls back to `"coming_soon"` to fail safe.
- Status is rendered via the shared `Badge` component (`variant="success"` / `variant="warning"`).
- Column header links to https://pyth.dourolabs.app/docs/?urls.primaryName=Hermes+API.

## Upgrade-guide cross-link

`apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/index.mdx` — the "Move your Hermes calls to the new Hermes endpoint" step now ends with:

> Per-chain availability: see the **Pro-compatible** column on the [EVM](/price-feeds/core/push-feeds/evm), [Solana](/price-feeds/core/push-feeds/solana), and [Sui](/price-feeds/core/push-feeds/sui) push-feed tables to confirm which feeds are already served by the upgraded Hermes today.

## Uncertainty / open items

- The carve-out logic treats Avalanche specially even though its sole feed currently coincides with the Hermes-derived value. Kept the spec-mandated branch so the file stays deliberate if Avalanche feeds change.
- No `pro_compatible_status` data is wired for the aptos / movement / fogo JSON files because their pages do not show the column; left untouched.

## Verification

Ran from the repo root against Node 24 / pnpm 10.28:

- `pnpm turbo run test:format --filter=@pythnetwork/developer-hub` — passing
- `pnpm turbo run test:lint --filter=@pythnetwork/developer-hub` — passing (triggers the dependency `build` task, which also succeeded)
- `pnpm turbo run test:lint:stylelint --filter=@pythnetwork/developer-hub` — passing
- `pnpm turbo run test:types --filter=@pythnetwork/developer-hub` — passing
- `pnpm turbo run build --filter=@pythnetwork/developer-hub` — passing (195 static pages generated)

No visual smoke screenshots — the agent session has no browser, so the dev server was not started.