### PR TITLE
chore: remove ali-behjati from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,8 +18,8 @@ turbo.json @pyth-network/web-team
 .github/workflows/ci-turbo-build.yml @pyth-network/web-team
 .github/workflows/ci-turbo-test.yml @pyth-network/web-team
 
-/lazer/contracts/aptos @Riateche @ali-behjati
-/lazer/contracts/evm @Riateche @ali-behjati
+/lazer/contracts/aptos @Riateche
+/lazer/contracts/evm @Riateche
 
 flake.lock @cprussin
 *.nix @cprussin


### PR DESCRIPTION
Removes @ali-behjati from CODEOWNERS for the lazer aptos and evm contract directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->