### PR TITLE
docs(developer-hub): soften Coming-soon migration wording on Pro-compatible tables

### DIFF
--- a/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
+++ b/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
@@ -294,8 +294,9 @@ export const SponsoredFeedsTable = ({
           The <strong>Pro-compatible</strong> column shows whether each feed is
           already served by the upgraded Hermes endpoint for the{" "}
           <a href={PRO_COMPATIBLE_DOCS_URL}>Pyth Core upgrade</a>. Feeds marked{" "}
-          <strong>Available</strong> are already served by the upgraded Hermes;{" "}
-          <strong>Coming soon</strong> feeds are still being migrated.
+          <strong>Available</strong> are already served by the upgraded Hermes.
+          Not all <strong>Coming soon</strong> feeds will necessarily be
+          migrated; please reach out if you rely on a specific feed.
         </p>
       )}
       <div className={styles.tableWrapper}>


### PR DESCRIPTION
Reword the **Pro-compatible** explanatory paragraph on push-feed tables so users don't infer that every "Coming soon" feed is guaranteed to be migrated to the upgraded Hermes endpoint. The new wording flags that not all Coming-soon feeds will necessarily migrate and asks readers to reach out if they rely on a specific one.

Single-file diff in `apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx`, inside the `{showProCompatibleStatus && (…)}` block. Component API (props, badge variants, link target) is unchanged; no data files or MDX touched.

Context:
- Pro-compatible column introduced in [PR #3830](https://github.com/pyth-network/pyth-crosschain/pull/3830).
- Parent issue: [[i-opjibssp]]; Slack ask drove the copy change.
- Apollo's earlier direct PR [#3835](https://github.com/pyth-network/pyth-crosschain/pull/3835) was closed; this is a fresh PR off current `main`.

Validation (Node 24, pnpm 10.28.0):
- `pnpm install --frozen-lockfile` — OK
- `pnpm turbo test:lint --filter=@pythnetwork/developer-hub` — 41 tasks succeeded
- `pnpm turbo test:types --filter=@pythnetwork/developer-hub` — `tsc` clean
- `pnpm exec biome format` (stdin) — no formatter changes for the touched paragraph
- `git merge-tree origin/main HEAD` — clean (no conflicts)

Note: pre-existing `assist/source/useSortedKeys` / `useSortedAttributes` biome assist findings exist in this file on `main` and are unrelated to this change — none fall in the touched lines, and the repo's CI workflows (`ci-turbo-test.yml`) do not run biome.