### PR TITLE
feat(crosschain): add Stellar Lazer governance E2E tests

### DIFF
--- a/contract_manager/scripts/test_stellar_lazer_contract.ts
+++ b/contract_manager/scripts/test_stellar_lazer_contract.ts
@@ -1,0 +1,413 @@
+/** biome-ignore-all lint/suspicious/noConsole: this is a CLI script */
+import { createECDH } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+import type { Options } from "yargs";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+import { toPrivateKey } from "../src/core/base";
+import { StellarChain } from "../src/core/chains";
+import {
+  StellarExecutorContract,
+  StellarLazerContract,
+} from "../src/core/contracts";
+import { loadHotWallet, WormholeEmitter } from "../src/node/utils/governance";
+import { DefaultStore } from "../src/node/utils/store";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Deploying the throwaway contracts these tests run against
+//
+// These scenarios CANNOT run against the canonical testnet executor/verifier:
+// those are owned by the Pyth DAO multisig, so only the DAO can produce a
+// governance VAA they accept. Deploy a throwaway executor + verifier whose owner
+// emitter is a key YOU control, then sign the governance VAA directly with that
+// key (the test stand-in for the multisig). All `test-*` commands then take the
+// deployed addresses via `--executor-contract` / `--lazer-contract`.
+//
+// 1. Pick the Solana keypair you will pass as `--emitter` (the Wormhole
+//    governance emitter), e.g. `$HOME/.config/solana/id.json`. Its Wormhole
+//    emitter address is just its public key as 32 raw bytes. `deploy.sh` wants
+//    that as hex (no 0x), so derive it from the keypair's base58 pubkey (run
+//    from this `contract_manager/` directory so @solana/web3.js resolves):
+//
+//      PUBKEY=$(solana-keygen pubkey "$EMITTER_KEY")
+//      EMITTER_HEX=$(node -e "const {PublicKey}=require('@solana/web3.js'); \
+//        console.log(new PublicKey(process.argv[1]).toBuffer().toString('hex'))" \
+//        "$PUBKEY")
+//
+//    (equivalently: base58-decode the pubkey to its 32 bytes and hex-encode.)
+//
+// 2. Deploy the throwaway pair, overriding only the owner emitter — see deploy.sh
+//    --help in `pyth-lazer/contracts/stellar/scripts/` for all flags:
+//
+//      ./scripts/deploy.sh --secret <stellar-secret-or-identity> \
+//        --network testnet --emitter-address "$EMITTER_HEX"
+//
+//    deploy.sh prints the deployed executor and verifier contract addresses;
+//    pass them as `--executor-contract` / `--lazer-contract`.
+//
+// Why mainnet-beta? deploy.sh defaults to the Wormhole *mainnet* guardian set
+// (index 4) on both networks, because the canonical owner emitter lives on Solana
+// mainnet. The executor checks guardian signatures against the set it holds, so
+// with that default the VAA must be signed by the mainnet guardians — post the
+// message on `mainnet-beta` (the `--guardian-cluster` default) with the `--emitter`
+// wallet funded there to pay the Wormhole fee. (To post elsewhere, deploy with a
+// matching `--guardian-set` / `--guardian-index` and set `--guardian-cluster`.)
+// ─────────────────────────────────────────────────────────────────────────────
+const DEFAULT_GUARDIAN_CLUSTER = "mainnet-beta";
+const DEFAULT_CHAIN = "stellar_testnet";
+
+function getChain(name: string): StellarChain {
+  const chain = DefaultStore.chains[name];
+  if (!(chain instanceof StellarChain)) {
+    throw new TypeError(`Not a valid Stellar chain: ${name}`);
+  }
+  return chain;
+}
+
+function txUrl(chain: StellarChain, hash: string): string {
+  const network = chain.isMainnet() ? "public" : "testnet";
+  return `https://stellar.expert/explorer/${network}/tx/${hash}`;
+}
+
+/** A fresh, valid compressed secp256k1 public key that signs nothing. */
+function dummyTrustedSigner(): string {
+  const ecdh = createECDH("secp256k1");
+  ecdh.generateKeys();
+  return ecdh.getPublicKey(null, "compressed").toString("hex");
+}
+
+/**
+ * Produce a guardian-signed governance VAA for `payload` by posting it directly
+ * through the `--emitter` wallet on `guardianCluster`. This is the test-only stand
+ * -in for the mainnet path, where the VAA only exists after the DAO Squads
+ * multisig votes and executes the proposal (days later) — there, `propose` and
+ * `executeGovernanceAction` are separate, manually-run steps, not one call.
+ */
+async function signGovernanceVaa(
+  payload: Buffer,
+  emitterPath: string,
+  guardianCluster: string,
+): Promise<Buffer> {
+  const emitterWallet = await loadHotWallet(emitterPath);
+  const emitter = new WormholeEmitter(guardianCluster, emitterWallet);
+  console.info(
+    `Governance emitter (must equal the executor's owner emitter): ${emitterWallet.publicKey.toBase58()}`,
+  );
+  console.info(`Posting governance message on '${guardianCluster}'...`);
+  const submitted = await emitter.sendMessage(payload);
+  console.info(
+    `Awaiting signed VAA #${submitted.sequenceNumber.toString()}...`,
+  );
+  return submitted.fetchVaa(30);
+}
+
+/**
+ * Submit a signed governance `vaa` to the executor, surfacing the two
+ * misconfiguration traps that otherwise produce an opaque on-chain failure: a VAA
+ * signed by a guardian set the executor does not hold (`InvalidGuardianSignature`)
+ * or posted from an emitter the executor was not deployed with (invalid governance
+ * data source).
+ */
+async function dispatchGovernance(
+  executor: StellarExecutorContract,
+  privateKey: string,
+  vaa: Buffer,
+): Promise<string> {
+  try {
+    const { id } = await executor.executeGovernanceAction(
+      toPrivateKey(privateKey),
+      vaa,
+    );
+    return id;
+  } catch (error: unknown) {
+    console.error(
+      "Governance dispatch failed. The two common causes are:\n" +
+        "  - InvalidGuardianSignature: the VAA was signed by a guardian set the\n" +
+        "    executor does not hold. Post the message on the cluster whose\n" +
+        "    guardians match the executor's deployed guardian set (`--guardian-set`\n" +
+        "    / `--guardian-index` in deploy.sh).\n" +
+        "  - Invalid governance data source: the emitter wallet is not the\n" +
+        "    executor's configured owner emitter. Use the key the executor was\n" +
+        "    deployed with (`--emitter-address` in deploy.sh).",
+    );
+    throw error;
+  }
+}
+
+const commonOptions = {
+  emitter: {
+    demandOption: true,
+    description:
+      "Path to a Solana keypair (JSON array) used as the Wormhole governance " +
+      "emitter. Must be the throwaway executor's owner emitter, and must post on " +
+      "`--guardian-cluster` so its guardians sign the VAA. A mismatch is rejected " +
+      "on-chain with InvalidGuardianSignature.",
+    type: "string",
+  },
+  "executor-contract": {
+    demandOption: true,
+    description:
+      "Soroban contract address of your throwaway wormhole-executor-stellar " +
+      "(deployed with --emitter-address = your --emitter wallet's emitter).",
+    type: "string",
+  },
+  "guardian-cluster": {
+    default: DEFAULT_GUARDIAN_CLUSTER,
+    description:
+      "Solana cluster to post the governance message on. Its guardians sign the " +
+      "VAA, so it must match the guardian set the executor was deployed with " +
+      "(`--guardian-set` / `--guardian-index` in deploy.sh).",
+    type: "string",
+  },
+  "lazer-contract": {
+    demandOption: true,
+    description:
+      "Soroban contract address of your throwaway pyth-lazer-stellar verifier " +
+      "(its executor must be the --executor-contract).",
+    type: "string",
+  },
+  "private-key": {
+    demandOption: true,
+    description:
+      "32-byte ed25519 seed (hex, no 0x) of the Stellar account that pays for " +
+      "and signs the Soroban dispatch. Authority comes from the VAA, not this key.",
+    type: "string",
+  },
+} as const satisfies Record<string, Options>;
+
+const parser = yargs(hideBin(process.argv))
+  .usage(
+    "E2E tests for Stellar PythLazer governance via contract_manager.\n" +
+      "Each command drives the integrated contract_manager -> executor -> " +
+      "verifier path against a throwaway testnet contract you deploy, signing " +
+      "the VAA directly with the --emitter key (the test stand-in for the DAO " +
+      "multisig).",
+  )
+  .epilogue(
+    "Deploy the throwaway executor/verifier first (the canonical testnet " +
+      "contracts are DAO-owned and reject a self-signed VAA):\n" +
+      "  1. Derive your --emitter wallet's Wormhole emitter (its base58 pubkey as " +
+      "32-byte hex, no 0x).\n" +
+      "  2. pyth-lazer/contracts/stellar/scripts/deploy.sh --secret <key> " +
+      "--network testnet --emitter-address <that hex>\n" +
+      "  3. Pass the printed executor/verifier addresses as --executor-contract / " +
+      "--lazer-contract.\n" +
+      "See the header comment in this file for the exact derivation + deploy " +
+      "commands and why messages are posted on mainnet-beta.",
+  )
+  .options({
+    chain: {
+      alias: "c",
+      coerce: getChain,
+      default: DEFAULT_CHAIN,
+      description: "chain name (from StellarChains.json)",
+      type: "string",
+    },
+  })
+  .strict()
+  .demandCommand(1);
+
+parser.command(
+  "test-update-trusted-signer",
+  "E2E: add a dummy trusted signer, assert it, then remove it (cleanup)",
+  (b) =>
+    b.options({
+      emitter: commonOptions.emitter,
+      "executor-contract": commonOptions["executor-contract"],
+      expires: {
+        coerce: BigInt,
+        // Far-future default so the assertion is stable; the signer is removed
+        // again in teardown regardless.
+        default: "4102444800", // 2100-01-01
+        description: "expiry timestamp (unix seconds) for the dummy signer",
+        type: "string",
+      },
+      "guardian-cluster": commonOptions["guardian-cluster"],
+      "lazer-contract": commonOptions["lazer-contract"],
+      "private-key": commonOptions["private-key"],
+      signer: {
+        description:
+          "33-byte compressed secp256k1 key (hex, no 0x) to add/remove. " +
+          "Defaults to a fresh dummy key generated in-script.",
+        type: "string",
+      },
+    }),
+  async ({
+    chain,
+    emitter: emitterPath,
+    "executor-contract": executorAddress,
+    expires,
+    "guardian-cluster": guardianCluster,
+    "lazer-contract": lazerAddress,
+    "private-key": privateKey,
+    signer,
+  }) => {
+    const lazer = new StellarLazerContract(chain, lazerAddress);
+    const executor = new StellarExecutorContract(chain, executorAddress);
+
+    // The verifier frames the action as a Call to the executor it authorizes;
+    // it must be the executor we dispatch to, or the action is unauthorized.
+    const authorizedExecutor = await lazer.getExecutor();
+    if (authorizedExecutor !== executor.address) {
+      throw new Error(
+        `Verifier authorizes executor ${authorizedExecutor}, but ` +
+          `--executor-contract is ${executor.address}.`,
+      );
+    }
+
+    const pubkey = signer ?? dummyTrustedSigner();
+    console.info(`Dummy trusted signer: ${pubkey}`);
+
+    const existing = await lazer.getTrustedSignerExpiry(pubkey);
+    if (existing !== undefined) {
+      throw new Error(
+        `Signer already trusted (expiry ${existing.toString()}); refusing to ` +
+          "clobber it. Pick a different --signer.",
+      );
+    }
+
+    // 1. Add the signer.
+    console.info(`\n[1/2] Adding signer with expiry ${expires.toString()}...`);
+    const addPayload = await lazer.generateUpdateTrustedSignerPayload(
+      pubkey,
+      expires,
+    );
+    const addVaa = await signGovernanceVaa(
+      addPayload,
+      emitterPath,
+      guardianCluster,
+    );
+    const addTx = await dispatchGovernance(executor, privateKey, addVaa);
+    console.info(`Dispatched: ${txUrl(chain, addTx)}`);
+
+    const afterAdd = await lazer.getTrustedSignerExpiry(pubkey);
+    if (afterAdd !== expires) {
+      throw new Error(
+        `Assertion failed: expected expiry ${expires.toString()}, read ` +
+          `${afterAdd === undefined ? "<absent>" : afterAdd.toString()}.`,
+      );
+    }
+    console.info("Asserted: signer present with expected expiry.");
+
+    // 2. Teardown — remove the signer (expiry 0) and assert it is gone.
+    console.info("\n[2/2] Removing signer (teardown)...");
+    const removePayload = await lazer.generateUpdateTrustedSignerPayload(
+      pubkey,
+      0n,
+    );
+    const removeVaa = await signGovernanceVaa(
+      removePayload,
+      emitterPath,
+      guardianCluster,
+    );
+    const removeTx = await dispatchGovernance(executor, privateKey, removeVaa);
+    console.info(`Dispatched: ${txUrl(chain, removeTx)}`);
+
+    const afterRemove = await lazer.getTrustedSignerExpiry(pubkey);
+    if (afterRemove !== undefined) {
+      throw new Error(
+        `Teardown failed: signer still present (expiry ${afterRemove.toString()}).`,
+      );
+    }
+    console.info("Asserted: signer removed. Contract restored to start state.");
+    console.info("\ntest-update-trusted-signer: PASS");
+  },
+);
+
+parser.command(
+  "test-upgrade",
+  "E2E: upgrade the executor to a rebuilt WASM, assert it, then roll back",
+  (b) =>
+    b.options({
+      emitter: commonOptions.emitter,
+      "executor-contract": commonOptions["executor-contract"],
+      "executor-wasm": {
+        demandOption: true,
+        description:
+          "Path to a rebuilt wormhole-executor-stellar WASM with a different " +
+          "hash than the deployed one (e.g. a doc-string change). Build it with " +
+          "`stellar contract build`.",
+        type: "string",
+      },
+      "guardian-cluster": commonOptions["guardian-cluster"],
+      "private-key": commonOptions["private-key"],
+    }),
+  async ({
+    chain,
+    emitter: emitterPath,
+    "executor-contract": executorAddress,
+    "executor-wasm": wasmPath,
+    "guardian-cluster": guardianCluster,
+    "private-key": privateKey,
+  }) => {
+    const executor = new StellarExecutorContract(chain, executorAddress);
+    const dispatchKey = toPrivateKey(privateKey);
+
+    // Capture the canonical hash to roll back to.
+    const originalHash = await executor.getCurrentWasmHash();
+    console.info(`Current executor WASM hash: ${originalHash}`);
+
+    // 1. Upload the rebuilt WASM and capture its hash.
+    console.info(`\n[1/2] Uploading rebuilt WASM from ${wasmPath}...`);
+    const wasm = readFileSync(wasmPath);
+    const newHash = await chain.uploadContractWasm(wasm, dispatchKey);
+    console.info(`Uploaded WASM hash: ${newHash}`);
+    if (newHash === originalHash) {
+      throw new Error(
+        "Rebuilt WASM is identical to the deployed one; supply a WASM with a " +
+          "different hash (e.g. add a doc-string) so the upgrade is observable.",
+      );
+    }
+
+    // Dispatch the self-upgrade and assert the instance now runs the new hash.
+    const upgradePayload = executor.generateUpgradeExecutorPayload(newHash);
+    const upgradeVaa = await signGovernanceVaa(
+      upgradePayload,
+      emitterPath,
+      guardianCluster,
+    );
+    const upgradeTx = await dispatchGovernance(
+      executor,
+      privateKey,
+      upgradeVaa,
+    );
+    console.info(`Dispatched: ${txUrl(chain, upgradeTx)}`);
+
+    const afterUpgrade = await executor.getCurrentWasmHash();
+    if (afterUpgrade !== newHash) {
+      throw new Error(
+        `Assertion failed: expected WASM hash ${newHash}, read ${afterUpgrade}.`,
+      );
+    }
+    console.info("Asserted: executor now runs the rebuilt WASM.");
+
+    // 2. Teardown — roll back to the canonical WASM (already on-chain).
+    console.info("\n[2/2] Rolling back to original WASM (teardown)...");
+    const rollbackPayload =
+      executor.generateUpgradeExecutorPayload(originalHash);
+    const rollbackVaa = await signGovernanceVaa(
+      rollbackPayload,
+      emitterPath,
+      guardianCluster,
+    );
+    const rollbackTx = await dispatchGovernance(
+      executor,
+      privateKey,
+      rollbackVaa,
+    );
+    console.info(`Dispatched: ${txUrl(chain, rollbackTx)}`);
+
+    const afterRollback = await executor.getCurrentWasmHash();
+    if (afterRollback !== originalHash) {
+      throw new Error(
+        `Teardown failed: expected WASM hash ${originalHash}, read ${afterRollback}.`,
+      );
+    }
+    console.info("Asserted: executor restored to original WASM.");
+    console.info("\ntest-upgrade: PASS");
+  },
+);
+
+await parser.parseAsync();

