### PR TITLE
contract_manager: add Cardano chain + CardanoLazerContract + governance test + audit integration

### DIFF
--- a/contract_manager/package.json
+++ b/contract_manager/package.json
@@ -16,6 +16,8 @@
     "@pythnetwork/price-service-client": "workspace:*",
     "@pythnetwork/pyth-fuel-js": "workspace:*",
     "@pythnetwork/pyth-iota-js": "workspace:*",
+    "@pythnetwork/pyth-lazer-cardano-cli": "workspace:*",
+    "@pythnetwork/pyth-lazer-cardano-js": "workspace:*",
     "@pythnetwork/pyth-sdk-solidity": "workspace:^",
     "@pythnetwork/pyth-solana-receiver": "workspace:*",
     "@pythnetwork/pyth-starknet-js": "^0.2.1",
@@ -98,6 +100,16 @@
       "require": {
         "default": "./dist/cjs/core/contracts/aptos.cjs",
         "types": "./dist/cjs/core/contracts/aptos.d.ts"
+      }
+    },
+    "./core/contracts/cardano": {
+      "import": {
+        "default": "./dist/esm/core/contracts/cardano.mjs",
+        "types": "./dist/esm/core/contracts/cardano.d.ts"
+      },
+      "require": {
+        "default": "./dist/cjs/core/contracts/cardano.cjs",
+        "types": "./dist/cjs/core/contracts/cardano.d.ts"
       }
     },
     "./core/contracts/cosmwasm": {

--- a/contract_manager/scripts/list_lazer_signers.ts
+++ b/contract_manager/scripts/list_lazer_signers.ts
@@ -6,6 +6,7 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
 import {
+  CardanoLazerContract,
   EvmLazerContract,
   StellarLazerContract,
   SuiLazerContract,
@@ -107,6 +108,19 @@ async function main() {
           );
         }
       } else if (contract instanceof StellarLazerContract) {
+        for (const signer of await contract.getTrustedSigners()) {
+          rows.push(
+            makeRow(
+              contractId,
+              chain,
+              signer.publicKey,
+              signer.expiresAt,
+              nowSeconds,
+              warnWithinSeconds,
+            ),
+          );
+        }
+      } else if (contract instanceof CardanoLazerContract) {
         for (const signer of await contract.getTrustedSigners()) {
           rows.push(
             makeRow(

--- a/contract_manager/scripts/test_cardano_lazer_contract.ts
+++ b/contract_manager/scripts/test_cardano_lazer_contract.ts
@@ -1,5 +1,5 @@
 /** biome-ignore-all lint/suspicious/noConsole: this is a CLI script */
-import { createECDH } from "node:crypto";
+import { generateKeyPairSync } from "node:crypto";
 
 import { ClientContext } from "@pythnetwork/pyth-lazer-cardano-cli/client";
 import { applyGovernanceAction } from "@pythnetwork/pyth-lazer-cardano-cli/transactions";
@@ -57,13 +57,14 @@ function getChain(name: string): CardanoChain {
   return chain;
 }
 
-/** A fresh 32-byte secp256k1 (x-only) verification key that signs nothing. */
+/** A fresh 32-byte Ed25519 verification key that signs nothing. */
 function dummyTrustedSigner(): string {
-  const ecdh = createECDH("secp256k1");
-  ecdh.generateKeys();
-  // Drop the 0x02/0x03 prefix of the compressed key to get the 32-byte key
-  // the Cardano validator stores (`VerificationKey` in pyth_state.ak).
-  return ecdh.getPublicKey(null, "compressed").subarray(1).toString("hex");
+  // Cardano stores Ed25519 trusted-signer keys (`VerificationKey` in
+  // pyth_state.ak), matching Lazer's Ed25519-signed "solana" update format.
+  // The test only exercises add/remove round-trips, so the key never signs.
+  const { publicKey } = generateKeyPairSync("ed25519");
+  const { x } = publicKey.export({ format: "jwk" });
+  return Buffer.from(x as string, "base64url").toString("hex");
 }
 
 function digestToHex(digest: unknown): string {
@@ -221,7 +222,7 @@ parser.command(
       "policy-id": commonOptions["policy-id"],
       signer: {
         description:
-          "32-byte secp256k1 key (hex, no 0x) to add/remove. Defaults to a fresh " +
+          "32-byte Ed25519 key (hex, no 0x) to add/remove. Defaults to a fresh " +
           "dummy key generated in-script.",
         type: "string",
       },

--- a/contract_manager/scripts/test_cardano_lazer_contract.ts
+++ b/contract_manager/scripts/test_cardano_lazer_contract.ts
@@ -1,0 +1,303 @@
+/** biome-ignore-all lint/suspicious/noConsole: this is a CLI script */
+import { createECDH } from "node:crypto";
+
+import { ClientContext } from "@pythnetwork/pyth-lazer-cardano-cli/client";
+import { applyGovernanceAction } from "@pythnetwork/pyth-lazer-cardano-cli/transactions";
+import { prepareGovernanceAction } from "@pythnetwork/pyth-lazer-cardano-cli/wormhole";
+import type { Options } from "yargs";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+import { CardanoChain } from "../src/core/chains";
+import { CardanoLazerContract } from "../src/core/contracts";
+import { loadHotWallet, WormholeEmitter } from "../src/node/utils/governance";
+import { DefaultStore } from "../src/node/utils/store";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Deploying the throwaway contract these tests run against
+//
+// The canonical mainnet deployment (policy `c935c937…e154`) is owned by the Pyth
+// DAO multisig — Wormhole governance VAAs only originate after a Squads vote. To
+// exercise the governance flow end-to-end without the multisig, deploy a
+// throwaway instance on `preview` (or `preprod`) whose governance emitter is a
+// Solana key YOU control, then sign VAAs directly with that key.
+//
+// Throwaway deploy (run from `pyth-crosschain/lazer/contracts/cardano/cli/js`,
+// following its README):
+//   1. Prepare `.env` per `.env.example` (provider key + a funded CARDANO_MNEMONIC).
+//   2. pnpm cli build --env preview
+//   3. pnpm cli init --network preview --emitter-chain 1 \
+//        --emitter-address <hex of your Solana emitter pubkey as 32 bytes>
+//      -> prints the deployed PYTH_ID (policy id). Pass it via --policy-id.
+//
+// The preview/preprod deployments embed the Wormhole *testnet* guardian set, so
+// the VAA must be signed by those guardians: post the governance message on
+// Solana `devnet` (the `--guardian-cluster` default), funding the --emitter
+// wallet there (devnet SOL is free via `solana airdrop`). This mirrors
+// `manage_cardano_governance.ts`, which posts on `devnet`.
+//
+// Faucets:
+//   - Cardano `preview` ADA: https://docs.cardano.org/cardano-testnets/tools/faucet
+//   - Solana devnet SOL: `solana airdrop 1 <addr> --url devnet`
+// ─────────────────────────────────────────────────────────────────────────────
+const DEFAULT_GUARDIAN_CLUSTER = "devnet";
+const DEFAULT_CHAIN = "cardano_preview";
+
+/** Maps a store chain id to the Aiken env the dispatch helpers expect. */
+const DISPATCH_ENV: Record<string, "preprod" | "preview" | undefined> = {
+  cardano_preprod: "preprod",
+  cardano_preview: "preview",
+};
+
+function getChain(name: string): CardanoChain {
+  const chain = DefaultStore.chains[name];
+  if (!(chain instanceof CardanoChain)) {
+    throw new TypeError(`Not a valid Cardano chain: ${name}`);
+  }
+  return chain;
+}
+
+/** A fresh 32-byte secp256k1 (x-only) verification key that signs nothing. */
+function dummyTrustedSigner(): string {
+  const ecdh = createECDH("secp256k1");
+  ecdh.generateKeys();
+  // Drop the 0x02/0x03 prefix of the compressed key to get the 32-byte key
+  // the Cardano validator stores (`VerificationKey` in pyth_state.ak).
+  return ecdh.getPublicKey(null, "compressed").subarray(1).toString("hex");
+}
+
+function digestToHex(digest: unknown): string {
+  if (typeof digest === "string") return digest;
+  if (digest instanceof Uint8Array) return Buffer.from(digest).toString("hex");
+  return String(digest);
+}
+
+/**
+ * Produce a guardian-signed governance VAA for `payload` by posting it directly
+ * through the `--emitter` wallet on `guardianCluster`. This is the test-only
+ * stand-in for the mainnet path, where the VAA only exists after the DAO Squads
+ * multisig votes and executes the proposal.
+ */
+async function signGovernanceVaa(
+  payload: Buffer,
+  emitterPath: string,
+  guardianCluster: string,
+): Promise<Buffer> {
+  const emitterWallet = await loadHotWallet(emitterPath);
+  const emitter = new WormholeEmitter(guardianCluster, emitterWallet);
+  console.info(
+    `Governance emitter (must equal the deployment's emitter address): ${emitterWallet.publicKey.toBase58()}`,
+  );
+  console.info(`Posting governance message on '${guardianCluster}'...`);
+  const submitted = await emitter.sendMessage(payload);
+  console.info(
+    `Awaiting signed VAA #${submitted.sequenceNumber.toString()}...`,
+  );
+  return submitted.fetchVaa(30);
+}
+
+/**
+ * Submit a signed governance `vaa` to the Cardano deployment by building and
+ * running the spend transaction that carries the VAA as redeemer data. Surfaces
+ * the common misconfiguration: a VAA signed by guardians the deployment does not
+ * hold, or posted from an emitter the deployment was not initialized with.
+ */
+async function dispatchGovernance(
+  ctx: ClientContext,
+  policyId: string,
+  vaa: Buffer,
+  env: "preprod" | "preview" | undefined,
+): Promise<string> {
+  try {
+    const prepared = prepareGovernanceAction(vaa);
+    const [digest] = await ctx.run(() =>
+      applyGovernanceAction(ctx, policyId, prepared, env),
+    );
+    return digestToHex(digest);
+  } catch (error: unknown) {
+    console.error(
+      "Governance dispatch failed. The two common causes are:\n" +
+        "  - Invalid guardian signatures: the VAA was signed by a guardian set\n" +
+        "    the deployment does not hold. Post the message on the cluster whose\n" +
+        "    guardians match the deployment's guardian set (preview/preprod embed\n" +
+        "    the Wormhole testnet guardians -> post on Solana `devnet`).\n" +
+        "  - Invalid governance data source: the --emitter wallet is not the\n" +
+        "    deployment's configured emitter. Use the key the deployment was\n" +
+        "    initialized with (`--emitter-address` in `cli init`).",
+    );
+    throw error;
+  }
+}
+
+/** Read the on-chain expiry (unix seconds) of `pubkey`, or undefined if absent. */
+async function getSignerExpiry(
+  lazer: CardanoLazerContract,
+  pubkey: string,
+): Promise<bigint | undefined> {
+  const signers = await lazer.getTrustedSigners();
+  return signers.find((s) => s.publicKey === pubkey)?.expiresAt;
+}
+
+const commonOptions = {
+  "api-key": {
+    default: "",
+    description:
+      "Provider (Koios) token used by the Cardano signing client. Koios works " +
+      "tokenless at low rate, so this is optional.",
+    type: "string",
+  },
+  "cardano-wallet": {
+    demandOption: true,
+    description:
+      "Cardano wallet mnemonic (space-separated words) that pays for and signs " +
+      "the dispatch transaction. Authority comes from the VAA, not this wallet.",
+    type: "string",
+  },
+  emitter: {
+    demandOption: true,
+    description:
+      "Path to a Solana keypair (JSON array) used as the Wormhole governance " +
+      "emitter. Must be the throwaway deployment's emitter address, and must " +
+      "post on `--guardian-cluster` so its guardians sign the VAA.",
+    type: "string",
+  },
+  "guardian-cluster": {
+    default: DEFAULT_GUARDIAN_CLUSTER,
+    description:
+      "Solana cluster to post the governance message on. Its guardians sign the " +
+      "VAA, so it must match the guardian set the deployment embeds (preview/" +
+      "preprod use the Wormhole testnet guardians -> `devnet`).",
+    type: "string",
+  },
+  "policy-id": {
+    demandOption: true,
+    description:
+      "Hex policy id of your throwaway Cardano deployment (printed by `cli init`).",
+    type: "string",
+  },
+} as const satisfies Record<string, Options>;
+
+const parser = yargs(hideBin(process.argv))
+  .usage(
+    "E2E tests for Cardano PythLazer governance via contract_manager.\n" +
+      "Drives the integrated contract_manager -> Wormhole -> Cardano path against " +
+      "a throwaway testnet deployment you create, signing the VAA directly with " +
+      "the --emitter key (the test stand-in for the DAO multisig).",
+  )
+  .epilogue(
+    "Deploy the throwaway instance first (the canonical deployment is DAO-owned " +
+      "and rejects a self-signed VAA) — see the header comment in this file for " +
+      "the `cli init` commands and faucet links.",
+  )
+  .options({
+    chain: {
+      alias: "c",
+      coerce: getChain,
+      default: DEFAULT_CHAIN,
+      description: "chain name (from CardanoChains.json)",
+      type: "string",
+    },
+  })
+  .strict()
+  .demandCommand(1);
+
+parser.command(
+  "test-update-trusted-signer",
+  "E2E: add a dummy trusted signer, assert it, then remove it (cleanup)",
+  (b) =>
+    b.options({
+      "api-key": commonOptions["api-key"],
+      "cardano-wallet": commonOptions["cardano-wallet"],
+      emitter: commonOptions.emitter,
+      expires: {
+        coerce: BigInt,
+        // Far-future default so the assertion is stable; the signer is removed
+        // again in teardown regardless.
+        default: "4102444800", // 2100-01-01
+        description: "expiry timestamp (unix seconds) for the dummy signer",
+        type: "string",
+      },
+      "guardian-cluster": commonOptions["guardian-cluster"],
+      "policy-id": commonOptions["policy-id"],
+      signer: {
+        description:
+          "32-byte secp256k1 key (hex, no 0x) to add/remove. Defaults to a fresh " +
+          "dummy key generated in-script.",
+        type: "string",
+      },
+    }),
+  async ({
+    chain,
+    "api-key": apiKey,
+    "cardano-wallet": cardanoWallet,
+    emitter: emitterPath,
+    expires,
+    "guardian-cluster": guardianCluster,
+    "policy-id": policyId,
+    signer,
+  }) => {
+    const lazer = new CardanoLazerContract(chain, policyId);
+    const env = DISPATCH_ENV[chain.getId()];
+    const ctx = await ClientContext.create(
+      chain.network,
+      { token: apiKey, type: "koios" },
+      cardanoWallet,
+    );
+
+    const pubkey = signer ?? dummyTrustedSigner();
+    console.info(`Dummy trusted signer: ${pubkey}`);
+
+    const existing = await getSignerExpiry(lazer, pubkey);
+    if (existing !== undefined) {
+      throw new Error(
+        `Signer already trusted (expiry ${existing.toString()}); refusing to ` +
+          "clobber it. Pick a different --signer.",
+      );
+    }
+
+    // 1. Add the signer.
+    console.info(`\n[1/2] Adding signer with expiry ${expires.toString()}...`);
+    const addPayload = lazer.generateUpdateTrustedSignerPayload(
+      pubkey,
+      expires,
+    );
+    const addVaa = await signGovernanceVaa(
+      addPayload,
+      emitterPath,
+      guardianCluster,
+    );
+    const addTx = await dispatchGovernance(ctx, policyId, addVaa, env);
+    console.info(`Dispatched: ${addTx}`);
+
+    const afterAdd = await getSignerExpiry(lazer, pubkey);
+    if (afterAdd !== expires) {
+      throw new Error(
+        `Assertion failed: expected expiry ${expires.toString()}, read ` +
+          `${afterAdd === undefined ? "<absent>" : afterAdd.toString()}.`,
+      );
+    }
+    console.info("Asserted: signer present with expected expiry.");
+
+    // 2. Teardown — remove the signer (expiry 0) and assert it is gone.
+    console.info("\n[2/2] Removing signer (teardown)...");
+    const removePayload = lazer.generateUpdateTrustedSignerPayload(pubkey, 0n);
+    const removeVaa = await signGovernanceVaa(
+      removePayload,
+      emitterPath,
+      guardianCluster,
+    );
+    const removeTx = await dispatchGovernance(ctx, policyId, removeVaa, env);
+    console.info(`Dispatched: ${removeTx}`);
+
+    const afterRemove = await getSignerExpiry(lazer, pubkey);
+    if (afterRemove !== undefined) {
+      throw new Error(
+        `Teardown failed: signer still present (expiry ${afterRemove.toString()}).`,
+      );
+    }
+    console.info("Asserted: signer removed. Contract restored to start state.");
+    console.info("\ntest-update-trusted-signer: PASS");
+  },
+);
+
+await parser.parseAsync();

--- a/contract_manager/src/core/chains.ts
+++ b/contract_manager/src/core/chains.ts
@@ -24,7 +24,6 @@ import {
 import { FUEL_ETH_ASSET_ID } from "@pythnetwork/pyth-fuel-js";
 import type {
   CardanoNetwork,
-  CardanoProvider,
   ReadClient,
 } from "@pythnetwork/pyth-lazer-cardano-js";
 import { createReadClient } from "@pythnetwork/pyth-lazer-cardano-js";
@@ -1870,11 +1869,6 @@ export class CardanoChain extends Chain {
 
   /**
    * @param network - Evolution SDK network preset this deployment lives on
-   * @param providerType - data provider used to build the read client. The
-   *   credential (if any) is read from the environment at {@link getProvider}
-   *   time, never stored in config: `BLOCKFROST_PROJECT_ID` for `blockfrost`,
-   *   `MAESTRO_API_KEY` for `maestro`, optional `KOIOS_TOKEN` for `koios`
-   *   (Koios reads work tokenless at low rate, which is enough for the audit).
    */
   constructor(
     id: string,
@@ -1882,7 +1876,6 @@ export class CardanoChain extends Chain {
     wormholeChainName: string,
     nativeToken: TokenId | undefined,
     public network: CardanoNetwork,
-    public providerType: CardanoProvider["type"],
   ) {
     super(id, mainnet, wormholeChainName, nativeToken);
   }
@@ -1895,7 +1888,6 @@ export class CardanoChain extends Chain {
       parsed.wormholeChainName ?? "",
       parsed.nativeToken,
       parsed.network as CardanoNetwork,
-      parsed.providerType as CardanoProvider["type"],
     );
   }
 
@@ -1904,7 +1896,6 @@ export class CardanoChain extends Chain {
       id: this.id,
       mainnet: this.mainnet,
       network: this.network,
-      providerType: this.providerType,
       type: CardanoChain.type,
       wormholeChainName: this.wormholeChainName,
     };
@@ -1914,35 +1905,11 @@ export class CardanoChain extends Chain {
     return CardanoChain.type;
   }
 
-  private getProviderConfig(): CardanoProvider {
-    switch (this.providerType) {
-      case "blockfrost": {
-        const projectId = process.env.BLOCKFROST_PROJECT_ID;
-        if (!projectId) {
-          throw new Error(
-            "BLOCKFROST_PROJECT_ID must be set to use the blockfrost provider",
-          );
-        }
-        return { projectId, type: "blockfrost" };
-      }
-      case "koios": {
-        const token = process.env.KOIOS_TOKEN;
-        return { type: "koios", ...(token ? { token } : {}) };
-      }
-      case "maestro": {
-        const apiKey = process.env.MAESTRO_API_KEY;
-        if (!apiKey) {
-          throw new Error(
-            "MAESTRO_API_KEY must be set to use the maestro provider",
-          );
-        }
-        return { apiKey, type: "maestro" };
-      }
-    }
-  }
-
   getProvider(): ReadClient {
-    return createReadClient(this.network, this.getProviderConfig());
+    // Reads go through Koios, which is tokenless at a low rate limit — enough
+    // for the audit. KOIOS_TOKEN only raises that limit and need not be set in
+    // practice; it's picked up from the environment here if present.
+    return createReadClient(this.network, process.env.KOIOS_TOKEN);
   }
 
   /**

--- a/contract_manager/src/core/chains.ts
+++ b/contract_manager/src/core/chains.ts
@@ -22,6 +22,12 @@ import {
   InjectiveExecutor,
 } from "@pythnetwork/cosmwasm-deploy-tools";
 import { FUEL_ETH_ASSET_ID } from "@pythnetwork/pyth-fuel-js";
+import type {
+  CardanoNetwork,
+  CardanoProvider,
+  ReadClient,
+} from "@pythnetwork/pyth-lazer-cardano-js";
+import { createReadClient } from "@pythnetwork/pyth-lazer-cardano-js";
 import { getStructFields } from "@pythnetwork/pyth-sui-js";
 import { PythContract } from "@pythnetwork/pyth-ton-js";
 import type { ChainName, DataSource } from "@pythnetwork/xc-admin-common";
@@ -1847,5 +1853,120 @@ export class StellarChain extends Chain {
     }
 
     return createHash("sha256").update(wasm).digest("hex");
+  }
+}
+
+/**
+ * A Cardano network hosting a Lazer deployment (see {@link CardanoLazerContract}).
+ *
+ * Cardano is UTxO-based with Aiken validators; all reads go through the Evolution
+ * SDK read client exposed by {@link getProvider}, mirroring how
+ * {@link StellarChain.getProvider} hands back its SDK client. Governance is
+ * Wormhole-VAA based and dispatched out-of-band (the VAA is submitted as redeemer
+ * data in a Cardano transaction), so this chain class only needs read access.
+ */
+export class CardanoChain extends Chain {
+  static override type = "CardanoChain";
+
+  /**
+   * @param network - Evolution SDK network preset this deployment lives on
+   * @param providerType - data provider used to build the read client. The
+   *   credential (if any) is read from the environment at {@link getProvider}
+   *   time, never stored in config: `BLOCKFROST_PROJECT_ID` for `blockfrost`,
+   *   `MAESTRO_API_KEY` for `maestro`, optional `KOIOS_TOKEN` for `koios`
+   *   (Koios reads work tokenless at low rate, which is enough for the audit).
+   */
+  constructor(
+    id: string,
+    mainnet: boolean,
+    wormholeChainName: string,
+    nativeToken: TokenId | undefined,
+    public network: CardanoNetwork,
+    public providerType: CardanoProvider["type"],
+  ) {
+    super(id, mainnet, wormholeChainName, nativeToken);
+  }
+
+  static fromJson(parsed: ChainConfig): CardanoChain {
+    if (parsed.type !== CardanoChain.type) throw new Error("Invalid type");
+    return new CardanoChain(
+      parsed.id,
+      parsed.mainnet,
+      parsed.wormholeChainName ?? "",
+      parsed.nativeToken,
+      parsed.network as CardanoNetwork,
+      parsed.providerType as CardanoProvider["type"],
+    );
+  }
+
+  toJson(): KeyValueConfig {
+    return {
+      id: this.id,
+      mainnet: this.mainnet,
+      network: this.network,
+      providerType: this.providerType,
+      type: CardanoChain.type,
+      wormholeChainName: this.wormholeChainName,
+    };
+  }
+
+  getType(): string {
+    return CardanoChain.type;
+  }
+
+  private getProviderConfig(): CardanoProvider {
+    switch (this.providerType) {
+      case "blockfrost": {
+        const projectId = process.env.BLOCKFROST_PROJECT_ID;
+        if (!projectId) {
+          throw new Error(
+            "BLOCKFROST_PROJECT_ID must be set to use the blockfrost provider",
+          );
+        }
+        return { projectId, type: "blockfrost" };
+      }
+      case "koios": {
+        const token = process.env.KOIOS_TOKEN;
+        return { type: "koios", ...(token ? { token } : {}) };
+      }
+      case "maestro": {
+        const apiKey = process.env.MAESTRO_API_KEY;
+        if (!apiKey) {
+          throw new Error(
+            "MAESTRO_API_KEY must be set to use the maestro provider",
+          );
+        }
+        return { apiKey, type: "maestro" };
+      }
+    }
+  }
+
+  getProvider(): ReadClient {
+    return createReadClient(this.network, this.getProviderConfig());
+  }
+
+  /**
+   * Cardano governance upgrades are Wormhole VAA actions targeting a specific
+   * deployment, so build them with {@link CardanoLazerContract} instead.
+   */
+  generateGovernanceUpgradePayload(): Buffer {
+    throw new Error(
+      "Use CardanoLazerContract.generateUpgradeSpendScriptPayload / " +
+        "generateUpgradeWithdrawScriptPayload — Cardano upgrades require a policy id.",
+    );
+  }
+
+  getAccountAddress(): Promise<string> {
+    throw new Error(
+      "Cardano accounts are derived from a mnemonic wallet, not a hex private " +
+        "key; signing is handled by @pythnetwork/pyth-lazer-cardano-cli.",
+    );
+  }
+
+  getAccountBalance(): Promise<number> {
+    throw new Error(
+      "Cardano accounts are derived from a mnemonic wallet, not a hex private " +
+        "key; signing is handled by @pythnetwork/pyth-lazer-cardano-cli.",
+    );
   }
 }

--- a/contract_manager/src/core/contracts/cardano.ts
+++ b/contract_manager/src/core/contracts/cardano.ts
@@ -1,0 +1,150 @@
+import type {
+  CardanoUTxO,
+  TrustedSigner,
+} from "@pythnetwork/pyth-lazer-cardano-js";
+import {
+  getPythScriptHash,
+  getPythState,
+  getTrustedSigners,
+} from "@pythnetwork/pyth-lazer-cardano-js";
+import {
+  UpdateTrustedSigner256Bit,
+  UpgradeCardanoSpendScript,
+  UpgradeCardanoWithdrawScript,
+} from "@pythnetwork/xc-admin-common";
+
+import { Storable } from "../base";
+import type { Chain } from "../chains";
+import { CardanoChain } from "../chains";
+
+/**
+ * Lazer on Cardano. The deployment is identified by its **policy id** — the
+ * NFT-minting policy that gates the on-chain State UTxO (Cardano's analogue of a
+ * contract address). Governance is Wormhole-VAA based, like Sui/Stellar, but
+ * there is no separate executor contract: a governance VAA is submitted as
+ * redeemer data in a Cardano transaction that the spending/withdraw scripts
+ * validate in-line. See `pyth-crosschain/lazer/contracts/cardano/DESIGN.md`.
+ *
+ * Reads wrap the existing `@pythnetwork/pyth-lazer-cardano-js` SDK; the governance
+ * payload builders wrap `@pythnetwork/xc-admin-common`, producing the raw
+ * Wormhole payload (not a VAA) so a test script can sign and dispatch it the same
+ * way Stellar's does.
+ */
+export class CardanoLazerContract extends Storable {
+  static type = "CardanoLazerContract";
+
+  /**
+   * @param chain - the Cardano chain this contract is deployed on
+   * @param policyId - hex-encoded policy id of the Pyth state NFT
+   */
+  constructor(
+    public readonly chain: CardanoChain,
+    public readonly policyId: string,
+  ) {
+    super();
+  }
+
+  getId(): string {
+    return `${this.chain.getId()}_${this.policyId}`;
+  }
+
+  getType(): string {
+    return CardanoLazerContract.type;
+  }
+
+  toJson() {
+    return {
+      chain: this.chain.getId(),
+      policyId: this.policyId,
+      type: CardanoLazerContract.type,
+    };
+  }
+
+  static fromJson(
+    chain: Chain,
+    parsed: { type: string; policyId: string },
+  ): CardanoLazerContract {
+    if (parsed.type !== CardanoLazerContract.type) {
+      throw new Error("Invalid type");
+    }
+    if (!(chain instanceof CardanoChain)) {
+      throw new Error(`Wrong chain type ${chain}`);
+    }
+    return new CardanoLazerContract(chain, parsed.policyId);
+  }
+
+  /** Fetch the on-chain State UTxO (carries the inline datum) for this policy. */
+  getPythState(): Promise<CardanoUTxO> {
+    return getPythState(this.policyId, this.chain.getProvider());
+  }
+
+  /** Hex-encoded hash of the withdraw script currently stored in the state. */
+  async getWithdrawScriptHash(): Promise<string> {
+    return getPythScriptHash(await this.getPythState());
+  }
+
+  /**
+   * Read the trusted Lazer signers from the on-chain state, each with its expiry
+   * as a unix timestamp in seconds. This is the read path the signer audit uses.
+   */
+  async getTrustedSigners(): Promise<TrustedSigner[]> {
+    return getTrustedSigners(await this.getPythState());
+  }
+
+  /**
+   * Build the raw Wormhole governance payload that updates (or, with
+   * `expiresAt = 0n`, removes) a trusted Lazer signer.
+   *
+   * @param publicKey - 32-byte secp256k1 signer key, hex without `0x`
+   * @param expiresAt - expiry timestamp in unix seconds (0 removes the signer)
+   */
+  generateUpdateTrustedSignerPayload(
+    publicKey: string,
+    expiresAt: bigint,
+  ): Buffer {
+    const key = Buffer.from(publicKey, "hex");
+    if (key.length !== 32) {
+      throw new Error(`Trusted signer key must be 32 bytes, got ${key.length}`);
+    }
+    return new UpdateTrustedSigner256Bit(
+      this.chain.wormholeChainName,
+      publicKey,
+      expiresAt,
+    ).encode();
+  }
+
+  /**
+   * Build the raw Wormhole governance payload that upgrades the spending script.
+   *
+   * TODO(i-hrvptavr): end-to-end dispatch of the upgrade actions is out of scope;
+   * only the payload builder is wired up here.
+   *
+   * @param scriptHash - 28-byte spend script hash, hex without `0x`
+   */
+  generateUpgradeSpendScriptPayload(scriptHash: string): Buffer {
+    return new UpgradeCardanoSpendScript(
+      this.chain.wormholeChainName,
+      scriptHash,
+    ).encode();
+  }
+
+  /**
+   * Build the raw Wormhole governance payload that upgrades the withdraw script.
+   *
+   * TODO(i-hrvptavr): end-to-end dispatch of the upgrade actions is out of scope;
+   * only the payload builder is wired up here.
+   *
+   * @param scriptHash - 28-byte new withdraw script hash, hex without `0x`
+   * @param previousExpiresAt - expiry (unix seconds) of the superseded script
+   */
+  generateUpgradeWithdrawScriptPayload(
+    scriptHash: string,
+    previousExpiresAt: bigint,
+  ): Buffer {
+    return new UpgradeCardanoWithdrawScript(
+      this.chain.wormholeChainName,
+      scriptHash,
+      previousExpiresAt,
+    ).encode();
+  }
+}

--- a/contract_manager/src/core/contracts/cardano.ts
+++ b/contract_manager/src/core/contracts/cardano.ts
@@ -95,7 +95,7 @@ export class CardanoLazerContract extends Storable {
    * Build the raw Wormhole governance payload that updates (or, with
    * `expiresAt = 0n`, removes) a trusted Lazer signer.
    *
-   * @param publicKey - 32-byte secp256k1 signer key, hex without `0x`
+   * @param publicKey - 32-byte Ed25519 signer key, hex without `0x`
    * @param expiresAt - expiry timestamp in unix seconds (0 removes the signer)
    */
   generateUpdateTrustedSignerPayload(

--- a/contract_manager/src/core/contracts/index.ts
+++ b/contract_manager/src/core/contracts/index.ts
@@ -1,4 +1,5 @@
 export * from "./aptos";
+export * from "./cardano";
 export * from "./cosmwasm";
 export * from "./evm";
 export * from "./evm_abis";

--- a/contract_manager/src/node/utils/store.ts
+++ b/contract_manager/src/node/utils/store.ts
@@ -15,6 +15,7 @@ import type { PriceFeedContract, Storable } from "../../core/base";
 import type { Chain } from "../../core/chains";
 import {
   AptosChain,
+  CardanoChain,
   CosmWasmChain,
   EvmChain,
   FuelChain,
@@ -31,6 +32,7 @@ import type { EvmPulseContract } from "../../core/contracts";
 import {
   AptosPriceFeedContract,
   AptosWormholeContract,
+  CardanoLazerContract,
   CosmWasmPriceFeedContract,
   CosmWasmWormholeContract,
   EvmEntropyContract,
@@ -76,7 +78,10 @@ export class Store {
   public vaults: Record<string, Vault> = {};
   public lazer_contracts: Record<
     string,
-    EvmLazerContract | SuiLazerContract | StellarLazerContract
+    | EvmLazerContract
+    | SuiLazerContract
+    | StellarLazerContract
+    | CardanoLazerContract
   > = {};
 
   constructor(public path: string) {
@@ -124,6 +129,7 @@ export class Store {
       [IotaChain.type]: IotaChain,
       [SvmChain.type]: SvmChain,
       [StellarChain.type]: StellarChain,
+      [CardanoChain.type]: CardanoChain,
     };
 
     for (const jsonFile of this.getJsonFiles(`${this.path}/chains/`)) {
@@ -215,6 +221,7 @@ export class Store {
       [SuiLazerContract.type]: SuiLazerContract,
       [StellarLazerContract.type]: StellarLazerContract,
       [StellarExecutorContract.type]: StellarExecutorContract,
+      [CardanoLazerContract.type]: CardanoLazerContract,
     };
     for (const jsonFile of this.getJsonFiles(`${this.path}/contracts/`)) {
       const parsedArray = JSON.parse(readFileSync(jsonFile, "utf8"));
@@ -252,7 +259,8 @@ export class Store {
         } else if (
           chainContract instanceof EvmLazerContract ||
           chainContract instanceof SuiLazerContract ||
-          chainContract instanceof StellarLazerContract
+          chainContract instanceof StellarLazerContract ||
+          chainContract instanceof CardanoLazerContract
         ) {
           this.lazer_contracts[chainContract.getId()] = chainContract;
         } else {

--- a/contract_manager/src/store/chains/CardanoChains.json
+++ b/contract_manager/src/store/chains/CardanoChains.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "cardano_mainnet",
+    "mainnet": true,
+    "network": "mainnet",
+    "providerType": "koios",
+    "type": "CardanoChain",
+    "wormholeChainName": "cardano_mainnet"
+  },
+  {
+    "id": "cardano_preprod",
+    "mainnet": false,
+    "network": "preprod",
+    "providerType": "koios",
+    "type": "CardanoChain",
+    "wormholeChainName": "cardano_preprod"
+  },
+  {
+    "id": "cardano_preview",
+    "mainnet": false,
+    "network": "preview",
+    "providerType": "koios",
+    "type": "CardanoChain",
+    "wormholeChainName": "cardano_preview"
+  }
+]

--- a/contract_manager/src/store/chains/CardanoChains.json
+++ b/contract_manager/src/store/chains/CardanoChains.json
@@ -3,7 +3,6 @@
     "id": "cardano_mainnet",
     "mainnet": true,
     "network": "mainnet",
-    "providerType": "koios",
     "type": "CardanoChain",
     "wormholeChainName": "cardano_mainnet"
   },
@@ -11,7 +10,6 @@
     "id": "cardano_preprod",
     "mainnet": false,
     "network": "preprod",
-    "providerType": "koios",
     "type": "CardanoChain",
     "wormholeChainName": "cardano_preprod"
   },
@@ -19,7 +17,6 @@
     "id": "cardano_preview",
     "mainnet": false,
     "network": "preview",
-    "providerType": "koios",
     "type": "CardanoChain",
     "wormholeChainName": "cardano_preview"
   }

--- a/contract_manager/src/store/contracts/CardanoLazerContracts.json
+++ b/contract_manager/src/store/contracts/CardanoLazerContracts.json
@@ -1,0 +1,7 @@
+[
+  {
+    "chain": "cardano_mainnet",
+    "policyId": "c935c937d0deda8975142c7b77aeef8f8cd48791e89a8ca7a0edc154",
+    "type": "CardanoLazerContract"
+  }
+]

--- a/lazer/contracts/cardano/cli/js/package.json
+++ b/lazer/contracts/cardano/cli/js/package.json
@@ -26,67 +26,83 @@
   "exports": {
     "./cli": {
       "import": {
-        "default": "./dist/esm/cli.mjs"
+        "default": "./dist/esm/cli.mjs",
+        "types": "./dist/esm/cli.d.ts"
       },
       "require": {
-        "default": "./dist/cjs/cli.cjs"
+        "default": "./dist/cjs/cli.cjs",
+        "types": "./dist/cjs/cli.d.ts"
       }
     },
     "./client": {
       "import": {
-        "default": "./dist/esm/client.mjs"
+        "default": "./dist/esm/client.mjs",
+        "types": "./dist/esm/client.d.ts"
       },
       "require": {
-        "default": "./dist/cjs/client.cjs"
+        "default": "./dist/cjs/client.cjs",
+        "types": "./dist/cjs/client.d.ts"
       }
     },
     "./devnet": {
       "import": {
-        "default": "./dist/esm/devnet.mjs"
+        "default": "./dist/esm/devnet.mjs",
+        "types": "./dist/esm/devnet.d.ts"
       },
       "require": {
-        "default": "./dist/cjs/devnet.cjs"
+        "default": "./dist/cjs/devnet.cjs",
+        "types": "./dist/cjs/devnet.d.ts"
       }
     },
     "./eval": {
       "import": {
-        "default": "./dist/esm/eval.mjs"
+        "default": "./dist/esm/eval.mjs",
+        "types": "./dist/esm/eval.d.ts"
       },
       "require": {
-        "default": "./dist/cjs/eval.cjs"
+        "default": "./dist/cjs/eval.cjs",
+        "types": "./dist/cjs/eval.d.ts"
       }
     },
     "./offchain": {
       "import": {
-        "default": "./dist/esm/offchain.mjs"
+        "default": "./dist/esm/offchain.mjs",
+        "types": "./dist/esm/offchain.d.ts"
       },
       "require": {
-        "default": "./dist/cjs/offchain.cjs"
+        "default": "./dist/cjs/offchain.cjs",
+        "types": "./dist/cjs/offchain.d.ts"
       }
     },
     "./package.json": "./package.json",
     "./transactions": {
       "import": {
-        "default": "./dist/esm/transactions.mjs"
+        "default": "./dist/esm/transactions.mjs",
+        "types": "./dist/esm/transactions.d.ts"
       },
       "require": {
-        "default": "./dist/cjs/transactions.cjs"
+        "default": "./dist/cjs/transactions.cjs",
+        "types": "./dist/cjs/transactions.d.ts"
       }
     },
     "./utils": {
       "import": {
-        "default": "./dist/esm/utils.mjs"
+        "default": "./dist/esm/utils.mjs",
+        "types": "./dist/esm/utils.d.ts"
       },
       "require": {
-        "default": "./dist/cjs/utils.cjs"
+        "default": "./dist/cjs/utils.cjs",
+        "types": "./dist/cjs/utils.d.ts"
       }
     },
     "./wormhole": {
       "import": {
-        "default": "./dist/esm/wormhole.mjs"
+        "default": "./dist/esm/wormhole.mjs",
+        "types": "./dist/esm/wormhole.d.ts"
       },
       "require": {
-        "default": "./dist/cjs/wormhole.cjs"
+        "default": "./dist/cjs/wormhole.cjs",
+        "types": "./dist/cjs/wormhole.d.ts"
       }
     }
   },

--- a/lazer/contracts/cardano/sdk/js/src/index.ts
+++ b/lazer/contracts/cardano/sdk/js/src/index.ts
@@ -1,8 +1,12 @@
 import type { UTxO } from "@evolution-sdk/evolution";
 import {
   AssetName,
+  Client,
   Data,
   DatumOption,
+  mainnet,
+  preprod,
+  preview,
   Schema,
   TSchema,
 } from "@evolution-sdk/evolution";
@@ -10,9 +14,36 @@ import type { ReadClient } from "@evolution-sdk/evolution/sdk/client/Client";
 
 const PYTH_STATE_NFT = AssetName.fromBytes(Buffer.from("Pyth State", "utf-8"));
 
-// Minimal schema matching the on-chain Pyth state datum layout.
-// Only the `withdraw_script` field is used; the preceding fields
-// are defined to keep positional alignment with the Plutus struct.
+/**
+ * `aiken/interval` bound, mirroring the on-chain `IntervalBound` Plutus layout.
+ * Trusted-signer expiry is stored as the upper bound of a validity range, so the
+ * `Finite` variant carries the expiry instant (in milliseconds).
+ */
+const IntervalBoundType = TSchema.Union(
+  TSchema.TaggedStruct("NegativeInfinity", {}, { flatInUnion: true }),
+  TSchema.TaggedStruct(
+    "Finite",
+    { finite: TSchema.Integer },
+    {
+      flatInUnion: true,
+    },
+  ),
+  TSchema.TaggedStruct("PositiveInfinity", {}, { flatInUnion: true }),
+);
+
+const IntervalBound = TSchema.Struct({
+  bound_type: IntervalBoundType,
+  is_inclusive: TSchema.Boolean,
+});
+
+const ValidityRange = TSchema.Struct({
+  lower_bound: IntervalBound,
+  upper_bound: IntervalBound,
+});
+
+// Schema matching the on-chain Pyth state datum layout. `trusted_signers` maps
+// a 32-byte secp256k1 verification key to the validity range that bounds the
+// signer's expiry (see `validators/pyth_state.ak`).
 // biome-ignore assist/source/useSortedKeys: order-sensistive
 const PythStateDatum = TSchema.Struct({
   // biome-ignore assist/source/useSortedKeys: order-sensitive
@@ -22,7 +53,7 @@ const PythStateDatum = TSchema.Struct({
     emitter_address: TSchema.ByteArray,
     seen_sequence: TSchema.Integer,
   }),
-  trusted_signers: TSchema.Map(TSchema.PlutusData, TSchema.PlutusData),
+  trusted_signers: TSchema.Map(TSchema.ByteArray, ValidityRange),
   deprecated_withdraw_scripts: TSchema.Map(
     TSchema.PlutusData,
     TSchema.PlutusData,
@@ -30,12 +61,83 @@ const PythStateDatum = TSchema.Struct({
   withdraw_script: TSchema.ByteArray,
 });
 
+/** A trusted Lazer signer read from the on-chain Pyth state. */
+export type TrustedSigner = {
+  /** 32-byte secp256k1 verification key, hex-encoded without `0x`. */
+  publicKey: string;
+  /** Expiry timestamp in unix seconds. */
+  expiresAt: bigint;
+};
+
+/** Cardano network the deployment lives on. */
+export type CardanoNetwork = "mainnet" | "preprod" | "preview";
+
+/**
+ * Data provider used to read chain state. `koios` works without a token for
+ * low-rate read access; `blockfrost` and `maestro` require a credential.
+ */
+export type CardanoProvider =
+  | { type: "blockfrost"; projectId: string }
+  | { type: "koios"; token?: string }
+  | { type: "maestro"; apiKey: string };
+
+const CHAINS = { mainnet, preprod, preview } as const;
+
+/**
+ * Build a read-only Evolution SDK client for the given network and provider.
+ * The returned client is what {@link getPythState} expects.
+ */
+export function createReadClient(
+  network: CardanoNetwork,
+  provider: CardanoProvider,
+): ReadClient {
+  const assembly = Client.make(CHAINS[network]);
+  switch (provider.type) {
+    case "blockfrost": {
+      return assembly.withBlockfrost({
+        baseUrl: `https://cardano-${network}.blockfrost.io/api/v0`,
+        projectId: provider.projectId,
+      });
+    }
+    case "koios": {
+      const subdomain = {
+        mainnet: "api",
+        preprod: "preprod",
+        preview: "preview",
+      }[network];
+      return assembly.withKoios({
+        baseUrl: `https://${subdomain}.koios.rest/api/v1`,
+        ...(provider.token ? { token: provider.token } : {}),
+      });
+    }
+    case "maestro": {
+      return assembly.withMaestro({
+        apiKey: provider.apiKey,
+        baseUrl: `https://${network}.gomaestro-api.org/v1`,
+      });
+    }
+  }
+}
+
 export async function getPythState(
   policyId: string,
   client: ReadClient,
 ): Promise<UTxO.UTxO> {
   const unit = policyId + AssetName.toHex(PYTH_STATE_NFT);
   return await client.getUtxoByUnit(unit);
+}
+
+function decodePythState(pythState: UTxO.UTxO) {
+  if (!DatumOption.isInlineDatum(pythState.datumOption)) {
+    throw new TypeError("State NFT UTxO does not have an inline datum");
+  }
+
+  const { data } = pythState.datumOption;
+  if (!(data instanceof Data.Constr)) {
+    throw new TypeError("State NFT datum is not a Constr");
+  }
+
+  return Schema.decodeSync(PythStateDatum)(data);
 }
 
 /**
@@ -49,15 +151,39 @@ export async function getPythState(
  * @returns The withdraw script hash as a hex string.
  */
 export function getPythScriptHash(pythState: UTxO.UTxO): string {
-  if (!DatumOption.isInlineDatum(pythState.datumOption)) {
-    throw new TypeError("State NFT UTxO does not have an inline datum");
-  }
-
-  const { data } = pythState.datumOption;
-  if (!(data instanceof Data.Constr)) {
-    throw new TypeError("State NFT datum is not a Constr");
-  }
-
-  const state = Schema.decodeSync(PythStateDatum)(data);
-  return Buffer.from(state.withdraw_script).toString("hex");
+  return Buffer.from(decodePythState(pythState).withdraw_script).toString(
+    "hex",
+  );
 }
+
+/**
+ * Returns the set of trusted Lazer signers stored in the on-chain Pyth state,
+ * with each signer's expiry as a unix timestamp in seconds.
+ *
+ * On-chain the expiry is stored as the (millisecond) upper bound of an
+ * `aiken/interval` validity range; this converts it back to seconds. Signers
+ * without a finite upper bound (no expiry) are skipped — Lazer always sets a
+ * finite expiry.
+ *
+ * @param pythState - fetched Pyth State UTxO
+ */
+export function getTrustedSigners(pythState: UTxO.UTxO): TrustedSigner[] {
+  const { trusted_signers } = decodePythState(pythState);
+  const signers: TrustedSigner[] = [];
+  for (const [key, validity] of trusted_signers) {
+    const upperBound = validity.upper_bound.bound_type;
+    if (upperBound._tag !== "Finite") {
+      continue;
+    }
+    signers.push({
+      expiresAt: upperBound.finite / 1000n,
+      publicKey: Buffer.from(key).toString("hex"),
+    });
+  }
+  return signers;
+}
+
+export type { ReadClient } from "@evolution-sdk/evolution/sdk/client/Client";
+
+/** Re-export of the Evolution SDK UTxO type wrapping the Pyth state. */
+export type CardanoUTxO = UTxO.UTxO;

--- a/lazer/contracts/cardano/sdk/js/src/index.ts
+++ b/lazer/contracts/cardano/sdk/js/src/index.ts
@@ -61,6 +61,9 @@ const PythStateDatum = TSchema.Struct({
   withdraw_script: TSchema.ByteArray,
 });
 
+/** Decoded on-chain Pyth state datum (see {@link PythStateDatum}). */
+type PythState = Schema.Schema.Type<typeof PythStateDatum>;
+
 /** A trusted Lazer signer read from the on-chain Pyth state. */
 export type TrustedSigner = {
   /** 32-byte secp256k1 verification key, hex-encoded without `0x`. */
@@ -72,51 +75,28 @@ export type TrustedSigner = {
 /** Cardano network the deployment lives on. */
 export type CardanoNetwork = "mainnet" | "preprod" | "preview";
 
-/**
- * Data provider used to read chain state. `koios` works without a token for
- * low-rate read access; `blockfrost` and `maestro` require a credential.
- */
-export type CardanoProvider =
-  | { type: "blockfrost"; projectId: string }
-  | { type: "koios"; token?: string }
-  | { type: "maestro"; apiKey: string };
-
 const CHAINS = { mainnet, preprod, preview } as const;
 
 /**
- * Build a read-only Evolution SDK client for the given network and provider.
+ * Build a read-only Evolution SDK client backed by Koios for the given network.
  * The returned client is what {@link getPythState} expects.
+ *
+ * Koios read access works tokenless at a low rate limit, which is enough for
+ * enumerating trusted signers; `token` only raises that limit and is optional.
  */
 export function createReadClient(
   network: CardanoNetwork,
-  provider: CardanoProvider,
+  token?: string,
 ): ReadClient {
-  const assembly = Client.make(CHAINS[network]);
-  switch (provider.type) {
-    case "blockfrost": {
-      return assembly.withBlockfrost({
-        baseUrl: `https://cardano-${network}.blockfrost.io/api/v0`,
-        projectId: provider.projectId,
-      });
-    }
-    case "koios": {
-      const subdomain = {
-        mainnet: "api",
-        preprod: "preprod",
-        preview: "preview",
-      }[network];
-      return assembly.withKoios({
-        baseUrl: `https://${subdomain}.koios.rest/api/v1`,
-        ...(provider.token ? { token: provider.token } : {}),
-      });
-    }
-    case "maestro": {
-      return assembly.withMaestro({
-        apiKey: provider.apiKey,
-        baseUrl: `https://${network}.gomaestro-api.org/v1`,
-      });
-    }
-  }
+  const subdomain = {
+    mainnet: "api",
+    preprod: "preprod",
+    preview: "preview",
+  }[network];
+  return Client.make(CHAINS[network]).withKoios({
+    baseUrl: `https://${subdomain}.koios.rest/api/v1`,
+    ...(token ? { token } : {}),
+  });
 }
 
 export async function getPythState(
@@ -127,7 +107,7 @@ export async function getPythState(
   return await client.getUtxoByUnit(unit);
 }
 
-function decodePythState(pythState: UTxO.UTxO) {
+function decodePythState(pythState: UTxO.UTxO): PythState {
   if (!DatumOption.isInlineDatum(pythState.datumOption)) {
     throw new TypeError("State NFT UTxO does not have an inline datum");
   }

--- a/lazer/contracts/cardano/sdk/js/src/index.ts
+++ b/lazer/contracts/cardano/sdk/js/src/index.ts
@@ -42,8 +42,10 @@ const ValidityRange = TSchema.Struct({
 });
 
 // Schema matching the on-chain Pyth state datum layout. `trusted_signers` maps
-// a 32-byte secp256k1 verification key to the validity range that bounds the
-// signer's expiry (see `validators/pyth_state.ak`).
+// a 32-byte Ed25519 verification key to the validity range that bounds the
+// signer's expiry (see `validators/pyth_state.ak`). Cardano verifies Lazer's
+// Ed25519-signed "solana" update format, so the signer keys are Ed25519 — not
+// the secp256k1 keys/addresses used by the EVM and Sui integrations.
 // biome-ignore assist/source/useSortedKeys: order-sensistive
 const PythStateDatum = TSchema.Struct({
   // biome-ignore assist/source/useSortedKeys: order-sensitive
@@ -66,7 +68,7 @@ type PythState = Schema.Schema.Type<typeof PythStateDatum>;
 
 /** A trusted Lazer signer read from the on-chain Pyth state. */
 export type TrustedSigner = {
-  /** 32-byte secp256k1 verification key, hex-encoded without `0x`. */
+  /** 32-byte Ed25519 verification key, hex-encoded without `0x`. */
   publicKey: string;
   /** Expiry timestamp in unix seconds. */
   expiresAt: bigint;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1262,7 +1262,7 @@ importers:
         version: 0.9.36(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bs58@5.0.0)(react-dom@19.2.1(react@19.2.1))(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10))(react@19.2.1)
       '@solana/wallet-adapter-wallets':
         specifier: 'catalog:'
-        version: 0.19.33(@babel/runtime@7.28.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bs58@5.0.0)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.7.0)(react-dom@19.2.1(react@19.2.1))(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10))(react@19.2.1)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+        version: 0.19.33(@babel/runtime@7.28.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bs58@5.0.0)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.1(react@19.2.1))(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10))(react@19.2.1)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@solana/web3.js':
         specifier: 'catalog:'
         version: 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
@@ -1411,6 +1411,12 @@ importers:
       '@pythnetwork/pyth-iota-js':
         specifier: workspace:*
         version: link:../target_chains/sui/sdk/js-iota
+      '@pythnetwork/pyth-lazer-cardano-cli':
+        specifier: workspace:*
+        version: link:../lazer/contracts/cardano/cli/js
+      '@pythnetwork/pyth-lazer-cardano-js':
+        specifier: workspace:*
+        version: link:../lazer/contracts/cardano/sdk/js
       '@pythnetwork/pyth-sdk-solidity':
         specifier: workspace:^
         version: link:../target_chains/ethereum/sdk/solidity
@@ -1810,7 +1816,7 @@ importers:
         version: 0.9.36(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(react-dom@19.2.1(react@19.2.1))(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10))(react@19.2.1)
       '@solana/wallet-adapter-wallets':
         specifier: 'catalog:'
-        version: 0.19.33(@babel/runtime@7.28.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.7.0)(react-dom@19.2.1(react@19.2.1))(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10))(react@19.2.1)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)
+        version: 0.19.33(@babel/runtime@7.28.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.1(react@19.2.1))(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10))(react@19.2.1)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)
       '@solana/web3.js':
         specifier: ^1.73.0
         version: 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
@@ -1822,7 +1828,7 @@ importers:
         version: 8.21.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       axios:
         specifier: ^1.4.0
-        version: 1.8.4(debug@4.4.3)
+        version: 1.8.4(debug@4.4.0)
       copy-to-clipboard:
         specifier: ^3.3.3
         version: 3.3.3
@@ -2344,7 +2350,7 @@ importers:
         version: 8.18.1
       axios:
         specifier: ^1.5.1
-        version: 1.8.4(debug@4.4.3)
+        version: 1.8.4(debug@4.4.0)
       axios-retry:
         specifier: ^4.0.0
         version: 4.5.0(axios@1.8.4)
@@ -23507,7 +23513,7 @@ snapshots:
 
   '@aptos-labs/aptos-client@1.2.0(axios@1.18.1)(got@13.0.0)':
     dependencies:
-      axios: 1.18.1
+      axios: 1.18.1(debug@4.4.3)
       got: 13.0.0
 
   '@aptos-labs/aptos-dynamic-transaction-composer@0.1.3': {}
@@ -25939,7 +25945,7 @@ snapshots:
       eventemitter3: 5.0.1
       keccak: 3.0.4
       preact: 10.26.4
-      sha.js: 2.4.11
+      sha.js: 2.4.12
     transitivePeerDependencies:
       - supports-color
 
@@ -26407,7 +26413,7 @@ snapshots:
       '@cosmjs/socket': 0.30.1(bufferutil@4.0.7)(utf-8-validate@6.0.3)
       '@cosmjs/stream': 0.30.1
       '@cosmjs/utils': 0.30.1
-      axios: 0.21.4
+      axios: 0.21.4(debug@4.4.0)
       readonly-date: 1.0.0
       xstream: 11.14.0
     transitivePeerDependencies:
@@ -26425,7 +26431,7 @@ snapshots:
       '@cosmjs/socket': 0.30.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@cosmjs/stream': 0.30.1
       '@cosmjs/utils': 0.30.1
-      axios: 0.21.4
+      axios: 0.21.4(debug@4.4.0)
       readonly-date: 1.0.0
       xstream: 11.14.0
     transitivePeerDependencies:
@@ -26443,7 +26449,7 @@ snapshots:
       '@cosmjs/socket': 0.32.4(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@cosmjs/stream': 0.32.4
       '@cosmjs/utils': 0.32.4
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.8.4(debug@4.4.0)
       readonly-date: 1.0.0
       xstream: 11.14.0
     transitivePeerDependencies:
@@ -26460,7 +26466,7 @@ snapshots:
       '@cosmjs/socket': 0.32.4(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@cosmjs/stream': 0.32.4
       '@cosmjs/utils': 0.32.4
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.8.4(debug@4.4.0)
       readonly-date: 1.0.0
       xstream: 11.14.0
     transitivePeerDependencies:
@@ -26477,7 +26483,7 @@ snapshots:
       '@cosmjs/socket': 0.33.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@cosmjs/stream': 0.33.1
       '@cosmjs/utils': 0.33.1
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.8.4(debug@4.4.0)
       readonly-date: 1.0.0
       xstream: 11.14.0
     transitivePeerDependencies:
@@ -29028,7 +29034,7 @@ snapshots:
       '@metamask/eth-sig-util': 4.0.1
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.8.4(debug@4.4.0)
       bech32: 2.0.0
       bip39: 3.1.0
       cosmjs-types: 0.9.0
@@ -29074,7 +29080,7 @@ snapshots:
       '@metamask/eth-sig-util': 4.0.1
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.8.4(debug@4.4.0)
       bech32: 2.0.0
       bip39: 3.1.0
       cosmjs-types: 0.9.0
@@ -29153,7 +29159,7 @@ snapshots:
       '@injectivelabs/networks': 1.14.47
       '@injectivelabs/ts-types': 1.14.47
       '@injectivelabs/utils': 1.14.48
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.8.4(debug@4.4.0)
       bignumber.js: 9.3.1
       shx: 0.3.4
       snakecase-keys: 5.5.0
@@ -29199,7 +29205,7 @@ snapshots:
     dependencies:
       '@injectivelabs/exceptions': 1.14.47
       '@injectivelabs/ts-types': 1.14.47
-      axios: 0.21.4
+      axios: 0.21.4(debug@4.4.0)
       bignumber.js: 9.3.1
       http-status-codes: 2.3.0
       link-module-alias: 1.2.0
@@ -29216,7 +29222,7 @@ snapshots:
       '@injectivelabs/exceptions': 1.14.47
       '@injectivelabs/networks': 1.14.47
       '@injectivelabs/ts-types': 1.14.47
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.8.4(debug@4.4.0)
       bignumber.js: 9.1.2
       http-status-codes: 2.3.0
     transitivePeerDependencies:
@@ -29655,12 +29661,12 @@ snapshots:
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@jnwng/walletconnect-solana@0.2.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@jnwng/walletconnect-solana@0.2.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
       '@walletconnect/qrcode-modal': 1.8.0
-      '@walletconnect/sign-client': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/utils': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/sign-client': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       bs58: 5.0.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -29687,12 +29693,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@jnwng/walletconnect-solana@0.2.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)':
+  '@jnwng/walletconnect-solana@0.2.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)':
     dependencies:
       '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
       '@walletconnect/qrcode-modal': 1.8.0
-      '@walletconnect/sign-client': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)
-      '@walletconnect/utils': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)
+      '@walletconnect/sign-client': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)
+      '@walletconnect/utils': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)
       bs58: 5.0.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -30034,7 +30040,7 @@ snapshots:
     dependencies:
       '@matterlabs/hardhat-zksync-solc': 1.3.0(encoding@0.1.13)(hardhat@2.22.19(bufferutil@4.0.7)(ts-node@10.9.2(@swc/core@1.15.10)(@types/node@22.14.0)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@6.0.3))
       '@matterlabs/hardhat-zksync-telemetry': 1.1.1(debug@4.4.3)(hardhat@2.22.19(bufferutil@4.0.7)(ts-node@10.9.2(@swc/core@1.15.10)(@types/node@22.14.0)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@6.0.3))
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.18.1(debug@4.4.3)
       chai: 4.5.0
       chalk: 4.1.2
       debug: 4.4.3(supports-color@8.1.1)
@@ -30142,7 +30148,7 @@ snapshots:
       '@matterlabs/hardhat-zksync-solc': 1.3.0(encoding@0.1.13)(hardhat@2.22.19(bufferutil@4.0.7)(ts-node@10.9.2(@swc/core@1.15.10)(@types/node@22.14.0)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@6.0.3))
       '@matterlabs/hardhat-zksync-telemetry': 1.1.1(debug@4.4.3)(hardhat@2.22.19(bufferutil@4.0.7)(ts-node@10.9.2(@swc/core@1.15.10)(@types/node@22.14.0)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@6.0.3))
       '@nomicfoundation/hardhat-verify': 2.0.13(hardhat@2.22.19(bufferutil@4.0.7)(ts-node@10.9.2(@swc/core@1.15.10)(@types/node@22.14.0)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@6.0.3))
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.18.1(debug@4.4.3)
       cbor: 9.0.2
       chai: 4.5.0
       chalk: 4.1.2
@@ -31313,40 +31319,44 @@ snapshots:
   '@openzeppelin/defender-sdk-deploy-client@1.15.2(encoding@0.1.13)':
     dependencies:
       '@openzeppelin/defender-sdk-base-client': 1.15.2(encoding@0.1.13)
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.18.1(debug@4.4.3)
       lodash: 4.17.21
     transitivePeerDependencies:
       - debug
       - encoding
+      - supports-color
 
   '@openzeppelin/defender-sdk-deploy-client@2.5.0(debug@4.4.3)(encoding@0.1.13)':
     dependencies:
       '@openzeppelin/defender-sdk-base-client': 2.5.0(encoding@0.1.13)
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.18.1(debug@4.4.3)
       lodash: 4.17.21
     transitivePeerDependencies:
       - aws-crt
       - debug
       - encoding
+      - supports-color
 
   '@openzeppelin/defender-sdk-network-client@1.15.2(encoding@0.1.13)':
     dependencies:
       '@openzeppelin/defender-sdk-base-client': 1.15.2(encoding@0.1.13)
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.18.1(debug@4.4.3)
       lodash: 4.17.21
     transitivePeerDependencies:
       - debug
       - encoding
+      - supports-color
 
   '@openzeppelin/defender-sdk-network-client@2.5.0(debug@4.4.3)(encoding@0.1.13)':
     dependencies:
       '@openzeppelin/defender-sdk-base-client': 2.5.0(encoding@0.1.13)
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.18.1(debug@4.4.3)
       lodash: 4.17.21
     transitivePeerDependencies:
       - aws-crt
       - debug
       - encoding
+      - supports-color
 
   '@openzeppelin/hardhat-upgrades@1.28.0(@nomiclabs/hardhat-ethers@2.2.3(ethers@5.8.0(bufferutil@4.0.7)(utf-8-validate@6.0.3))(hardhat@2.22.19(bufferutil@4.0.7)(ts-node@10.9.2(@swc/core@1.15.10)(@types/node@22.14.0)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@6.0.3)))(@nomiclabs/hardhat-etherscan@3.1.8(hardhat@2.22.19(bufferutil@4.0.7)(ts-node@10.9.2(@swc/core@1.15.10)(@types/node@22.14.0)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@6.0.3)))(encoding@0.1.13)(ethers@5.8.0(bufferutil@4.0.7)(utf-8-validate@6.0.3))(hardhat@2.22.19(bufferutil@4.0.7)(ts-node@10.9.2(@swc/core@1.15.10)(@types/node@22.14.0)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@6.0.3))':
     dependencies:
@@ -31736,7 +31746,7 @@ snapshots:
     dependencies:
       '@pythnetwork/price-service-sdk': 1.8.0
       '@types/ws': 8.18.1
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.8.4(debug@4.4.0)
       axios-retry: 3.9.1
       isomorphic-ws: 4.0.1(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ts-log: 2.2.7
@@ -35049,7 +35059,7 @@ snapshots:
   '@solana/spl-governance@0.3.28(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.8.4(debug@4.4.0)
       bignumber.js: 9.1.2
       bn.js: 5.2.1
       borsh: 0.3.1
@@ -35582,9 +35592,9 @@ snapshots:
       '@solana/wallet-standard-util': 1.1.2
       '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
 
-  '@solana/wallet-adapter-walletconnect@0.1.17(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@solana/wallet-adapter-walletconnect@0.1.17(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@jnwng/walletconnect-solana': 0.2.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@jnwng/walletconnect-solana': 0.2.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@solana/wallet-adapter-base': 0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -35612,9 +35622,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@solana/wallet-adapter-walletconnect@0.1.17(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)':
+  '@solana/wallet-adapter-walletconnect@0.1.17(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)':
     dependencies:
-      '@jnwng/walletconnect-solana': 0.2.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)
+      '@jnwng/walletconnect-solana': 0.2.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)
       '@solana/wallet-adapter-base': 0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -35642,7 +35652,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@solana/wallet-adapter-wallets@0.19.33(@babel/runtime@7.28.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bs58@5.0.0)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.7.0)(react-dom@19.2.1(react@19.2.1))(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10))(react@19.2.1)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)':
+  '@solana/wallet-adapter-wallets@0.19.33(@babel/runtime@7.28.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bs58@5.0.0)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.1(react@19.2.1))(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10))(react@19.2.1)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
       '@solana/wallet-adapter-alpha': 0.1.11(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-avana': 0.1.14(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
@@ -35678,7 +35688,7 @@ snapshots:
       '@solana/wallet-adapter-trezor': 0.1.3(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-trust': 0.1.14(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-unsafe-burner': 0.1.8(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
-      '@solana/wallet-adapter-walletconnect': 0.1.17(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@solana/wallet-adapter-walletconnect': 0.1.17(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@solana/wallet-adapter-xdefi': 0.1.8(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -35720,7 +35730,7 @@ snapshots:
       - ws
       - zod
 
-  '@solana/wallet-adapter-wallets@0.19.33(@babel/runtime@7.28.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.7.0)(react-dom@19.2.1(react@19.2.1))(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10))(react@19.2.1)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)':
+  '@solana/wallet-adapter-wallets@0.19.33(@babel/runtime@7.28.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.1(react@19.2.1))(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10))(react@19.2.1)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)':
     dependencies:
       '@solana/wallet-adapter-alpha': 0.1.11(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-avana': 0.1.14(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
@@ -35756,7 +35766,7 @@ snapshots:
       '@solana/wallet-adapter-trezor': 0.1.3(@solana/sysvars@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-trust': 0.1.14(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-unsafe-burner': 0.1.8(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
-      '@solana/wallet-adapter-walletconnect': 0.1.17(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)
+      '@solana/wallet-adapter-walletconnect': 0.1.17(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)
       '@solana/wallet-adapter-xdefi': 0.1.8(@solana/web3.js@1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -36076,7 +36086,7 @@ snapshots:
   '@stellar/stellar-sdk@14.6.1':
     dependencies:
       '@stellar/stellar-base': 14.1.0
-      axios: 1.18.1
+      axios: 1.18.1(debug@4.4.3)
       bignumber.js: 9.3.1
       commander: 14.0.3
       eventsource: 2.0.2
@@ -36854,7 +36864,7 @@ snapshots:
     dependencies:
       '@ton/core': 0.59.1(@ton/crypto@3.3.0)
       '@ton/crypto': 3.3.0
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.8.4(debug@4.4.0)
       dataloader: 2.2.3
       symbol.inspect: 1.0.1
       teslabot: 1.5.0
@@ -38344,21 +38354,21 @@ snapshots:
       '@walletconnect/window-metadata': 1.0.0
       detect-browser: 5.2.0
 
-  '@walletconnect/core@2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/core@2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(ioredis@5.7.0)
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(ioredis@5.7.0)
       '@walletconnect/logger': 2.1.2
       '@walletconnect/relay-api': 1.0.11
       '@walletconnect/relay-auth': 1.1.0
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(ioredis@5.7.0)
-      '@walletconnect/utils': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(ioredis@5.7.0)
+      '@walletconnect/utils': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -38388,21 +38398,65 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/core@2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)':
+  '@walletconnect/core@2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(ioredis@5.7.0)
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))
       '@walletconnect/logger': 2.1.2
       '@walletconnect/relay-api': 1.0.11
       '@walletconnect/relay-auth': 1.1.0
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(ioredis@5.7.0)
-      '@walletconnect/utils': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)
+      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))
+      '@walletconnect/utils': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/window-getters': 1.0.1
+      es-toolkit: 1.33.0
+      events: 3.3.0
+      uint8arrays: 3.1.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/core@2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)':
+    dependencies:
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(ioredis@5.7.0)
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(ioredis@5.7.0)
+      '@walletconnect/utils': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -38442,12 +38496,12 @@ snapshots:
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(ioredis@5.7.0)
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(ioredis@5.7.0)
       '@walletconnect/modal': 2.7.0(@types/react@19.2.7)(react@19.2.1)
       '@walletconnect/sign-client': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(ioredis@5.7.0)
+      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(ioredis@5.7.0)
       '@walletconnect/universal-provider': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(encoding@0.1.13)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/utils': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -38524,11 +38578,38 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@walletconnect/keyvaluestorage@1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(ioredis@5.7.0)':
+  '@walletconnect/keyvaluestorage@1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(ioredis@5.7.0)':
     dependencies:
       '@walletconnect/safe-json': 1.0.2
       idb-keyval: 6.2.1
-      unstorage: 1.17.4(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(idb-keyval@6.2.1)(ioredis@5.7.0)
+      unstorage: 1.17.4(@vercel/blob@2.3.0)(idb-keyval@6.2.1)(ioredis@5.7.0)
+    optionalDependencies:
+      '@react-native-async-storage/async-storage': 1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10))
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - ioredis
+      - uploadthing
+
+  '@walletconnect/keyvaluestorage@1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))':
+    dependencies:
+      '@walletconnect/safe-json': 1.0.2
+      idb-keyval: 6.2.1
+      unstorage: 1.17.4(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(idb-keyval@6.2.1)
     optionalDependencies:
       '@react-native-async-storage/async-storage': 1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10))
     transitivePeerDependencies:
@@ -38610,88 +38691,88 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/sign-client@2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
-    dependencies:
-      '@walletconnect/core': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/events': 1.0.1
-      '@walletconnect/heartbeat': 1.2.2
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/logger': 2.1.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(ioredis@5.7.0)
-      '@walletconnect/utils': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@walletconnect/sign-client@2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)':
-    dependencies:
-      '@walletconnect/core': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)
-      '@walletconnect/events': 1.0.1
-      '@walletconnect/heartbeat': 1.2.2
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/logger': 2.1.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(ioredis@5.7.0)
-      '@walletconnect/utils': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@walletconnect/sign-client@2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@walletconnect/core': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/core': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(ioredis@5.7.0)
-      '@walletconnect/utils': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(ioredis@5.7.0)
+      '@walletconnect/utils': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/sign-client@2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+    dependencies:
+      '@walletconnect/core': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))
+      '@walletconnect/utils': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/sign-client@2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)':
+    dependencies:
+      '@walletconnect/core': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(ioredis@5.7.0)
+      '@walletconnect/utils': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -38724,12 +38805,41 @@ snapshots:
 
   '@walletconnect/types@1.8.0': {}
 
-  '@walletconnect/types@2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(ioredis@5.7.0)':
+  '@walletconnect/types@2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(ioredis@5.7.0)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(ioredis@5.7.0)
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(ioredis@5.7.0)
+      '@walletconnect/logger': 2.1.2
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - ioredis
+      - uploadthing
+
+  '@walletconnect/types@2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))':
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))
       '@walletconnect/logger': 2.1.2
       events: 3.3.0
     transitivePeerDependencies:
@@ -38760,11 +38870,11 @@ snapshots:
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(ioredis@5.7.0)
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(ioredis@5.7.0)
       '@walletconnect/logger': 2.1.2
       '@walletconnect/sign-client': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(ioredis@5.7.0)
-      '@walletconnect/utils': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(ioredis@5.7.0)
+      '@walletconnect/utils': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -38793,18 +38903,18 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/utils@2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
       '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(ioredis@5.7.0)
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(ioredis@5.7.0)
       '@walletconnect/relay-api': 1.0.11
       '@walletconnect/relay-auth': 1.1.0
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(ioredis@5.7.0)
+      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(ioredis@5.7.0)
       '@walletconnect/window-getters': 1.0.1
       '@walletconnect/window-metadata': 1.0.1
       bs58: 6.0.0
@@ -38837,18 +38947,62 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(bufferutil@4.0.9)(ioredis@5.7.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)':
+  '@walletconnect/utils@2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
       '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(ioredis@5.7.0)
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))
       '@walletconnect/relay-api': 1.0.11
       '@walletconnect/relay-auth': 1.1.0
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(ioredis@5.7.0)
+      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      bs58: 6.0.0
+      detect-browser: 5.3.0
+      query-string: 7.1.3
+      uint8arrays: 3.1.0
+      viem: 2.23.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/utils@2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.24.2)':
+    dependencies:
+      '@noble/ciphers': 1.2.1
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(ioredis@5.7.0)
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.19.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.78.2(@babel/core@7.28.6)(@babel/preset-env@7.29.0(@babel/core@7.28.6))(@types/react@19.2.7)(bufferutil@4.0.9)(react@19.2.1)(utf-8-validate@5.0.10)))(@vercel/blob@2.3.0)(ioredis@5.7.0)
       '@walletconnect/window-getters': 1.0.1
       '@walletconnect/window-metadata': 1.0.1
       bs58: 6.0.0
