### PR TITLE
docs(ethereum): clarify on-chain validation of price update payloads

### DIFF
--- a/target_chains/ethereum/contracts/README.md
+++ b/target_chains/ethereum/contracts/README.md
@@ -130,3 +130,45 @@ optimization with it. For more information, please refer to [Gas Snapshots docum
 Once you optimized the code, please share the snapshot difference (generated using `forge snapshot --diff <old-snapshot>`) in the PR too.
 This snapshot gas value also includes an initial transaction cost as well as reading from the contract storage itself. You can get the
 most accurate result by looking at the gas report or the gas shown in the call trace with `-vvvv` argument to `forge test`.
+
+## Important Integration Notes
+
+### On-Chain Payload Validation
+> [!WARNING]
+> Price update payloads (such as those retrieved from Hermes) undergo validation **strictly on-chain** at execution time.
+>
+> The client-side SDKs pass payload bytes transparently and do not perform pre-validation on:
+> - Wormhole VAA cryptographic integrity or structure
+> - Data source / emitter identity correctness
+>
+> If an invalid or malformed payload is passed to `updatePriceFeeds` (or equivalent methods), the client SDK will not throw an error. Instead, the transaction will proceed to the blockchain and revert on-chain with native contract errors like `InvalidWormholeVaa()` or `InvalidUpdateDataSource()`.
+
+## Important Integration Notes
+
+### On-Chain Payload Validation
+
+> [!WARNING]
+> Price update payloads (for example, those retrieved from Hermes) are **authoritatively validated on-chain** during transaction execution.
+>
+> Applications and SDKs forward the provided payload bytes and do not perform full validation of:
+> - Wormhole VAA integrity or structure
+> - Data source / emitter identity
+>
+> If an invalid or malformed payload is supplied to `updatePriceFeeds` (or equivalent methods), the application or SDK will not reject it before submission. Instead, the transaction will revert on-chain with native contract errors such as `InvalidWormholeVaa()` or `InvalidUpdateDataSource()`.
+>
+> To minimize failed transactions, obtain payloads from trusted providers (such as Hermes) and consider simulating transactions before broadcasting.
+
+## Important Integration Notes
+
+### On-Chain Payload Validation
+
+> [!WARNING]
+> Price update payloads (for example, those retrieved from Hermes) are **authoritatively validated on-chain** during transaction execution.
+>
+> Applications and SDKs forward the provided payload bytes and do not perform full validation of:
+> - Wormhole VAA integrity or structure
+> - Data source / emitter identity
+>
+> If an invalid or malformed payload is supplied to `updatePriceFeeds` (or equivalent methods), the application or SDK will not reject it before submission. Instead, the transaction will revert on-chain with native contract errors such as `InvalidWormholeVaa()` or `InvalidUpdateDataSource()`.
+>
+> To minimize failed transactions, obtain payloads from trusted providers (such as Hermes) and consider simulating transactions before broadcasting.

--- a/target_chains/ethereum/contracts/README.md
+++ b/target_chains/ethereum/contracts/README.md
@@ -134,33 +134,6 @@ most accurate result by looking at the gas report or the gas shown in the call t
 ## Important Integration Notes
 
 ### On-Chain Payload Validation
-> [!WARNING]
-> Price update payloads (such as those retrieved from Hermes) undergo validation **strictly on-chain** at execution time.
->
-> The client-side SDKs pass payload bytes transparently and do not perform pre-validation on:
-> - Wormhole VAA cryptographic integrity or structure
-> - Data source / emitter identity correctness
->
-> If an invalid or malformed payload is passed to `updatePriceFeeds` (or equivalent methods), the client SDK will not throw an error. Instead, the transaction will proceed to the blockchain and revert on-chain with native contract errors like `InvalidWormholeVaa()` or `InvalidUpdateDataSource()`.
-
-## Important Integration Notes
-
-### On-Chain Payload Validation
-
-> [!WARNING]
-> Price update payloads (for example, those retrieved from Hermes) are **authoritatively validated on-chain** during transaction execution.
->
-> Applications and SDKs forward the provided payload bytes and do not perform full validation of:
-> - Wormhole VAA integrity or structure
-> - Data source / emitter identity
->
-> If an invalid or malformed payload is supplied to `updatePriceFeeds` (or equivalent methods), the application or SDK will not reject it before submission. Instead, the transaction will revert on-chain with native contract errors such as `InvalidWormholeVaa()` or `InvalidUpdateDataSource()`.
->
-> To minimize failed transactions, obtain payloads from trusted providers (such as Hermes) and consider simulating transactions before broadcasting.
-
-## Important Integration Notes
-
-### On-Chain Payload Validation
 
 > [!WARNING]
 > Price update payloads (for example, those retrieved from Hermes) are **authoritatively validated on-chain** during transaction execution.

--- a/target_chains/ethereum/sdk/js/README.md
+++ b/target_chains/ethereum/sdk/js/README.md
@@ -79,18 +79,6 @@ if (pythUpdate) {
 ## Important Integration Notes
 
 ### On-Chain Payload Validation
-> [!WARNING]
-> Price update payloads (such as those retrieved from Hermes) undergo validation **strictly on-chain** at execution time.
->
-> The client-side SDKs pass payload bytes transparently and do not perform pre-validation on:
-> - Wormhole VAA cryptographic integrity or structure
-> - Data source / emitter identity correctness
->
-> If an invalid or malformed payload is passed to `updatePriceFeeds` (or equivalent methods), the client SDK will not throw an error. Instead, the transaction will proceed to the blockchain and revert on-chain with native contract errors like `InvalidWormholeVaa()` or `InvalidUpdateDataSource()`.
-
-## Important Integration Notes
-
-### On-Chain Payload Validation
 
 > [!WARNING]
 > Price update payloads (for example, those retrieved from Hermes) are **authoritatively validated on-chain** during transaction execution.

--- a/target_chains/ethereum/sdk/js/README.md
+++ b/target_chains/ethereum/sdk/js/README.md
@@ -75,3 +75,30 @@ if (pythUpdate) {
     console.log("No Pyth data needed for this transaction");
 }
 ```
+
+## Important Integration Notes
+
+### On-Chain Payload Validation
+> [!WARNING]
+> Price update payloads (such as those retrieved from Hermes) undergo validation **strictly on-chain** at execution time.
+>
+> The client-side SDKs pass payload bytes transparently and do not perform pre-validation on:
+> - Wormhole VAA cryptographic integrity or structure
+> - Data source / emitter identity correctness
+>
+> If an invalid or malformed payload is passed to `updatePriceFeeds` (or equivalent methods), the client SDK will not throw an error. Instead, the transaction will proceed to the blockchain and revert on-chain with native contract errors like `InvalidWormholeVaa()` or `InvalidUpdateDataSource()`.
+
+## Important Integration Notes
+
+### On-Chain Payload Validation
+
+> [!WARNING]
+> Price update payloads (for example, those retrieved from Hermes) are **authoritatively validated on-chain** during transaction execution.
+>
+> Client SDKs forward the provided payload bytes and do not perform full validation of:
+> - Wormhole VAA integrity or structure
+> - Data source / emitter identity
+>
+> If an invalid or malformed payload is supplied to `updatePriceFeeds` (or equivalent methods), the SDK will not reject it before submission. Instead, the transaction will revert on-chain with native contract errors such as `InvalidWormholeVaa()` or `InvalidUpdateDataSource()`.
+>
+> To minimize failed transactions, obtain payloads from trusted providers (such as Hermes) and consider simulating transactions before broadcasting.

--- a/target_chains/ethereum/sdk/solidity/README.md
+++ b/target_chains/ethereum/sdk/solidity/README.md
@@ -104,33 +104,6 @@ We use [Semantic Versioning](https://semver.org/) for our releases. In order to 
 ## Important Integration Notes
 
 ### On-Chain Payload Validation
-> [!WARNING]
-> Price update payloads (such as those retrieved from Hermes) undergo validation **strictly on-chain** at execution time.
->
-> The client-side SDKs pass payload bytes transparently and do not perform pre-validation on:
-> - Wormhole VAA cryptographic integrity or structure
-> - Data source / emitter identity correctness
->
-> If an invalid or malformed payload is passed to `updatePriceFeeds` (or equivalent methods), the client SDK will not throw an error. Instead, the transaction will proceed to the blockchain and revert on-chain with native contract errors like `InvalidWormholeVaa()` or `InvalidUpdateDataSource()`.
-
-## Important Integration Notes
-
-### On-Chain Payload Validation
-
-> [!WARNING]
-> Price update payloads (for example, those retrieved from Hermes) are **authoritatively validated on-chain** during transaction execution.
->
-> Client SDKs forward the provided payload bytes and do not perform full validation of:
-> - Wormhole VAA integrity or structure
-> - Data source / emitter identity
->
-> If an invalid or malformed payload is supplied to `updatePriceFeeds` (or equivalent methods), the SDK will not reject it before submission. Instead, the transaction will revert on-chain with native contract errors such as `InvalidWormholeVaa()` or `InvalidUpdateDataSource()`.
->
-> To minimize failed transactions, obtain payloads from trusted providers (such as Hermes) and consider simulating transactions before broadcasting.
-
-## Important Integration Notes
-
-### On-Chain Payload Validation
 
 > [!WARNING]
 > Price update payloads (for example, those retrieved from Hermes) are **authoritatively validated on-chain** during transaction execution.

--- a/target_chains/ethereum/sdk/solidity/README.md
+++ b/target_chains/ethereum/sdk/solidity/README.md
@@ -100,3 +100,45 @@ We use [Semantic Versioning](https://semver.org/) for our releases. In order to 
 
 1. Run `npm version <new version number> --no-git-tag-version`. This command will update the version of the package. Then push your changes to github.
 2. Once your change is merged into `main`, create a release with tag `v<new version number>` like `v1.5.2`, and a github action will automatically publish the new version of this package to npm.
+
+## Important Integration Notes
+
+### On-Chain Payload Validation
+> [!WARNING]
+> Price update payloads (such as those retrieved from Hermes) undergo validation **strictly on-chain** at execution time.
+>
+> The client-side SDKs pass payload bytes transparently and do not perform pre-validation on:
+> - Wormhole VAA cryptographic integrity or structure
+> - Data source / emitter identity correctness
+>
+> If an invalid or malformed payload is passed to `updatePriceFeeds` (or equivalent methods), the client SDK will not throw an error. Instead, the transaction will proceed to the blockchain and revert on-chain with native contract errors like `InvalidWormholeVaa()` or `InvalidUpdateDataSource()`.
+
+## Important Integration Notes
+
+### On-Chain Payload Validation
+
+> [!WARNING]
+> Price update payloads (for example, those retrieved from Hermes) are **authoritatively validated on-chain** during transaction execution.
+>
+> Client SDKs forward the provided payload bytes and do not perform full validation of:
+> - Wormhole VAA integrity or structure
+> - Data source / emitter identity
+>
+> If an invalid or malformed payload is supplied to `updatePriceFeeds` (or equivalent methods), the SDK will not reject it before submission. Instead, the transaction will revert on-chain with native contract errors such as `InvalidWormholeVaa()` or `InvalidUpdateDataSource()`.
+>
+> To minimize failed transactions, obtain payloads from trusted providers (such as Hermes) and consider simulating transactions before broadcasting.
+
+## Important Integration Notes
+
+### On-Chain Payload Validation
+
+> [!WARNING]
+> Price update payloads (for example, those retrieved from Hermes) are **authoritatively validated on-chain** during transaction execution.
+>
+> Client SDKs forward the provided payload bytes and do not perform full validation of:
+> - Wormhole VAA integrity or structure
+> - Data source / emitter identity
+>
+> If an invalid or malformed payload is supplied to `updatePriceFeeds` (or equivalent methods), the SDK will not reject it before submission. Instead, the transaction will revert on-chain with native contract errors such as `InvalidWormholeVaa()` or `InvalidUpdateDataSource()`.
+>
+> To minimize failed transactions, obtain payloads from trusted providers (such as Hermes) and consider simulating transactions before broadcasting.


### PR DESCRIPTION
## Summary

Fixes #3653 by clarifying how price update payloads are validated during Ethereum integrations.

### Changes

* Add warning notes to the Ethereum contracts, JavaScript SDK, and Solidity SDK READMEs.
* Clarify that payload integrity and source validation occur on-chain during transaction execution.
* Document that malformed payloads may revert with `InvalidWormholeVaa()` or `InvalidUpdateDataSource()`.
* Recommend obtaining payloads from trusted providers (such as Hermes) and simulating transactions before broadcasting.

Fixes #3653

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->