### PR TITLE
fix(price_pusher): use native gRPC transport for the Sui driver

### DIFF
--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -5,10 +5,12 @@
   "dependencies": {
     "@aptos-labs/ts-sdk": "^1.39.0",
     "@coral-xyz/anchor": "^0.30.0",
+    "@grpc/grpc-js": "^1.13.2",
     "@injectivelabs/networks": "1.14.47",
     "@injectivelabs/sdk-ts": "1.14.50",
     "@injectivelabs/utils": "^1.14.48",
     "@mysten/sui": "^2.7.0",
+    "@protobuf-ts/grpc-transport": "^2.11.1",
     "@pythnetwork/hermes-client": "workspace:*",
     "@pythnetwork/price-service-sdk": "workspace:^",
     "@pythnetwork/pyth-fuel-js": "workspace:*",
@@ -224,5 +226,5 @@
   },
   "type": "module",
   "types": "./dist/index.d.ts",
-  "version": "11.0.1"
+  "version": "11.2.1"
 }

--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -226,5 +226,5 @@
   },
   "type": "module",
   "types": "./dist/index.d.ts",
-  "version": "11.2.1"
+  "version": "11.2.2"
 }

--- a/apps/price_pusher/src/sui/command.ts
+++ b/apps/price_pusher/src/sui/command.ts
@@ -49,6 +49,16 @@ export default {
       required: true,
       type: "number",
     } as Options,
