### PR TITLE
feat(api-reference): clarify Pyth Core scope with site-wide banner

### DIFF
--- a/apps/api-reference/src/components/Banner/index.tsx
+++ b/apps/api-reference/src/components/Banner/index.tsx
@@ -1,0 +1,20 @@
+import { MaxWidth } from "../MaxWidth";
+
+export const Banner = () => (
+  <div className="w-full bg-pythpurple-100 text-pythpurple-950 dark:bg-pythpurple-600/20 dark:text-pythpurple-100">
+    <MaxWidth className="flex min-h-8 flex-wrap items-center justify-center gap-x-2 gap-y-0.5 py-1 text-center text-xs sm:text-sm">
+      <span>
+        This API reference is for{" "}
+        <span className="font-semibold">Pyth Core</span>, not Pyth Pro.
+      </span>
+      <a
+        className="font-semibold text-pythpurple-600 hover:underline dark:text-pythpurple-400"
+        href="https://docs.pyth.network/price-feeds/pro"
+        rel="noreferrer"
+        target="_blank"
+      >
+        Pyth Pro docs →
+      </a>
+    </MaxWidth>
+  </div>
+);

--- a/apps/api-reference/src/components/Header/index.tsx
+++ b/apps/api-reference/src/components/Header/index.tsx
@@ -12,10 +12,7 @@ export const Header = ({
 }: Omit<HTMLAttributes<HTMLElement>, "children">) => (
   <>
     <header
-      className={clsx(
-        "sticky top-0 w-full bg-white dark:bg-pythpurple-900",
-        className,
-      )}
+      className={clsx("w-full bg-white dark:bg-pythpurple-900", className)}
       {...props}
     >
       <MaxWidth className="flex h-16 items-center justify-between">

--- a/apps/api-reference/src/components/Home/index.tsx
+++ b/apps/api-reference/src/components/Home/index.tsx
@@ -1,5 +1,6 @@
 import type { ElementType, SVGProps } from "react";
 import { ButtonLink } from "../Button";
+import { InlineLink } from "../InlineLink";
 import { MaxWidth } from "../MaxWidth";
 import Benchmarks from "./benchmarks.svg";
 import Entropy from "./entropy.svg";
@@ -7,9 +8,24 @@ import PriceFeeds from "./price-feeds.svg";
 
 export const Home = () => (
   <main className="grid size-full place-content-center py-16 text-center">
-    <h1 className="mb-16 text-4xl font-semibold text-pythpurple-600 dark:text-pythpurple-400">
+    <h1 className="mb-4 text-4xl font-semibold text-pythpurple-600 dark:text-pythpurple-400">
       Pyth Network API Reference
     </h1>
+    <p className="mx-auto mb-16 max-w-2xl text-balance text-lg text-neutral-600 dark:text-neutral-400">
+      The interactive API reference for{" "}
+      <span className="font-medium text-pythpurple-600 dark:text-pythpurple-400">
+        Pyth Core
+      </span>
+      : real-time price feeds, Benchmarks, and Entropy. For Pyth Pro low-latency
+      streaming, see the{" "}
+      <InlineLink
+        href="https://docs.pyth.network/price-feeds/pro"
+        target="_blank"
+      >
+        Pyth Pro docs
+      </InlineLink>
+      .
+    </p>
     <MaxWidth>
       <nav
         aria-label="Products"

--- a/apps/api-reference/src/components/Root/index.tsx
+++ b/apps/api-reference/src/components/Root/index.tsx
@@ -12,6 +12,7 @@ import {
 } from "../../server-config";
 import { PriceFeedListProvider } from "../../use-price-feed-list";
 import { Amplitude } from "../Amplitude";
+import { Banner } from "../Banner";
 import { HighlighterProvider } from "../Code/use-highlighted-code";
 import { EvmProvider } from "../EvmProvider";
 import { Footer } from "../Footer";
@@ -45,7 +46,10 @@ export const Root = ({ children }: Props) => (
         <HighlighterProvider>
           <PriceFeedListProvider>
             <EvmProvider walletConnectProjectId={WALLETCONNECT_PROJECT_ID}>
-              <Header className="z-10 border-b border-neutral-400 dark:border-neutral-600" />
+              <div className="sticky top-0 z-20">
+                <Banner />
+                <Header className="border-b border-neutral-400 dark:border-neutral-600" />
+              </div>
               <div className="size-full">{children}</div>
               <Footer className="z-10 border-t border-neutral-400 dark:border-neutral-600" />
             </EvmProvider>

--- a/apps/api-reference/src/components/Sidebar/index.tsx
+++ b/apps/api-reference/src/components/Sidebar/index.tsx
@@ -40,7 +40,7 @@ export const Sidebar = ({
     <>
       <aside
         className={clsx(
-          "fixed inset-y-16 -ml-3 w-64 overflow-y-auto pr-4",
+          "fixed bottom-16 top-24 -ml-3 w-64 overflow-y-auto pr-4",
           className,
         )}
         {...props}


### PR DESCRIPTION
## What

Clarifies that the API Reference documents **Pyth Core**, not **Pyth Pro**, in two places:

- **Site-wide banner** on every page (Home, Price Feeds, Entropy, 404): _"This API reference is for Pyth Core, not Pyth Pro."_ with a link to the Pyth Pro docs.
- **Front-page subtitle** under the main heading, spelling out the Core scope (real-time price feeds, Benchmarks, Entropy) and pointing Pyth Pro users to the Pro docs.

Both link to https://docs.pyth.network/price-feeds/pro.

## Why

Users landing on the API Reference could mistake the Pyth Core pull-oracle price feeds here for Pyth Pro (low-latency streaming, formerly Lazer). This makes the scope explicit and self-routes Pro users.

## Changes

- `components/Banner/index.tsx` (new) — slim, theme-aware notice bar
- `components/Root/index.tsx` — renders Banner + Header in one shared `sticky top-0` region so both stay pinned
- `components/Header/index.tsx` — moved its `sticky top-0` up to the Root wrapper (no behavior change)
- `components/Sidebar/index.tsx` — bumped the price-feeds sidebar's fixed offset `top-16` → `top-24` so it clears the taller banner + header
- `components/Home/index.tsx` — added the subtitle

## Verification

- Banner confirmed on Home (light + dark), a Price Feeds method page, Entropy, and the 404 page.
- Price-feeds sidebar sits correctly below the banner (no overlap).
- `tsc` typecheck and Biome both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
