### PR TITLE
chore(developer-hub): remove 4 deprovisioned Solana push-feed entries

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json
@@ -118,33 +118,6 @@
       "pro_compatible_status": "available"
     },
     {
-      "alias": "HNT/USD",
-      "account_address": "4DdmDswskDxXGpwHrXUfn2CNUm9rt21ac79GHNTN3J33",
-      "id": "649fdd7ec08e8e2a20f425729854e90293dcbe2376abc47197a14da6ff339756",
-      "time_difference": 60,
-      "price_deviation": 0.5,
-      "confidence_ratio": 100,
-      "pro_compatible_status": "available"
-    },
-    {
-      "alias": "ORCA/USD",
-      "account_address": "4CBshVeNBEXz24GZpoj8SrqP5L7VGG3qjGd6tCST1pND",
-      "id": "37505261e557e251290b8c8899453064e8d760ed5c65a779726f2490980da74c",
-      "time_difference": 60,
-      "price_deviation": 0.5,
-      "confidence_ratio": 100,
-      "pro_compatible_status": "available"
-    },
-    {
-      "alias": "SAMO/USD",
-      "account_address": "2eUVzcYccqXzsDU1iBuatUaDCbRKBjegEaPPeChzfocG",
-      "id": "49601625e1a342c1f90c3fe6a03ae0251991a1d76e480d2741524c29037be28a",
-      "time_difference": 60,
-      "price_deviation": 0.5,
-      "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
-    },
-    {
       "alias": "WIF/USD",
       "account_address": "6B23K3tkb51vLZA14jcEQVCA1pfHptzEHFA93V5dYwbT",
       "id": "4ca4beeca86f0d164160323817a4e42b10010a724c2217c6ee41b54cd4cc61fc",
@@ -193,15 +166,6 @@
       "alias": "WBTC/USD",
       "account_address": "9gNX5vguzarZZPjTnE1hWze3s6UsZ7dsU3UnAmKPnMHG",
       "id": "c9d8b075a5c69303365ae23633d4e085199bf5c520a3b90fed1322a0342ffc33",
-      "time_difference": 60,
-      "price_deviation": 0.5,
-      "confidence_ratio": 100,
-      "pro_compatible_status": "available"
-    },
-    {
-      "alias": "PENGU/USD",
-      "account_address": "27zzC5wXCeZeuJ3h9uAJzV5tGn6r5Tzo98S1ZceYKEb8",
-      "id": "bed3097008b9b5e3c93bec20be79cb43986b85a996475589351a21e67bae9b61",
       "time_difference": 60,
       "price_deviation": 0.5,
       "confidence_ratio": 100,


### PR DESCRIPTION
## What
Removes 4 stale sponsored-feed rows from `content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json`: **ORCA/USD, SAMO/USD, HNT/USD, PENGU/USD**.

## Why
These were deprovisioned from the Solana price pusher on 2026-04-30 in the deployments repo (`platform-green` #4357, `platform-yellow` #4358) but were never removed from the docs (the docs JSONs are not auto-synced to the deployments `price-config.yaml`). Verified against deployments:
- **ORCA/SAMO/HNT** — not pushed on any chain (fully retired).
- **PENGU** — now publishes on **Abstract**, where it is already correctly listed; only the stale Solana entry is removed.
- **LBTC/USD** was removed in that same commit but later re-added, so it is intentionally **kept**.

Solana table goes 47 → 43 feeds, matching the deployments source of truth.

## Verification
`test:format`, `test:lint`, `test:types`, and `build` all pass for `@pythnetwork/developer-hub`; JSON valid; the 4 ids are absent and feed count is 43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->