+    "grpc-metadata": {
+      default: [],
+      description:
+        "Metadata header(s) sent with every gRPC request, formatted as " +
+        "`key=value`. Repeat for multiple headers. Use this to authenticate " +
+        "native-gRPC providers: `x-token=<secret>` for QuikNode/Ankr, " +
+        "`x-api-key=<secret>` for BlockVision. Only used with `--endpoint-type grpc`.",
+      required: false,
+      type: "array",
+    } as Options,
     "ignore-gas-objects": {
       default: [],
       description:
@@ -118,6 +128,7 @@ export default {
       ignoreGasObjects,
       gasBudget,
       accountIndex,
+      grpcMetadata: grpcMetadataArgs,
       logLevel,
       controllerLogLevel,
       enableMetrics,
@@ -125,6 +136,19 @@ export default {
     } = argv;
 
     const logger = pino({ level: logLevel });
+
+    // Parse `--grpc-metadata key=value` pairs into the metadata map forwarded
+    // to the gRPC transport (e.g. the `x-token` auth header).
+    const grpcMetadata: Record<string, string> = {};
+    for (const entry of grpcMetadataArgs as string[]) {
+      const eq = entry.indexOf("=");
+      if (eq === -1) {
+        throw new Error(
+          `Invalid --grpc-metadata "${entry}": expected key=value`,
+        );
+      }
+      grpcMetadata[entry.slice(0, eq)] = entry.slice(eq + 1);
+    }
 
     const priceConfigs = readPriceConfigFile(priceConfigFile);
     const hermesClient = new HermesClient(priceServiceEndpoint, {
@@ -169,7 +193,12 @@ export default {
       logger.child({ module: "PythPriceListener" }),
     );
 
-    const suiClient = createSuiProvider(endpointType, network, endpoint);
+    const suiClient = createSuiProvider(
+      endpointType,
+      network,
+      endpoint,
+      grpcMetadata,
+    );
 
     const suiListener = new SuiPriceListener(
       pythStateId,
@@ -180,6 +209,7 @@ export default {
       priceItems,
       logger.child({ module: "SuiPriceListener" }),
       { pollingFrequency },
+      grpcMetadata,
     );
 
     const suiPusher = await SuiPricePusher.createWithAutomaticGasPool(
@@ -194,6 +224,7 @@ export default {
       gasBudget,
       numGasObjects,
       ignoreGasObjects,
+      grpcMetadata,
     );
 
     const controller = new Controller(

--- a/apps/price_pusher/src/sui/sui.ts
+++ b/apps/price_pusher/src/sui/sui.ts
@@ -3,12 +3,14 @@
 /* biome-ignore-all lint/complexity/noForEach: pre-existing */
 /* biome-ignore-all lint/suspicious/useAwait: pre-existing */
 
+import { ChannelCredentials } from "@grpc/grpc-js";
 import type { ClientWithCoreApi, SuiClientTypes } from "@mysten/sui/client";
 import { SuiGrpcClient } from "@mysten/sui/grpc";
 import type { SuiObjectRef } from "@mysten/sui/jsonRpc";
 import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import type { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { Transaction } from "@mysten/sui/transactions";
+import { GrpcTransport } from "@protobuf-ts/grpc-transport";
 import type { HermesClient } from "@pythnetwork/hermes-client";
 import { getStructFields, SuiPythClient } from "@pythnetwork/pyth-sui-js";
 import type { Logger } from "pino";
@@ -35,20 +37,65 @@ export type SuiEndpointType = "json-rpc" | "grpc";
 /** Sui network label passed to the `@mysten/sui` v2 clients. */
 export type SuiNetwork = "mainnet" | "testnet" | "devnet" | "localnet";
 
+/** gRPC request metadata (e.g. `{ "x-token": "<secret>" }`) sent on every call. */
+export type SuiGrpcMetadata = Record<string, string>;
+
+/**
+ * Turn a gRPC endpoint into a `@grpc/grpc-js` `host:port` plus channel
+ * credentials. Third-party Sui gRPC endpoints (QuikNode `:9000`, Ankr /
+ * BlockVision `:443`) serve **native gRPC over HTTP/2**, so the host must be
+ * a bare `host:port` with no scheme or path. A `http://` prefix selects an
+ * insecure channel (local devnet); anything else uses TLS.
+ */
+function parseGrpcEndpoint(url: string): {
+  host: string;
+  credentials: ChannelCredentials;
+} {
+  let host = url.trim();
+  let insecure = false;
+  if (host.startsWith("https://")) {
+    host = host.slice("https://".length);
+  } else if (host.startsWith("http://")) {
+    host = host.slice("http://".length);
+    insecure = true;
+  }
+  // Drop any path/token segment — native gRPC authenticates via metadata, not URL.
+  host = host.replace(/\/.*$/, "");
+  return {
+    credentials: insecure
+      ? ChannelCredentials.createInsecure()
+      : ChannelCredentials.createSsl(),
+    host,
+  };
+}
+
 /**
  * Both the `@mysten/sui` v2 JSON-RPC client (`SuiJsonRpcClient`) and the
  * experimental gRPC client (`SuiGrpcClient`) expose the unified `.core` API.
  * The pusher reads and writes exclusively through `.core` so the same driver
  * works over either transport.
+ *
+ * `SuiGrpcClient` defaults to a grpc-web (HTTP/1.1) transport, which the Sui
+ * providers' native-gRPC (HTTP/2) endpoints reject; it also drops the `meta`
+ * option on that default path, so credentials never reach the wire. We
+ * therefore build an explicit `@protobuf-ts/grpc-transport` (native gRPC over
+ * `@grpc/grpc-js`) and pass the auth header through its `meta`.
  */
 export function createSuiProvider(
   endpointType: SuiEndpointType,
   network: SuiNetwork,
   url: string,
+  grpcMetadata?: SuiGrpcMetadata,
 ): ClientWithCoreApi {
   switch (endpointType) {
     case "grpc": {
-      return new SuiGrpcClient({ baseUrl: url, network });
+      const { host, credentials } = parseGrpcEndpoint(url);
+      const transport = new GrpcTransport({
+        channelCredentials: credentials,
+        host,
+        ...(grpcMetadata && { meta: grpcMetadata }),
+      });
+      return new SuiGrpcClient({ network, transport });
     }
     case "json-rpc": {
       return new SuiJsonRpcClient({ network, url });
@@ -93,9 +140,15 @@ export class SuiPriceListener extends ChainPriceListener {
     config: {
       pollingFrequency: DurationInSeconds;
     },
+    grpcMetadata?: SuiGrpcMetadata,
   ) {
     super(config.pollingFrequency, priceItems);
-    this.provider = createSuiProvider(endpointType, network, endpoint);
+    this.provider = createSuiProvider(
+      endpointType,
+      network,
+      endpoint,
+      grpcMetadata,
+    );
     this.pythClient = new SuiPythClient(
       this.provider,
       pythStateId,
@@ -187,6 +240,7 @@ export class SuiPricePusher implements IPricePusher {
     gasBudget: number,
     numGasObjects: number,
     ignoreGasObjects: string[],
+    grpcMetadata?: SuiGrpcMetadata,
   ): Promise<SuiPricePusher> {
     if (numGasObjects > MAX_NUM_OBJECTS_IN_ARGUMENT) {
       throw new Error(
@@ -194,7 +248,12 @@ export class SuiPricePusher implements IPricePusher {
       );
     }
 
-    const provider = createSuiProvider(endpointType, network, endpoint);
+    const provider = createSuiProvider(
+      endpointType,
+      network,
+      endpoint,
+      grpcMetadata,
+    );
 
     const gasPool = await SuiPricePusher.initializeGasPool(
       keypair,

--- a/apps/price_pusher/src/sui/sui.ts
+++ b/apps/price_pusher/src/sui/sui.ts
@@ -598,13 +598,21 @@ export class SuiPricePusher implements IPricePusher {
         }
         throw error_;
       }
-      const effects = getExecutedTransaction(mergeResult).effects;
+      const executed = getExecutedTransaction(mergeResult);
+      const effects = executed.effects;
       if (effects.status.error) {
         throw new Error(
           `Failed to merge coins when initializing gas pool: ${JSON.stringify(effects.status.error)}. Try re-running the script`,
         );
       }
       finalCoin = changedObjectToRef(effects.gasObject!);
+      // Block until this merge is observable before the next transaction spends
+      // its output (the next chunk's gas, or the subsequent split). gRPC
+      // endpoints are load-balanced across fullnodes at different checkpoints,
+      // so without this the follow-up tx can be simulated against a backend
+      // that has not yet applied this merge and fail with a version conflict.
+      // The legacy JSON-RPC path got this for free via WaitForLocalExecution.
+      await provider.core.waitForTransaction({ digest: executed.digest });
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1109,6 +1109,9 @@ importers:
       '@coral-xyz/anchor':
         specifier: ^0.30.0
         version: 0.30.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@grpc/grpc-js':
+        specifier: ^1.13.2
+        version: 1.13.2
       '@injectivelabs/networks':
         specifier: 1.14.47
         version: 1.14.47
@@ -1121,6 +1124,9 @@ importers:
       '@mysten/sui':
         specifier: ^2.7.0
         version: 2.7.0(typescript@5.9.3)
+      '@protobuf-ts/grpc-transport':
+        specifier: ^2.11.1
+        version: 2.11.1(@grpc/grpc-js@1.13.2)
       '@pythnetwork/hermes-client':
         specifier: workspace:*
         version: link:../hermes/client/js
@@ -8183,6 +8189,11 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@solana/web3.js': ^1.5.0
+
+  '@protobuf-ts/grpc-transport@2.11.1':
+    resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
+    peerDependencies:
+      '@grpc/grpc-js': ^1.6.0
 
   '@protobuf-ts/grpcweb-transport@2.11.1':
     resolution: {integrity: sha512-1W4utDdvOB+RHMFQ0soL4JdnxjXV+ddeGIUg08DvZrA8Ms6k5NN6GBFU2oHZdTOcJVpPrDJ02RJlqtaoCMNBtw==}
@@ -31685,6 +31696,12 @@ snapshots:
       '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
       bs58: 4.0.1
       eventemitter3: 4.0.7
+
+  '@protobuf-ts/grpc-transport@2.11.1(@grpc/grpc-js@1.13.2)':
+    dependencies:
+      '@grpc/grpc-js': 1.13.2
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
 
   '@protobuf-ts/grpcweb-transport@2.11.1':
     dependencies:


### PR DESCRIPTION
## Problem

The Sui price-pusher gRPC path did not work end-to-end against real mainnet gRPC endpoints. The driver constructed `new SuiGrpcClient({ baseUrl, network })`, which defaults to `@protobuf-ts/grpcweb-transport` — a **grpc-web** transport over Node's HTTP/1.1 `fetch`.

Two independent bugs made every gRPC call fail:

1. **Transport mismatch.** Third-party Sui gRPC providers (QuikNode `:9000`, Ankr / BlockVision `:443`) serve **native gRPC over HTTP/2** and only accept `application/grpc`. They reject grpc-web content types (`grpc-message: invalid gRPC request content-type "application/grpc-web+proto"`), and Node's `fetch` (HTTP/1.1) gets `other side closed` from the HTTP/2-only listener. Result: every call threw `fetch failed`.
2. **Auth header dropped.** On its default-transport branch `SuiGrpcClient` forwards only `baseUrl`/`fetchInit` and silently drops the `meta` option, so no auth header could ever be sent. The canary shipped the token in the URL path, which native gRPC ignores.

## Fix

- `createSuiProvider` now builds an explicit `@protobuf-ts/grpc-transport` (native gRPC over `@grpc/grpc-js`) and passes it to `SuiGrpcClient`. The gRPC endpoint is parsed to a bare `host:port`; a `http://` prefix selects an insecure channel (local devnet), otherwise TLS.
- Auth is plumbed through gRPC metadata via a new repeatable `--grpc-metadata key=value` CLI flag, threaded into the listener, the pusher's gas-pool client, and the balance-tracker client. Use `x-token=<secret>` for QuikNode/Ankr, `x-api-key=<secret>` for BlockVision.
- The JSON-RPC path is untouched (`SuiJsonRpcClient({ network, url })`), so there is no regression.
- New deps: `@protobuf-ts/grpc-transport` and `@grpc/grpc-js` (the latter already resolved transitively). Pusher version bumped to `11.2.1`.

## Verification (Sui mainnet)

Exercised the real `SuiPricePusher` / `SuiPriceListener` classes against QuikNode mainnet gRPC (`hidden-omniscient-arrow.sui-mainnet.quiknode.pro:9000`, `x-token` header) with a funded account:

- Reads: `getReferenceGasPrice`, `getObject` (Pyth state), price-feed dynamic-field lookup, `getBalance`, `listCoins` — all OK.
- Gas pool: coin split executed over gRPC.
- **Real price update landed on mainnet**, tx `HGKCxn65LKrMwyMQvPZswUd6i2ccPA58HPmQsQqkaxNa` (status `success`, checkpoint 295477853), calling `pyth::update_single_price_feed` / `create_authenticated_price_infos_using_accumulator`.
- JSON-RPC no-regression check: same flow over the JSON-RPC endpoint, tx `AYNUy8xHzcY3oPTrQCkD22oQ7fS6UTb37G6bAqTkU8nc` (status `success`).

## Follow-up (not in this PR)

The deployments repo still needs the gRPC wiring: point `--endpoint` at `host:9000`, add `--endpoint-type grpc` + `--grpc-metadata x-token=<secret-from-1Password>`, and re-implement the `rpc-selector` health probe as a gRPC liveness check (JSON-RPC is being decommissioned). Tracked separately.

---
## Follow-up fix: gas-pool init resilience (v11.2.2)

Manual coin-smashing testing on mainnet surfaced a second gRPC-only failure the initial verification missed because it ran from a **single** gas coin (the merge is skipped when only one coin exists).

**Bug.** The gas-pool init chains transactions that each spend the object the previous one produced: merge chunk *i* → chunk *i+1* (when `--num-gas-objects` > 254, e.g. the canary's 300), and merge → split. Native-gRPC endpoints are load-balanced across fullnodes at slightly different checkpoints, so the follow-up transaction can be simulated (during `build()`'s `SimulateTransaction`) against a backend that has **not yet applied** the prior one → `provided version doesn't match, provided: Some(N) actual: N-1`, aborting pusher startup. The legacy JSON-RPC path got read-your-writes for free via `WaitForLocalExecution`.

**Fix.** Await each merge's finality with the SDK's built-in `client.core.waitForTransaction({ digest })` before the next transaction spends its output. No custom polling/retry — just the intended primitive at the two hand-off points.

**Verification (mainnet, native gRPC QuikNode `:9000`):**
- Isolated A/B with the built-in wait: merge over gRPC → `waitForTransaction` → split over gRPC succeeded **5/5**; without any wait the split reproducibly fails with `provided version doesn't match`.
- Full production path via the real `SuiPricePusher`: fan out to **261 coins**, smash → merge (**2 chunks, crossing the 254 boundary**) → split → **30-coin pool** → real price update landed on-chain: tx `13oNrzRoYUYYguVT8EEkixxXw2sAzanRbcDZr2r5tx2S` (`status: success`, checkpoint 295568761, `pyth::update_single_price_feed`).
- Gate: `biome check` clean; `tsc` clean for `src/sui/*` (other-chain errors are pre-existing unbuilt-package artifacts); unit tests 15/15.

**Transport workaround tracked separately.** The remaining "hacking around `SuiGrpcClient`" — hand-building `@protobuf-ts/grpc-transport` because `SuiGrpcClient` defaults to grpc-web and drops the `meta` auth header — is filed as its own issue to fix at the SDK level and pull back in once shipped. It stays in this PR only as the interim enabler.