### PR TITLE
fix(hip-3-pusher): disable loguru diagnose to stop private-key leak in tracebacks

### DIFF
--- a/apps/hip-3-pusher/src/pusher/main.py
+++ b/apps/hip-3-pusher/src/pusher/main.py
@@ -37,8 +37,19 @@ def load_config() -> Config:
 def init_logging() -> None:
     logger.remove()
     log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+    # diagnose=True annotates tracebacks with the values of every local in the
+    # offending frame, which would dump the secp256k1 signing key (read into a
+    # local in Publisher.__init__) into plaintext logs on any startup error
+    # path. Default off in production; devs can opt in with LOG_DIAGNOSE=1.
+    diagnose = os.getenv("LOG_DIAGNOSE") == "1"
     # serialize=True if we want json logging
-    logger.add(sys.stderr, level=log_level, serialize=False)
+    logger.add(
+        sys.stderr,
+        level=log_level,
+        serialize=False,
+        backtrace=False,
+        diagnose=diagnose,
+    )
 
 
 async def main() -> None:


### PR DESCRIPTION
## Summary

`loguru.logger.add(...)` defaults to `backtrace=True, diagnose=True`. With `diagnose=True`, loguru annotates every traceback frame with the values of all locals in that frame. `Publisher.__init__` (`apps/hip-3-pusher/src/pusher/publisher.py:91-92`) reads the operator's secp256k1 signing key into a local (`oracle_pusher_key`), so any exception escaping while that key is in scope — bad key file, KMS misconfig, `eth_account` validation on a truncated key, any startup error reaching `main.py`'s top-level `logger.exception` — renders the raw hex private key into stderr and every downstream log sink (Loki / CloudWatch / journald).

## Change

`apps/hip-3-pusher/src/pusher/main.py` — `init_logging()` now passes `backtrace=False` and `diagnose=False` by default. Developers can opt back into annotated tracebacks with `LOG_DIAGNOSE=1`; production defaults to off. This is the loguru-documented production hardening.

## Scope

Narrow, per the issue's tactical-fix instruction: only the `logger.add` call named in the finding's root cause is touched. No newtypes / SecretStr wrapping / sibling call-site refactors. Note the same class of leak would recur anywhere a future `logger.add` re-enables `diagnose` while a secret is in a live frame; the defense-in-depth `SecretStr` wrapping is tracked separately and intentionally out of scope here.

## Verification

All four CI-gate commands pass from `apps/hip-3-pusher/`:
- `uv run ruff format src/ tests/` — 28 files unchanged
- `uv run ruff check src/ tests/` — All checks passed
- `uv run mypy src/` — Success, no issues (13 files)
- `uv run pytest tests/` — 19 passed

Behavioral repro confirming the leak is closed: triggered an exception with a secret hex string in a local and logged via the patched `init_logging()`. With `LOG_DIAGNOSE` unset the traceback is clean (no `= '0x...'` frame annotations); with `LOG_DIAGNOSE=1` the annotations return, confirming the dev opt-in still works.

## Suggested reviewers

- `@merolish` (Mike Rolish) — primary committer of `hip-3-pusher/main.py` and CODEOWNER for the sibling `apps/pyth-lazer-agent`
- `@tejasbadadare` (Tejas Badadare) — recent committer to this app

Resolves [[i-anbduflw]] (parent audit [[i-vcllsgqo]]).