@@ -38985,7 +39139,7 @@ snapshots:
     dependencies:
       '@wormhole-foundation/sdk-base': 4.19.0
       '@wormhole-foundation/sdk-definitions': 4.19.0
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.8.4(debug@4.4.0)
     transitivePeerDependencies:
       - debug
 
@@ -39075,12 +39229,12 @@ snapshots:
 
   '@zodios/core@10.9.6(axios@1.18.1)(zod@3.24.2)':
     dependencies:
-      axios: 1.18.1
+      axios: 1.18.1(debug@4.4.3)
       zod: 3.24.2
 
   '@zodios/core@10.9.6(axios@1.8.4)(zod@3.25.76)':
     dependencies:
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.8.4(debug@4.4.0)
       zod: 3.25.76
 
   JSONStream@1.3.2:
@@ -39541,7 +39695,7 @@ snapshots:
       ultrahtml: 1.6.0
       unifont: 0.7.3
       unist-util-visit: 5.0.0
-      unstorage: 1.17.4(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(idb-keyval@6.2.1)(ioredis@5.7.0)
+      unstorage: 1.17.4(@vercel/blob@2.3.0)(idb-keyval@6.2.1)(ioredis@5.7.0)
       vfile: 6.0.3
       vite: 6.4.1(@types/node@22.14.0)(jiti@2.6.1)(lightningcss@1.29.2)(sass@1.86.1)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.0)
       vitefu: 1.1.1(vite@6.4.1(@types/node@22.14.0)(jiti@2.6.1)(lightningcss@1.29.2)(sass@1.86.1)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.0))
