### PR TITLE
feat(stellar): DAO/multisig vault-based management for Stellar Lazer contracts

### DIFF
--- a/contract_manager/scripts/manage_stellar_lazer_contract.ts
+++ b/contract_manager/scripts/manage_stellar_lazer_contract.ts
@@ -1,0 +1,296 @@
+/** biome-ignore-all lint/suspicious/noConsole: this is a CLI script */
+import { parseVaa } from "@certusone/wormhole-sdk";
+import type { Wallet } from "@coral-xyz/anchor";
+import type { PythCluster } from "@pythnetwork/client";
+import {
+  CallStellarExecutor,
+  decodeGovernancePayload,
+  UpgradeStellarExecutor,
+  WORMHOLE_API_ENDPOINT,
+} from "@pythnetwork/xc-admin-common";
+import type { Options } from "yargs";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+import { toPrivateKey } from "../src/core/base";
+import {
+  StellarExecutorContract,
+  StellarLazerContract,
+} from "../src/core/contracts";
+import type { Vault } from "../src/node/utils/governance";
+import {
+  loadHotWallet,
+  SubmittedWormholeMessage,
+} from "../src/node/utils/governance";
+import { DefaultStore } from "../src/node/utils/store";
+
+function getMainnetVault(): Vault {
+  const vault = Object.entries(DefaultStore.vaults).find(([id]) =>
+    id.startsWith("mainnet-beta_"),
+  )?.[1];
+  if (!vault) {
+    throw new Error("Could not find mainnet vault.");
+  }
+  return vault;
+}
+
+function connectMainnetVault(wallet: Wallet): Vault {
+  // Override these URLs to use a different RPC node for mainnet / testnet.
+  const RPCS = {
+    devnet: "https://api.devnet.solana.com",
+    "mainnet-beta": "https://api.mainnet-beta.solana.com",
+    testnet: "https://api.testnet.solana.com",
+  } as Record<PythCluster, string>;
+
+  const vault = getMainnetVault();
+  vault.connect(wallet, (rpc) => RPCS[rpc]);
+  return vault;
+}
+
+/** Build a proposal carrying a single Wormhole governance payload. */
+async function propose(walletPath: string, payload: Buffer) {
+  const wallet = await loadHotWallet(walletPath);
+  const vault = connectMainnetVault(wallet);
+  console.info("Using wallet:", wallet.publicKey.toBase58());
+  console.info("Using vault for proposal:", vault.getId());
+
+  console.info("Submitting governance proposal...");
+  const proposal = await vault.proposeWormholeMessage([payload]);
+  console.log("Proposal address:", proposal.address.toBase58());
+}
+
+const commonOptions = {
+  executor: {
+    coerce: (id: string) => {
+      const contract = DefaultStore.executor_contracts[id];
+      if (!(contract instanceof StellarExecutorContract)) {
+        throw new TypeError(`ID '${id}' is not a Stellar executor contract.`);
+      }
+      return contract;
+    },
+    demandOption: true,
+    description: "Executor contract ID in StellarExecutorContracts.json",
+    type: "string",
+  },
+  "ops-key-path": {
+    demandOption: true,
+    description: "path to the Solana wallet used to create the DAO proposal",
+    type: "string",
+  },
+  "private-key": {
+    demandOption: true,
+    description:
+      "32-byte ed25519 seed (hex, no 0x) of the Stellar account paying tx fees",
+    type: "string",
+  },
+  verifier: {
+    coerce: (id: string) => {
+      const contract = DefaultStore.lazer_contracts[id];
+      if (!(contract instanceof StellarLazerContract)) {
+        throw new TypeError(`ID '${id}' is not a Stellar Lazer contract.`);
+      }
+      return contract;
+    },
+    demandOption: true,
+    description: "Verifier contract ID in StellarLazerContracts.json",
+    type: "string",
+  },
+  "wasm-hash": {
+    demandOption: true,
+    description: "32-byte WASM hash of the new contract (hex, no 0x)",
+    type: "string",
+  },
+} as const satisfies Record<string, Options>;
+
+const parser = yargs(hideBin(process.argv))
+  .usage(
+    "Vault-based (DAO Squads multisig) management of Stellar PythLazer contracts.",
+  )
+  .strict()
+  .demandCommand(1);
+
+parser.command(
+  "propose-update-trusted-signer",
+  "propose a trusted-signer update through the DAO vault",
+  (b) =>
+    b.options({
+      "expires-at": {
+        coerce: BigInt,
+        demandOption: true,
+        description:
+          "expiry timestamp (unix seconds); 0 removes the trusted signer",
+        type: "string",
+      },
+      "ops-key-path": commonOptions["ops-key-path"],
+      "trusted-signer": {
+        demandOption: true,
+        description: "33-byte compressed secp256k1 signer key (hex, no 0x)",
+        type: "string",
+      },
+      verifier: commonOptions.verifier,
+    }),
+  async (argv) => {
+    const payload = await argv.verifier.generateUpdateTrustedSignerPayload(
+      argv["trusted-signer"],
+      argv["expires-at"],
+    );
+    await propose(argv["ops-key-path"], payload);
+  },
+);
+
+parser.command(
+  "propose-upgrade-verifier",
+  "propose a verifier WASM upgrade through the DAO vault",
+  (b) =>
+    b.options({
+      "ops-key-path": commonOptions["ops-key-path"],
+      verifier: commonOptions.verifier,
+      "wasm-hash": commonOptions["wasm-hash"],
+    }),
+  async (argv) => {
+    const payload = await argv.verifier.generateUpgradeVerifierPayload(
+      argv["wasm-hash"],
+    );
+    await propose(argv["ops-key-path"], payload);
+  },
+);
+
+parser.command(
+  "propose-upgrade-executor",
+  "propose an executor self-upgrade through the DAO vault",
+  (b) =>
+    b.options({
+      executor: commonOptions.executor,
+      "ops-key-path": commonOptions["ops-key-path"],
+      "wasm-hash": commonOptions["wasm-hash"],
+    }),
+  async (argv) => {
+    const payload = argv.executor.generateUpgradeExecutorPayload(
+      argv["wasm-hash"],
+    );
+    await propose(argv["ops-key-path"], payload);
+  },
+);
+
+parser.command(
+  "execute-proposals",
+  "submit DAO-approved governance VAAs to the executor (run after the DAO votes)",
+  (b) =>
+    b.options({
+      executor: commonOptions.executor,
+      "private-key": commonOptions["private-key"],
+      since: {
+        description:
+          "Wormhole sequence to start scanning from (inclusive). Defaults to the executor's last executed sequence + 1; pass it explicitly to avoid scanning from the beginning.",
+        type: "number",
+      },
+    }),
+  async (argv) => {
+    const executor = argv.executor;
+    const vault = getMainnetVault();
+    const emitter = await vault.getEmitter();
+    const targetChain = executor.chain.wormholeChainName;
+
+    const since =
+      argv.since ?? Number(await executor.getLastExecutedSequence()) + 1;
+    console.info(
+      `Scanning vault ${vault.getId()} from sequence ${since.toString()} for '${targetChain}' proposals...`,
+    );
+
+    for (let i = since; ; i++) {
+      const ref = new SubmittedWormholeMessage(emitter, i, vault.cluster);
+      let vaa: Buffer;
+      try {
+        vaa = await ref.fetchVaa();
+      } catch {
+        console.warn(`Could not find VAA #${i.toString()}, ending.`);
+        break;
+      }
+
+      const action = decodeGovernancePayload(parseVaa(vaa).payload);
+      if (!action) {
+        console.warn(`Could not parse VAA #${i.toString()}, skipping...`);
+        continue;
+      }
+      if (action.targetChainId !== targetChain) {
+        console.warn(
+          `VAA #${i.toString()} targets '${action.targetChainId}', not '${targetChain}', skipping...`,
+        );
+        continue;
+      }
+      if (
+        !(
+          action instanceof CallStellarExecutor ||
+          action instanceof UpgradeStellarExecutor
+        )
+      ) {
+        console.warn(
+          `VAA #${i.toString()} is not a Stellar executor action, skipping...`,
+        );
+        continue;
+      }
+
+      console.info(`Submitting governance VAA #${i.toString()}...`);
+      const result = await executor.executeGovernanceAction(
+        toPrivateKey(argv["private-key"]),
+        vaa,
+      );
+      console.info(`  Transaction finished: ${result.id}`);
+    }
+  },
+);
+
+parser.command(
+  "upgrade-guardian-set",
+  "advance the executor's stored Wormhole guardian set to the current mainnet set",
+  (b) =>
+    b.options({
+      executor: commonOptions.executor,
+      "private-key": commonOptions["private-key"],
+    }),
+  async (argv) => {
+    const executor = argv.executor;
+    const before = await executor.getCurrentGuardianSetIndex();
+    console.info(`Current guardian set index: ${before.toString()}`);
+    await executor.syncMainnetGuardianSets(toPrivateKey(argv["private-key"]));
+    const after = await executor.getCurrentGuardianSetIndex();
+    console.info(`Guardian set index is now: ${after.toString()}`);
+  },
+);
+
+parser.command(
+  "show-guardian-set",
+  "show the executor's stored guardian set index against the live mainnet index",
+  (b) =>
+    b.options({
+      executor: commonOptions.executor,
+    }),
+  async (argv) => {
+    const executor = argv.executor;
+    const index = await executor.getCurrentGuardianSetIndex();
+    const guardians = await executor.getGuardianSet();
+    console.log(`Executor stored guardian set index: ${index.toString()}`);
+    console.log(`  guardians (${guardians.length.toString()}):`);
+    for (const guardian of guardians) {
+      console.log(`    ${guardian}`);
+    }
+
+    const endpoint = WORMHOLE_API_ENDPOINT["mainnet-beta"];
+    const response = await fetch(`${endpoint}/v1/guardianset/current`);
+    const { guardianSet } = (await response.json()) as {
+      guardianSet: { index: number; addresses: string[] };
+    };
+    console.log(
+      `Live mainnet guardian set index: ${guardianSet.index.toString()}`,
+    );
+    if (index === guardianSet.index) {
+      console.log("Executor is up to date.");
+    } else {
+      console.log(
+        `Executor is ${(guardianSet.index - index).toString()} set(s) behind; run upgrade-guardian-set.`,
+      );
+    }
+  },
+);
+
+await parser.parseAsync();

