### PR TITLE
docs(price-feeds): mark Pyth Pro History and REST endpoints as auth-required from July 24

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/acquire-api-key.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/acquire-api-key.mdx
@@ -6,7 +6,7 @@ slug: /price-feeds/pro/acquire-api-key
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-This guide explains how to acquire an API key for Pyth Pro, which is required to authenticate websocket connections and subscribe to price updates.
+This guide explains how to acquire an API key for Pyth Pro, which is required to authenticate websocket connections and authenticated HTTP endpoints (the [History](/price-feeds/pro/api/history) and [REST](/price-feeds/pro/api/rest) APIs) and subscribe to price updates.
 
 ## Request API Key
 
@@ -15,8 +15,8 @@ This guide explains how to acquire an API key for Pyth Pro, which is required to
 Once you have logged in, click on the **🔑 View your API key** button to obtain your API key.
 
 <Callout type="info">
-  API keys are required for all Pyth Pro websocket connections. Make sure
-  to keep your key secure and do not share it publicly.
+  API keys are required for Pyth Pro websocket connections and for authenticated
+  HTTP endpoints. Make sure to keep your key secure and do not share it publicly.
 </Callout>
 
 ## Using the API Key
@@ -37,6 +37,19 @@ const client = await PythLazerClient.create(
   "YOUR_API_KEY",
 );
 ```
+
+The same `Authorization: Bearer <PRO_API_KEY>` header authenticates the History
+and REST HTTP endpoints. For example, against the History API:
+
+```bash copy
+curl -H "Authorization: Bearer $PRO_API_KEY" \
+  "https://pyth.dourolabs.app/v1/fixed_rate@200ms/price?ids=1&timestamp=1704067200000000"
+```
+
+Browser and frontend apps must not embed the key — route requests through your
+own backend, which injects the header before forwarding. See the Authentication
+sections on the [History](/price-feeds/pro/api/history#authentication) and
+[REST](/price-feeds/pro/api/rest#authentication) API pages for full details.
 
 ## Next Steps
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/api/history.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/api/history.mdx
@@ -189,8 +189,8 @@ curl -H "Authorization: Bearer $PRO_API_KEY" \
 **Do not embed your Pro API key in frontend or browser applications.** The key
 must stay server-side. Route requests through your own backend, which injects
 the `Authorization` header before forwarding to this API. A client-safe JWT
-authentication option is expected around **July 10, 2026** for teams that do not
-want to run their own proxy.
+authentication option is planned for teams that do not want to run their own
+proxy.
 
 See [Acquire an API Key](/price-feeds/pro/acquire-api-key) to obtain a key.
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/api/history.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/api/history.mdx
@@ -20,19 +20,30 @@ All `{channel}` path segments refer to a price channel (e.g. `real_time`, `fixed
   connect TradingView charting UIs directly to this API.
 </Callout>
 