@@ -39671,15 +39825,8 @@ snapshots:
 
   axios-retry@4.5.0(axios@1.8.4):
     dependencies:
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.8.4(debug@4.4.0)
       is-retry-allowed: 2.2.0
-
-  axios@0.21.4:
-    dependencies:
-      follow-redirects: 1.15.9(debug@4.4.3)
-    transitivePeerDependencies:
-      - debug
-    optional: true
 
   axios@0.21.4(debug@4.4.0):
     dependencies:
@@ -39689,32 +39836,32 @@ snapshots:
 
   axios@0.24.0:
     dependencies:
-      follow-redirects: 1.15.9(debug@4.4.3)
+      follow-redirects: 1.15.9(debug@4.4.0)
     transitivePeerDependencies:
       - debug
 
   axios@0.25.0:
     dependencies:
-      follow-redirects: 1.15.9(debug@4.4.3)
+      follow-redirects: 1.15.9(debug@4.4.0)
     transitivePeerDependencies:
       - debug
 
   axios@0.26.1:
     dependencies:
-      follow-redirects: 1.15.9(debug@4.4.3)
+      follow-redirects: 1.15.9(debug@4.4.0)
     transitivePeerDependencies:
       - debug
 
   axios@0.27.2:
     dependencies:
-      follow-redirects: 1.15.9(debug@4.4.3)
+      follow-redirects: 1.15.9(debug@4.4.0)
       form-data: 4.0.2
     transitivePeerDependencies:
       - debug
 