--- a/contract_manager/src/core/chains.ts
+++ b/contract_manager/src/core/chains.ts
@@ -1,6 +1,7 @@
 /** biome-ignore-all lint/style/noProcessEnv: utils used through CLI */
 /** biome-ignore-all lint/suspicious/noConsole: utils used through CLI */
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { readFile, writeFile } from "node:fs/promises";
 import nodePath from "node:path";
 
@@ -44,8 +45,11 @@ import {
   PublicKey,
 } from "@solana/web3.js";
 import {
+  BASE_FEE,
   Horizon as StellarHorizon,
   Keypair as StellarKeypair,
+  Operation as StellarOperation,
+  TransactionBuilder as StellarTransactionBuilder,
   rpc as stellarRpc,
 } from "@stellar/stellar-sdk";
 import { keyPairFromSeed } from "@ton/crypto";
@@ -1795,5 +1799,53 @@ export class StellarChain extends Chain {
       (balance) => balance.asset_type === "native",
     );
     return native ? Number(native.balance) : 0;
+  }
+
+  /**
+   * Upload a contract WASM blob to the network so it can later be referenced by
+   * hash (e.g. as the target of a governance `UpgradeExecutor`/`upgrade` action)
+   * and return its hash, hex without `0x`.
+   *
+   * The on-chain WASM hash is the SHA-256 of the blob, so it is computed locally
+   * from `wasm` and returned regardless of how the ledger reports the upload —
+   * uploading the same bytes twice is idempotent and yields the same hash.
+   *
+   * @param wasm - the WASM blob to upload
+   * @param senderPrivateKey - 32-byte ed25519 seed of the account that pays for
+   *   and signs the upload, hex without `0x`
+   */
+  async uploadContractWasm(
+    wasm: Buffer,
+    senderPrivateKey: PrivateKey,
+  ): Promise<string> {
+    const server = this.getProvider();
+    const keypair = StellarKeypair.fromRawEd25519Seed(
+      Buffer.from(senderPrivateKey, "hex"),
+    );
+    const account = await server.getAccount(keypair.publicKey());
+
+    const tx = new StellarTransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(StellarOperation.uploadContractWasm({ wasm }))
+      .setTimeout(30)
+      .build();
+
+    const prepared = await server.prepareTransaction(tx);
+    prepared.sign(keypair);
+
+    const sent = await server.sendTransaction(prepared);
+    if (sent.status === "ERROR") {
+      throw new Error(
+        `Failed to upload WASM: ${JSON.stringify(sent.errorResult)}`,
+      );
+    }
+    const result = await server.pollTransaction(sent.hash);
+    if (result.status !== stellarRpc.Api.GetTransactionStatus.SUCCESS) {
+      throw new Error(`WASM upload transaction ${sent.hash} failed`);
+    }
+
+    return createHash("sha256").update(wasm).digest("hex");
   }
 }

