### PR TITLE
contract_manager: add list_lazer_signers.ts audit script

### DIFF
--- a/contract_manager/scripts/list_lazer_signers.ts
+++ b/contract_manager/scripts/list_lazer_signers.ts
@@ -1,0 +1,116 @@
+/** biome-ignore-all lint/suspicious/noConsole: this is a CLI script */
+/* eslint-disable @typescript-eslint/no-floating-promises */
+/* eslint-disable unicorn/prefer-top-level-await */
+
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+import { EvmLazerContract, SuiLazerContract } from "../src/core/contracts";
+import { DefaultStore } from "../src/node/utils/store";
+
+const parser = yargs(hideBin(process.argv))
+  .usage("Usage: $0 [--testnet] [--warn-within-days <n>]")
+  .options({
+    testnet: {
+      default: false,
+      desc: "Audit testnet contracts instead of mainnet",
+      type: "boolean",
+    },
+    "warn-within-days": {
+      default: 365,
+      desc: "Flag a signer as EXPIRES_SOON if it expires within this many days",
+      type: "number",
+    },
+  });
+
+type SignerRow = {
+  contract_id: string;
+  chain: string;
+  signer: string;
+  expires_at_unix: string;
+  expires_at_iso: string;
+  status: string;
+};
+
+function statusFor(
+  expiresAt: bigint,
+  nowSeconds: bigint,
+  warnWithinSeconds: bigint,
+): string {
+  if (expiresAt <= nowSeconds) return "EXPIRED";
+  if (expiresAt <= nowSeconds + warnWithinSeconds) return "EXPIRES_SOON";
+  return "OK";
+}
+
+function makeRow(
+  contractId: string,
+  chain: string,
+  signer: string,
+  expiresAt: bigint,
+  nowSeconds: bigint,
+  warnWithinSeconds: bigint,
+): SignerRow {
+  return {
+    chain,
+    contract_id: contractId,
+    expires_at_iso: new Date(Number(expiresAt) * 1000).toISOString(),
+    expires_at_unix: expiresAt.toString(),
+    signer,
+    status: statusFor(expiresAt, nowSeconds, warnWithinSeconds),
+  };
+}
+
+async function main() {
+  const argv = await parser.argv;
+
+  const nowSeconds = BigInt(Math.floor(Date.now() / 1000));
+  const warnWithinSeconds = BigInt(
+    Math.round(argv["warn-within-days"] * 86_400),
+  );
+
+  const rows: SignerRow[] = [];
+
+  // Stellar verifiers expose no on-chain enumeration of trusted signers, so
+  // they are intentionally excluded here; that audit is tracked separately.
+  for (const contract of Object.values(DefaultStore.lazer_contracts)) {
+    if (contract.chain.isMainnet() === argv.testnet) continue;
+    const contractId = contract.getId();
+    const chain = contract.chain.getId();
+
+    try {
+      if (contract instanceof SuiLazerContract) {
+        for (const signer of await contract.getTrustedSigners()) {
+          rows.push(
+            makeRow(
+              contractId,
+              chain,
+              signer.publicKey,
+              signer.expiresAt,
+              nowSeconds,
+              warnWithinSeconds,
+            ),
+          );
+        }
+      } else if (contract instanceof EvmLazerContract) {
+        for (const signer of await contract.getTrustedSigners()) {
+          rows.push(
+            makeRow(
+              contractId,
+              chain,
+              signer.address,
+              signer.expiresAt,
+              nowSeconds,
+              warnWithinSeconds,
+            ),
+          );
+        }
+      }
+    } catch (error) {
+      console.error(`Error fetching trusted signers for ${contractId}`, error);
+    }
+  }
+
+  console.table(rows);
+}
+
+main();

--- a/contract_manager/src/core/contracts/evm.ts
+++ b/contract_manager/src/core/contracts/evm.ts
@@ -1031,6 +1031,37 @@ export class EvmLazerContract extends Storable {
     return await contract.methods.version().call();
   }
 
