### PR TITLE
fix(contract_manager): read Stellar Lazer trusted signers from the new enumerable map + add Stellar to list_lazer_signers audit

### DIFF
--- a/contract_manager/scripts/list_lazer_signers.ts
+++ b/contract_manager/scripts/list_lazer_signers.ts
@@ -5,7 +5,11 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
-import { EvmLazerContract, SuiLazerContract } from "../src/core/contracts";
+import {
+  EvmLazerContract,
+  StellarLazerContract,
+  SuiLazerContract,
+} from "../src/core/contracts";
 import { DefaultStore } from "../src/node/utils/store";
 
 const parser = yargs(hideBin(process.argv))
@@ -70,8 +74,6 @@ async function main() {
 
   const rows: SignerRow[] = [];
 
-  // Stellar verifiers expose no on-chain enumeration of trusted signers, so
-  // they are intentionally excluded here; that audit is tracked separately.
   for (const contract of Object.values(DefaultStore.lazer_contracts)) {
     if (contract.chain.isMainnet() === argv.testnet) continue;
     const contractId = contract.getId();
@@ -98,6 +100,19 @@ async function main() {
               contractId,
               chain,
               signer.address,
+              signer.expiresAt,
+              nowSeconds,
+              warnWithinSeconds,
+            ),
+          );
+        }
+      } else if (contract instanceof StellarLazerContract) {
+        for (const signer of await contract.getTrustedSigners()) {
+          rows.push(
+            makeRow(
+              contractId,
+              chain,
+              signer.publicKey,
               signer.expiresAt,
               nowSeconds,
               warnWithinSeconds,

--- a/contract_manager/src/core/contracts/stellar.ts
+++ b/contract_manager/src/core/contracts/stellar.ts
@@ -157,34 +157,50 @@ export class StellarLazerContract extends Storable {
   }
 
   /**
-   * Read the expiry timestamp (unix seconds) of a trusted signer, or `undefined`
-   * if the signer is not currently trusted.
+   * Read the current set of trusted Lazer signers from the verifier. The whole
+   * set lives in a single persistent entry under `DataKey::TrustedSigners`
+   * (unit variant -> key `ScVec([Symbol("TrustedSigners")])`) as a
+   * `Map<BytesN<33>, u64>` (compressed pubkey -> expiry), so a single fetch
+   * enumerates every signer.
    *
-   * The verifier keys trusted signers individually by public key and exposes no
-   * enumeration, so callers must supply the key of interest — there is no
-   * on-chain "list all signers" to mirror.
-   *
-   * @param publicKey - 33-byte compressed secp256k1 key, hex without 0x
+   * @returns one entry per signer: `publicKey` (33-byte compressed secp256k1,
+   *   hex without 0x) and `expiresAt` (unix seconds). Empty for an
+   *   uninitialized verifier or one with no trusted signers.
    */
-  async getTrustedSignerExpiry(publicKey: string): Promise<bigint | undefined> {
+  async getTrustedSigners(): Promise<
+    { publicKey: string; expiresAt: bigint }[]
+  > {
     const server = this.chain.getProvider();
-    const key = xdr.ScVal.scvVec([
-      xdr.ScVal.scvSymbol("TrustedSigner"),
-      xdr.ScVal.scvBytes(Buffer.from(publicKey, "hex")),
-    ]);
+    const key = xdr.ScVal.scvVec([xdr.ScVal.scvSymbol("TrustedSigners")]);
+    let entry;
     try {
-      const entry = await server.getContractData(
+      entry = await server.getContractData(
         this.address,
         key,
         stellarRpc.Durability.Persistent,
       );
-      return BigInt(
-        scValToNative(entry.val.contractData().val()) as number | bigint,
-      );
     } catch {
-      // getContractData throws when the entry does not exist.
-      return undefined;
+      // getContractData throws when the entry does not exist (uninitialized).
+      return [];
     }
+    const map = entry.val.contractData().val().map() ?? [];
+    return map.map((item) => ({
+      expiresAt: BigInt(scValToNative(item.val()) as number | bigint),
+      publicKey: (scValToNative(item.key()) as Buffer).toString("hex"),
+    }));
+  }
+
+  /**
+   * Read the expiry timestamp (unix seconds) of a trusted signer, or `undefined`
+   * if the signer is not currently trusted.
+   *
+   * @param publicKey - 33-byte compressed secp256k1 key, hex without 0x
+   */
+  async getTrustedSignerExpiry(publicKey: string): Promise<bigint | undefined> {
+    const target = publicKey.toLowerCase();
+    const signers = await this.getTrustedSigners();
+    return signers.find((signer) => signer.publicKey.toLowerCase() === target)
+      ?.expiresAt;
   }
 }
 


### PR DESCRIPTION
Resolves [[i-evtasvhw]]. Two contract_manager reader bugs from the [[i-rqicqgmp]] Stellar storage-layout change, surfaced during config verification on [[i-sqhbiwii]].

## Changes
`contract_manager/src/core/contracts/stellar.ts`
- Add `StellarLazerContract.getTrustedSigners(): Promise<{ publicKey: string; expiresAt: bigint }[]>` which reads the single persistent `DataKey::TrustedSigners` entry (key `ScVec([Symbol("TrustedSigners")])`, durability Persistent) and decodes each `scvMap` entry (33-byte compressed pubkey hex -> u64 expiry). Returns `[]` for an uninitialized/empty verifier instead of throwing.
- Reimplement `getTrustedSignerExpiry()` on top of `getTrustedSigners()` (case-insensitive pubkey match). Previously it read the stale per-signer key `ScVec([Symbol("TrustedSigner"), Bytes(pubkey)])`, always missed, and reported every signer as untrusted.
- Update the now-false docstring that claimed the verifier exposes no enumeration.

`contract_manager/scripts/list_lazer_signers.ts`
- Remove the stale exclusion comment and add a `StellarLazerContract` branch that pushes one row per signer (`signer.publicKey`), mirroring the Sui/EVM branches.

## Verification (Stellar testnet, live)
Exercised the real class against the redeployed, populated verifier `CAYFT5JE3UQTKT4Q6ZOZK4FXVYVT6RE3MFC7STA4UB6WAEGBT65MRU52` (RPC `https://soroban-testnet.stellar.org`):
- `getTrustedSigners()` -> `[{ publicKey: 03a4380f01136eb2640f90c17e1e319e02bbafbeef2e6e67dc48af53f9827e155b, expiresAt: 9999999999n }]` ✅ (matches acceptance)
- `getTrustedSignerExpiry(03a4380f…155b)` = `9999999999` (and case-insensitively); nonexistent -> `undefined` ✅
- Against the empty/uninitialized registered verifier `CCE62RN3…`, `getTrustedSigners()` -> `[]` without throwing ✅
- `list_lazer_signers.ts --testnet` with the store pointed at `CAYFT5JE…` emits a `stellar_testnet` row for `03a4380f…155b` with status `OK` ✅ (the store repoint itself lands via [[i-sqhbiwii]]; on current main the record still points at the empty `CCE62RN3…`).

Full command output posted as an issue comment.

## Checks
- biome clean on both files; `turbo build` (tsc typecheck) green for `@pythnetwork/contract-manager`; `git merge-tree origin/main HEAD` conflict-free.

No unit test added: contract_manager defines no test runner (only build/clean/shell scripts), so the map decode is validated by the live testnet run above.