--- a/contract_manager/src/core/contracts/stellar.ts
+++ b/contract_manager/src/core/contracts/stellar.ts
@@ -317,6 +317,30 @@ export class StellarExecutorContract extends Storable {
     }
     return Number(scValToNative(value) as number | bigint);
   }
+
+  /**
+   * Read the WASM hash the executor instance is currently running, hex without
+   * `0x`. This is the executable backing the contract instance ledger entry, not
+   * a value in instance storage, so a self-upgrade governance action changes it.
+   * Used to assert an upgrade took effect (and to capture the canonical hash to
+   * roll back to).
+   */
+  async getCurrentWasmHash(): Promise<string> {
+    const server = this.chain.getProvider();
+    const entry = await server.getContractData(
+      this.address,
+      xdr.ScVal.scvLedgerKeyContractInstance(),
+      stellarRpc.Durability.Persistent,
+    );
+    const executable = entry.val.contractData().val().instance().executable();
+    if (
+      executable.switch() !==
+      xdr.ContractExecutableType.contractExecutableWasm()
+    ) {
+      throw new Error("Executor instance is not backed by a WASM executable");
+    }
+    return executable.wasmHash().toString("hex");
+  }
 }
 
 /** XDR-encode an argument vector as the `ScVec` the executor's `Call` expects. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ catalogs:
       specifier: ^1.98.0
       version: 1.98.0
     '@stellar/stellar-sdk':
-      specifier: ^13.3.0
-      version: 13.3.0
+      specifier: ^14.6.1
+      version: 14.6.1
     '@storybook/addon-styling-webpack':
       specifier: ^3.0.0
       version: 3.0.0
@@ -853,7 +853,7 @@ importers:
     dependencies:
       '@zodios/core':
         specifier: ^10.9.6
-        version: 10.9.6(axios@1.8.4)(zod@3.24.2)
+        version: 10.9.6(axios@1.18.1)(zod@3.24.2)
       eventsource:
         specifier: ^3.0.5
         version: 3.0.6
@@ -1105,7 +1105,7 @@ importers:
     dependencies:
       '@aptos-labs/ts-sdk':
         specifier: ^1.39.0
-        version: 1.39.0(axios@1.8.4)(got@13.0.0)
+        version: 1.39.0(axios@1.18.1)(got@13.0.0)
       '@coral-xyz/anchor':
         specifier: ^0.30.0
         version: 0.30.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
@@ -1443,7 +1443,7 @@ importers:
         version: 1.0.6(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
       '@stellar/stellar-sdk':
         specifier: 'catalog:'
-        version: 13.3.0
+        version: 14.6.1
       '@ton/blueprint':
         specifier: ^0.22.0
         version: 0.22.0(patch_hash=87640a947e37634630debe8c6d3959cc24098499df6ba20cefbaec73c56e81fe)(@swc/core@1.15.10)(@ton/core@0.59.1(@ton/crypto@3.3.0))(@ton/crypto@3.3.0)(@ton/ton@15.2.1(@ton/core@0.59.1(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@types/node@22.14.0)(encoding@0.1.13)(typescript@5.9.3)
@@ -11032,14 +11032,15 @@ packages:
   '@stellar/js-xdr@3.1.2':
     resolution: {integrity: sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==}
 
-  '@stellar/stellar-base@13.1.0':
-    resolution: {integrity: sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==}
-    engines: {node: '>=18.0.0'}
+  '@stellar/stellar-base@14.1.0':
+    resolution: {integrity: sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw==}
+    engines: {node: '>=20.0.0'}
     deprecated: This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.
 
-  '@stellar/stellar-sdk@13.3.0':
-    resolution: {integrity: sha512-8+GHcZLp+mdin8gSjcgfb/Lb6sSMYRX6Nf/0LcSJxvjLQR0XHpjGzOiRbYb2jSXo51EnA6kAV5j+4Pzh5OUKUg==}
-    engines: {node: '>=18.0.0'}
+  '@stellar/stellar-sdk@14.6.1':
+    resolution: {integrity: sha512-A1rQWDLdUasXkMXnYSuhgep+3ZZzyuXJKdt5/KAIc0gkmSp906HTvUpbT4pu+bVr41tu0+J4Ugz9J4BQAGGytg==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
 
   '@storybook/addon-styling-webpack@3.0.0':
     resolution: {integrity: sha512-6iI7wGf/tEt5awB8NYAWU+I/hI7PwOdoaNb5V8Z+GkhEko4nZFpXfp8jz2nMblAnx9Jsl95LfIaH9Spa0JksuQ==}
@@ -13250,6 +13251,9 @@ packages:
   axios@0.27.2:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
 
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
+
   axios@1.7.4:
     resolution: {integrity: sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==}
 
@@ -13358,25 +13362,6 @@ packages:
 
   balanced-match@2.0.0:
     resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==}
-
-  bare-addon-resolve@1.10.0:
-    resolution: {integrity: sha512-sSd0jieRJlDaODOzj0oe0RjFVC1QI0ZIjGIdPkbrTXsdVVtENg14c+lHHAhHwmWCZ2nQlMhy8jA3Y5LYPc/isA==}
-    peerDependencies:
-      bare-url: '*'
-    peerDependenciesMeta:
-      bare-url:
-        optional: true
-
-  bare-module-resolve@1.12.2:
-    resolution: {integrity: sha512-j+hiD5k99qec4KjJvYsI67q5AOBifmy9JG3oeMVxTmvrhn2sIdp8StrUvZu4YNgwTpO+NhniQG16N1ETDe1k5w==}
-    peerDependencies:
-      bare-url: '*'
-    peerDependenciesMeta:
-      bare-url:
-        optional: true
-
-  bare-semver@1.1.0:
-    resolution: {integrity: sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==}
 
   base-64@1.0.0:
     resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
@@ -14159,6 +14144,10 @@ packages:
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -15980,6 +15969,15 @@ packages:
       debug:
         optional: true
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   fontace@0.4.0:
     resolution: {integrity: sha512-moThBCItUe2bjZip5PF/iZClpKHGLwMvR79Kp8XpGRBrvoRSnySN4VcILdv3/MJzbhvUA5WeiUXF5o538m5fvg==}
 
@@ -16039,6 +16037,10 @@ packages:
 
   form-data@4.0.2:
     resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
+    engines: {node: '>= 6'}
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   format@0.2.2:
@@ -16566,6 +16568,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hast-util-from-dom@5.0.1:
@@ -19779,6 +19785,10 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   proxycheck-ts@0.0.11:
     resolution: {integrity: sha512-RxkN5FuklqDjiTNdRqair96AgkP/tc6boVZgNcLil17qNNmlZhXHPKhIlw51EdC+vgrsDCk5MA1fUzojEXo4Bg==}
 
@@ -20341,10 +20351,6 @@ packages:
   requestidlecallback@0.3.0:
     resolution: {integrity: sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==}
 
-  require-addon@1.2.0:
-    resolution: {integrity: sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==}
-    engines: {bare: '>=1.10.0'}
-
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -20750,6 +20756,11 @@ packages:
     resolution: {integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==}
     hasBin: true
 
+  sha.js@2.4.12:
+    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
+    engines: {node: '>= 0.10'}
+    hasBin: true
+
   sha3@2.1.4:
     resolution: {integrity: sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==}
 
@@ -20908,9 +20919,6 @@ packages:
   socks@2.8.4:
     resolution: {integrity: sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
-
-  sodium-native@4.3.3:
-    resolution: {integrity: sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==}
 
   solc@0.8.26:
     resolution: {integrity: sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==}
@@ -21587,6 +21595,10 @@ packages:
   to-buffer@1.1.1:
     resolution: {integrity: sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==}
 
+  to-buffer@1.2.2:
+    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
+    engines: {node: '>= 0.4'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -21923,6 +21935,10 @@ packages:
 
   type@2.7.3:
     resolution: {integrity: sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==}
+
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
 
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
@@ -23489,9 +23505,9 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@aptos-labs/aptos-client@1.2.0(axios@1.8.4)(got@13.0.0)':
+  '@aptos-labs/aptos-client@1.2.0(axios@1.18.1)(got@13.0.0)':
     dependencies:
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.18.1
       got: 13.0.0
 
   '@aptos-labs/aptos-dynamic-transaction-composer@0.1.3': {}
@@ -23500,10 +23516,10 @@ snapshots:
     dependencies:
       '@aptos-labs/aptos-dynamic-transaction-composer': 0.1.3
 
-  '@aptos-labs/ts-sdk@1.39.0(axios@1.8.4)(got@13.0.0)':
+  '@aptos-labs/ts-sdk@1.39.0(axios@1.18.1)(got@13.0.0)':
     dependencies:
       '@aptos-labs/aptos-cli': 1.0.2
-      '@aptos-labs/aptos-client': 1.2.0(axios@1.8.4)(got@13.0.0)
+      '@aptos-labs/aptos-client': 1.2.0(axios@1.18.1)(got@13.0.0)
       '@aptos-labs/script-composer-pack': 0.0.9
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
@@ -29138,7 +29154,7 @@ snapshots:
       '@injectivelabs/ts-types': 1.14.47
       '@injectivelabs/utils': 1.14.48
       axios: 1.8.4(debug@4.4.3)
-      bignumber.js: 9.1.2
+      bignumber.js: 9.3.1
       shx: 0.3.4
       snakecase-keys: 5.5.0
       store2: 2.14.4
@@ -29184,7 +29200,7 @@ snapshots:
       '@injectivelabs/exceptions': 1.14.47
       '@injectivelabs/ts-types': 1.14.47
       axios: 0.21.4
-      bignumber.js: 9.1.2
+      bignumber.js: 9.3.1
       http-status-codes: 2.3.0
       link-module-alias: 1.2.0
       shx: 0.3.4
@@ -30728,7 +30744,7 @@ snapshots:
     dependencies:
       '@keystonehq/alias-sampling': 0.1.2
       assert: 2.1.0
-      bignumber.js: 9.1.2
+      bignumber.js: 9.3.1
       cbor-sync: 1.0.4
       crc: 3.8.0
       jsbi: 3.2.5
@@ -36048,32 +36064,29 @@ snapshots:
 
   '@stellar/js-xdr@3.1.2': {}
 
-  '@stellar/stellar-base@13.1.0':
+  '@stellar/stellar-base@14.1.0':
     dependencies:
+      '@noble/curves': 1.9.6
       '@stellar/js-xdr': 3.1.2
       base32.js: 0.1.0
       bignumber.js: 9.3.1
       buffer: 6.0.3
-      sha.js: 2.4.11
-      tweetnacl: 1.0.3
-    optionalDependencies:
-      sodium-native: 4.3.3
-    transitivePeerDependencies:
-      - bare-url
+      sha.js: 2.4.12
 
-  '@stellar/stellar-sdk@13.3.0':
+  '@stellar/stellar-sdk@14.6.1':
     dependencies:
-      '@stellar/stellar-base': 13.1.0
-      axios: 1.8.4(debug@4.4.3)
+      '@stellar/stellar-base': 14.1.0
+      axios: 1.18.1
       bignumber.js: 9.3.1
+      commander: 14.0.3
       eventsource: 2.0.2
       feaxios: 0.0.23
       randombytes: 2.1.0
       toml: 3.0.0
       urijs: 1.19.11
     transitivePeerDependencies:
-      - bare-url
       - debug
+      - supports-color
 
   '@storybook/addon-styling-webpack@3.0.0(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.0.9)(prettier@3.5.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(utf-8-validate@6.0.3))(webpack@5.98.0(@swc/core@1.15.10))':
     dependencies:
@@ -36886,7 +36899,7 @@ snapshots:
       '@toruslabs/http-helpers': 3.4.0(@babel/runtime@7.28.6)
       '@toruslabs/openlogin-jrpc': 4.7.2(@babel/runtime@7.28.6)
       async-mutex: 0.4.1
-      bignumber.js: 9.1.2
+      bignumber.js: 9.3.1
       bowser: 2.11.0
       eth-rpc-errors: 4.0.3
       json-rpc-random-id: 1.0.1
@@ -37181,7 +37194,7 @@ snapshots:
 
   '@trezor/utils@9.3.3(tslib@2.8.1)':
     dependencies:
-      bignumber.js: 9.1.2
+      bignumber.js: 9.3.1
       tslib: 2.8.1
 
   '@trezor/utxo-lib@2.3.3(tslib@2.8.1)':
@@ -39060,9 +39073,9 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
-  '@zodios/core@10.9.6(axios@1.8.4)(zod@3.24.2)':
+  '@zodios/core@10.9.6(axios@1.18.1)(zod@3.24.2)':
     dependencies:
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.18.1
       zod: 3.24.2
 
   '@zodios/core@10.9.6(axios@1.8.4)(zod@3.25.76)':
@@ -39699,6 +39712,16 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  axios@1.18.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   axios@1.7.4:
     dependencies:
       follow-redirects: 1.15.9(debug@4.4.3)
@@ -39895,20 +39918,6 @@ snapshots:
   balanced-match@1.0.2: {}
 
   balanced-match@2.0.0: {}
-
-  bare-addon-resolve@1.10.0:
-    dependencies:
-      bare-module-resolve: 1.12.2
-      bare-semver: 1.1.0
-    optional: true
-
-  bare-module-resolve@1.12.2:
-    dependencies:
-      bare-semver: 1.1.0
-    optional: true
-
-  bare-semver@1.1.0:
-    optional: true
 
   base-64@1.0.0:
     optional: true
@@ -40793,6 +40802,8 @@ snapshots:
   commander@12.1.0: {}
 
   commander@13.1.0: {}
+
+  commander@14.0.3: {}
 
   commander@2.20.3: {}
 
@@ -43241,6 +43252,8 @@ snapshots:
     optionalDependencies:
       debug: 4.4.3(supports-color@8.1.1)
 
+  follow-redirects@1.16.0: {}
+
   fontace@0.4.0:
     dependencies:
       fontkitten: 1.0.2
@@ -43322,6 +43335,14 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
+      mime-types: 2.1.35
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   format@0.2.2: {}
@@ -44113,6 +44134,10 @@ snapshots:
       minimalistic-assert: 1.0.1
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -45888,7 +45913,7 @@ snapshots:
 
   json-bigint@1.0.0:
     dependencies:
-      bignumber.js: 9.1.2
+      bignumber.js: 9.3.1
 
   json-buffer@3.0.1: {}
 
@@ -48708,6 +48733,8 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  proxy-from-env@2.1.0: {}
+
   proxycheck-ts@0.0.11(encoding@0.1.13):
     dependencies:
       cross-fetch: 4.1.0(encoding@0.1.13)
@@ -49662,13 +49689,6 @@ snapshots:
 
   requestidlecallback@0.3.0: {}
 
-  require-addon@1.2.0:
-    dependencies:
-      bare-addon-resolve: 1.10.0
-    transitivePeerDependencies:
-      - bare-url
-    optional: true
-
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -49816,14 +49836,14 @@ snapshots:
 
   ripple-lib-transactionparser@0.8.2:
     dependencies:
-      bignumber.js: 9.1.2
+      bignumber.js: 9.3.1
       lodash: 4.17.21
 
   ripple-lib@1.10.1(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     dependencies:
       '@types/lodash': 4.17.16
       '@types/ws': 7.4.7
-      bignumber.js: 9.1.2
+      bignumber.js: 9.3.1
       https-proxy-agent: 5.0.1
       jsonschema: 1.2.2
       lodash: 4.17.21
@@ -50195,6 +50215,12 @@ snapshots:
       inherits: 2.0.4
       safe-buffer: 5.2.1
 
+  sha.js@2.4.12:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
+
   sha3@2.1.4:
     dependencies:
       buffer: 6.0.3
@@ -50489,13 +50515,6 @@ snapshots:
     dependencies:
       ip-address: 9.0.5
       smart-buffer: 4.2.0
-
-  sodium-native@4.3.3:
-    dependencies:
-      require-addon: 1.2.0
-    transitivePeerDependencies:
-      - bare-url
-    optional: true
 
   solc@0.8.26(debug@4.4.0):
     dependencies:
@@ -51370,6 +51389,12 @@ snapshots:
 
   to-buffer@1.1.1: {}
 
+  to-buffer@1.2.2:
+    dependencies:
+      isarray: 2.0.5
+      safe-buffer: 5.2.1
+      typed-array-buffer: 1.0.3
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -51891,6 +51916,12 @@ snapshots:
       mime-types: 3.0.2
 
   type@2.7.3: {}
+
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
 
   typedarray-to-buffer@3.1.5:
     dependencies:
@@ -52861,7 +52892,7 @@ snapshots:
     dependencies:
       '@types/bn.js': 5.1.6
       '@types/node': 12.20.55
-      bignumber.js: 9.1.2
+      bignumber.js: 9.3.1
       web3-core-helpers: 1.10.0
       web3-core-method: 1.10.0
       web3-core-requestmanager: 1.10.0(encoding@0.1.13)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,7 +68,7 @@ catalog:
   "@solana/wallet-adapter-react-ui": ^0.9.36
   "@solana/wallet-adapter-wallets": ^0.19.33
   "@solana/web3.js": ^1.98.0
-  "@stellar/stellar-sdk": ^13.3.0
+  "@stellar/stellar-sdk": ^14.6.1
   "@storybook/addon-styling-webpack": ^3.0.0
   "@storybook/addon-themes": ^10.1.11
   "@storybook/nextjs": ^10.1.11


### PR DESCRIPTION
Adds the Stellar governance E2E **test** harness to `contract_manager`, plus the `@stellar/stellar-sdk` bump required for it to run against current Stellar testnet. Resolves [[i-bhfzaeve]] (parent [[i-rzpskiav]]); builds on the Stellar `contract_manager` support from [[p-nsyokjwd]] / [[i-wtmljxan]].

## What this adds

`contract_manager/scripts/test_stellar_lazer_contract.ts` — drives the integrated `contract_manager` → Stellar executor → Lazer verifier governance path against a **throwaway** testnet contract, the production pipeline minus the DAO Squads multisig leg (the test stands in for the multisig by signing the VAA directly with the `--emitter` key).

- **`test-update-trusted-signer`** (add-assert-remove): generates a fresh dummy compressed secp256k1 key (signs nothing), builds the payload with `StellarLazerContract.generateUpdateTrustedSignerPayload`, dispatches via the executor, asserts the key is in the verifier set with the expected expiry, then removes it (expiry `0`) and asserts removal.
- **`test-upgrade`** (executor self-upgrade): uploads a rebuilt executor WASM, dispatches `UpgradeExecutor`, asserts the executor instance now runs the new hash, then rolls back to the original WASM (captured at start).

## Propose / execute stay separate (no emitter abstraction)

The governance steps reuse the existing core primitives directly — the `generate*Payload` builders (the **propose** half) and `StellarExecutorContract.executeGovernanceAction` (the **execute**/submit half). They stay distinct on purpose: on the mainnet path, propose and execute are separate, manually-run steps days apart (the DAO Squads multisig votes in between), so a single "produce-a-VAA" function would be wrong. The test signs the VAA inline (`signGovernanceVaa`) only as a stand-in for that asynchronous leg; the real vault-based management script is follow-up [[i-trftrmpi]].

