### PR TITLE
feat(contract_manager): add gRPC support for Sui chains

### DIFF
--- a/contract_manager/src/core/chains.ts
+++ b/contract_manager/src/core/chains.ts
@@ -9,25 +9,19 @@ import { IotaClient } from "@iota/iota-sdk/client";
 import { Ed25519Keypair as IotaEd25519Keypair } from "@iota/iota-sdk/keypairs/ed25519";
 import { NANOS_PER_IOTA } from "@iota/iota-sdk/utils";
 import * as suiBytecode from "@mysten/move-bytecode-template";
-import type {
-  MoveStruct as SuiMoveStruct,
-  MoveValue as SuiMoveValue,
-  SuiTransactionBlockResponseOptions,
-} from "@mysten/sui/jsonRpc";
+import type { ClientWithCoreApi, SuiClientTypes } from "@mysten/sui/client";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
 import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import { Ed25519Keypair as SuiEd25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { Transaction as SuiTransaction } from "@mysten/sui/transactions";
-import {
-  MIST_PER_SUI,
-  SUI_CLOCK_OBJECT_ID,
-  SUI_FRAMEWORK_ADDRESS,
-} from "@mysten/sui/utils";
+import { MIST_PER_SUI, SUI_CLOCK_OBJECT_ID } from "@mysten/sui/utils";
 import {
   CosmwasmExecutor,
   CosmwasmQuerier,
   InjectiveExecutor,
 } from "@pythnetwork/cosmwasm-deploy-tools";
 import { FUEL_ETH_ASSET_ID } from "@pythnetwork/pyth-fuel-js";
+import { getStructFields } from "@pythnetwork/pyth-sui-js";
 import { PythContract } from "@pythnetwork/pyth-ton-js";
 import type { ChainName, DataSource } from "@pythnetwork/xc-admin-common";
 import {
@@ -64,7 +58,6 @@ import * as chains from "viem/chains";
 import Web3 from "web3";
 
 import { execFileAsync } from "../utils/exec-file-async";
-import { hasProperty } from "../utils/utils";
 import type { KeyValueConfig, PrivateKey, TxResult } from "./base";
 import { Storable } from "./base";
 import type { TokenId } from "./token";
@@ -318,6 +311,51 @@ export class CosmWasmChain extends Chain {
   }
 }
 
+/**
+ * Sui transport selector. `json-rpc` is the legacy default; `grpc` migrates to
+ * the transport Sui Foundation is replacing JSON-RPC with — the public
+ * JSON-RPC endpoints are turned off in July 2026 and removed entirely by
+ * mid-Oct 2026. Mirrors the price pusher's dual-protocol support.
+ */
+export type SuiEndpointType = "json-rpc" | "grpc";
+
+/**
+ * Both the `@mysten/sui` v2 JSON-RPC client (`SuiJsonRpcClient`) and the
+ * experimental gRPC client (`SuiGrpcClient`) expose the unified `.core` API.
+ * The chain reads and writes exclusively through `.core` so the same code
+ * works over either transport.
+ */
+function createSuiProvider(
+  endpointType: SuiEndpointType,
+  mainnet: boolean,
+  url: string,
+): ClientWithCoreApi {
+  const network = mainnet ? "mainnet" : "testnet";
+  switch (endpointType) {
+    case "grpc": {
+      return new SuiGrpcClient({ baseUrl: url, network });
+    }
+    case "json-rpc": {
+      return new SuiJsonRpcClient({ network, url });
+    }
+  }
+}
+
+/**
+ * Unwrap the executed (or simulated) transaction from the `.core` result union.
+ * Both transports return a `Transaction` / `FailedTransaction` tagged union
+ * rather than throwing on on-chain failure, so callers must inspect the status.
+ */
+export function getExecutedTransaction<T>(
+  result:
+    | { $kind: "Transaction"; Transaction: T }
+    | { $kind: "FailedTransaction"; FailedTransaction: T },
+): T {
+  return result.$kind === "Transaction"
+    ? result.Transaction
+    : result.FailedTransaction;
+}
+
 export class SuiChain extends Chain {
   static override type = "SuiChain";
 
@@ -327,6 +365,7 @@ export class SuiChain extends Chain {
     wormholeChainName: string,
     nativeToken: TokenId | undefined,
     public rpcUrl: string,
+    public endpointType: SuiEndpointType = "json-rpc",
   ) {
     super(id, mainnet, wormholeChainName, nativeToken);
   }
@@ -339,11 +378,13 @@ export class SuiChain extends Chain {
       parsed.wormholeChainName ?? "",
       parsed.nativeToken,
       parsed.rpcUrl ?? "",
+      (parsed.endpointType as SuiEndpointType | undefined) ?? "json-rpc",
     );
   }
 
   toJson(): KeyValueConfig {
     return {
+      endpointType: this.endpointType,
       id: this.id,
       mainnet: this.mainnet,
       rpcUrl: this.rpcUrl,
@@ -400,11 +441,8 @@ export class SuiChain extends Chain {
     ).encode();
   }
 
-  getProvider(): SuiJsonRpcClient {
-    return new SuiJsonRpcClient({
-      network: this.mainnet ? "mainnet" : "testnet",
-      url: this.rpcUrl,
-    });
+  getProvider(): ClientWithCoreApi {
+    return createSuiProvider(this.endpointType, this.mainnet, this.rpcUrl);
   }
 
   getAccountAddress(privateKey: PrivateKey): Promise<string> {
@@ -416,10 +454,10 @@ export class SuiChain extends Chain {
 
   async getAccountBalance(privateKey: PrivateKey): Promise<number> {
     const provider = this.getProvider();
-    const balance = await provider.getBalance({
+    const { balance } = await provider.core.getBalance({
       owner: await this.getAccountAddress(privateKey),
     });
-    return Number(balance.totalBalance) / Number(MIST_PER_SUI);
+    return Number(balance.balance) / Number(MIST_PER_SUI);
   }
 
   async getCliEnv(): Promise<string> {
@@ -466,25 +504,13 @@ export class SuiChain extends Chain {
     const upgrade_cap = tx.publish({ dependencies, modules });
     tx.transferObjects([upgrade_cap], signer.toSuiAddress());
 
-    const { digest, objectChanges } = await this.executeTransaction(
-      tx,
-      signer,
-      { showObjectChanges: true },
-    );
-    await this.getProvider().waitForTransaction({ digest });
+    const executed = await this.executeTransaction(tx, signer);
 
-    let packageId: string | undefined;
-    let upgradeCapId: string | undefined;
-    for (const change of objectChanges ?? []) {
-      if (change.type === "published") {
-        packageId = change.packageId;
-      } else if (
-        change.type === "created" &&
-        change.objectType === `${SUI_FRAMEWORK_ADDRESS}::package::UpgradeCap`
-      ) {
-        upgradeCapId = change.objectId;
-      }
-    }
+    const packageId = this.findPublishedPackageId(executed);
+    const upgradeCapId = this.findCreatedObjectId(
+      executed,
+      "::package::UpgradeCap",
+    );
     if (!packageId) {
       throw new Error("Could not find package ID in transaction results");
     }
@@ -569,20 +595,9 @@ export class SuiChain extends Chain {
       target: `${packageId}::actions::init_lazer`,
     });
 
-    const { objectChanges } = await this.executeTransaction(tx, signer, {
-      showObjectChanges: true,
-    });
+    const executed = await this.executeTransaction(tx, signer);
 
-    let stateId: string | undefined;
-    for (const change of objectChanges ?? []) {
-      if (
-        change.type === "created" &&
-        change.objectType === `${packageId}::state::State`
-      ) {
-        stateId = change.objectId;
-      }
-    }
-
+    const stateId = this.findCreatedObjectId(executed, "::state::State");
     if (!stateId) {
       throw new Error("Could not find State ID in transcation results");
     }
@@ -592,27 +607,11 @@ export class SuiChain extends Chain {
 
   async getUpgradeCapPackage(upgradeCapId: string) {
     const client = this.getProvider();
-    const { data, error } = await client.getObject({
-      id: upgradeCapId,
-      options: { showContent: true },
-    });
-    if (!data?.content || error) {
-      throw new Error(
-        `Failed to get UpgradeCap: ${error?.code ?? "undefined"}`,
-      );
-    }
-    if (data.content.dataType !== "moveObject") {
-      throw new Error("Supplied ID does not have a valid UpgradeCap object");
-    }
-
-    const upgradeCap = data.content;
-    if (
-      !this.hasStructField(upgradeCap, "package") ||
-      typeof upgradeCap.fields.package !== "string"
-    ) {
+    const fields = await this.getObjectFields(client, upgradeCapId);
+    if (typeof fields.package !== "string") {
       throw new TypeError("Could not find package string in UpgradeCap object");
     }
-    return upgradeCap.fields.package;
+    return fields.package;
   }
 
   /**
@@ -620,79 +619,89 @@ export class SuiChain extends Chain {
    * `{ .., upgrade_cap: UpgradeCap }` convention.
    */
   async getStatePackageInfo(
-    client: SuiJsonRpcClient,
+    client: ClientWithCoreApi,
     stateId: string,
   ): Promise<{
     package: string;
     version: string;
   }> {
-    const state = await this.getStateObject(client, stateId);
-
-    if (!this.hasStructField(state, "upgrade_cap")) {
+    const state = await this.getObjectFields(client, stateId);
+    if (state.upgrade_cap === undefined) {
       throw new Error("Missing 'upgrade_cap' in state object");
     }
-    const upgradeCap = state.fields.upgrade_cap;
-    if (
-      !this.hasStructField(upgradeCap, "package") ||
-      typeof upgradeCap.fields.package !== "string"
-    ) {
+    const upgradeCap = getStructFields(state.upgrade_cap);
+    if (typeof upgradeCap.package !== "string") {
       throw new Error("Could not find 'package' string in UpgradeCap");
     }
-    if (
-      !this.hasStructField(upgradeCap, "version") ||
-      typeof upgradeCap.fields.version !== "string"
-    ) {
+    if (typeof upgradeCap.version !== "string") {
       throw new Error("Could not find 'version' number in UpgradeCap");
     }
     return {
-      package: upgradeCap.fields.package,
-      version: upgradeCap.fields.version,
+      package: upgradeCap.package,
+      version: upgradeCap.version,
     };
   }
 
-  async getStateGovernanceInfo(client: SuiJsonRpcClient, stateId: string) {
-    const state = await this.getStateObject(client, stateId);
-
-    if (!this.hasStructField(state, "governance")) {
+  async getStateGovernanceInfo(client: ClientWithCoreApi, stateId: string) {
+    const state = await this.getObjectFields(client, stateId);
+    if (state.governance === undefined) {
       throw new Error("Missing 'governance' in state object");
     }
-    const governance = state.fields.governance;
-    if (
-      !this.hasStructField(governance, "seen_sequence") ||
-      typeof governance.fields.seen_sequence !== "string"
-    ) {
+    const governance = getStructFields(state.governance);
+    if (typeof governance.seen_sequence !== "string") {
       throw new Error("Could not find 'seen_sequence' BigInt in Governance");
     }
-    return { seen_sequence: BigInt(governance.fields.seen_sequence) };
+    return { seen_sequence: BigInt(governance.seen_sequence) };
   }
 
-  private async getStateObject(
-    client: SuiJsonRpcClient,
-    stateId: string,
-  ): Promise<SuiMoveStruct> {
-    const { data: stateObject, error } = await client.getObject({
-      id: stateId,
-      options: { showContent: true },
+  /**
+   * Reads an object's Move struct fields through the transport-agnostic `.core`
+   * API. `getStructFields` normalises the JSON shape, which differs between the
+   * JSON-RPC (`{ type, fields }`) and gRPC (flattened) transports.
+   */
+  private async getObjectFields(
+    client: ClientWithCoreApi,
+    objectId: string,
+  ): Promise<Record<string, unknown>> {
+    const { object } = await client.core.getObject({
+      include: { json: true },
+      objectId,
     });
-    if (!stateObject?.content || error) {
-      throw new Error(
-        `Failed to get state object: ${error?.code ?? "undefined"}`,
-      );
+    if (!object.json) {
+      throw new Error(`Failed to get object content for ${objectId}`);
     }
-    if (stateObject.content.dataType !== "moveObject") {
-      throw new Error(
-        `State must be an object, got: ${stateObject.content.dataType}`,
-      );
-    }
-
-    return stateObject.content;
+    return getStructFields(object.json);
   }
 
-  private hasStructField<const F extends string>(
-    value: SuiMoveValue,
-    name: F,
-  ): value is { fields: Record<F, SuiMoveValue> } {
-    return hasProperty(value, "fields") && hasProperty(value.fields, name);
+  /** The published package id from a `.core` execution's effects. */
+  private findPublishedPackageId(
+    executed: SuiClientTypes.Transaction<{
+      effects: true;
+      objectTypes: true;
+    }>,
+  ): string | undefined {
+    return executed.effects.changedObjects.find(
+      (obj) => obj.outputState === "PackageWrite",
+    )?.objectId;
+  }
+
+  /**
+   * The id of a newly-created object whose Move type ends with `typeSuffix`
+   * (e.g. `::package::UpgradeCap`). Matching the suffix rather than the full
+   * type avoids depending on how the transport normalises the package address.
+   */
+  private findCreatedObjectId(
+    executed: SuiClientTypes.Transaction<{
+      effects: true;
+      objectTypes: true;
+    }>,
+    typeSuffix: string,
+  ): string | undefined {
+    return executed.effects.changedObjects.find(
+      (obj) =>
+        obj.idOperation === "Created" &&
+        executed.objectTypes[obj.objectId]?.endsWith(typeSuffix),
+    )?.objectId;
   }
 
   /**
@@ -803,33 +812,55 @@ export class SuiChain extends Chain {
 
   /**
    * Given a transaction block and a keypair, sign and execute it.
-   * Sets the gas budget to 2x the estimated gas cost.
+   * Sets the gas budget to 2x the simulated gas cost.
    *
    * @param tx - the transaction
    * @param keypair - the keypair
-   * @param options - transaction response options
    */
   async executeTransaction(
     tx: SuiTransaction,
     keypair: SuiEd25519Keypair,
-    options?: SuiTransactionBlockResponseOptions,
-  ) {
+  ): Promise<SuiClientTypes.Transaction<{ effects: true; objectTypes: true }>> {
     const provider = this.getProvider();
 
     tx.setSender(keypair.toSuiAddress());
-    const dryRun = await provider.dryRunTransactionBlock({
-      transactionBlock: await tx.build({ client: provider }),
-    });
-    tx.setGasBudget(BigInt(dryRun.input.gasData.budget.toString()) * BigInt(2));
+    const simulation = getExecutedTransaction(
+      await provider.core.simulateTransaction({
+        include: { effects: true },
+        transaction: await tx.build({ client: provider }),
+      }),
+    );
+    if (simulation.effects.status.error) {
+      throw new Error(
+        `Transaction simulation failed: ${JSON.stringify(
+          simulation.effects.status.error,
+        )}`,
+      );
+    }
+    const { computationCost, storageCost } = simulation.effects.gasUsed;
+    tx.setGasBudget(
+      (BigInt(computationCost) + BigInt(storageCost)) * BigInt(2),
+    );
 
-    const res = await provider.signAndExecuteTransaction({
-      options,
-      signer: keypair,
-      transaction: tx,
-    });
+    const executed = getExecutedTransaction(
+      await provider.core.signAndExecuteTransaction({
+        include: { effects: true, objectTypes: true },
+        signer: keypair,
+        transaction: tx,
+      }),
+    );
+    // The `.core` API returns a `FailedTransaction` for on-chain execution
+    // failures rather than throwing, so check the status explicitly.
+    if (executed.effects.status.error) {
+      throw new Error(
+        `Transaction ${executed.digest} failed on-chain: ${JSON.stringify(
+          executed.effects.status.error,
+        )}`,
+      );
+    }
 
-    await provider.waitForTransaction({ digest: res.digest });
-    return res;
+    await provider.core.waitForTransaction({ digest: executed.digest });
+    return executed;
   }
 
   explorerUrl(type: "object" | "address" | "txblock", id: string): string {
@@ -850,6 +881,15 @@ export type SuiLazerMeta = {
   receiver_chain_id: number;
 };
 
+/**
+ * IOTA transport selector, kept symmetric with {@link SuiEndpointType} so the
+ * chain config schema is consistent across the two Move chains. The IOTA SDK
+ * (`@iota/iota-sdk`) does not yet ship a gRPC client, so only `json-rpc` is
+ * functional today; the `grpc` variant exists so configs are ready the moment
+ * IOTA's fork adds one.
+ */
+export type IotaEndpointType = "json-rpc" | "grpc";
+
 export class IotaChain extends Chain {
   static override type = "IotaChain";
 
@@ -859,6 +899,7 @@ export class IotaChain extends Chain {
     wormholeChainName: string,
     nativeToken: TokenId | undefined,
     public rpcUrl: string,
+    public endpointType: IotaEndpointType = "json-rpc",
   ) {
     super(id, mainnet, wormholeChainName, nativeToken);
   }
@@ -871,11 +912,13 @@ export class IotaChain extends Chain {
       parsed.wormholeChainName ?? "",
       parsed.nativeToken,
       parsed.rpcUrl ?? "",
+      (parsed.endpointType as IotaEndpointType | undefined) ?? "json-rpc",
     );
   }
 
   toJson(): KeyValueConfig {
     return {
+      endpointType: this.endpointType,
       id: this.id,
       mainnet: this.mainnet,
       rpcUrl: this.rpcUrl,
@@ -897,6 +940,11 @@ export class IotaChain extends Chain {
   }
 
   getProvider(): IotaClient {
+    if (this.endpointType === "grpc") {
+      throw new Error(
+        "gRPC is not supported for IOTA yet: @iota/iota-sdk does not ship a gRPC client. Use endpointType 'json-rpc'.",
+      );
+    }
     return new IotaClient({ url: this.rpcUrl });
   }
 

--- a/contract_manager/src/core/chains.ts
+++ b/contract_manager/src/core/chains.ts
@@ -356,6 +356,60 @@ export function getExecutedTransaction<T>(
     : result.FailedTransaction;
 }
 
+/**
+ * Sign and execute a transaction over the transport-agnostic `.core` API,
+ * setting the gas budget to 2x the simulated cost. Works over both the
+ * JSON-RPC and gRPC clients. Throws if the simulation or the on-chain
+ * execution fails, and waits for the transaction to be available before
+ * returning.
+ *
+ * @param provider - the Sui client (JSON-RPC or gRPC)
+ * @param tx - the transaction
+ * @param keypair - the keypair
+ */
+export async function executeSuiTransaction(
+  provider: ClientWithCoreApi,
+  tx: SuiTransaction,
+  keypair: SuiEd25519Keypair,
+): Promise<SuiClientTypes.Transaction<{ effects: true; objectTypes: true }>> {
+  tx.setSender(keypair.toSuiAddress());
+  const simulation = getExecutedTransaction(
+    await provider.core.simulateTransaction({
+      include: { effects: true },
+      transaction: await tx.build({ client: provider }),
+    }),
+  );
+  if (simulation.effects.status.error) {
+    throw new Error(
+      `Transaction simulation failed: ${JSON.stringify(
+        simulation.effects.status.error,
+      )}`,
+    );
+  }
+  const { computationCost, storageCost } = simulation.effects.gasUsed;
+  tx.setGasBudget((BigInt(computationCost) + BigInt(storageCost)) * BigInt(2));
+
+  const executed = getExecutedTransaction(
+    await provider.core.signAndExecuteTransaction({
+      include: { effects: true, objectTypes: true },
+      signer: keypair,
+      transaction: tx,
+    }),
+  );
+  // The `.core` API returns a `FailedTransaction` for on-chain execution
+  // failures rather than throwing, so check the status explicitly.
+  if (executed.effects.status.error) {
+    throw new Error(
+      `Transaction ${executed.digest} failed on-chain: ${JSON.stringify(
+        executed.effects.status.error,
+      )}`,
+    );
+  }
+
+  await provider.core.waitForTransaction({ digest: executed.digest });
+  return executed;
+}
+
 export class SuiChain extends Chain {
   static override type = "SuiChain";
 
@@ -817,50 +871,11 @@ export class SuiChain extends Chain {
    * @param tx - the transaction
    * @param keypair - the keypair
    */
-  async executeTransaction(
+  executeTransaction(
     tx: SuiTransaction,
     keypair: SuiEd25519Keypair,
   ): Promise<SuiClientTypes.Transaction<{ effects: true; objectTypes: true }>> {
-    const provider = this.getProvider();
-
-    tx.setSender(keypair.toSuiAddress());
-    const simulation = getExecutedTransaction(
-      await provider.core.simulateTransaction({
-        include: { effects: true },
-        transaction: await tx.build({ client: provider }),
-      }),
-    );
-    if (simulation.effects.status.error) {
-      throw new Error(
-        `Transaction simulation failed: ${JSON.stringify(
-          simulation.effects.status.error,
-        )}`,
-      );
-    }
-    const { computationCost, storageCost } = simulation.effects.gasUsed;
-    tx.setGasBudget(
-      (BigInt(computationCost) + BigInt(storageCost)) * BigInt(2),
-    );
-
-    const executed = getExecutedTransaction(
-      await provider.core.signAndExecuteTransaction({
-        include: { effects: true, objectTypes: true },
-        signer: keypair,
-        transaction: tx,
-      }),
-    );
-    // The `.core` API returns a `FailedTransaction` for on-chain execution
-    // failures rather than throwing, so check the status explicitly.
-    if (executed.effects.status.error) {
-      throw new Error(
-        `Transaction ${executed.digest} failed on-chain: ${JSON.stringify(
-          executed.effects.status.error,
-        )}`,
-      );
-    }
-
-    await provider.core.waitForTransaction({ digest: executed.digest });
-    return executed;
+    return executeSuiTransaction(this.getProvider(), tx, keypair);
   }
 
   explorerUrl(type: "object" | "address" | "txblock", id: string): string {

--- a/contract_manager/src/core/contracts/sui.ts
+++ b/contract_manager/src/core/contracts/sui.ts
@@ -9,10 +9,12 @@
 /* eslint-disable @typescript-eslint/no-base-to-string */
 import { parseVaa } from "@certusone/wormhole-sdk";
 import { uint8ArrayToBCS } from "@certusone/wormhole-sdk/lib/cjs/sui";
+import { bcs } from "@mysten/sui/bcs";
+import type { ClientWithCoreApi } from "@mysten/sui/client";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { Transaction } from "@mysten/sui/transactions";
 import { SUI_CLOCK_OBJECT_ID } from "@mysten/sui/utils";
-import { SuiPythClient } from "@pythnetwork/pyth-sui-js";
+import { getStructFields, SuiPythClient } from "@pythnetwork/pyth-sui-js";
 import type { DataSource } from "@pythnetwork/xc-admin-common";
 import {
   decodeGovernancePayload,
@@ -24,10 +26,45 @@ import { SubmittedWormholeMessage } from "../../node/utils/governance";
 import type { DeploymentType, PrivateKey, TxResult } from "../base";
 import { PriceFeedContract, Storable, toDeploymentType } from "../base";
 import type { Chain, SuiLazerMeta } from "../chains";
-import { SuiChain } from "../chains";
+import { getExecutedTransaction, SuiChain } from "../chains";
 import { WormholeContract } from "./wormhole";
 
 type ObjectId = string;
+
+/**
+ * Sign and execute a transaction over the transport-agnostic `.core` API,
+ * setting the gas budget to 2x the simulated cost. Works over both the
+ * JSON-RPC and gRPC clients.
+ */
+async function executeSuiTransaction(
+  provider: ClientWithCoreApi,
+  tx: Transaction,
+  keypair: Ed25519Keypair,
+) {
+  tx.setSender(keypair.toSuiAddress());
+  const simulation = getExecutedTransaction(
+    await provider.core.simulateTransaction({
+      include: { effects: true },
+      transaction: await tx.build({ client: provider }),
+    }),
+  );
+  if (simulation.effects.status.error) {
+    throw new Error(
+      `Transaction simulation failed: ${JSON.stringify(
+        simulation.effects.status.error,
+      )}`,
+    );
+  }
+  const { computationCost, storageCost } = simulation.effects.gasUsed;
+  tx.setGasBudget((BigInt(computationCost) + BigInt(storageCost)) * BigInt(2));
+  return getExecutedTransaction(
+    await provider.core.signAndExecuteTransaction({
+      include: { effects: true, events: true },
+      signer: keypair,
+      transaction: tx,
+    }),
+  );
+}
 
 export class SuiPriceFeedContract extends PriceFeedContract {
   static type = "SuiPriceFeedContract";
@@ -114,24 +151,19 @@ export class SuiPriceFeedContract extends PriceFeedContract {
     return `${this.chain.getId()}_${this.stateId}`;
   }
 
-  private async parsePrice(priceInfo: {
-    type: string;
-    fields: {
-      expo: { fields: { magnitude: string; negative: boolean } };
-      price: { fields: { magnitude: string; negative: boolean } };
-      conf: string;
-      timestamp: string;
-    };
-  }) {
-    let expo = priceInfo.fields.expo.fields.magnitude;
-    if (priceInfo.fields.expo.fields.negative) expo = "-" + expo;
-    let price = priceInfo.fields.price.fields.magnitude;
-    if (priceInfo.fields.price.fields.negative) price = "-" + price;
+  private parsePrice(priceInfo: unknown) {
+    const fields = getStructFields(priceInfo);
+    const expoFields = getStructFields(fields.expo);
+    let expo = expoFields.magnitude as string;
+    if (expoFields.negative) expo = "-" + expo;
+    const priceFields = getStructFields(fields.price);
+    let price = priceFields.magnitude as string;
+    if (priceFields.negative) price = "-" + price;
     return {
-      conf: priceInfo.fields.conf,
+      conf: fields.conf as string,
       expo,
       price,
-      publishTime: priceInfo.fields.timestamp,
+      publishTime: fields.timestamp as string,
     };
   }
 
@@ -139,32 +171,21 @@ export class SuiPriceFeedContract extends PriceFeedContract {
     const provider = this.getProvider();
     const priceInfoObjectId = await this.client.getPriceFeedObjectId(feedId);
     if (!priceInfoObjectId) return;
-    const priceInfo = await provider.getObject({
-      id: priceInfoObjectId,
-      options: { showContent: true },
+    const { object } = await provider.core.getObject({
+      include: { json: true },
+      objectId: priceInfoObjectId,
     });
-    if (!priceInfo.data?.content) {
+    if (!object.json) {
       throw new Error(
         `Price feed ID ${priceInfoObjectId} in price table but object not found!!`,
       );
     }
-    if (priceInfo.data.content.dataType !== "moveObject") {
-      throw new Error(
-        `Expected ${priceInfoObjectId} to be a moveObject (PriceInfoObject)`,
-      );
-    }
+    const priceFeed = getStructFields(
+      getStructFields(object.json.price_info).price_feed,
+    );
     return {
-      emaPrice: await this.parsePrice(
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        priceInfo.data.content.fields.price_info.fields.price_feed.fields
-          .ema_price,
-      ),
-      price: await this.parsePrice(
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        priceInfo.data.content.fields.price_info.fields.price_feed.fields.price,
-      ),
+      emaPrice: this.parsePrice(priceFeed.ema_price),
+      price: this.parsePrice(priceFeed.price),
     };
   }
 
@@ -320,93 +341,67 @@ export class SuiPriceFeedContract extends PriceFeedContract {
    * @param tx - the transaction
    * @param keypair - the keypair
    */
-  private async executeTransaction(tx: Transaction, keypair: Ed25519Keypair) {
+  private executeTransaction(tx: Transaction, keypair: Ed25519Keypair) {
     const provider = this.getProvider();
-    tx.setSender(keypair.toSuiAddress());
-    const dryRun = await provider.dryRunTransactionBlock({
-      transactionBlock: await tx.build({ client: provider }),
-    });
-    tx.setGasBudget(BigInt(dryRun.input.gasData.budget.toString()) * BigInt(2));
-    return provider.signAndExecuteTransaction({
-      options: {
-        showEffects: true,
-        showEvents: true,
-      },
-      signer: keypair,
-      transaction: tx,
-    });
+    return executeSuiTransaction(provider, tx, keypair);
   }
 
   async getValidTimePeriod() {
     const fields = await this.getStateFields();
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     return Number(fields.stale_price_threshold);
   }
 
   async getDataSources(): Promise<DataSource[]> {
     const provider = this.getProvider();
-    const result = await provider.getDynamicFieldObject({
+    const { object } = await provider.core.getDynamicObjectField({
+      include: { json: true },
       name: {
+        bcs: bcs
+          .vector(bcs.u8())
+          .serialize(Array.from(Buffer.from("data_sources", "utf8")))
+          .toBytes(),
         type: "vector<u8>",
-        value: "data_sources",
       },
       parentId: this.stateId,
     });
-    if (!result.data?.content) {
+    if (!object.json) {
       throw new Error(
         "Data Sources not found, contract may not be initialized",
       );
     }
-    if (result.data.content.dataType !== "moveObject") {
-      throw new Error("Data Sources type mismatch");
-    }
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    return result.data.content.fields.value.fields.keys.map(
-      ({
-        fields,
-      }: {
-        fields: {
-          emitter_address: { fields: { value: { fields: { data: string } } } };
-          emitter_chain: string;
-        };
-      }) => {
-        return {
-          emitterAddress: Buffer.from(
-            fields.emitter_address.fields.value.fields.data,
-          ).toString("hex"),
-          emitterChain: Number(fields.emitter_chain),
-        };
-      },
-    );
+    const keys = getStructFields(getStructFields(object.json).value)
+      .keys as unknown[];
+    return keys.map((key) => {
+      const fields = getStructFields(key);
+      const data = getStructFields(
+        getStructFields(fields.emitter_address).value,
+      ).data as number[];
+      return {
+        emitterAddress: Buffer.from(data).toString("hex"),
+        emitterChain: Number(fields.emitter_chain),
+      };
+    });
   }
 
   async getGovernanceDataSource(): Promise<DataSource> {
     const fields = await this.getStateFields();
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const governanceFields = fields.governance_data_source.fields;
-    const chainId = governanceFields.emitter_chain;
-    const emitterAddress =
-      governanceFields.emitter_address.fields.value.fields.data;
+    const governanceFields = getStructFields(fields.governance_data_source);
+    const emitterAddress = getStructFields(
+      getStructFields(governanceFields.emitter_address).value,
+    ).data as number[];
     return {
       emitterAddress: Buffer.from(emitterAddress).toString("hex"),
-      emitterChain: Number(chainId),
+      emitterChain: Number(governanceFields.emitter_chain),
     };
   }
 
   async getBaseUpdateFee() {
     const fields = await this.getStateFields();
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    return { amount: fields.base_update_fee };
+    return { amount: fields.base_update_fee as string };
   }
 
   async getLastExecutedGovernanceSequence() {
     const fields = await this.getStateFields();
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     return Number(fields.last_executed_governance_sequence);
   }
 
@@ -414,15 +409,14 @@ export class SuiPriceFeedContract extends PriceFeedContract {
     return this.chain.getProvider();
   }
 
-  private async getStateFields() {
+  private async getStateFields(): Promise<Record<string, unknown>> {
     const provider = this.getProvider();
-    const result = await provider.getObject({
-      id: this.stateId,
-      options: { showContent: true },
+    const { object } = await provider.core.getObject({
+      include: { json: true },
+      objectId: this.stateId,
     });
-    if (!result.data?.content || result.data.content.dataType !== "moveObject")
-      throw new Error("Unable to fetch pyth state object");
-    return result.data.content.fields;
+    if (!object.json) throw new Error("Unable to fetch pyth state object");
+    return getStructFields(object.json);
   }
 }
 
@@ -556,13 +550,12 @@ export class SuiWormholeContract extends WormholeContract {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async getStateFields(): Promise<any> {
     const provider = this.chain.getProvider();
-    const result = await provider.getObject({
-      id: this.stateId,
-      options: { showContent: true },
+    const { object } = await provider.core.getObject({
+      include: { json: true },
+      objectId: this.stateId,
     });
-    if (!result.data?.content || result.data.content.dataType !== "moveObject")
-      throw new Error("Unable to fetch pyth state object");
-    return result.data.content.fields;
+    if (!object.json) throw new Error("Unable to fetch pyth state object");
+    return getStructFields(object.json);
   }
 
   /**
@@ -571,21 +564,9 @@ export class SuiWormholeContract extends WormholeContract {
    * @param tx - the transaction
    * @param keypair - the keypair
    */
-  private async executeTransaction(tx: Transaction, keypair: Ed25519Keypair) {
+  private executeTransaction(tx: Transaction, keypair: Ed25519Keypair) {
     const provider = this.chain.getProvider();
-    tx.setSender(keypair.toSuiAddress());
-    const dryRun = await provider.dryRunTransactionBlock({
-      transactionBlock: await tx.build({ client: provider }),
-    });
-    tx.setGasBudget(BigInt(dryRun.input.gasData.budget.toString()) * BigInt(2));
-    return provider.signAndExecuteTransaction({
-      options: {
-        showEffects: true,
-        showEvents: true,
-      },
-      signer: keypair,
-      transaction: tx,
-    });
+    return executeSuiTransaction(provider, tx, keypair);
   }
 }
 

--- a/contract_manager/src/core/contracts/sui.ts
+++ b/contract_manager/src/core/contracts/sui.ts
@@ -30,6 +30,18 @@ import { WormholeContract } from "./wormhole";
 
 type ObjectId = string;
 
+/**
+ * A Move `vector<u8>` field rendered into the object's JSON comes back as a
+ * `number[]` over JSON-RPC but as a base64-encoded `string` over gRPC (the
+ * `.json` shape is explicitly transport-dependent per `@mysten/sui`). Normalise
+ * both representations to a `Buffer`.
+ */
+function bytesFromMoveField(data: number[] | string): Buffer {
+  return typeof data === "string"
+    ? Buffer.from(data, "base64")
+    : Buffer.from(data);
+}
+
 export class SuiPriceFeedContract extends PriceFeedContract {
   static type = "SuiPriceFeedContract";
   private client: SuiPythClient;
@@ -316,8 +328,11 @@ export class SuiPriceFeedContract extends PriceFeedContract {
 
   async getDataSources(): Promise<DataSource[]> {
     const provider = this.getProvider();
-    const { object } = await provider.core.getDynamicObjectField({
-      include: { json: true },
+    // `data_sources` is a plain dynamic field (a `Set<DataSource>` stored
+    // inline), not a dynamic *object* field, so resolve the field wrapper id
+    // and load it. `getDynamicObjectField` derives a different child id and
+    // fails ("object does not exist") on both JSON-RPC and gRPC.
+    const { dynamicField } = await provider.core.getDynamicField({
       name: {
         bcs: bcs
           .vector(bcs.u8())
@@ -326,6 +341,10 @@ export class SuiPriceFeedContract extends PriceFeedContract {
         type: "vector<u8>",
       },
       parentId: this.stateId,
+    });
+    const { object } = await provider.core.getObject({
+      include: { json: true },
+      objectId: dynamicField.fieldId,
     });
     if (!object.json) {
       throw new Error(
@@ -338,9 +357,9 @@ export class SuiPriceFeedContract extends PriceFeedContract {
       const fields = getStructFields(key);
       const data = getStructFields(
         getStructFields(fields.emitter_address).value,
-      ).data as number[];
+      ).data as number[] | string;
       return {
-        emitterAddress: Buffer.from(data).toString("hex"),
+        emitterAddress: bytesFromMoveField(data).toString("hex"),
         emitterChain: Number(fields.emitter_chain),
       };
     });
@@ -351,9 +370,9 @@ export class SuiPriceFeedContract extends PriceFeedContract {
     const governanceFields = getStructFields(fields.governance_data_source);
     const emitterAddress = getStructFields(
       getStructFields(governanceFields.emitter_address).value,
-    ).data as number[];
+    ).data as number[] | string;
     return {
-      emitterAddress: Buffer.from(emitterAddress).toString("hex"),
+      emitterAddress: bytesFromMoveField(emitterAddress).toString("hex"),
       emitterChain: Number(governanceFields.emitter_chain),
     };
   }

--- a/contract_manager/src/core/contracts/sui.ts
+++ b/contract_manager/src/core/contracts/sui.ts
@@ -10,7 +10,6 @@
 import { parseVaa } from "@certusone/wormhole-sdk";
 import { uint8ArrayToBCS } from "@certusone/wormhole-sdk/lib/cjs/sui";
 import { bcs } from "@mysten/sui/bcs";
-import type { ClientWithCoreApi } from "@mysten/sui/client";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { Transaction } from "@mysten/sui/transactions";
 import { SUI_CLOCK_OBJECT_ID } from "@mysten/sui/utils";
@@ -26,45 +25,10 @@ import { SubmittedWormholeMessage } from "../../node/utils/governance";
 import type { DeploymentType, PrivateKey, TxResult } from "../base";
 import { PriceFeedContract, Storable, toDeploymentType } from "../base";
 import type { Chain, SuiLazerMeta } from "../chains";
-import { getExecutedTransaction, SuiChain } from "../chains";
+import { SuiChain } from "../chains";
 import { WormholeContract } from "./wormhole";
 
 type ObjectId = string;
-
-/**
- * Sign and execute a transaction over the transport-agnostic `.core` API,
- * setting the gas budget to 2x the simulated cost. Works over both the
- * JSON-RPC and gRPC clients.
- */
-async function executeSuiTransaction(
-  provider: ClientWithCoreApi,
-  tx: Transaction,
-  keypair: Ed25519Keypair,
-) {
-  tx.setSender(keypair.toSuiAddress());
-  const simulation = getExecutedTransaction(
-    await provider.core.simulateTransaction({
-      include: { effects: true },
-      transaction: await tx.build({ client: provider }),
-    }),
-  );
-  if (simulation.effects.status.error) {
-    throw new Error(
-      `Transaction simulation failed: ${JSON.stringify(
-        simulation.effects.status.error,
-      )}`,
-    );
-  }
-  const { computationCost, storageCost } = simulation.effects.gasUsed;
-  tx.setGasBudget((BigInt(computationCost) + BigInt(storageCost)) * BigInt(2));
-  return getExecutedTransaction(
-    await provider.core.signAndExecuteTransaction({
-      include: { effects: true, events: true },
-      signer: keypair,
-      transaction: tx,
-    }),
-  );
-}
 
 export class SuiPriceFeedContract extends PriceFeedContract {
   static type = "SuiPriceFeedContract";
@@ -342,8 +306,7 @@ export class SuiPriceFeedContract extends PriceFeedContract {
    * @param keypair - the keypair
    */
   private executeTransaction(tx: Transaction, keypair: Ed25519Keypair) {
-    const provider = this.getProvider();
-    return executeSuiTransaction(provider, tx, keypair);
+    return this.chain.executeTransaction(tx, keypair);
   }
 
   async getValidTimePeriod() {
@@ -565,8 +528,7 @@ export class SuiWormholeContract extends WormholeContract {
    * @param keypair - the keypair
    */
   private executeTransaction(tx: Transaction, keypair: Ed25519Keypair) {
-    const provider = this.chain.getProvider();
-    return executeSuiTransaction(provider, tx, keypair);
+    return this.chain.executeTransaction(tx, keypair);
   }
 }
 

--- a/contract_manager/src/store/chains/IotaChains.json
+++ b/contract_manager/src/store/chains/IotaChains.json
@@ -1,5 +1,6 @@
 [
   {
+    "endpointType": "json-rpc",
     "id": "iota_testnet",
     "mainnet": false,
     "rpcUrl": "https://api.testnet.iota.cafe/",
@@ -7,6 +8,7 @@
     "wormholeChainName": "iota_sui_testnet"
   },
   {
+    "endpointType": "json-rpc",
     "id": "iota_mainnet",
     "mainnet": true,
     "rpcUrl": "https://api.mainnet.iota.cafe/",

--- a/contract_manager/src/store/chains/SuiChains.json
+++ b/contract_manager/src/store/chains/SuiChains.json
@@ -1,5 +1,6 @@
 [
   {
+    "endpointType": "json-rpc",
     "id": "sui_testnet",
     "mainnet": false,
     "rpcUrl": "https://fullnode.testnet.sui.io:443",
@@ -7,6 +8,7 @@
     "wormholeChainName": "sui"
   },
   {
+    "endpointType": "json-rpc",
     "id": "sui_mainnet",
     "mainnet": true,
     "rpcUrl": "https://fullnode.mainnet.sui.io:443",
@@ -14,6 +16,7 @@
     "wormholeChainName": "sui"
   },
   {
+    "endpointType": "json-rpc",
     "id": "movement_m2_devnet",
     "mainnet": false,
     "rpcUrl": "https://sui.devnet.m2.movementlabs.xyz:443",

--- a/target_chains/sui/cli/src/cli.ts
+++ b/target_chains/sui/cli/src/cli.ts
@@ -275,6 +275,7 @@ yargs
       const pythPackageOld = await contract.getPackageId(contract.stateId);
       console.log("Old package id:", pythPackageOld);
       const signedVaa = Buffer.from(argv.vaa, "hex");
+      // `upgradePyth` throws if the upgrade fails (simulation or on-chain).
       const upgradeResults = await upgradePyth(
         keypair,
         contract.chain.getProvider(),
@@ -284,12 +285,6 @@ yargs
         contract,
       );
       console.log("Tx digest", upgradeResults.digest);
-      if (
-        !upgradeResults.effects ||
-        upgradeResults.effects.status.status !== "success"
-      ) {
-        throw new Error("Upgrade failed");
-      }
 
       console.log(
         "Upgrade successful, Executing the migrate function in a separate transaction...",
@@ -298,22 +293,22 @@ yargs
       // We can not do the migration in the same transaction since the newly published package is not found
       // on chain at the beginning of the transaction.
 
-      const migrateResults = await migratePyth(
-        keypair,
-        contract.chain.getProvider(),
-        signedVaa,
-        contract,
-        pythPackageOld,
-      );
-      console.log("Tx digest", migrateResults.digest);
-      if (
-        !migrateResults.effects ||
-        migrateResults.effects.status.status !== "success"
-      ) {
+      let migrateResults;
+      try {
+        migrateResults = await migratePyth(
+          keypair,
+          contract.chain.getProvider(),
+          signedVaa,
+          contract,
+          pythPackageOld,
+        );
+      } catch (error) {
         throw new Error(
           `Migrate failed. Old package id is ${pythPackageOld}. Please do the migration manually`,
+          { cause: error },
         );
       }
+      console.log("Tx digest", migrateResults.digest);
       console.log("Migrate successful");
     },
   )

--- a/target_chains/sui/cli/src/pyth_deploy.ts
+++ b/target_chains/sui/cli/src/pyth_deploy.ts
@@ -3,19 +3,16 @@
 
 import { execSync } from "node:child_process";
 import { bcs } from "@mysten/sui/bcs";
-import type { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
+import type { ClientWithCoreApi } from "@mysten/sui/client";
 import type { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { Transaction } from "@mysten/sui/transactions";
-import {
-  fromBase64,
-  MIST_PER_SUI,
-  normalizeSuiObjectId,
-} from "@mysten/sui/utils";
+import { fromBase64, normalizeSuiObjectId } from "@mysten/sui/utils";
+import { executeSuiTransaction } from "@pythnetwork/contract-manager/core/chains";
 import type { DataSource } from "@pythnetwork/xc-admin-common/governance_payload/SetDataSources";
 
 export async function publishPackage(
   keypair: Ed25519Keypair,
-  provider: SuiJsonRpcClient,
+  provider: ClientWithCoreApi,
   packagePath: string,
 ): Promise<{ packageId: string; upgradeCapId: string; deployerCapId: string }> {
   // Build contracts
@@ -36,8 +33,6 @@ export async function publishPackage(
   // Publish contracts
   const txb = new Transaction();
 
-  txb.setGasBudget(MIST_PER_SUI / 2n); // 0.5 SUI
-
   const [upgradeCap] = txb.publish({
     dependencies: buildOutput.dependencies.map((d: string) =>
       normalizeSuiObjectId(d),
@@ -48,44 +43,31 @@ export async function publishPackage(
   // Transfer upgrade capability to deployer
   txb.transferObjects([upgradeCap!], txb.pure.address(keypair.toSuiAddress()));
 
-  // Execute transactions
-  const result = await provider.signAndExecuteTransaction({
-    options: {
-      showInput: true,
-      showObjectChanges: true,
-    },
-    signer: keypair,
-    transaction: txb,
-  });
+  // Execute transaction over the transport-agnostic `.core` API.
+  const executed = await executeSuiTransaction(provider, txb, keypair);
 
-  const publishedChanges = result.objectChanges?.filter(
-    (change) => change.type === "published",
-  );
-
-  if (
-    publishedChanges?.length !== 1 ||
-    publishedChanges[0]?.type !== "published"
-  ) {
-    throw new Error(
-      "No publish event found in transaction:" +
-        JSON.stringify(result.objectChanges, null, 2),
-    );
+  const packageId = executed.effects.changedObjects.find(
+    (change) => change.outputState === "PackageWrite",
+  )?.objectId;
+  if (!packageId) {
+    throw new Error("No published package found in transaction effects");
   }
 
-  const packageId = publishedChanges[0].packageId;
-
   console.log("Published with package id: ", packageId);
-  console.log("Tx digest", result.digest);
+  console.log("Tx digest", executed.digest);
+  // Match object types by suffix: the package address in the type string is
+  // normalised differently across transports, but the module/struct suffix is
+  // stable.
   let upgradeCapId: string | undefined;
   let deployerCapId: string | undefined;
-  for (const objectChange of result.objectChanges!) {
-    if (objectChange.type === "created") {
-      if (objectChange.objectType === "0x2::package::UpgradeCap") {
-        upgradeCapId = objectChange.objectId;
-      }
-      if (objectChange.objectType === `${packageId}::setup::DeployerCap`) {
-        deployerCapId = objectChange.objectId;
-      }
+  for (const change of executed.effects.changedObjects) {
+    if (change.idOperation !== "Created") continue;
+    const objectType = executed.objectTypes[change.objectId];
+    if (objectType?.endsWith("::package::UpgradeCap")) {
+      upgradeCapId = change.objectId;
+    }
+    if (objectType?.endsWith("::setup::DeployerCap")) {
+      deployerCapId = change.objectId;
     }
   }
   if (!upgradeCapId || !deployerCapId) {
@@ -102,7 +84,7 @@ export async function publishPackage(
 
 export async function initPyth(
   keypair: Ed25519Keypair,
-  provider: SuiJsonRpcClient,
+  provider: ClientWithCoreApi,
   pythPackageId: string,
   deployerCapId: string,
   upgradeCapId: string,
@@ -156,33 +138,19 @@ export async function initPyth(
     target: `${pythPackageId}::pyth::init_pyth`,
   });
 
-  tx.setGasBudget(MIST_PER_SUI / 10n); // 0.1 sui
+  // `executeSuiTransaction` throws on simulation / on-chain failure, so a
+  // successful return means the init succeeded.
+  const executed = await executeSuiTransaction(provider, tx, keypair);
+  console.log("Pyth init successful");
+  console.log("Tx digest", executed.digest);
 
-  const result = await provider.signAndExecuteTransaction({
-    options: {
-      showBalanceChanges: true,
-      showEffects: true,
-      showEvents: true,
-      showInput: true,
-      showObjectChanges: true,
-    },
-    signer: keypair,
-    transaction: tx,
-  });
-  if (!result.effects || !result.objectChanges) {
-    throw new Error("No effects or object changes found in transaction");
+  const stateId = executed.effects.changedObjects.find(
+    (change) =>
+      change.idOperation === "Created" &&
+      executed.objectTypes[change.objectId]?.endsWith("::state::State"),
+  )?.objectId;
+  if (stateId) {
+    console.log("Pyth state id: ", stateId);
   }
-  if (result.effects.status.status === "success") {
-    console.log("Pyth init successful");
-    console.log("Tx digest", result.digest);
-  }
-  for (const objectChange of result.objectChanges) {
-    if (
-      objectChange.type === "created" &&
-      objectChange.objectType === `${pythPackageId}::state::State`
-    ) {
-      console.log("Pyth state id: ", objectChange.objectId);
-    }
-  }
-  return result;
+  return executed;
 }

--- a/target_chains/sui/cli/src/upgrade_pyth.ts
+++ b/target_chains/sui/cli/src/upgrade_pyth.ts
@@ -2,14 +2,11 @@
 /* biome-ignore-all lint/style/noNonNullAssertion: pre-existing */
 
 import { execSync } from "node:child_process";
-import type { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
+import type { ClientWithCoreApi } from "@mysten/sui/client";
 import type { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { Transaction } from "@mysten/sui/transactions";
-import {
-  fromBase64,
-  MIST_PER_SUI,
-  normalizeSuiObjectId,
-} from "@mysten/sui/utils";
+import { fromBase64, normalizeSuiObjectId } from "@mysten/sui/utils";
+import { executeSuiTransaction } from "@pythnetwork/contract-manager/core/chains";
 import type { SuiPriceFeedContract } from "@pythnetwork/contract-manager/core/contracts/sui";
 
 export function buildForBytecodeAndDigest(packagePath: string) {
@@ -34,7 +31,7 @@ export function buildForBytecodeAndDigest(packagePath: string) {
 
 export async function upgradePyth(
   keypair: Ed25519Keypair,
-  provider: SuiJsonRpcClient,
+  provider: ClientWithCoreApi,
   modules: number[][],
   dependencies: string[],
   signedVaa: Buffer,
@@ -70,21 +67,12 @@ export async function upgradePyth(
     target: `${pythPackage}::contract_upgrade::commit_upgrade`,
   });
 
-  tx.setGasBudget(MIST_PER_SUI / 4n); // 0.25 SUI
-
-  return provider.signAndExecuteTransaction({
-    options: {
-      showEffects: true,
-      showEvents: true,
-    },
-    signer: keypair,
-    transaction: tx,
-  });
+  return executeSuiTransaction(provider, tx, keypair);
 }
 
 export async function migratePyth(
   keypair: Ed25519Keypair,
-  provider: SuiJsonRpcClient,
+  provider: ClientWithCoreApi,
   signedUpgradeVaa: Buffer,
   contract: SuiPriceFeedContract,
   pythPackageOld: string,
@@ -104,14 +92,5 @@ export async function migratePyth(
     target: `${pythPackage}::migrate::migrate`,
   });
 
-  tx.setGasBudget(MIST_PER_SUI / 10n); //0.1 SUI
-
-  return provider.signAndExecuteTransaction({
-    options: {
-      showEffects: true,
-      showEvents: true,
-    },
-    signer: keypair,
-    transaction: tx,
-  });
+  return executeSuiTransaction(provider, tx, keypair);
 }


### PR DESCRIPTION
## What

Adds gRPC support to `contract_manager`'s Sui chain/contract code, alongside the existing JSON-RPC client — the same dual-protocol pattern as the price pusher ([[i-vumtfomk]]). Sui Foundation turns off public JSON-RPC endpoints in July 2026 (removed entirely by mid-Oct 2026), so ops tooling needs a gRPC path.

Resolves [[i-mjqwrtbw]] (child of audit [[i-vurepyya]]).

## Changes

- **`contract_manager/src/core/chains.ts`**
  - `SuiChain` and `IotaChain` gain an `endpointType` field (`json-rpc` | `grpc`), parsed from / serialised to the chain config (defaults to `json-rpc`).
  - `SuiChain.getProvider()` now constructs a `SuiGrpcClient` or `SuiJsonRpcClient` via a `createSuiProvider` factory and returns the unified `ClientWithCoreApi`. All reads/writes go through the transport-agnostic `.core` API (`getBalance`, `getObject`, `simulateTransaction`, `signAndExecuteTransaction`, `waitForTransaction`).
  - Governance/state struct parsing now uses `getStructFields` from `@pythnetwork/pyth-sui-js`, which normalises the JSON shape (it differs between JSON-RPC `{ type, fields }` and gRPC flattened). Removed the now-dead `hasStructField`/`getStateObject` helpers.
  - `publishPackage`/`initLazerContract` derive package/UpgradeCap/State ids from `.core` effects (`changedObjects` + `objectTypes`) instead of JSON-RPC `objectChanges`. Object-type matching uses a type **suffix** to stay robust to address normalisation across transports.
  - A single exported `executeSuiTransaction(provider, tx, keypair)` helper holds the full sign-and-execute path (simulate, 2× gas budget, sign+execute, on-chain error check, `waitForTransaction`). `SuiChain.executeTransaction` and the Sui contract classes all route through it.
- **`contract_manager/src/core/contracts/sui.ts`**
  - `SuiPriceFeedContract` / `SuiWormholeContract` migrated to `.core` (price-feed reads, data-source dynamic field via BCS-encoded name, governance/state reads). They delegate transaction execution to `this.chain.executeTransaction`, so the simulate / 2× gas / error-check / wait logic is shared with `SuiChain` and cannot drift.
- **`target_chains/sui/cli/` (downstream consumer)**
  - `pyth-sui-cli`'s deploy/upgrade helpers (`publishPackage`, `initPyth` in `pyth_deploy.ts`; `upgradePyth`, `migratePyth` in `upgrade_pyth.ts`) consumed `SuiChain.getProvider()`, whose return type changed from `SuiJsonRpcClient` to `ClientWithCoreApi`. That broke the `build` CI check (the `--filter=@pythnetwork/contract-manager` build never compiled this consumer, so it slipped through local verification). Migrated all four helpers onto the same `.core` API via the exported `executeSuiTransaction` helper: ids are now read from `.core` effects (`changedObjects` + `objectTypes`, suffix-matched) and on-chain failure throws (matching contract-manager). The redundant post-execution `effects.status.status` checks in `cli.ts` were removed (the helper now throws); the migrate command preserves its operator-facing "do the migration manually" guidance via a `try/catch`.
- **Store JSON** (`SuiChains.json`, `IotaChains.json`): added `endpointType: "json-rpc"` to every entry.

## Decisions / scope notes

- **IOTA has no gRPC client.** `@iota/iota-sdk` (v1.14.0, range `^1.11.0`) ships only the legacy JSON-RPC `IotaClient` — no `./grpc` export, no `.core` API. So `IotaChain` keeps using `IotaClient` for `json-rpc` and `getProvider()` throws a clear error on `grpc`. The field is added for config-schema symmetry and future readiness; re-check the IOTA SDK before promising IOTA gRPC.
- **No dependency bump needed.** The existing `@mysten/sui: ^2.7.0` range already resolves to a gRPC-shipping 2.x (the price pusher imports `@mysten/sui/grpc` on the same pin).
- **gRPC sibling chain entries deferred.** Per the issue, dropping the hardcoded `fullnode.*.sui.io` URLs / adding gRPC siblings is gated on validated gRPC endpoint URLs from the provider-validation issue, which aren't available yet. Flipping a chain to gRPC is now a one-field config change (`endpointType: "grpc"` + gRPC `rpcUrl`).
- JSON-RPC code paths are unchanged in behavior. One intentional improvement: `executeTransaction` now throws on on-chain execution failure (the `.core` API returns a `FailedTransaction` rather than throwing), matching the price pusher.

## Validation

- `pnpm tsc --project tsconfig.build.json --noEmit`: clean.
- `turbo run build --filter=pyth-sui-cli`: 34/34 successful (this is the build that the CI `build` check failed on; it now passes, exercising both `contract-manager` and the migrated CLI consumer).
- biome: changed files formatted; no new lint violations introduced (the remaining `cli.ts` `noConsole`/`useNodejsImportProtocol`/`useAwait` diagnostics are pre-existing — identical count before and after this change).
- `git merge-tree origin/main HEAD`: clean.
- End-to-end gRPC validation on a live Sui mainnet endpoint is a manual ops step pending a validated gRPC URL.