### PR TITLE
docs(push-feeds): refresh pro_compatible_status and drop Avalanche carve-out

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/avalanche-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/avalanche-mainnet.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Avalanche feeds are intentionally pinned to pro_compatible_status \"coming_soon\": Pro-compatible push feeds are not deployed for this chain (no deployment-pro-compatible.yaml). Do NOT auto-derive this field from the Hermes listing for this file. See the JSDoc on ProCompatibleStatus in src/components/SponsoredFeedsTable/index.tsx.",
   "feeds": [
     {
       "alias": "HLP0/USDC.RR",

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/berachain-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/berachain-mainnet.json
@@ -54,7 +54,7 @@
       "time_difference": 3600,
       "price_deviation": 1,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "HONEY/USD",

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/hyperevm-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/hyperevm-mainnet.json
@@ -54,7 +54,7 @@
       "time_difference": 3600,
       "price_deviation": 1,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USH/USD",
@@ -102,7 +102,7 @@
       "time_difference": 3600,
       "price_deviation": 1,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WSTHYPE/STHYPE.RR",

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/monad-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/monad-mainnet.json
@@ -78,7 +78,7 @@
       "time_difference": 3600,
       "price_deviation": 0.2,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "STETH/ETH.RR",
@@ -118,7 +118,7 @@
       "time_difference": 3600,
       "price_deviation": 0.2,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDE/USD",
@@ -166,7 +166,7 @@
       "time_difference": 3600,
       "price_deviation": 0.2,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "FDUSD/USD",

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json
@@ -54,7 +54,7 @@
       "time_difference": 10,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "DEEP/USD",

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json
@@ -34,7 +34,7 @@
       "time_difference": 60,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "BONK/USD",
@@ -250,7 +250,7 @@
       "time_difference": 60,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "NAV.USTB/USD",
@@ -412,7 +412,7 @@
       "time_difference": 240,
       "price_deviation": 0.05,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "JUPUSD/USD",

--- a/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
+++ b/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
@@ -24,12 +24,8 @@ const PRO_COMPATIBLE_DOCS_URL = "/price-feeds/core/upgrade/preparing";
  *      GET https://pyth.dourolabs.app/hermes/v2/price_feeds
  *   2. For each feed, set "available" if its `id` is present in that listing,
  *      otherwise "coming_soon".
- *   3. Avalanche carve-out: every Avalanche feed is pinned to "coming_soon"
- *      regardless of the listing, because Pro-compatible push feeds are not
- *      deployed for that chain (no deployment-pro-compatible.yaml). See the
- *      `_comment` in data/evm/avalanche-mainnet.json.
  *
- * Last refreshed 2026-06-23. To refresh, re-run the steps above.
+ * Last refreshed 2026-07-03. To refresh, re-run the steps above.
  */
 type ProCompatibleStatus = "available" | "coming_soon";
 


### PR DESCRIPTION
## Summary

Refresh `pro_compatible_status` across the Pro-compatible push-feed docs JSONs by re-deriving each entry against a single fresh Hermes fetch, and drop the Avalanche pinned-to-`coming_soon` carve-out so Avalanche is data-driven like every other chain.

Related: [[i-ttsthjrp]], [[i-gcyfpicb]].

## Hermes fetch summary

- **Endpoint**: `https://pyth.dourolabs.app/hermes/v2/price_feeds`
- **Fetched at**: `2026-07-03T13:05:48Z`
- **Feed ids returned**: `1300` entries → `1298` unique 32-byte lowercase hex ids (used as the truth set for the whole PR — endpoint not re-fetched mid-run)

## Scope note

`pro_compatible_status` today lives on the `evm/*.json`, `sui/sui-mainnet.json`, and `svm/solana-mainnet.json` files (the ones whose MDX pages render `<SponsoredFeedsTable ... showProCompatibleStatus />`). `aptos/aptos-mainnet.json`, `movement/movement-mainnet.json`, and `svm/fogo-{main,test}net.json` do NOT currently carry the field — their MDX pages render without the Pro-compatible column. This PR touches only files that already opt in, and the SponsoredFeedsTable JSDoc still enumerates `{evm,sui,svm}` for that reason. Adding the field to the other chains' data files would be a schema-scope change beyond this drift refresh and is not attempted here.

## Before / after status counts (available / coming_soon)

| file | before | after |
| --- | --- | --- |
| evm/abstract-mainnet.json | 4 / 0 | 4 / 0 |
| evm/arbitrum-mainnet.json | 0 / 1 | 0 / 1 |
| evm/avalanche-mainnet.json | 0 / 1 | 0 / 1 |
| evm/base-mainnet.json | 6 / 1 | 6 / 1 |
| evm/berachain-mainnet.json | 6 / 3 | 7 / 2 |
| evm/ethereum-mainnet.json | 3 / 1 | 3 / 1 |
| evm/hyperevm-mainnet.json | 14 / 29 | 16 / 27 |
| evm/linea-mainnet.json | 1 / 0 | 1 / 0 |
| evm/monad-mainnet.json | 45 / 15 | 48 / 12 |
| evm/optimism-mainnet.json | 5 / 0 | 5 / 0 |
| evm/soneium-mainnet.json | 7 / 0 | 7 / 0 |
| evm/sonic-mainnet.json | 7 / 4 | 7 / 4 |
| sui/sui-mainnet.json | 17 / 19 | 18 / 18 |
| svm/solana-mainnet.json | 30 / 17 | 33 / 14 |
| **TOTAL** | **145 / 91** | **155 / 81** |

## Flip list

All 10 flips are `coming_soon -> available`, matching the parent-issue drift report exactly. No additional drift was surfaced by the fresh fetch.

| file | alias | id-short | old -> new |
| --- | --- | --- | --- |
| evm/berachain-mainnet.json | SUSDE/USDE.RR | `271c64ce…` | `coming_soon -> available` |
| evm/hyperevm-mainnet.json | WSTETH/STETH.RR | `f59ead01…` | `coming_soon -> available` |
| evm/hyperevm-mainnet.json | SUSDE/USDE.RR | `271c64ce…` | `coming_soon -> available` |
| evm/monad-mainnet.json | WSTETH/STETH.RR | `f59ead01…` | `coming_soon -> available` |
| evm/monad-mainnet.json | SUSDE/USDE.RR | `271c64ce…` | `coming_soon -> available` |
| evm/monad-mainnet.json | SUSDS/USDS.RR | `6968a864…` | `coming_soon -> available` |
| sui/sui-mainnet.json | CETUS/USD | `e5b274b2…` | `coming_soon -> available` |
| svm/solana-mainnet.json | SSOL/SOL | `add6499a…` | `coming_soon -> available` |
| svm/solana-mainnet.json | JUPSOL/SOL.RR | `f8d8d6b6…` | `coming_soon -> available` |
| svm/solana-mainnet.json | PST/USDC.RR | `675e36f8…` | `coming_soon -> available` |

**Additional drift found beyond the parent-issue report**: none. The parent's 10-flip list is complete.

## Avalanche carve-out removal

- Deleted the top-level `_comment` field from `data/evm/avalanche-mainnet.json` (per issue scope).
- Removed step 3 (`Avalanche carve-out`) from the JSDoc on `ProCompatibleStatus` in `apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx`; the general refresh rule (steps 1–2) remains.
- Bumped the JSDoc `Last refreshed` line to `2026-07-03`.
- Avalanche's single feed `HLP0/USDC.RR` (`aa388e24…`) is not present in the current Hermes listing, so under the data-driven rule it stays `coming_soon` — the visible status is unchanged, but the mechanism producing it is now uniform with every other chain.

## Verification

- Fresh Hermes fetch → id set built exactly once at the start of the run.
- Every feed id in every touched JSON is validated as 64-char lowercase hex before rewriting.
- Post-write sanity sweep confirms zero divergences between each `pro_compatible_status` and the expected value derived from the Hermes set (`in-set ⇒ available`, `out-of-set ⇒ coming_soon`).
- `pnpm turbo run test:format test:lint test:types --filter @pythnetwork/developer-hub` — all 46 tasks green (includes `build` via the task graph → `next build` compiled and pre-rendered 196 pages successfully).

## Out of scope (not touched)

- Any changes to `SponsoredFeedsTable` rendering / column logic.
- Feed additions, alias renames, and `time_difference` / `price_deviation` / `confidence_ratio` / `id` edits.
- Ordering of feed entries.
- MDX/prose anywhere outside the JSDoc header.
- Other push-feed docs (`.mdx` pages, `llms-price-feeds-core.txt`, `BinaryFormatCards`, etc.).