### PR TITLE
PythLazer.sol: add public getters for unreadable trusted-signer state

### DIFF
--- a/contract_manager/src/core/contracts/evm_abis.ts
+++ b/contract_manager/src/core/contracts/evm_abis.ts
@@ -1404,6 +1404,30 @@ export const LAZER_ABI = [
     type: "function",
   },
   {
+    inputs: [],
+    name: "getTrustedSigners",
+    outputs: [
+      {
+        components: [
+          { internalType: "address", name: "pubkey", type: "address" },
+          { internalType: "uint256", name: "expiresAt", type: "uint256" },
+        ],
+        internalType: "struct PythLazer.TrustedSignerInfo[]",
+        name: "",
+        type: "tuple[]",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "signer", type: "address" }],
+    name: "getTrustedSignerExpiry",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
     inputs: [{ internalType: "address", name: "signer", type: "address" }],
     name: "isValidSigner",
     outputs: [{ internalType: "bool", name: "", type: "bool" }],

--- a/lazer/contracts/evm/src/PythLazer.sol
+++ b/lazer/contracts/evm/src/PythLazer.sol
@@ -67,6 +67,39 @@ contract PythLazer is OwnableUpgradeable, UUPSUpgradeable {
         return block.timestamp < trustedSignerToExpiresAtMapping[signer];
     }
 
+    /// @notice Returns all trusted signers with a non-zero pubkey, in slot order.
+    /// @dev Empty slots (pubkey == address(0)) are skipped, so the returned
+    /// array length is the number of populated signers (≤ 100).
+    function getTrustedSigners()
+        external
+        view
+        returns (TrustedSignerInfo[] memory)
+    {
+        uint256 count = 0;
+        for (uint8 i = 0; i < trustedSigners.length; i++) {
+            if (trustedSigners[i].pubkey != address(0)) {
+                count++;
+            }
+        }
+
+        TrustedSignerInfo[] memory signers = new TrustedSignerInfo[](count);
+        uint256 j = 0;
+        for (uint8 i = 0; i < trustedSigners.length; i++) {
+            if (trustedSigners[i].pubkey != address(0)) {
+                signers[j] = trustedSigners[i];
+                j++;
+            }
+        }
+        return signers;
+    }
+
+    /// @notice Returns the stored expiry timestamp for a signer, or 0 if unknown.
+    function getTrustedSignerExpiry(
+        address signer
+    ) external view returns (uint256) {
+        return trustedSignerToExpiresAtMapping[signer];
+    }
+
     function verifyUpdate(
         bytes calldata update
     ) external payable returns (bytes calldata payload, address signer) {
@@ -106,6 +139,6 @@ contract PythLazer is OwnableUpgradeable, UUPSUpgradeable {
     }
 
     function version() public pure returns (string memory) {
-        return "0.1.1";
+        return "0.2.0";
     }
 }

--- a/lazer/contracts/evm/test/PythLazer.t.sol
+++ b/lazer/contracts/evm/test/PythLazer.t.sol
@@ -42,6 +42,86 @@ contract PythLazerTest is Test {
         assert(!pythLazer.isValidSigner(address(2)));
     }
 
+    function test_get_trusted_signers_empty() public view {
+        PythLazer.TrustedSignerInfo[] memory signers = pythLazer
+            .getTrustedSigners();
+        assertEq(signers.length, 0);
+    }
+
+    function test_get_trusted_signers_insertion_order() public {
+        address signerA = address(10);
+        address signerB = address(11);
+        address signerC = address(12);
+        uint256 expiryA = block.timestamp + 1000;
+        uint256 expiryB = block.timestamp + 2000;
+        uint256 expiryC = block.timestamp + 3000;
+
+        vm.startPrank(owner);
+        pythLazer.updateTrustedSigner(signerA, expiryA);
+        pythLazer.updateTrustedSigner(signerB, expiryB);
+        pythLazer.updateTrustedSigner(signerC, expiryC);
+        vm.stopPrank();
+
+        PythLazer.TrustedSignerInfo[] memory signers = pythLazer
+            .getTrustedSigners();
+        assertEq(signers.length, 3);
+        assertEq(signers[0].pubkey, signerA);
+        assertEq(signers[0].expiresAt, expiryA);
+        assertEq(signers[1].pubkey, signerB);
+        assertEq(signers[1].expiresAt, expiryB);
+        assertEq(signers[2].pubkey, signerC);
+        assertEq(signers[2].expiresAt, expiryC);
+    }
+
+    function test_get_trusted_signers_removal_and_reuse() public {
+        address signerA = address(10);
+        address signerB = address(11);
+        address signerC = address(12);
+        uint256 expiry = block.timestamp + 1000;
+
+        vm.startPrank(owner);
+        pythLazer.updateTrustedSigner(signerA, expiry);
+        pythLazer.updateTrustedSigner(signerB, expiry);
+
+        // Remove the first signer; its slot must be skipped.
+        pythLazer.updateTrustedSigner(signerA, 0);
+        vm.stopPrank();
+
+        PythLazer.TrustedSignerInfo[] memory signers = pythLazer
+            .getTrustedSigners();
+        assertEq(signers.length, 1);
+        assertEq(signers[0].pubkey, signerB);
+
+        // Adding a new signer reuses the freed slot 0, which comes before
+        // signerB in slot order.
+        vm.prank(owner);
+        pythLazer.updateTrustedSigner(signerC, expiry);
+
+        signers = pythLazer.getTrustedSigners();
+        assertEq(signers.length, 2);
+        assertEq(signers[0].pubkey, signerC);
+        assertEq(signers[1].pubkey, signerB);
+    }
+
+    function test_get_trusted_signer_expiry() public {
+        address signer = address(10);
+        uint256 expiry = block.timestamp + 1234;
+
+        assertEq(pythLazer.getTrustedSignerExpiry(address(99)), 0);
+
+        vm.prank(owner);
+        pythLazer.updateTrustedSigner(signer, expiry);
+        assertEq(pythLazer.getTrustedSignerExpiry(signer), expiry);
+
+        vm.prank(owner);
+        pythLazer.updateTrustedSigner(signer, 0);
+        assertEq(pythLazer.getTrustedSignerExpiry(signer), 0);
+    }
+
+    function test_version() public view {
+        assertEq(pythLazer.version(), "0.2.0");
+    }
+
     function test_verify() public {
         // Prepare dummy update and signer
         address trustedSigner = 0xb8d50f0bAE75BF6E03c104903d7C3aFc4a6596Da;


### PR DESCRIPTION
Resolves [[i-sghnfsil]].

## Changes

### `lazer/contracts/evm/src/PythLazer.sol`
- Add `getTrustedSigners() external view returns (TrustedSignerInfo[] memory)` — returns only populated slots (skips `pubkey == address(0)`), preserving slot order; length ≤ 100.
- Add `getTrustedSignerExpiry(address) external view returns (uint256)` — reads `trustedSignerToExpiresAtMapping[signer]`, exposing a named function rather than flipping the mapping to `public`.
- Bump `version()` from `"0.1.1"` to `"0.2.0"`.

Both additions are pure view functions with no new state — **storage layout is unchanged** (verified, see below). This is upgrade-safe.

Audit per parent guidance: the only previously-unreadable state was `trustedSigners` (internal, no getter) and `trustedSignerToExpiresAtMapping` (default-internal); both are now covered. `verification_fee` is already `public`, and inherited `owner()` / `proxiableUUID()` are readable. No other gaps.

### `contract_manager/src/core/contracts/evm_abis.ts`
- Added `getTrustedSigners` and `getTrustedSignerExpiry` entries to the hand-written `LAZER_ABI`. All existing entries left intact.

### `lazer/contracts/evm/test/PythLazer.t.sol`
Test names use the file's snake_case convention (matching `test_update_add_signer`):
- `test_get_trusted_signers_empty` — zero-length array on empty state.
- `test_get_trusted_signers_insertion_order` — N signers returned in insertion/slot order with no zero entries.
- `test_get_trusted_signers_removal_and_reuse` — removing a signer (`expiresAt = 0`) frees its slot, which is skipped and then reused by a subsequent add.
- `test_get_trusted_signer_expiry` — `0` for unknown, stored expiry for known, `0` again after removal.
- `test_version` — asserts `"0.2.0"`.

## Verification

- `forge test --ffi` (in `lazer/contracts/evm/`): 20/20 pass — all 18 tests in `PythLazer.t.sol` (incl. the 5 new) and 2 in `PythLazerApi.t.sol`.
- Storage layout unchanged: compared `forge inspect PythLazer storage-layout` before vs. after — byte-identical (slots: `trustedSigners` @0, `verification_fee` @200, `trustedSignerToExpiresAtMapping` @201).
- `prettier --check` clean on the modified `evm_abis.ts`.
- `git merge-tree origin/main HEAD`: no conflict.

## Out of scope (per issue)

Contract deployment/upgrade and switching `EvmLazerContract.getTrustedSigners()` ([[i-hnsfnbfk]]) off storage-slot reads are deferred until all deployed proxies are upgraded.