### PR TITLE
ops(stellar): point testnet Lazer verifier + executor at redeployed contract ids

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/contract-addresses.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/contract-addresses.mdx
@@ -43,7 +43,7 @@ For Sui, both the package ID and the shared state object ID are relevant. Integr
 
 | Network         | Contract Address                                                                                                                                                                                            |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Stellar Testnet | <CopyAddress address="CD2KMDOR274ZVPVVSDIBWNBLGAXJOHKJBQGNWYQHF3O6H767UOYJJYJZ" url="https://stellar.expert/explorer/testnet/contract/CD2KMDOR274ZVPVVSDIBWNBLGAXJOHKJBQGNWYQHF3O6H767UOYJJYJZ" /> |
+| Stellar Testnet | <CopyAddress address="CAYFT5JE3UQTKT4Q6ZOZK4FXVYVT6RE3MFC7STA4UB6WAEGBT65MRU52" url="https://stellar.expert/explorer/testnet/contract/CAYFT5JE3UQTKT4Q6ZOZK4FXVYVT6RE3MFC7STA4UB6WAEGBT65MRU52" /> |
 
 ## EVM Mainnets
 

--- a/contract_manager/src/store/contracts/StellarExecutorContracts.json
+++ b/contract_manager/src/store/contracts/StellarExecutorContracts.json
@@ -1,6 +1,6 @@
 [
   {
-    "address": "PLACEHOLDER_EXECUTOR_TESTNET_NOT_YET_DEPLOYED",
+    "address": "CA542YLVDLBQXTTS2FOERQAED2WE5DQRKLRZUUEG75DQ2TEX2525QNBG",
     "chain": "stellar_testnet",
     "type": "StellarExecutorContract"
   }

--- a/contract_manager/src/store/contracts/StellarLazerContracts.json
+++ b/contract_manager/src/store/contracts/StellarLazerContracts.json
@@ -1,6 +1,6 @@
 [
   {
-    "address": "CCE62RN3NUTNMD2SQ2EGWRJ6XHL7RUYQBNCEK7LVGFRLPCW7U7FGACM5",
+    "address": "CAYFT5JE3UQTKT4Q6ZOZK4FXVYVT6RE3MFC7STA4UB6WAEGBT65MRU52",
     "chain": "stellar_testnet",
     "type": "StellarLazerContract"
   }

--- a/governance/xc_admin/packages/xc_admin_common/src/__tests__/StellarExecutorAction.test.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/__tests__/StellarExecutorAction.test.ts
@@ -9,9 +9,9 @@ import {
   UpgradeStellarExecutor,
 } from "../governance_payload";
 
-// A 56-character Soroban contract id (testnet Lazer verifier).
-const VERIFIER = "CCE62RN3NUTNMD2SQ2EGWRJ6XHL7RUYQBNCEK7LVGFRLPCW7U7FGACM5";
-const EXECUTOR = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+// 56-character Soroban contract ids of the deployed testnet Lazer contracts.
+const VERIFIER = "CAYFT5JE3UQTKT4Q6ZOZK4FXVYVT6RE3MFC7STA4UB6WAEGBT65MRU52";
+const EXECUTOR = "CA542YLVDLBQXTTS2FOERQAED2WE5DQRKLRZUUEG75DQ2TEX2525QNBG";
 
 function expectHeader(buffer: Buffer, action: number) {
   // Magic "PTGM" is MAGIC_NUMBER serialized little-endian (u32).


### PR DESCRIPTION
The Stellar **testnet** Lazer contracts were redeployed (see [[i-sqhbiwii]]) under the current Wormhole mainnet guardian set (index 7) with the new enumerable trusted-signer storage from [[i-rqicqgmp]]. New ids: verifier `CAYFT5JE3UQTKT4Q6ZOZK4FXVYVT6RE3MFC7STA4UB6WAEGBT65MRU52`, executor `CA542YLVDLBQXTTS2FOERQAED2WE5DQRKLRZUUEG75DQ2TEX2525QNBG`.

Updates every testnet contract-id reference in this repo — **both** the verifier and the executor (the original revision only did the verifier; the human reviewer flagged that the executor was redeployed too):

- `contract_manager/src/store/contracts/StellarLazerContracts.json` — `StellarLazerContract` registry record `CCE62RN3…` → verifier `CAYFT5JE…`. (On `main` this held `CCE62RN3…` from PR #3824, not the `CD2KMDOR…` the issue anticipated; both predate the [[i-rqicqgmp]] storage change, so it is repointed at the live redeploy.)
- `contract_manager/src/store/contracts/StellarExecutorContracts.json` — `StellarExecutorContract` registry record `PLACEHOLDER_EXECUTOR_TESTNET_NOT_YET_DEPLOYED` → executor `CA542YLV…`. When the issue was scoped this entry was still a placeholder (executor not yet deployed); the redeploy stood up the executor, so the placeholder is now filled in.
- `apps/developer-hub/content/docs/price-feeds/pro/contract-addresses.mdx` — the testnet row (`CD2KMDOR…` → new verifier).
- `governance/xc_admin/packages/xc_admin_common/src/__tests__/StellarExecutorAction.test.ts` — the `VERIFIER` and `EXECUTOR` fixtures, repointed at the real deployed ids (both were stale: verifier `CCE62RN3…`, executor `CDLZFC3S…`). Value-only swaps; the test asserts the encoder round-trips whatever 56-char Soroban ids it is handed.

**On-chain verification (Stellar testnet):** read the verifier `CAYFT5JE…`'s instance storage via `soroban-testnet.stellar.org` `getLedgerEntries`; its `Executor` entry resolves to `CA542YLV…`, exactly matching the registered executor. The executor contract itself is deployed and initialized (`ChainId=50140`, `OwnerEmitterChain=1`, owner emitter `5635979a…75b12e9e`). `pnpm jest StellarExecutorAction` → 6/6 pass; biome clean; merges cleanly to `origin/main`.