### PR TITLE
fix(contract-manager): support networkId serialization in TonChain config

### DIFF
--- a/contract_manager/src/core/chains.ts
+++ b/contract_manager/src/core/chains.ts
@@ -1519,6 +1519,7 @@ export class TonChain extends Chain {
     wormholeChainName: string,
     nativeToken: TokenId | undefined,
     private rpcUrl: string,
+    private networkId: string,
   ) {
     super(id, mainnet, wormholeChainName, nativeToken);
   }
@@ -1583,6 +1584,7 @@ export class TonChain extends Chain {
     return {
       id: this.id,
       mainnet: this.mainnet,
+      networkId: this.networkId,
       rpcUrl: this.rpcUrl,
       type: TonChain.type,
       wormholeChainName: this.wormholeChainName,
@@ -1597,6 +1599,7 @@ export class TonChain extends Chain {
       parsed.wormholeChainName ?? "",
       parsed.nativeToken,
       parsed.rpcUrl ?? "",
+      parsed.networkId ?? "",
     );
   }
 

--- a/contract_manager/src/store/chains/TonChains.json
+++ b/contract_manager/src/store/chains/TonChains.json
@@ -2,6 +2,7 @@
   {
     "id": "ton_testnet",
     "mainnet": false,
+    "networkId": "0x2",
     "rpcUrl": "https://testnet.toncenter.com/api/v2/jsonRPC#$ENV_TON_TESTNET_API_KEY",
     "type": "TonChain",
     "wormholeChainName": "ton_testnet"
@@ -9,6 +10,7 @@
   {
     "id": "ton_mainnet",
     "mainnet": true,
+    "networkId": "0x27",
     "rpcUrl": "https://toncenter.com/api/v2/jsonRPC#$ENV_TON_MAINNET_API_KEY",
     "type": "TonChain",
     "wormholeChainName": "ton_mainnet"


### PR DESCRIPTION
## Summary

Fixes #3652 by adding missing `networkId` values for TON chain configurations and ensuring they are preserved during serialization.

### Changes

* Add `networkId` values to `contract_manager/src/store/chains/TonChains.json`:

  * `0x2` for TON Testnet
  * `0x27` for TON Mainnet
* Update `TonChain` serialization to preserve `networkId` through:

  * the constructor,
  * `fromJson()`,
  * `toJson()`.

### Verification

* Ran `npx turbo run build`.
* All workspaces compiled successfully.

Fixes #3652

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3853" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->