### PR TITLE
docs(developer-hub): link Pyth Pro contracts from Core upgrade page

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/contracts.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/contracts.mdx
@@ -65,6 +65,11 @@ Each Solana push feed lives at a PDA derived from the Price Feed program ID and 
 />
 
 <Callout type="info">
-  **Don't see your chain?** We're adding chains regularly and can discuss
-  custom arrangements. [Contact the team →](mailto:data@dourolabs.xyz)
+  **Don't see your chain?** Absence from the upgraded Core table does not
+  necessarily mean Pyth has no contract on that chain. Some chains are supported
+  through [Pyth Pro contract addresses](/price-feeds/pro/contract-addresses)
+  instead of an upgraded Core contract, though not every chain receives both.
+  Deployment availability depends on commercial and support arrangements. We're
+  adding chains regularly and can discuss custom arrangements.
+  [Contact the team →](mailto:data@dourolabs.xyz)
 </Callout>


### PR DESCRIPTION
## Summary

The Core upgrade [contract addresses page](https://docs.pyth.network/price-feeds/core/upgrade/contracts#evm) doesn't point users to Pyth Pro contracts. For chains like Fluent — where Pyth Pro is available but an upgraded Core contract is not listed — a user seeing their chain missing from the Core table could wrongly assume Pyth has no contract path on that chain.

This updates the existing "Don't see your chain?" callout on the Core upgrade contracts page to:
- Clarify that absence from the upgraded Core table does **not** necessarily mean there's no Pyth contract on that chain.
- Link to the [Pyth Pro contract addresses](/price-feeds/pro/contract-addresses) page so Pro-only chains are discoverable.
- Note that deployment availability depends on commercial/support arrangements.

Copy is deliberately worded ("though not every chain receives both") so it does not imply every chain gets both upgraded Core and Pro contracts. Existing Core upgrade guidance is unchanged.

No contract data changes — docs-only.

## Acceptance criteria (PFG-1186)

- [x] Core upgrade contract docs link to the Pyth Pro contract address page
- [x] Docs make clear that absence from the upgraded Core table ≠ no Pyth contract on that chain
- [x] Fluent users can discover the Pro contract path from the Core upgrade page
- [x] Copy does not imply every chain receives both upgraded Core and Pro contracts
- [x] Existing Core upgrade guidance remains intact

## Test plan

Ran the developer-hub dev server and verified the rendered callout: the "Pyth Pro contract addresses" link resolves to `/price-feeds/pro/contract-addresses` (target page returns 200).

Related: PFG-1186, and the inverse direction DEVREL-210 (Core guidance added to Pro docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->