### PR TITLE
docs(developer-hub): clarify "Coming soon" feeds may not all be migrated

### DIFF
--- a/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
+++ b/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
@@ -294,8 +294,10 @@ export const SponsoredFeedsTable = ({
           The <strong>Pro-compatible</strong> column shows whether each feed is
           already served by the upgraded Hermes endpoint for the{" "}
           <a href={PRO_COMPATIBLE_DOCS_URL}>Pyth Core upgrade</a>. Feeds marked{" "}
-          <strong>Available</strong> are already served by the upgraded Hermes;{" "}
-          <strong>Coming soon</strong> feeds are still being migrated.
+          <strong>Available</strong> are already served by the upgraded Hermes.
+          Not all <strong>Coming soon</strong> feeds are guaranteed to be
+          migrated. If you rely on a specific feed,{" "}
+          <a href={`${PRO_COMPATIBLE_DOCS_URL}#get-help`}>contact the team</a>.
         </p>
       )}
       <div className={styles.tableWrapper}>


### PR DESCRIPTION
## What

Rewords the one-line note under the **Pro-compatible** column on the EVM/Solana/Sui push-feed tables (shared `SponsoredFeedsTable` component).

**Before:** "Feeds marked **Available** are already served by the upgraded Hermes; **Coming soon** feeds are still being migrated."

**After:** "Feeds marked **Available** are already served by the upgraded Hermes. Not all **Coming soon** feeds are guaranteed to be migrated. If you rely on a specific feed, [contact the team](/price-feeds/core/upgrade/preparing#get-help)."

## Why

"Coming soon" previously implied every such feed would be migrated, which isn't guaranteed. The new copy sets that expectation and routes anyone depending on a specific feed to the upgrade guide's **Get help** section (Telegram + email) — the same `#get-help` / "contact the team" pattern already used in `preparing/index.mdx`.

## Verification

`test:format`, `test:types`, and `build` pass for `@pythnetwork/developer-hub`. Rendered the EVM page locally and confirmed: the new copy displays, "contact the team" links to `/price-feeds/core/upgrade/preparing#get-help`, that anchor resolves to the Get help section (Telegram + email cards), and there are no dashes in the text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3838" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->