### PR TITLE
fix(developer-hub): refresh push-feed pro_compatible_status; drop Avalanche carve-out

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/avalanche-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/avalanche-mainnet.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Avalanche feeds are intentionally pinned to pro_compatible_status \"coming_soon\": Pro-compatible push feeds are not deployed for this chain (no deployment-pro-compatible.yaml). Do NOT auto-derive this field from the Hermes listing for this file. See the JSDoc on ProCompatibleStatus in src/components/SponsoredFeedsTable/index.tsx.",
   "feeds": [
     {
       "alias": "HLP0/USDC.RR",

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/berachain-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/berachain-mainnet.json
@@ -54,7 +54,7 @@
       "time_difference": 3600,
       "price_deviation": 1,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "HONEY/USD",

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/hyperevm-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/hyperevm-mainnet.json
@@ -54,7 +54,7 @@
       "time_difference": 3600,
       "price_deviation": 1,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USH/USD",
@@ -102,7 +102,7 @@
       "time_difference": 3600,
       "price_deviation": 1,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WSTHYPE/STHYPE.RR",

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/monad-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/monad-mainnet.json
@@ -78,7 +78,7 @@
       "time_difference": 3600,
       "price_deviation": 0.2,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "STETH/ETH.RR",
@@ -118,7 +118,7 @@
       "time_difference": 3600,
       "price_deviation": 0.2,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDE/USD",
@@ -166,7 +166,7 @@
       "time_difference": 3600,
       "price_deviation": 0.2,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "FDUSD/USD",

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json
@@ -22,7 +22,7 @@
       "time_difference": 10,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "BNB/USD",
@@ -54,7 +54,7 @@
       "time_difference": 10,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "DEEP/USD",
@@ -70,7 +70,7 @@
       "time_difference": 10,
       "price_deviation": 3,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "DOGE/USD",
@@ -102,7 +102,7 @@
       "time_difference": 10,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "HASUI/USD",
@@ -126,7 +126,7 @@
       "time_difference": 10,
       "price_deviation": 3,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "LBTC/USD",

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json
@@ -34,7 +34,7 @@
       "time_difference": 60,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "BONK/USD",
@@ -250,7 +250,7 @@
       "time_difference": 60,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "NAV.USTB/USD",
@@ -412,7 +412,7 @@
       "time_difference": 240,
       "price_deviation": 0.05,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "JUPUSD/USD",

--- a/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
+++ b/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
@@ -24,12 +24,8 @@ const PRO_COMPATIBLE_DOCS_URL = "/price-feeds/core/upgrade/preparing";
  *      GET https://pyth.dourolabs.app/hermes/v2/price_feeds
  *   2. For each feed, set "available" if its `id` is present in that listing,
  *      otherwise "coming_soon".
- *   3. Avalanche carve-out: every Avalanche feed is pinned to "coming_soon"
- *      regardless of the listing, because Pro-compatible push feeds are not
- *      deployed for that chain (no deployment-pro-compatible.yaml). See the
- *      `_comment` in data/evm/avalanche-mainnet.json.
  *
- * Last refreshed 2026-06-23. To refresh, re-run the steps above.
+ * Last refreshed 2026-07-08. To refresh, re-run the steps above.
  */
 type ProCompatibleStatus = "available" | "coming_soon";
 


### PR DESCRIPTION
Refreshes `pro_compatible_status` on all in-scope Pyth Core push-feed JSONs against a fresh fetch of the Hermes Pro-compatible listing, and removes the now-stale Avalanche carve-out so the field is uniformly data-driven.

Re-derived on 2026-07-08 after the prior 2026-07-01 snapshot went stale (an additional 12 feeds have entered the listing during the week the PR sat open on human review; 4 of those affect in-scope JSONs).

## Hermes fetch

- Endpoint: `GET https://pyth.dourolabs.app/hermes/v2/price_feeds`
- Fetched: 2026-07-08 (UTC)
- Listing size: 1309 unique ids (1311 raw entries)

## Files changed

- `apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/berachain-mainnet.json` — 1 feed flipped to `available`.
- `apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/hyperevm-mainnet.json` — 2 feeds flipped to `available`.
- `apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/monad-mainnet.json` — 3 feeds flipped to `available`.
- `apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json` — 3 feeds flipped to `available`.
- `apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json` — 5 feeds flipped to `available`.
- `apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/avalanche-mainnet.json` — removed the top-of-file `_comment` describing the carve-out. The single Avalanche feed (HLP0/USDC.RR) is still absent from the listing, so its status remains `coming_soon`, but it is now derived rather than pinned.
- `apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx` — JSDoc above `type ProCompatibleStatus`: dropped the Avalanche carve-out clause (item 3) and bumped "Last refreshed" to 2026-07-08.

All other in-scope JSONs (abstract, arbitrum, base, ethereum, linea, optimism, soneium, sonic) were re-derived from the same listing and serialized back byte-identical — no diff.

## Before/after counts

Aggregate across the 14 in-scope JSONs (236 feeds total):

| | available | coming_soon |
|---|---|---|
| Before | 145 | 91 |
| After  | 159 | 77 |

Per chain:

| chain | before avail/coming | after avail/coming |
|---|---|---|
| evm/abstract | 4/0 | 4/0 |
| evm/arbitrum | 0/1 | 0/1 |
| evm/avalanche | 0/1 | 0/1 |
| evm/base | 6/1 | 6/1 |
| evm/berachain | 6/3 | 7/2 |
| evm/ethereum | 3/1 | 3/1 |
| evm/hyperevm | 14/29 | 16/27 |
| evm/linea | 1/0 | 1/0 |
| evm/monad | 45/15 | 48/12 |
| evm/optimism | 5/0 | 5/0 |
| evm/soneium | 7/0 | 7/0 |
| evm/sonic | 7/4 | 7/4 |
| svm/solana | 30/17 | 33/14 |
| sui/sui | 17/19 | 22/14 |

## Flips

Fourteen feeds changed status against the current `main` snapshot; all flips are `coming_soon → available` (the listing has grown monotonically; no feeds have been removed):

| chain | alias | id | before | after |
|---|---|---|---|---|
| evm/berachain | SUSDE/USDE.RR | `271c64ce459937abf721d42552035713b6c58f80eeceab716a624607fda4b10f` | coming_soon | available |
| evm/hyperevm | WSTETH/STETH.RR | `f59ead01ed0faba85332a1e2feae8ddb14a1c94ebac259f1c982c92fc7ce333e` | coming_soon | available |
| evm/hyperevm | SUSDE/USDE.RR | `271c64ce459937abf721d42552035713b6c58f80eeceab716a624607fda4b10f` | coming_soon | available |
| evm/monad | WSTETH/STETH.RR | `f59ead01ed0faba85332a1e2feae8ddb14a1c94ebac259f1c982c92fc7ce333e` | coming_soon | available |
| evm/monad | SUSDE/USDE.RR | `271c64ce459937abf721d42552035713b6c58f80eeceab716a624607fda4b10f` | coming_soon | available |
| evm/monad | SUSDS/USDS.RR | `6968a8641208463d17ae3b9cfa0e4841a7aa7a5d54122b9f692b84fe9ce3409f` | coming_soon | available |
| svm/solana | SSOL/SOL | `add6499a420f809bbebc0b22fbf68acb8c119023897f6ea801688e0d6e391af4` | coming_soon | available |
| svm/solana | JUPSOL/SOL.RR | `f8d8d6b6c866c8b2624fb5b679ae846738725e5fc887fa8e927c8d8645018a2b` | coming_soon | available |
| svm/solana | PST/USDC.RR | `675e36f84a6be779ed793c71eb5c03151e1866c125767f46933626e0610af84d` | coming_soon | available |
| sui/sui | CETUS/USD | `e5b274b2611143df055d6e7cd8d93fe1961716bcd4dca1cad87a83bc1e78c1ef` | coming_soon | available |
| sui/sui | BLUE/USD | `04cfeb7b143eb9c48e9b074125c1a3447b85f59c31164dc20c1beaa6f21f2b6b` | coming_soon | available |
| sui/sui | DMC/USD | `8abfa63ae82ca2fbc271861375e497166d8792580fb7c2ffcf014d2a131433f0` | coming_soon | available |
| sui/sui | HAEDAL/USD | `e67d98cc1fbd94f569d5ba6c3c3c759eb3ffc5d2b28e64538a53ae13efad8fd1` | coming_soon | available |
| sui/sui | IKA/USD | `2b529621fa6e2c8429f623ba705572aa64175d7768365ef829df6a12c9f365f4` | coming_soon | available |

## Avalanche carve-out

Removed per the parent-issue clarification: Avalanche is now treated like every other chain. The single Avalanche feed (`HLP0/USDC.RR`, id `aa388e24e74d5dd12145f74fad3180266f78ed08c0a2f47c60583fdb612587ba`) is **not** in the current Hermes listing, so it remains `coming_soon`. The structural changes (drop the `_comment`, drop the JSDoc item 3) still matter because the field is now data-driven rather than pinned and the documentation no longer lies.

## Header link discrepancy (flagged, deliberately not changed)

`PRO_COMPATIBLE_DOCS_URL` in `SponsoredFeedsTable/index.tsx` still points to `/price-feeds/core/upgrade/preparing` (the editorial choice from [[p-xmoijznl]]). The parent issue notes a "keep the link pointing at https://pyth.dourolabs.app/docs/?urls.primaryName=Hermes+API" guardrail. Per scope, that's a flag rather than a change request — leaving the link as-is. Open a follow-up if the API-spec URL should win.

## Verification

From the repo root, ran the full developer-hub gate per `apps/developer-hub/AGENTS.md`:

```
pnpm turbo run test:format test:lint test:lint:stylelint test:types build --filter=@pythnetwork/developer-hub
```

All 42 tasks succeeded (Node 24.18.0, pnpm 10.28.0).

Idempotency: re-running the derivation against the same 2026-07-08 snapshot produces a no-op diff.

Rebase readiness: `git merge-tree origin/main HEAD` clean against current `main` (`6c1c9138e`).