-  axios@1.18.1:
+  axios@1.18.1(debug@4.4.3):
     dependencies:
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
@@ -39724,7 +39871,7 @@ snapshots:
 
   axios@1.7.4:
     dependencies:
-      follow-redirects: 1.15.9(debug@4.4.3)
+      follow-redirects: 1.15.9(debug@4.4.0)
       form-data: 4.0.2
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -39733,14 +39880,6 @@ snapshots:
   axios@1.8.4(debug@4.4.0):
     dependencies:
       follow-redirects: 1.15.9(debug@4.4.0)
-      form-data: 4.0.2
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.8.4(debug@4.4.3):
-    dependencies:
-      follow-redirects: 1.15.9(debug@4.4.3)
       form-data: 4.0.2
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -43248,11 +43387,9 @@ snapshots:
     optionalDependencies:
       debug: 4.4.0
 
-  follow-redirects@1.15.9(debug@4.4.3):
+  follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3(supports-color@8.1.1)
-
-  follow-redirects@1.16.0: {}
 
   fontace@0.4.0:
     dependencies:
@@ -47902,7 +48039,7 @@ snapshots:
       '@apidevtools/swagger-parser': 10.1.1(openapi-types@12.1.3)
       '@liuli-util/fs-extra': 0.1.0
       '@zodios/core': 10.9.6(axios@1.8.4)(zod@3.25.76)
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.8.4(debug@4.4.0)
       cac: 6.7.14
       handlebars: 4.7.8
       openapi-types: 12.1.3
