### PR TITLE
docs(push-feeds): add WEETH/USD to Base

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/base-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/base-mainnet.json
@@ -55,6 +55,14 @@
       "price_deviation": 1,
       "confidence_ratio": 100,
       "pro_compatible_status": "available"
+    },
+    {
+      "alias": "WEETH/USD",
+      "id": "9ee4e7c60b940440a261eb54b6d8149c23b580ed7da3139f7f08f4ea29dad395",
+      "time_difference": 3600,
+      "price_deviation": 1,
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     }
   ]
 }


### PR DESCRIPTION
Add WEETH/USD to the Developer Hub Base pushed-feed docs table so the docs mirror the on-chain deployments config.

The feed id `9ee4e7c6…dad395` is verified live on Pyth Core via Hermes (`display_symbol: WEETH/USD`, `symbol: Crypto.WEETH/USD`). It uses the same update parameters as every other Base feed (3600s heartbeat / 1% price deviation / 100 confidence ratio).

`pro_compatible_status` is set to `coming_soon`, following the `CBETH/USD` precedent already in this file — Lazer's `history/v1/symbols` currently reports `Crypto.WEETH/USD` in the `coming_soon` state. This will be flipped to `available` in a follow-up once Lazer promotes the feed to `stable`.

This docs change lands alongside sibling PRs against `pyth-network/deployments` that add the same WEETH/USD feed to the platform-green and platform-yellow config, so docs and deployment config do not drift.

Reviewer: @aditya520

Validation: JSON parses cleanly (8 feeds, WEETH/USD appended after XRP/USD). The entry matches the `SponsoredFeed` type consumed by `SponsoredFeedsTable`; `pro_compatible_status: "coming_soon"` is an existing valid literal already used by CBETH/USD in this same file.