### PR TITLE
contract_manager: enumerate Stellar Lazer trusted signers

### DIFF
--- a/contract_manager/scripts/list_lazer_signers.ts
+++ b/contract_manager/scripts/list_lazer_signers.ts
@@ -5,7 +5,11 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
-import { EvmLazerContract, SuiLazerContract } from "../src/core/contracts";
+import {
+  EvmLazerContract,
+  StellarLazerContract,
+  SuiLazerContract,
+} from "../src/core/contracts";
 import { DefaultStore } from "../src/node/utils/store";
 
 const parser = yargs(hideBin(process.argv))
@@ -70,8 +74,6 @@ async function main() {
 
   const rows: SignerRow[] = [];
 
-  // Stellar verifiers expose no on-chain enumeration of trusted signers, so
-  // they are intentionally excluded here; that audit is tracked separately.
   for (const contract of Object.values(DefaultStore.lazer_contracts)) {
     if (contract.chain.isMainnet() === argv.testnet) continue;
     const contractId = contract.getId();
@@ -98,6 +100,19 @@ async function main() {
               contractId,
               chain,
               signer.address,
+              signer.expiresAt,
+              nowSeconds,
+              warnWithinSeconds,
+            ),
+          );
+        }
+      } else if (contract instanceof StellarLazerContract) {
+        for (const signer of await contract.getTrustedSigners()) {
+          rows.push(
+            makeRow(
+              contractId,
+              chain,
+              signer.publicKey,
               signer.expiresAt,
               nowSeconds,
               warnWithinSeconds,

--- a/contract_manager/src/core/contracts/stellar.ts
+++ b/contract_manager/src/core/contracts/stellar.ts
@@ -3,6 +3,7 @@ import {
   UpgradeStellarExecutor,
 } from "@pythnetwork/xc-admin-common";
 import {
+  Account,
   BASE_FEE,
   Contract,
   nativeToScVal,
@@ -161,9 +162,9 @@ export class StellarLazerContract extends Storable {
    * Read the expiry timestamp (unix seconds) of a trusted signer, or `undefined`
    * if the signer is not currently trusted.
    *
-   * The verifier keys trusted signers individually by public key and exposes no
-   * enumeration, so callers must supply the key of interest — there is no
-   * on-chain "list all signers" to mirror.
+   * This reads the individual `TrustedSigner(<pubkey>)` storage entry directly,
+   * so it requires knowing the key of interest. To enumerate the full set
+   * instead, use {@link getTrustedSigners}.
    *
    * @param publicKey - 33-byte compressed secp256k1 key, hex without 0x
    */
@@ -186,6 +187,48 @@ export class StellarLazerContract extends Storable {
       // getContractData throws when the entry does not exist.
       return undefined;
     }
+  }
+
+  /**
+   * Enumerate every currently trusted signer by invoking the verifier's
+   * `list_trusted_signers` view, returning each `(publicKey, expiresAt)` pair.
+   *
+   * Unlike {@link getTrustedSignerExpiry} (a direct storage read), this is a
+   * contract function call, so it is run through simulation — nothing is
+   * submitted on-chain and no signing is required.
+   */
+  async getTrustedSigners(): Promise<
+    { publicKey: string; expiresAt: bigint }[]
+  > {
+    const server = this.chain.getProvider();
+    const contract = new Contract(this.address);
+
+    // Simulation never submits the transaction, so a throwaway source account
+    // with a zero sequence number suffices — no on-chain account or signature.
+    const source = new Account(StellarKeypair.random().publicKey(), "0");
+    const tx = new TransactionBuilder(source, {
+      fee: BASE_FEE,
+      networkPassphrase: this.chain.networkPassphrase,
+    })
+      .addOperation(contract.call("list_trusted_signers"))
+      .setTimeout(30)
+      .build();
+
+    const sim = await server.simulateTransaction(tx);
+    if (stellarRpc.Api.isSimulationError(sim)) {
+      throw new Error(`Failed to list trusted signers: ${sim.error}`);
+    }
+    const retval = sim.result?.retval;
+    if (!retval) {
+      return [];
+    }
+    // `list_trusted_signers` returns Vec<(BytesN<33>, u64)>, which decodes to an
+    // array of [pubkeyBytes, expiry] tuples.
+    const signers = scValToNative(retval) as [Uint8Array, bigint | number][];
+    return signers.map(([pubkey, expiresAt]) => ({
+      expiresAt: BigInt(expiresAt),
+      publicKey: Buffer.from(pubkey).toString("hex"),
+    }));
   }
 }
 


### PR DESCRIPTION
Adds Stellar to the Lazer trusted-signer audit. Two commits:

1. **`StellarLazerContract.getTrustedSigners()`** (`contract_manager/src/core/contracts/stellar.ts`) — invokes the verifier's `list_trusted_signers` view via `server.simulateTransaction` (read-only, no signing; throwaway zero-sequence source account). Decodes the returned `Vec<(BytesN<33>, u64)>` via `scValToNative` into `{ publicKey: hex, expiresAt: bigint }`. Companion to pyth-lazer verifier change [[p-cwjhnvrd]]. Also refreshes the now-stale `getTrustedSignerExpiry` doc comment.

2. **Wire Stellar into `contract_manager/scripts/list_lazer_signers.ts`** — the cross-chain Lazer signer audit now enumerates Stellar verifiers alongside EVM and Sui, instead of skipping them. Drops the stale "Stellar exposes no on-chain enumeration" note.

Rebased onto current `main` (picks up the testnet redeploy #3867, so the live `stellar_testnet` verifier now has `list_trusted_signers`).

## Checks
- `npx @biomejs/biome check` on both changed files ✓
- `turbo run build --filter=@pythnetwork/contract-manager` ✓ (deps built)
- `tsc --noEmit -p tsconfig.json` (incl. `scripts/`): the two changed files are clean; the only remaining errors are pre-existing and unrelated (`deploy_solana_programs.ts`, `upgrade_evm_pricefeed_contracts.ts` on `main`).
- `git merge-tree origin/main HEAD`: no conflicts.

## Testnet validation
Ran `npx tsx scripts/list_lazer_signers.ts --testnet` against live Stellar testnet — the `stellar_testnet` verifier row is now returned. See issue comment for full output.