@@ -48576,9 +48713,10 @@ snapshots:
 
   posthog-node@4.11.1(debug@4.4.3):
     dependencies:
-      axios: 1.8.4(debug@4.4.3)
+      axios: 1.18.1(debug@4.4.3)
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   preact@10.26.4: {}
 
@@ -50532,7 +50670,7 @@ snapshots:
     dependencies:
       command-exists: 1.2.9
       commander: 8.3.0
-      follow-redirects: 1.15.9(debug@4.4.3)
+      follow-redirects: 1.15.9(debug@4.4.0)
       js-sha3: 0.8.0
       memorystream: 0.3.1
       semver: 5.7.2
@@ -50544,7 +50682,7 @@ snapshots:
     dependencies:
       command-exists: 1.2.9
       commander: 3.0.2
-      follow-redirects: 1.15.9(debug@4.4.3)
+      follow-redirects: 1.15.9(debug@4.4.0)
       fs-extra: 0.30.0
       js-sha3: 0.8.0
       memorystream: 0.3.1
@@ -52105,7 +52243,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unstorage@1.17.4(@vercel/blob@2.3.0)(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(idb-keyval@6.2.1)(ioredis@5.7.0):
+  unstorage@1.17.4(@vercel/blob@2.3.0)(idb-keyval@6.2.1)(ioredis@5.7.0):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -52117,9 +52255,22 @@ snapshots:
       ufo: 1.6.3
     optionalDependencies:
       '@vercel/blob': 2.3.0
-      '@vercel/functions': 2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0)
       idb-keyval: 6.2.1
       ioredis: 5.7.0