## Deploy is documented (in the script header), not scripted

The tests run against a throwaway executor/verifier the operator deploys via `pyth-lazer/contracts/stellar/scripts/deploy.sh` with `--emitter-address` set to their own emitter. The script header + `--help` epilogue walk through the recipe: deriving the 32-byte emitter hex from the Solana keypair's base58 pubkey, the `deploy.sh` invocation, and why messages post on mainnet-beta.

## @stellar/stellar-sdk 13.3.0 → 14.6.1

Bumped in the workspace catalog (`contract_manager` is the SDK's only consumer). 13.3.0 cannot parse Stellar testnet **protocol-23** `TransactionMeta` V4 (`Bad union switch: 4`), which broke the result readback in `executeGovernanceAction` / `uploadContractWasm` — every Stellar `contract_manager` write path on current testnet. 14.6.1 adds protocol-23 support; no source changes were required. Lockfile diff is scoped to the SDK + its transitive deps. Live-verified: **both E2E scenarios run green on testnet** (see the issue's verification comment for tx hashes + explorer links).

Supporting `contract_manager` core additions:
- `StellarExecutorContract.getCurrentWasmHash()` — reads the executor instance's live WASM hash (upgrade assert + rollback).
- `StellarChain.uploadContractWasm()` — uploads a WASM blob via `@stellar/stellar-sdk`, returns its SHA-256 hash.

## Verification

`pnpm turbo test:types` + `test:unit --filter=@pythnetwork/contract-manager` green; `tsc -p tsconfig.json` clean on changed files; `biome check` clean; both subcommands run **green end-to-end on Stellar testnet** with the bumped SDK. Merge-clean against `origin/main`.

## Related scope

- [[i-trftrmpi]] — real vault-based DAO management script (`propose-*` / `execute-proposals`), now also scoped to add an `upgrade-guardian-set` operation.
- [[i-ovhqjoor]] — upgrade the guardian set on the real testnet executor (it holds stale index 4; current mainnet is index 7) — surfaced by the live run.