--- a/contract_manager/src/core/contracts/stellar.ts
+++ b/contract_manager/src/core/contracts/stellar.ts
@@ -18,6 +18,7 @@ import type { PrivateKey, TxResult } from "../base";
 import { Storable } from "../base";
 import type { Chain } from "../chains";
 import { StellarChain } from "../chains";
+import { WormholeContract } from "./wormhole";
 
 /**
  * Lazer on Stellar (Soroban) is split across two contracts (see
@@ -192,8 +193,13 @@ export class StellarLazerContract extends Storable {
  * The Wormhole governance **executor** (`wormhole-executor-stellar`). It verifies
  * Pyth governance VAAs and dispatches the decoded PTGM action to the verifier, or
  * upgrades itself. Mirrors {@link EvmExecutorContract}.
+ *
+ * Unlike the EVM split, the Stellar executor also *holds the Wormhole guardian
+ * set* itself (there is no separate core-bridge contract on this chain), so it is
+ * a {@link WormholeContract}: guardian-set rotations are submitted to its own
+ * `update_guardian_set` entry point.
  */
-export class StellarExecutorContract extends Storable {
+export class StellarExecutorContract extends WormholeContract {
   static type = "StellarExecutorContract";
 
   /**
@@ -214,6 +220,14 @@ export class StellarExecutorContract extends Storable {
 
   getType(): string {
     return StellarExecutorContract.type;
+  }
+
+  getChain(): StellarChain {
+    return this.chain;
+  }
+
+  getChainId(): Promise<number> {
+    return Promise.resolve(this.chain.getWormholeChainId());
   }
 
   toJson() {
@@ -259,8 +273,39 @@ export class StellarExecutorContract extends Storable {
    *   guardian-signed VAA, not the sender.
    * @param vaa - the signed Wormhole governance VAA wrapping the PTGM payload
    */
-  async executeGovernanceAction(
+  executeGovernanceAction(
     senderPrivateKey: PrivateKey,
+    vaa: Buffer,
+  ): Promise<TxResult> {
+    return this.submitVaa(senderPrivateKey, "execute_governance_action", vaa);
+  }
+
+  /**
+   * Submit a signed Wormhole core guardian-set-upgrade VAA to the executor's
+   * `update_guardian_set` entry point. This is a distinct authorization path from
+   * {@link executeGovernanceAction}: the VAA must be signed by the *current*
+   * guardian set and authorized by the executor's guardian-set-upgrade emitter
+   * (the Wormhole core bridge), not the Pyth governance emitter.
+   *
+   * @param senderPrivateKey - 32-byte ed25519 seed of the submitting account,
+   *   hex without 0x. The submitter only pays fees.
+   * @param vaa - the signed Wormhole core guardian-set-upgrade VAA
+   */
+  upgradeGuardianSets(
+    senderPrivateKey: PrivateKey,
+    vaa: Buffer,
+  ): Promise<TxResult> {
+    return this.submitVaa(senderPrivateKey, "update_guardian_set", vaa);
+  }
+
+  /**
+   * Submit a signed VAA to a single-`Bytes`-argument executor entry point
+   * (`execute_governance_action` or `update_guardian_set`) and wait for the
+   * transaction to confirm.
+   */
+  private async submitVaa(
+    senderPrivateKey: PrivateKey,
+    method: string,
     vaa: Buffer,
   ): Promise<TxResult> {
     const server = this.chain.getProvider();
@@ -274,9 +319,7 @@ export class StellarExecutorContract extends Storable {
       fee: BASE_FEE,
       networkPassphrase: this.chain.networkPassphrase,
     })
-      .addOperation(
-        executor.call("execute_governance_action", xdr.ScVal.scvBytes(vaa)),
-      )
+      .addOperation(executor.call(method, xdr.ScVal.scvBytes(vaa)))
       .setTimeout(30)
       .build();
 
@@ -286,7 +329,7 @@ export class StellarExecutorContract extends Storable {
     const sent = await server.sendTransaction(prepared);
     if (sent.status === "ERROR") {
       throw new Error(
-        `Failed to submit governance transaction: ${JSON.stringify(sent.errorResult)}`,
+        `Failed to submit ${method} transaction: ${JSON.stringify(sent.errorResult)}`,
       );
     }
 
@@ -297,7 +340,7 @@ export class StellarExecutorContract extends Storable {
     }
 
     if (result.status !== stellarRpc.Api.GetTransactionStatus.SUCCESS) {
-      throw new Error(`Governance transaction ${sent.hash} failed`);
+      throw new Error(`${method} transaction ${sent.hash} failed`);
     }
 
     return { id: sent.hash, info: result };
@@ -305,12 +348,16 @@ export class StellarExecutorContract extends Storable {
 
   /**
    * Read the executor's current Wormhole guardian set index.
+   *
+   * The index lives in *persistent* storage (see the executor's `guardian.rs`),
+   * not instance storage, so it is fetched as a standalone ledger entry keyed by
+   * the `GuardianSetIndex` data key.
    */
   async getCurrentGuardianSetIndex(): Promise<number> {
-    const value = await readInstanceStorage(
+    const value = await readPersistentStorage(
       this.chain,
       this.address,
-      "GuardianSetIndex",
+      xdr.ScVal.scvVec([xdr.ScVal.scvSymbol("GuardianSetIndex")]),
     );
     if (!value) {
       throw new Error("Executor has no guardian set index (not initialized)");
@@ -341,11 +388,74 @@ export class StellarExecutorContract extends Storable {
     }
     return executable.wasmHash().toString("hex");
   }
+
+  /**
+   * Read the Ethereum addresses of the executor's current guardian set, returned
+   * as `0x`-prefixed hex strings.
+   */
+  async getGuardianSet(): Promise<string[]> {
+    const index = await this.getCurrentGuardianSetIndex();
+    const value = await readPersistentStorage(
+      this.chain,
+      this.address,
+      xdr.ScVal.scvVec([
+        xdr.ScVal.scvSymbol("GuardianSetByIndex"),
+        xdr.ScVal.scvU32(index),
+      ]),
+    );
+    if (!value) {
+      throw new Error(`Executor has no guardian set at index ${index}`);
+    }
+    const stored = scValToNative(value) as { keys: Uint8Array[] };
+    return stored.keys.map((key) => `0x${Buffer.from(key).toString("hex")}`);
+  }
+
+  /**
+   * Read the sequence number of the last governance VAA the executor has
+   * executed. Returns `0n` if none has been executed yet. Governance VAAs are
+   * accepted only with strictly increasing sequence numbers, so the next
+   * proposal to execute is the first one after this value.
+   */
+  async getLastExecutedSequence(): Promise<bigint> {
+    const value = await readPersistentStorage(
+      this.chain,
+      this.address,
+      xdr.ScVal.scvVec([xdr.ScVal.scvSymbol("LastExecutedSequence")]),
+    );
+    return value ? BigInt(scValToNative(value) as number | bigint) : 0n;
+  }
 }
 
 /** XDR-encode an argument vector as the `ScVec` the executor's `Call` expects. */
 function encodeScVecArgs(args: xdr.ScVal[]): Buffer {
   return xdr.ScVal.scvVec(args).toXDR();
+}
+
+/**
+ * Read a single entry from a contract's persistent storage by its `ScVal` key,
+ * returning the stored value or `undefined` if the entry does not exist.
+ *
+ * Persistent entries are individual ledger entries (unlike instance storage,
+ * which is bundled in the contract instance), so each is fetched directly with
+ * its data key.
+ */
+async function readPersistentStorage(
+  chain: StellarChain,
+  contractId: string,
+  key: xdr.ScVal,
+): Promise<xdr.ScVal | undefined> {
+  const server = chain.getProvider();
+  try {
+    const entry = await server.getContractData(
+      contractId,
+      key,
+      stellarRpc.Durability.Persistent,
+    );
+    return entry.val.contractData().val();
+  } catch {
+    // getContractData throws when the entry does not exist.
+    return undefined;
+  }
 }
 
 /**

--- a/contract_manager/src/node/utils/store.ts
+++ b/contract_manager/src/node/utils/store.ts
@@ -239,13 +239,16 @@ export class Store {
           );
         if (chainContract instanceof EvmEntropyContract) {
           this.entropy_contracts[chainContract.getId()] = chainContract;
-        } else if (chainContract instanceof WormholeContract) {
-          this.wormhole_contracts[chainContract.getId()] = chainContract;
         } else if (
           chainContract instanceof EvmExecutorContract ||
           chainContract instanceof StellarExecutorContract
         ) {
+          // Checked before WormholeContract: the Stellar executor *is* a
+          // WormholeContract (it holds the guardian set) but belongs in
+          // executor_contracts.
           this.executor_contracts[chainContract.getId()] = chainContract;
+        } else if (chainContract instanceof WormholeContract) {
+          this.wormhole_contracts[chainContract.getId()] = chainContract;
         } else if (
           chainContract instanceof EvmLazerContract ||
           chainContract instanceof SuiLazerContract ||


### PR DESCRIPTION
Implements the operator-facing **vault-based (DAO Squads multisig) management** path for the Stellar Lazer contracts — the `manage_stellar_lazer_contract.ts` counterpart to `manage_sui_lazer_contract.ts`, for [[i-trftrmpi]].

## What's added

`contract_manager/scripts/manage_stellar_lazer_contract.ts` with **propose** and **execute** as distinct commands (the mainnet flow runs them days apart, with a DAO vote in between):

- `propose-update-trusted-signer` / `propose-upgrade-verifier` — build the verifier PTGM payload via `StellarLazerContract.generate*Payload` and route it through the Pyth DAO Squads mainnet vault with `Vault.proposeWormholeMessage([payload])`.
- `propose-upgrade-executor` — same, for the executor self-upgrade payload.
- `execute-proposals` — run after the DAO votes: scan the vault emitter's VAAs from the executor's last-executed sequence, keep only `CallStellarExecutor` / `UpgradeStellarExecutor` actions targeting this chain, and submit each via `StellarExecutorContract.executeGovernanceAction`.
- `upgrade-guardian-set` — advance the executor's stored Wormhole guardian set to the current mainnet set. This is a **distinct auth path** from PTGM/DAO: core-bridge guardian-set-upgrade VAAs, applied in order (each must be current+1). Reuses the proven `WormholeContract.syncMainnetGuardianSets`.
- `show-guardian-set` — read-only companion: executor's stored index + guardians vs. the live mainnet index (from the public Wormholescan API).

Vault wiring (`getMainnetVault` / `connectMainnetVault` / `DefaultStore.vaults`) mirrors the Sui script.

## Core changes (`src/core/contracts/stellar.ts`)

`StellarExecutorContract` now `extends WormholeContract` — on Stellar the executor *holds the guardian set itself* (no separate core-bridge contract), so the standard `WormholeContract` surface is the right fit and gives `syncMainnetGuardianSets` for free. Added:

- `upgradeGuardianSets(senderPrivateKey, vaa)` — submits to the `update_guardian_set` entry point (factored a shared `submitVaa` helper out of `executeGovernanceAction`).
- `getGuardianSet()`, `getChain()`, `getChainId()`, `getLastExecutedSequence()`.
- **Fix:** `getCurrentGuardianSetIndex` now reads **persistent** storage (the executor's `guardian.rs` stores `GuardianSetIndex` in persistent, not instance, storage — the prior instance read would never find it). Added a `readPersistentStorage` helper mirroring the proven `getTrustedSignerExpiry` pattern.

`store.ts` classification now checks the executor branch before `WormholeContract` (the Stellar executor is now a `WormholeContract` but must land in `executor_contracts`).

## Verification

Local gate: `tsc --noEmit` (clean for changed files; two unrelated pre-existing script errors remain), `biome check` clean, no merge conflicts vs `main`.

This touches Soroban (a blockchain). The **executor is not yet deployed** on testnet (store holds a placeholder) and there is no Stellar CLI / wasm toolchain in this environment, so a fresh executor deploy was not possible; the DAO mainnet propose/execute path likewise cannot be exercised without the real Pyth multisig. What **was** exercised live against Stellar testnet (full details in the issue verification comment):

- Live instance-storage read from the deployed verifier (`getExecutor()` → `GBFAFD67…`) — same read mechanism the new code uses.
- PTGM trusted-signer payload built against the live executor address (212 bytes, `5054474d`="PTGM").
- Live persistent-storage read path (`getTrustedSignerExpiry`).
- The new executor persistent keys encode to the exact Soroban contracttype scheme (`GuardianSetIndex` unit-variant = `Vec[Symbol]`; `GuardianSetByIndex(4)` = `Vec[Symbol, U32(4)]`), identical to the proven verifier reads.
- Live mainnet guardian-set API → index 7, 19 guardians (used by `show-guardian-set`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)