### PR TITLE
fix(price_pusher): redact provider URLs/API keys from logged RPC errors

### DIFF
--- a/apps/price_pusher/src/__tests__/logger.test.ts
+++ b/apps/price_pusher/src/__tests__/logger.test.ts
@@ -1,0 +1,73 @@
+import { HttpRequestError, WebSocketRequestError } from "viem";
+
+import { createLogger } from "../logger.js";
+
+const SECRET = "SUPERSECRETKEY";
+const ENDPOINT = `https://eth-mainnet.g.alchemy.com/v2/${SECRET}`;
+
+// Collects every line pino writes so we can assert on the serialized output.
+const collect = () => {
+  const lines: string[] = [];
+  const stream = {
+    write: (chunk: string) => {
+      lines.push(chunk);
+    },
+  };
+  return { stream, lines };
+};
+
+describe("createLogger URL redaction", () => {
+  it("strips the API key from a viem HttpRequestError logged positionally", () => {
+    const { stream, lines } = collect();
+    const logger = createLogger("debug", stream);
+    const error = new HttpRequestError({
+      body: { method: "eth_call" },
+      status: 500,
+      url: ENDPOINT,
+    });
+
+    logger.error(error, "Polling on-chain price failed.");
+
+    const line = lines.join("");
+    expect(line).not.toContain(SECRET);
+    const parsed = JSON.parse(line);
+    // The error is still logged with a useful message and origin.
+    expect(parsed.err.message).toContain("HTTP request failed.");
+    expect(line).toContain("https://eth-mainnet.g.alchemy.com/[REDACTED]");
+  });
+
+  it("strips the API key whether the error is under `err` or `error`", () => {
+    const { stream, lines } = collect();
+    const logger = createLogger("debug", stream);
+    const error = new HttpRequestError({ status: 500, url: ENDPOINT });
+
+    logger.error({ err: error }, "err key");
+    logger.warn({ error }, "error key");
+
+    expect(lines.join("")).not.toContain(SECRET);
+    expect(lines).toHaveLength(2);
+  });
+
+  it("redacts userinfo and query-string secrets in WebSocket URLs", () => {
+    const { stream, lines } = collect();
+    const logger = createLogger("debug", stream);
+    const wsUrl = "wss://user:topsecret@rpc.example.com/ws?apikey=QUERYSECRET";
+    const error = new WebSocketRequestError({ url: wsUrl });
+
+    logger.error(error, "socket failed");
+
+    const line = lines.join("");
+    expect(line).not.toContain("topsecret");
+    expect(line).not.toContain("QUERYSECRET");
+    expect(line).toContain("[REDACTED]");
+  });
+
+  it("leaves plain hosts without secrets untouched", () => {
+    const { stream, lines } = collect();
+    const logger = createLogger("debug", stream);
+
+    logger.info("connecting to https://rpc.publicnode.com");
+
+    expect(lines.join("")).toContain("https://rpc.publicnode.com");
+  });
+});

--- a/apps/price_pusher/src/aptos/command.ts
+++ b/apps/price_pusher/src/aptos/command.ts
@@ -7,10 +7,10 @@ import fs from "node:fs";
 
 import { HermesClient } from "@pythnetwork/hermes-client";
 import { AptosAccount } from "aptos";
-import pino from "pino";
 import type { Options } from "yargs";
 
 import { Controller } from "../controller.js";
+import { createLogger } from "../logger.js";
 import { PricePusherMetrics } from "../metrics.js";
 import * as options from "../options.js";
 import { readPriceConfigFile } from "../price-config.js";
@@ -72,7 +72,7 @@ export default {
       metricsPort,
     } = argv;
 
