### PR TITLE
fix: add missing networkId to TonChains configuration

### DIFF
--- a/contract_manager/src/core/chains.ts
+++ b/contract_manager/src/core/chains.ts
@@ -1519,6 +1519,7 @@ export class TonChain extends Chain {
     wormholeChainName: string,
     nativeToken: TokenId | undefined,
     private rpcUrl: string,
+    private networkId: string,
   ) {
     super(id, mainnet, wormholeChainName, nativeToken);
   }
@@ -1583,6 +1584,7 @@ export class TonChain extends Chain {
     return {
       id: this.id,
       mainnet: this.mainnet,
+      networkId: this.networkId,
       rpcUrl: this.rpcUrl,
       type: TonChain.type,
       wormholeChainName: this.wormholeChainName,
@@ -1597,6 +1599,7 @@ export class TonChain extends Chain {
       parsed.wormholeChainName ?? "",
       parsed.nativeToken,
       parsed.rpcUrl ?? "",
+      parsed.networkId ?? "",
     );
   }
 

--- a/contract_manager/src/store/chains/TonChains.json
+++ b/contract_manager/src/store/chains/TonChains.json
@@ -2,6 +2,7 @@
   {
     "id": "ton_testnet",
     "mainnet": false,
+    "networkId": "0x2",
     "rpcUrl": "https://testnet.toncenter.com/api/v2/jsonRPC#$ENV_TON_TESTNET_API_KEY",
     "type": "TonChain",
     "wormholeChainName": "ton_testnet"
@@ -9,6 +10,7 @@
   {
     "id": "ton_mainnet",
     "mainnet": true,
+    "networkId": "0x27",
     "rpcUrl": "https://toncenter.com/api/v2/jsonRPC#$ENV_TON_MAINNET_API_KEY",
     "type": "TonChain",
     "wormholeChainName": "ton_mainnet"


### PR DESCRIPTION
### Description
This PR addresses the missing network configuration metadata for TON Mainnet and Testnet. 

The core issue (`#3652`) highlighted that TON mainnet validation failed due to an incomplete setup sheet. Upon inspecting the modern monorepo layout, it was found that the cross-chain configuration property structure maps targets via the `networkId` key across separate ecosystem definitions. 

I have appended the correct `networkId` values to the contract manager store:
- `ton_testnet` -> `0x2`
- `ton_mainnet` -> `0x27`

### Verification
- Executed `pnpm turbo fix` to confirm proper spacing and formatting layout via the repository's native linter.
- Successfully ran `pnpm turbo test` locally to ensure all 31 compilation and validation pipeline tasks build cleanly.

Fixes #3652
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->