+<Callout type="warning" title="API key required starting July 24, 2026">
+  Starting **July 24, 2026**, `GET /{channel}/price` and `GET /{channel}/history`
+  require API-key authentication, and unauthenticated access to them will be
+  disabled. API-key auth is supported today, so add the
+  `Authorization: Bearer <PRO_API_KEY>` header now to stay forward-compatible.
+  See [Authentication](#authentication) for the header format and frontend-safe
+  guidance. See the
+  [announcement](https://dev-forum.pyth.network/t/action-required-pyth-pro-history-api-auth-required-starting-july-24/808)
+  for details.
+</Callout>
+
 ## Endpoints
 
-| Method | Path                   | Auth | Description                   |
-| ------ | ---------------------- | ---- | ----------------------------- |
-| GET    | `/live`                | No   | Health check                  |
-| GET    | `/symbols`             | No   | List available symbols        |
-| GET    | `/{channel}/price`     | No   | Price at a specific timestamp |
-| GET    | `/{channel}/history`   | No   | OHLC candlestick data         |
-| GET    | `/{channel}/search`    | No   | Search symbols                |
-| GET    | `/{channel}/symbols`   | No   | Resolve a single symbol       |
-| GET    | `/{channel}/streaming` | No   | SSE price stream              |
-| GET    | `/{channel}/config`    | No   | TradingView configuration     |
-| GET    | `/publisher_updates`   | Yes  | Raw publisher updates         |
+| Method | Path                   | Auth                       | Description                   |
+| ------ | ---------------------- | -------------------------- | ----------------------------- |
+| GET    | `/live`                | No                         | Health check                  |
+| GET    | `/symbols`             | No                         | List available symbols        |
+| GET    | `/{channel}/price`     | Yes (from July 24, 2026)   | Price at a specific timestamp |
+| GET    | `/{channel}/history`   | Yes (from July 24, 2026)   | OHLC candlestick data         |
+| GET    | `/{channel}/search`    | No                         | Search symbols                |
+| GET    | `/{channel}/symbols`   | No                         | Resolve a single symbol       |
+| GET    | `/{channel}/streaming` | No                         | SSE price stream              |
+| GET    | `/{channel}/config`    | No                         | TradingView configuration     |
+| GET    | `/publisher_updates`   | Yes                        | Raw publisher updates         |
 
 ---
 
@@ -163,6 +174,25 @@ Returns raw publisher price updates. Requires authentication.
 | `limit`         | `number`   | No       | Max results, 1–10000 (default: `15`)      |
 
 ---
+
+## Authentication
+
+Starting **July 24, 2026**, `GET /{channel}/price` and `GET /{channel}/history`
+require API-key authentication, and unauthenticated access to them will be
+disabled. Pass your Pro API key as a bearer token:
+
+```bash copy
+curl -H "Authorization: Bearer $PRO_API_KEY" \
+  "https://pyth.dourolabs.app/v1/fixed_rate@200ms/price?ids=1&timestamp=1704067200000000"
+```
+
+**Do not embed your Pro API key in frontend or browser applications.** The key
+must stay server-side. Route requests through your own backend, which injects
+the `Authorization` header before forwarding to this API. A client-safe JWT
+authentication option is expected around **July 10, 2026** for teams that do not
+want to run their own proxy.
+
+See [Acquire an API Key](/price-feeds/pro/acquire-api-key) to obtain a key.
 
 ## OpenAPI Schema
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/api/rest.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/api/rest.mdx
@@ -12,12 +12,23 @@ import { Callout } from "fumadocs-ui/components/callout";
 https://pyth-lazer.dourolabs.app
 ```
 
+<Callout type="warning" title="API key required for POST /v1/price starting July 24, 2026">
+  Starting **July 24, 2026**, `POST /v1/price` requires API-key authentication,
+  and unauthenticated access to it will be disabled. Pass
+  `Authorization: Bearer <PRO_API_KEY>`; API-key auth is supported today, so add
+  the header now to stay forward-compatible. Do not expose the key in browser
+  apps — keep it server-side. See [Authentication](#authentication) for the
+  header format and frontend-safe guidance, and the
+  [announcement](https://dev-forum.pyth.network/t/action-required-pyth-pro-history-api-auth-required-starting-july-24/808)
+  for details.
+</Callout>
+
 ## Endpoints
 
-| Method | Path               | Description                                         |
-| ------ | ------------------ | --------------------------------------------------- |
-| POST   | `/v1/latest_price` | Fetch the latest price for one or more price feeds  |
-| POST   | `/v1/price`        | Fetch price data at a specific historical timestamp |
+| Method | Path               | Auth                       | Description                                         |
+| ------ | ------------------ | -------------------------- | --------------------------------------------------- |
+| POST   | `/v1/latest_price` | —                          | Fetch the latest price for one or more price feeds  |
+| POST   | `/v1/price`        | Yes (from July 24, 2026)   | Fetch price data at a specific historical timestamp |
 
 ### POST /v1/latest_price
 
@@ -50,6 +61,27 @@ All fields from `/v1/latest_price`, plus:
 | `timestamp` | `u64` | Yes      | Unix timestamp in microseconds. Must be a raw integer — do not quote it. |
 
 For the full response schema — including price feed fields, signed payloads, and available properties — see the [Payload Reference](/price-feeds/pro/payload-reference).
+
+## Authentication
+
+Starting **July 24, 2026**, `POST /v1/price` requires API-key authentication,
+and unauthenticated access to it will be disabled. Pass your Pro API key as a
+bearer token:
+
+```bash copy
+curl -X POST -H "Authorization: Bearer $PRO_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"priceFeedIds":[1,2],"properties":["price"],"formats":["solana"],"channel":"fixed_rate@200ms","timestamp":1704067200000000}' \
+  "https://pyth-lazer.dourolabs.app/v1/price"
+```
+
+**Do not embed your Pro API key in frontend or browser applications.** The key
+must stay server-side. Route requests through your own backend, which injects
+the `Authorization` header before forwarding to this API. A client-safe JWT
+authentication option is expected around **July 10, 2026** for teams that do not
+want to run their own proxy.
+
+See [Acquire an API Key](/price-feeds/pro/acquire-api-key) to obtain a key.
 
 ## OpenAPI Schema
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/api/rest.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/api/rest.mdx
@@ -27,7 +27,7 @@ https://pyth-lazer.dourolabs.app
 
 | Method | Path               | Auth                       | Description                                         |
 | ------ | ------------------ | -------------------------- | --------------------------------------------------- |
-| POST   | `/v1/latest_price` | —                          | Fetch the latest price for one or more price feeds  |
+| POST   | `/v1/latest_price` | Yes                        | Fetch the latest price for one or more price feeds  |
 | POST   | `/v1/price`        | Yes (from July 24, 2026)   | Fetch price data at a specific historical timestamp |
 
 ### POST /v1/latest_price
@@ -78,8 +78,8 @@ curl -X POST -H "Authorization: Bearer $PRO_API_KEY" \
 **Do not embed your Pro API key in frontend or browser applications.** The key
 must stay server-side. Route requests through your own backend, which injects
 the `Authorization` header before forwarding to this API. A client-safe JWT
-authentication option is expected around **July 10, 2026** for teams that do not
-want to run their own proxy.
+authentication option is planned for teams that do not want to run their own
+proxy.
 
 See [Acquire an API Key](/price-feeds/pro/acquire-api-key) to obtain a key.
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/faq.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/faq.mdx
@@ -142,7 +142,7 @@ Starting **July 24, 2026**, `POST /v1/price` will require the `Authorization: Be
 
 #### Q. How should I authenticate the History and REST endpoints from a frontend app?
 
-Do not embed your Pro API key in browsers or frontend apps. Route requests through your own backend or proxy that injects the `Authorization: Bearer <PRO_API_KEY>` header before forwarding. A client-safe JWT authentication option is expected around **July 10, 2026** for teams that do not want to run their own proxy.
+Do not embed your Pro access token in browsers or frontend apps. Route requests through your own backend or proxy that injects the `Authorization: Bearer <PRO_API_KEY>` header before forwarding. A client-safe JWT authentication option is expected around **July 10, 2026** for teams that do not want to run their own proxy.
 
 ## API Keys & Permissions
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/faq.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/faq.mdx
@@ -142,13 +142,13 @@ Starting **July 24, 2026**, `POST /v1/price` will require the `Authorization: Be
 
 #### Q. How should I authenticate the History and REST endpoints from a frontend app?
 
-Do not embed your Pro access token in browsers or frontend apps. Route requests through your own backend or proxy that injects the `Authorization: Bearer <PRO_API_KEY>` header before forwarding. A client-safe JWT authentication option is expected around **July 10, 2026** for teams that do not want to run their own proxy.
+Do not embed your Pro access token in browsers or frontend apps. Route requests through your own backend or proxy that injects the `Authorization: Bearer <PRO_API_KEY>` header before forwarding. A client-safe JWT authentication option is planned for teams that do not want to run their own proxy.
 
-## API Keys & Permissions
+## Access Tokens & Permissions
 
-#### Q. How are API keys permissioned for different asset classes?
+#### Q. How are access tokens permissioned for different asset classes?
 
-Each API key is permissioned for a specific set of:
+Each access token is permissioned for a specific set of:
 
 - **Asset types** (e.g., crypto, equity, fx, metals, rates)
 - **Minimum channel** (e.g., `fixed_rate@200ms`, `real_time`)
@@ -161,7 +161,7 @@ One customer might have access to all asset types; another might be restricted t
 Common causes:
 
 1. **Wrong endpoint:** Ensure you are using the correct WebSocket or REST endpoint for your token.
-2. **Asset class restriction:** Your API key may not be entitled to the requested feed types.
+2. **Asset class restriction:** Your access token may not be entitled to the requested feed types.
 3. **Expired token:** Demo tokens expire; request a production token for long-term use.
 
 ## Troubleshooting

--- a/apps/developer-hub/content/docs/price-feeds/pro/faq.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/faq.mdx
@@ -123,6 +123,8 @@ https://pyth.dourolabs.app/v1/fixed_rate@200ms/history?symbol=Crypto.BTC/USD&fro
 
 See the [History API](/price-feeds/pro/api/history) for full endpoint details, query parameters, and resolutions.
 
+Starting **July 24, 2026**, `GET /{channel}/history` and `GET /{channel}/price` require the `Authorization: Bearer <PRO_API_KEY>` header, and unauthenticated access to them will be disabled. See the [History API](/price-feeds/pro/api/history#authentication) for the header format and frontend-safe guidance.
+
 #### Q. How do I fetch the latest price via HTTP?
 
 Use the REST API. Base URL:
@@ -135,6 +137,12 @@ https://pyth-lazer.dourolabs.app
 - **Price at a timestamp:** `POST /v1/price` — returns price data at a specific historical timestamp (request body includes a `timestamp` field).
 
 See the [REST API](/price-feeds/pro/api/rest) for request/response schemas and examples.
+
+Starting **July 24, 2026**, `POST /v1/price` will require the `Authorization: Bearer <PRO_API_KEY>` header, and unauthenticated access to it will be disabled. See the [REST API](/price-feeds/pro/api/rest#authentication) for details. `POST /v1/latest_price` is unaffected by this change.
+
+#### Q. How should I authenticate the History and REST endpoints from a frontend app?
+
+Do not embed your Pro API key in browsers or frontend apps. Route requests through your own backend or proxy that injects the `Authorization: Bearer <PRO_API_KEY>` header before forwarding. A client-safe JWT authentication option is expected around **July 10, 2026** for teams that do not want to run their own proxy.
 
 ## API Keys & Permissions
 


### PR DESCRIPTION
Surface the upcoming API-key authentication requirement for the Pyth Pro (Lazer) History and REST HTTP endpoints in the developer-hub docs.

Starting July 24, 2026, `GET /v1/{channel}/price`, `GET /v1/{channel}/history`, and `POST /v1/price` require `Authorization: Bearer <PRO_API_KEY>`; unauthenticated access to them is disabled on that date. API-key auth is already supported today, so integrators can add the header now and stay forward-compatible. Each affected page also documents the frontend-safe pattern (keep the key server-side, proxy through your own backend) and forward-references the client-safe JWT option expected around July 10, 2026.

Files changed:
- `content/docs/price-feeds/pro/api/history.mdx` — warning Callout, `Auth` column flipped to `Yes (from July 24, 2026)` for the two affected rows, and a new Authentication section.
- `content/docs/price-feeds/pro/api/rest.mdx` — warning Callout scoped to `POST /v1/price`, added `Auth` column, and a new Authentication section. `POST /v1/latest_price` treatment left unchanged.
- `content/docs/price-feeds/pro/acquire-api-key.mdx` — broadened key scope to WebSocket + HTTP endpoints, added an HTTP curl example and frontend-safe note.
- `content/docs/price-feeds/pro/faq.mdx` — appended auth notes to the historical-data and latest-price HTTP Q&As, plus one terse frontend-auth Q&A.

Docs-only. WebSocket and Proxy pages untouched. Validated from `apps/developer-hub/`: `test:format`, `test:lint`, `test:types`, and production `build` all pass.

See the [announcement](https://dev-forum.pyth.network/t/action-required-pyth-pro-history-api-auth-required-starting-july-24/808) for details.