### PR TITLE
feat(developer-hub): link change-log feeds to the Pyth Terminal

### DIFF
--- a/apps/developer-hub/src/components/ChangeLog/EventRow.tsx
+++ b/apps/developer-hub/src/components/ChangeLog/EventRow.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import type { ChangeLogEntry, ChangeType } from "./data";
-import { fmtDateShort } from "./data";
+import { fmtDateShort, terminalUrl } from "./data";
 import styles from "./index.module.scss";
 
 const CHANGE_LABELS: Record<ChangeType, string> = {
@@ -39,7 +39,14 @@ export const EventRow = ({
       {CHANGE_LABELS[entry.changeType]}
     </span>
     <div className={styles.eventInfo}>
-      <span className={styles.eventId}>{entry.id}</span>
+      <a
+        className={styles.eventId}
+        href={terminalUrl(entry.id)}
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        {entry.id}
+      </a>
       <span className={styles.eventAsset}>{entry.asset}</span>
       <span className={styles.eventAssetType}>· {entry.assetType}</span>
     </div>

--- a/apps/developer-hub/src/components/ChangeLog/data.ts
+++ b/apps/developer-hub/src/components/ChangeLog/data.ts
@@ -52,6 +52,15 @@ export type ChangeLog = {
 // constant — no fetching, loading, or error states needed at the call site.
 export const getChangeLog = (): ChangeLog => GENERATED_CHANGE_LOG;
 
+// ─── Links ───────────────────────────────────────────────────────────────
+
+// Deep-link a feed symbol into the Pyth Terminal explore view. The symbol id
+// maps directly onto the route — e.g. `Metal.Index.SILVER/USD` becomes
+// `/explore/Metal.Index.SILVER%2FUSD` — and encodeURIComponent escapes the
+// slash (and anything else) safely.
+export const terminalUrl = (id: string): string =>
+  `https://app.pyth.com/explore/${encodeURIComponent(id)}`;
+
 // ─── Display helpers ─────────────────────────────────────────────────────
 
 export const fmtDateShort = (iso: string): string => {

--- a/apps/developer-hub/src/components/ChangeLog/index.module.scss
+++ b/apps/developer-hub/src/components/ChangeLog/index.module.scss
@@ -392,7 +392,7 @@
   &::after {
     content: "↗";
     margin-inline-start: theme.spacing(1);
-    font-size: 0.75em;
+    font-size: 1em;
     color: theme.color("muted");
   }
 

--- a/apps/developer-hub/src/components/ChangeLog/index.module.scss
+++ b/apps/developer-hub/src/components/ChangeLog/index.module.scss
@@ -386,6 +386,25 @@
   font-weight: theme.font-weight("semibold");
   color: theme.color("foreground");
   white-space: nowrap;
+  text-decoration: none;
+
+  // Small external-link cue so the symbol reads as a link out to the terminal.
+  &::after {
+    content: "↗";
+    margin-inline-start: theme.spacing(1);
+    font-size: 0.75em;
+    color: theme.color("muted");
+  }
+
+  &:hover,
+  &:focus-visible {
+    color: theme.color("link", "primary");
+    text-decoration: underline;
+
+    &::after {
+      color: theme.color("link", "primary");
+    }
+  }
 }
 
 .eventAsset {


### PR DESCRIPTION
## What

Makes every feed symbol on the change-log page (`/price-feeds/changelog`) a clickable deep link into the **Pyth Terminal** explore view, so readers can jump straight from "X was added/went live/removed" to that feed.

Example: `Metal.Index.SILVER/USD` → https://app.pyth.com/explore/Metal.Index.SILVER%2FUSD

Part of **PFG-1150**.

## How

- **`ChangeLog/data.ts`** — new `terminalUrl(id)` helper: `https://app.pyth.com/explore/${encodeURIComponent(id)}`. The symbol id maps directly onto the terminal route; `encodeURIComponent` escapes the slash (`%2F`) and leaves dots/suffixes intact.
- **`ChangeLog/EventRow.tsx`** — the feed symbol is now an external `<a>` (`target="_blank" rel="noopener noreferrer"`). `EventRow` backs both the **day** and **stream** views, so all feeds on the page become clickable from one change.
- **`ChangeLog/index.module.scss`** — the symbol stays foreground at rest with a small muted `↗` external-link cue, and turns link-colored + underlined on hover/focus.

## Notes / decisions

- **All change types link**, including `removed`. A removed feed isn't a 404 — it resolves to a valid terminal page marked **INACTIVE** (no chart), so the link is still a sensible destination.
- Verified the deeplink format resolves on the live terminal across every asset type present in the data: crypto, equity, fx, metal, rates (no-slash, e.g. `InterestRate.US20Y`), crypto-index, crypto-redemption-rate (`.RR` suffix, e.g. `Crypto.MSFTX/MSFT.RR`), commodity, nav, and `Pyth.HL.`-prefixed symbols.

## Verification

Dev server, `/price-feeds/changelog`: 156 feed links rendered, all `https://app.pyth.com/explore/…` with correct encoding and `target=_blank` / `rel=noopener noreferrer`; `↗` cue present; both day and stream views covered. biome + stylelint clean; no type errors from the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->