+  /**
+   * Read the current set of trusted Lazer signers by reading contract storage
+   * directly. `PythLazer` exposes no getter, and `TrustedSignerInfo[100]
+   * internal trustedSigners` is the first state variable, so its entries occupy
+   * slots 0..199 (2 slots per struct: slot `2*i` holds `pubkey`, slot `2*i+1`
+   * holds `expiresAt`). Entries with a zero `pubkey` are unused and skipped.
+   *
+   * A sibling PR adds a public `getTrustedSigners()` view; once deployed
+   * everywhere this can switch to calling it.
+   *
+   * @returns one entry per active signer: checksummed `address` and `expiresAt`
+   *   (unix seconds)
+   */
+  async getTrustedSigners(): Promise<{ address: string; expiresAt: bigint }[]> {
+    const web3 = this.chain.getWeb3();
+    const signers: { address: string; expiresAt: bigint }[] = [];
+    for (let i = 0; i < 100; i++) {
+      const pubkeySlot = await web3.eth.getStorageAt(this.address, 2 * i);
+      const pubkey = BigInt(pubkeySlot);
+      if (pubkey === 0n) continue;
+      const expiresAtSlot = await web3.eth.getStorageAt(this.address, 2 * i + 1);
+      signers.push({
+        address: web3.utils.toChecksumAddress(
+          "0x" + pubkey.toString(16).padStart(40, "0"),
+        ),
+        expiresAt: BigInt(expiresAtSlot),
+      });
+    }
+    return signers;
+  }
+
   async getOwner(): Promise<string> {
     const contract = this.getContract();
     return contract.methods.owner().call();

--- a/contract_manager/src/core/contracts/sui.ts
+++ b/contract_manager/src/core/contracts/sui.ts
@@ -682,6 +682,36 @@ export class SuiLazerContract extends Storable {
   }
 
   /**
+   * Read the current set of trusted Lazer signers from the shared `State`
+   * object. The `trusted_signers: vector<TrustedSignerInfo>` field is stored
+   * inline on the state, so a single object fetch enumerates every signer.
+   *
+   * @returns one entry per signer: `publicKey` (33-byte compressed secp256k1,
+   *   hex without 0x) and `expiresAt` (unix seconds)
+   */
+  async getTrustedSigners(): Promise<
+    { publicKey: string; expiresAt: bigint }[]
+  > {
+    const provider = this.chain.getProvider();
+    const { object } = await provider.core.getObject({
+      include: { json: true },
+      objectId: this.stateId,
+    });
+    if (!object.json) {
+      throw new Error("Unable to fetch Lazer state object");
+    }
+    const signers = getStructFields(object.json).trusted_signers as unknown[];
+    return signers.map((signer) => {
+      const fields = getStructFields(signer);
+      const publicKey = fields.public_key as number[] | string;
+      return {
+        expiresAt: BigInt(fields.expires_at as string | number),
+        publicKey: bytesFromMoveField(publicKey).toString("hex"),
+      };
+    });
+  }
+
+  /**
    * Bumps contract version in source based on on-chain version and returns new
    * contract metadata.
    */


### PR DESCRIPTION
Adds `contract_manager/scripts/list_lazer_signers.ts`, which enumerates every **Sui + EVM** Lazer contract in `DefaultStore.lazer_contracts` and prints a per-`(contract, signer)` table — contract id, chain, signer pubkey/address, expiry (unix seconds + ISO), and status (`OK` / `EXPIRES_SOON` / `EXPIRED`). For [[i-hnsfnbfk]] (parent [[i-wfsldwlt]]: audit of Lazer trusted-signer expiries across chains).

## Per-chain enumeration

- **Sui** — new `SuiLazerContract.getTrustedSigners()` (`src/core/contracts/sui.ts`) reads the inline `trusted_signers: vector<TrustedSignerInfo>` field off the shared `State` object via `chain.getProvider()`, normalizing the byte transport with the existing `bytesFromMoveField` helper. Returns `{ publicKey, expiresAt }`.
- **EVM** — new `EvmLazerContract.getTrustedSigners()` (`src/core/contracts/evm.ts`) reads storage slots directly via `web3.eth.getStorageAt` (`TrustedSignerInfo[100]` is the first state var → slots 0..199, 2 slots per struct; zero-pubkey entries skipped). There is no public getter today; a sibling PR adds a view we can switch to later. Returns `{ address, expiresAt }`.
- **Stellar** — intentionally excluded. Per the scope reduction on the issue (Stellar verifier has no on-chain enumeration of trusted signers, so probe-by-key isn't a real audit), `StellarLazerContract` entries are skipped silently. Stellar enumeration is tracked separately.

## Script behavior

CLI mirrors `fetch_fees.ts`: `--testnet` (default false; mainnet-only otherwise) and `--warn-within-days <n>` (default 365, drives `EXPIRES_SOON`). Per-contract failures are caught and logged with the contract id without aborting the run.

## Verification

Ran live against mainnet and testnet RPCs (read-only on-chain reads; no keys/txs). See the verification comment on [[i-hnsfnbfk]] for full output. `turbo build` (tsc typecheck over `src`) passes; `tsc --noEmit` over `scripts/` is clean for the changed files; biome is clean on the new file and the two edited files introduce no new diagnostics.