-    const logger = pino({ level: logLevel });
+    const logger = createLogger(logLevel);
 
     const priceConfigs = readPriceConfigFile(priceConfigFile);
     const hermesClient = new HermesClient(priceServiceEndpoint, {

--- a/apps/price_pusher/src/evm/command.ts
+++ b/apps/price_pusher/src/evm/command.ts
@@ -6,10 +6,10 @@
 import fs from "node:fs";
 
 import { HermesClient } from "@pythnetwork/hermes-client";
-import pino from "pino";
 import type { Options } from "yargs";
 
 import { Controller } from "../controller.js";
+import { createLogger } from "../logger.js";
 import { PricePusherMetrics } from "../metrics.js";
 import * as options from "../options.js";
 import { readPriceConfigFile } from "../price-config.js";
@@ -151,9 +151,7 @@ export default {
       metricsPort,
     } = argv;
 
-    const logger = pino({
-      level: logLevel,
-    });
+    const logger = createLogger(logLevel);
 
     const priceConfigs = readPriceConfigFile(priceConfigFile);
     const hermesClient = new HermesClient(priceServiceEndpoint, {

--- a/apps/price_pusher/src/fuel/command.ts
+++ b/apps/price_pusher/src/fuel/command.ts
@@ -6,9 +6,9 @@ import fs from "node:fs";
 
 import { HermesClient } from "@pythnetwork/hermes-client";
 import { Provider, Wallet } from "fuels";
-import pino from "pino";
 import type { Options } from "yargs";
 import { Controller } from "../controller.js";
+import { createLogger } from "../logger.js";
 import * as options from "../options.js";
 import { readPriceConfigFile } from "../price-config.js";
 import { PythPriceListener } from "../pyth-price-listener.js";
@@ -56,7 +56,7 @@ export default {
       controllerLogLevel,
     } = argv;
 
-    const logger = pino({ level: logLevel });
+    const logger = createLogger(logLevel);
 
     const priceConfigs = readPriceConfigFile(priceConfigFile);
 

--- a/apps/price_pusher/src/injective/command.ts
+++ b/apps/price_pusher/src/injective/command.ts
@@ -5,9 +5,9 @@ import fs from "node:fs";
 
 import { getNetworkInfo } from "@injectivelabs/networks";
 import { HermesClient } from "@pythnetwork/hermes-client";
-import { pino } from "pino";
 import type { Options } from "yargs";
 import { Controller } from "../controller.js";
+import { createLogger } from "../logger.js";
 import * as options from "../options.js";
 import { readPriceConfigFile } from "../price-config.js";
 import { PythPriceListener } from "../pyth-price-listener.js";
@@ -73,7 +73,7 @@ export default {
       priceIdsProcessChunkSize,
     } = argv;
 
-    const logger = pino({ level: logLevel });
+    const logger = createLogger(logLevel);
 
     if (network !== "testnet" && network !== "mainnet") {
       throw new Error("Please specify network. One of [testnet, mainnet]");

--- a/apps/price_pusher/src/logger.ts
+++ b/apps/price_pusher/src/logger.ts
@@ -1,0 +1,64 @@
+import pino from "pino";
+import type { DestinationStream, Logger } from "pino";
+
+// RPC SDK errors (viem's HttpRequestError/RpcRequestError, the Injective SDK,
+// etc.) embed the transport URL in their `message`, `stack`, `metaMessages`,
+// and `url` fields. Operators routinely pass authenticated provider endpoints
+// (`https://eth-mainnet.g.alchemy.com/v2/<KEY>`, `wss://...?apikey=...`), so
+// logging these errors verbatim leaks the API key into structured logs. The
+// serializer below scrubs the secret-bearing part of any URL it finds while
+// keeping the origin for debuggability.
+const URL_PATTERN = /\b(?:https?|wss?):\/\/[^\s"'`<>\\]+/gi;
+
+const redactUrl = (raw: string): string => {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return raw;
+  }
+  const carriesSecret =
+    url.username !== "" ||
+    url.password !== "" ||
+    url.search !== "" ||
+    (url.pathname !== "" && url.pathname !== "/");
+  if (!carriesSecret) return raw;
+  return `${url.protocol}//${url.host}/[REDACTED]`;
+};
+
+const redactValue = (value: unknown, seen: WeakSet<object>): unknown => {
+  if (typeof value === "string") return value.replace(URL_PATTERN, redactUrl);
+  if (value === null || typeof value !== "object") return value;
+  if (seen.has(value)) return value;
+  seen.add(value);
+  if (Array.isArray(value)) return value.map((item) => redactValue(item, seen));
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) {
+    out[key] = redactValue(val, seen);
+  }
+  return out;
+};
+
+// Serializes an error (or any logged value) to a plain object and strips
+// secrets from the URLs it contains. Used for both the `err` and `error` log
+// keys the price pusher emits.
+const redactErrorSerializer = (value: unknown): unknown => {
+  const serialized =
+    value instanceof Error ? pino.stdSerializers.err(value) : value;
+  return redactValue(serialized, new WeakSet());
+};
+
+export const createLogger = (
+  level: string,
+  destination?: DestinationStream,
+): Logger =>
+  pino(
+    {
+      level,
+      serializers: {
+        err: redactErrorSerializer,
+        error: redactErrorSerializer,
+      },
+    },
+    destination,
+  );

--- a/apps/price_pusher/src/near/command.ts
+++ b/apps/price_pusher/src/near/command.ts
@@ -2,10 +2,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { HermesClient } from "@pythnetwork/hermes-client";
-import { pino } from "pino";
 import type { Options } from "yargs";
 
 import { Controller } from "../controller";
+import { createLogger } from "../logger";
 import * as options from "../options";
 import { readPriceConfigFile } from "../price-config";
 import { PythPriceListener } from "../pyth-price-listener";
@@ -63,7 +63,7 @@ export default {
       controllerLogLevel,
     } = argv;
 
-    const logger = pino({ level: logLevel });
+    const logger = createLogger(logLevel);
 
     const priceConfigs = readPriceConfigFile(priceConfigFile);
     const hermesClient = new HermesClient(priceServiceEndpoint, {

--- a/apps/price_pusher/src/solana/command.ts
+++ b/apps/price_pusher/src/solana/command.ts
@@ -19,10 +19,10 @@ import {
 import type { SearcherClient } from "jito-ts/dist/sdk/block-engine/searcher";
 import { searcherClient } from "jito-ts/dist/sdk/block-engine/searcher";
 import type { Logger } from "pino";
-import { pino } from "pino";
 import type { Options } from "yargs";
 import { Controller } from "../controller.js";
 import type { IBalanceTracker } from "../interface.js";
+import { createLogger } from "../logger.js";
 import { PricePusherMetrics } from "../metrics.js";
 import * as options from "../options.js";
 import { readPriceConfigFile } from "../price-config.js";
@@ -155,7 +155,7 @@ export default {
       wormholeProgramId,
     } = argv;
 
-    const logger = pino({ level: logLevel });
+    const logger = createLogger(logLevel);
 
     const priceConfigs = readPriceConfigFile(priceConfigFile);
 

--- a/apps/price_pusher/src/sui/command.ts
+++ b/apps/price_pusher/src/sui/command.ts
@@ -4,10 +4,10 @@ import fs from "node:fs";
 
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { HermesClient } from "@pythnetwork/hermes-client";
-import pino from "pino";
 import type { Options } from "yargs";
 
 import { Controller } from "../controller.js";
+import { createLogger } from "../logger.js";
 import { PricePusherMetrics } from "../metrics.js";
 import * as options from "../options.js";
 import { readPriceConfigFile } from "../price-config";
@@ -124,7 +124,7 @@ export default {
       metricsPort,
     } = argv;
 
-    const logger = pino({ level: logLevel });
+    const logger = createLogger(logLevel);
 
     const priceConfigs = readPriceConfigFile(priceConfigFile);
     const hermesClient = new HermesClient(priceServiceEndpoint, {

--- a/apps/price_pusher/src/ton/command.ts
+++ b/apps/price_pusher/src/ton/command.ts
@@ -5,10 +5,10 @@ import fs from "node:fs";
 
 import { HermesClient } from "@pythnetwork/hermes-client";
 import { Address, TonClient } from "@ton/ton";
-import { pino } from "pino";
 import type { Options } from "yargs";
 import { Controller } from "../controller.js";
 import type { IPriceListener } from "../interface.js";
+import { createLogger } from "../logger.js";
 import * as options from "../options.js";
 import { readPriceConfigFile } from "../price-config.js";
 import { PythPriceListener } from "../pyth-price-listener.js";
@@ -56,7 +56,7 @@ export default {
       controllerLogLevel,
     } = argv;
 
-    const logger = pino({ level: logLevel });
+    const logger = createLogger(logLevel);
 
     const priceConfigs = readPriceConfigFile(priceConfigFile);
 


### PR DESCRIPTION
## Summary

`price_pusher` logs raw RPC client errors that embed the configured endpoint URL, leaking provider API keys into structured logs. Operators routinely pass authenticated endpoints to `--endpoint` (e.g. `https://eth-mainnet.g.alchemy.com/v2/<KEY>`, `wss://...?apikey=...`). viem's `HttpRequestError` / `RpcRequestError` / `WebSocketRequestError` (and the Injective/Solana/etc. SDK errors) carry the transport URL in their `message`, `stack`, `metaMessages`, and `url` fields; these objects are passed wholesale to pino on routine RPC failures (nonce races, fee underpriced, transient 5xx).

Resolves [[i-vuiivvvg]].

## Fix

Centralized pino redaction (the finding's preferred remediation). New shared module `apps/price_pusher/src/logger.ts` exports `createLogger(level)`, which installs a serializer on the `err` and `error` log keys (the only two keys the pusher uses to log errors — positional `logger.error(error, …)` is routed to `err` by pino 9's default `errorKey`). The serializer runs `pino.stdSerializers.err` then deep-scrubs every string: any `http(s)`/`ws(s)` URL that carries a secret (userinfo, non-root path, or query string) is rewritten to `${protocol}//${host}/[REDACTED]`, keeping the origin for debuggability. Each chain's root logger in `command.ts` (evm, near, fuel, solana, aptos, sui, ton, injective) now calls `createLogger` instead of `pino({ level })`; child loggers (controller, balance trackers) inherit the serializers.

### Why a serializer and not the `redact` config suggested in the issue
The issue suggested `pino({ redact: { paths: ['*.url','err.shortMessage', …] } })`. That is **insufficient**: field-path redaction cannot scrub the secret out of `err.message` / `err.stack`, where viem embeds the full `URL: https://…/<KEY>` line (verified against viem 2.24.3 — its `getUrl()` is the identity, no built-in redaction). Redacting the whole `message` would destroy all diagnostic value, so a substring-scrubbing serializer is required.

## Testing

- New unit test `src/__tests__/logger.test.ts` (4 cases): positional viem error, `{err}` vs `{error}` keys, WebSocket userinfo+query secrets, and a no-op for secret-free hosts.
- `pnpm turbo test:unit test:types test:lint test:format --filter @pythnetwork/price-pusher` all green.
- Manually exercised edge cases (child logger, string at `error` key, nested `cause`) against real viem/pino — secret never reaches the output stream.

## Scope notes
Per issue guidance, scoped to the named defect. This does **not** cover secrets interpolated directly into a log *message string* (e.g. `logger.error(\`failed: ${endpoint}\`)`) — pino does not route the message through serializers — but no such site exists today; the finding is about raw error objects. No `SecretString`/newtype refactor.

## Suggested reviewers
- **guibescos** (Guillermo Bescos) — recent committer across price_pusher.
- **Aditya Arora** (`aditya520`) — top recent committer on price_pusher.