+
+  unstorage@1.17.4(@vercel/functions@2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0))(idb-keyval@6.2.1):
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 5.0.0
+      destr: 2.0.5
+      h3: 1.15.5
+      lru-cache: 11.2.1
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      ufo: 1.6.3
+    optionalDependencies:
+      '@vercel/functions': 2.0.0(@aws-sdk/credential-provider-web-identity@3.777.0)
+      idb-keyval: 6.2.1
 
   until-async@3.0.2: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,15 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalEnv": ["NODE_ENV"],
-  "globalPassThroughEnv": ["COREPACK_HOME", "FORCE_COLOR", "BIOME_BINARY"],
+  "globalPassThroughEnv": [
+    "COREPACK_HOME",
+    "FORCE_COLOR",
+    "BIOME_BINARY",
+    "BLOCKFROST_PROJECT_ID",
+    "KOIOS_TOKEN",
+    "KOIOS_API_KEY",
+    "MAESTRO_API_KEY"
+  ],
   "tasks": {
     "//#fix": {
       "cache": false,

--- a/turbo.json
+++ b/turbo.json
@@ -5,10 +5,7 @@
     "COREPACK_HOME",
     "FORCE_COLOR",
     "BIOME_BINARY",
-    "BLOCKFROST_PROJECT_ID",
-    "KOIOS_TOKEN",
-    "KOIOS_API_KEY",
-    "MAESTRO_API_KEY"
+    "KOIOS_TOKEN"
   ],
   "tasks": {
     "//#fix": {


### PR DESCRIPTION
Adds Cardano support to `contract_manager` following the Stellar Lazer pattern.

## What landed
- **`CardanoChain`** (`src/core/chains.ts`): read-only chain class for `cardano_mainnet|preprod|preview`. `getProvider()` returns an Evolution SDK `ReadClient` (mirroring `StellarChain.getProvider()`) backed by Koios. Koios reads work tokenless, which is enough for the audit; the optional `KOIOS_TOKEN` (only raises the rate limit) is read from env, never stored in config. `isMainnet()` is driven by the JSON `mainnet` flag so the existing `--testnet` filter works unchanged.
- **`CardanoLazerContract`** (`src/core/contracts/cardano.ts`): wraps the existing `@pythnetwork/pyth-lazer-cardano-js` SDK for reads (`getPythState`, `getWithdrawScriptHash`, `getTrustedSigners`) and `@pythnetwork/xc-admin-common` for governance payloads (`generateUpdateTrustedSignerPayload` + opportunistic `generateUpgrade{Spend,Withdraw}ScriptPayload`).
- **SDK accessors** (`lazer/contracts/cardano/sdk/js/src/index.ts`): added `getTrustedSigners` (typed decode of the on-chain `trusted_signers` map → `{publicKey, expiresAt}`, converting the ms validity-range upper bound to unix seconds) and `createReadClient` (Koios read client, optional token); tightened the datum schema's `trusted_signers` value to the real `ValidityRange` shape (matches the CLI's `offchain.ts` bindings). `decodePythState` has an explicit `PythState` return type.
- **Stores**: `CardanoChains.json` (mainnet/preprod/preview) + `CardanoLazerContracts.json` (mainnet policy `c935c937…e154`). Registered `CardanoChain`/`CardanoLazerContract` in `src/node/utils/store.ts` and `contracts/index.ts`.
- **Audit**: `scripts/list_lazer_signers.ts` now enumerates `CardanoLazerContract` signers, so `cardano_mainnet` appears in default mainnet runs.
- **Governance E2E test**: `scripts/test_cardano_lazer_contract.ts` mirrors `test_stellar_lazer_contract.ts` — throwaway-deploy header, add→assert→remove→assert teardown, `PASS` line, dispatching via `@pythnetwork/pyth-lazer-cardano-cli`.
- **Plumbing**: contract_manager deps on the two cardano packages; `turbo.json` passes through `KOIOS_TOKEN`.

Out of scope (per issue): upgrade-action dispatch (payload builders only, TODO-tagged), mainnet Squads proposal flow.

## human-iteration changes (this round)
Simplified `CardanoChain` to a Koios-only provider per human feedback: the pluggable blockfrost/koios/maestro indirection was unused (all three shipped configs use koios, tokenless), so the `CardanoProvider` union, the `providerType` config field, the private `getProviderConfig()` switch, and the blockfrost/maestro env-var throws were all dead code. `getProvider()` now builds a Koios read client directly. `turbo.json` `globalPassThroughEnv` trimmed to just `KOIOS_TOKEN` (also resolves the earlier `KOIOS_API_KEY`/`KOIOS_TOKEN` mismatch nit). Added an explicit return type to `decodePythState`.

## Verification
See the issue comment for raw stdout. Summary:
- **Mainnet audit (the core acceptance)** — `pnpm tsx scripts/list_lazer_signers.ts` enumerates the `cardano_mainnet` deployment's trusted signer (`80efc1f4…820c2e6c`, expiry 2027-05-04) via tokenless Koios. ✅ (from the original round; the read path is unchanged by the Koios-only simplification.)
- **Governance payload encoding** — `generateUpdateTrustedSignerPayload` round-trips through `decodeGovernancePayload` and is byte-identical to the on-chain Aiken parser test vector (`5054474d 03 01 eac1 <key> <u64be expires>`). ✅
- **Lint + typecheck (this round)** — biome clean on all touched files; cardano SDK `tsc --noEmit` + full build green; `chains.ts` typechecks with zero errors. A full `contract_manager` tsc run is blocked in this sandbox by an unrelated `price-service-sdk` build failure (a `Buffer.concat`/`@types/node` overload mismatch under Node v24), which cascades to `xc-admin-common`/`cardano-cli`; not introduced by this patch. ✅
- **Throwaway-testnet governance E2E** — NOT run in this headless environment: it needs an Aiken-built throwaway deployment on `preview`, a funded Cardano wallet, and a funded Solana devnet emitter. The script + repro steps are provided; see the issue comment for details.

Parent: i-wfsldwlt.