### PR TITLE
fix(developer-hub): hide page actions toolbar on changelog page

### DIFF
--- a/apps/developer-hub/src/components/Pages/BasePage/index.tsx
+++ b/apps/developer-hub/src/components/Pages/BasePage/index.tsx
@@ -20,8 +20,9 @@ export async function BasePage(props: { params: { slug: string[] } }) {
   const title = page.data.title;
   const url = page.url;
 
-  // Hide PageActions for api-reference pages
+  // Hide PageActions for api-reference and changelog pages
   const isApiReference = url.startsWith("/api-reference");
+  const isChangelog = url === "/price-feeds/changelog";
 
   return (
     <DocsPage
@@ -31,7 +32,7 @@ export async function BasePage(props: { params: { slug: string[] } }) {
     >
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
-      {!isApiReference && (
+      {!isApiReference && !isChangelog && (
         <PageActions content={content} title={title} url={url} />
       )}
       <DocsBody>


### PR DESCRIPTION
## What

Removes the **Copy Page / View Markdown / Ask in ChatGPT / Ask in Claude** toolbar from the Change Log page (`/price-feeds/changelog`).

## Why

That toolbar is the shared `PageActions` component, injected into every docs page by `BasePage`. The Change Log is a custom interactive component (not prose documentation), so "Copy Page" / "View Markdown" / "Ask in ChatGPT/Claude" aren't meaningful there.

## How

There was already a precedent guard hiding `PageActions` on `/api-reference` pages. This extends the same pattern to also exclude the changelog route:

```tsx
const isApiReference = url.startsWith("/api-reference");
const isChangelog = url === "/price-feeds/changelog";
...
{!isApiReference && !isChangelog && (
  <PageActions content={content} title={title} url={url} />
)}
```

One file changed.

## Verification

Ran the dev server and checked in the browser:
- **Changelog page** renders correctly (`Change Log` heading) with the toolbar gone — `Copy Page` / `View Markdown` no longer in the DOM.
- **Regression check** — a normal docs page (`/price-feeds/how-pyth-works`) still shows the toolbar, so only the changelog page is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->