### PR TITLE
feat(mcp): require access_token for get_historical_price and get_candlestick_data

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/mcp.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/mcp.mdx
@@ -26,7 +26,7 @@ The Pyth MCP server gives AI assistants direct, structured access to Pyth market
 Recommended workflow: `get_symbols` → `get_latest_price` / `get_historical_price` → `get_candlestick_data`
 
 <Callout type="warning">
-  `get_latest_price` requires a Pyth Pro API key passed as `access_token`. Get one at [acquire API key guide](./acquire-api-key). All other tools work without a key.
+  `get_latest_price`, `get_historical_price`, and `get_candlestick_data` require a Pyth Pro API key passed as `access_token`. Get one at [acquire API key guide](./acquire-api-key). `get_symbols` and `convert_date_to_timestamp` work without a key.
 </Callout>
 
 ## Setup
@@ -157,6 +157,7 @@ Get prices at a single historical timestamp.
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
+| `access_token` | string | **Yes** | Pyth Pro API key |
 | `symbols` | string[] | No\* | Full symbols |
 | `price_feed_ids` | number[] | No\* | Feed IDs |
 | `timestamp` | number | **Yes** | Unix seconds, milliseconds, or microseconds |
@@ -178,6 +179,7 @@ Fetch OHLC candlestick data for a single feed.
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
+| `access_token` | string | **Yes** | Pyth Pro API key |
 | `symbol` | string | **Yes** | Full symbol (e.g. `Crypto.BTC/USD`) |
 | `resolution` | string | **Yes** | `1`, `5`, `15`, `30`, `60`, `120`, `240`, `360`, `720`, `D`, `W`, `M` |
 | `from` | number | **Yes** | Start time (Unix seconds) |
@@ -192,7 +194,7 @@ Fetch OHLC candlestick data for a single feed.
 
 ### Invalid or expired API key
 
-- **Symptom:** `get_latest_price` returns an auth error
+- **Symptom:** `get_latest_price`, `get_historical_price`, or `get_candlestick_data` returns an auth error
 - **Fix:** Verify or regenerate your API key and pass it as `access_token`
 
 ### Symbol not found

--- a/apps/developer-hub/src/app/llms-price-feeds-pro.txt/route.ts
+++ b/apps/developer-hub/src/app/llms-price-feeds-pro.txt/route.ts
@@ -154,7 +154,7 @@ Pyth Pro also provides an MCP server so agents can discover feeds and fetch pric
 
 - MCP endpoint: https://mcp.pyth.network/mcp
 - Tool workflow: \`get_symbols\` -> \`get_latest_price\` / \`get_historical_price\` -> \`get_candlestick_data\`
-- Token behavior: only \`get_latest_price\` requires \`access_token\`
+- Token behavior: \`get_latest_price\`, \`get_historical_price\`, and \`get_candlestick_data\` require \`access_token\`
 - 9 pre-built skills for Claude Code: price alerts, cross-asset comparison, volatility analysis, FX conversion, portfolio tracking, funding rate monitoring, data export, time-series snapshots, and integration guidance
 - Skills docs: https://docs.pyth.network/price-feeds/pro/mcp-skills.mdx
 

--- a/apps/mcp/src/clients/history.ts
+++ b/apps/mcp/src/clients/history.ts
@@ -54,6 +54,7 @@ export class HistoryClient {
     resolution: string,
     from: number,
     to: number,
+    accessToken?: string,
   ): Promise<UpstreamResult<OHLCResponse>> {
     const url = new URL(`/v1/${channel}/history`, this.baseUrl);
     url.searchParams.set("symbol", symbol);
@@ -65,6 +66,9 @@ export class HistoryClient {
     const data = await withSingleRetry(async () => {
       this.logger.debug({ url: url.toString() }, "GET candlestick data");
       const res = await fetch(url, {
+        headers: accessToken
+          ? { Authorization: `Bearer ${accessToken}` }
+          : undefined,
         signal: AbortSignal.timeout(this.timeoutMs),
       });
       if (!res.ok) {
@@ -84,6 +88,7 @@ export class HistoryClient {
     channel: string,
     ids: number[],
     timestampUs: number,
+    accessToken?: string,
   ): Promise<UpstreamResult<HistoricalPriceResponse[]>> {
     const url = new URL(`/v1/${channel}/price`, this.baseUrl);
     for (const id of ids) {
@@ -95,6 +100,9 @@ export class HistoryClient {
     const data = await withSingleRetry(async () => {
       this.logger.debug({ url: url.toString() }, "GET historical price");
       const res = await fetch(url, {
+        headers: accessToken
+          ? { Authorization: `Bearer ${accessToken}` }
+          : undefined,
         signal: AbortSignal.timeout(this.timeoutMs),
       });
       if (!res.ok) {

--- a/apps/mcp/src/tools/get-candlestick-data.ts
+++ b/apps/mcp/src/tools/get-candlestick-data.ts
@@ -7,7 +7,11 @@ import { RESOLUTIONS } from "../constants.js";
 import type { SessionContext } from "../server.js";
 import { resolveChannel } from "../utils/channel.js";
 import { toolError } from "../utils/errors.js";
-import { logToolCall } from "../utils/logger.js";
+import {
+  computeTokenHash,
+  getApiKeyLast4,
+  logToolCall,
+} from "../utils/logger.js";
 import {
   DATA_AVAILABLE_FROM_ISO,
   DATA_AVAILABLE_FROM_UNIX,
@@ -18,6 +22,11 @@ import {
 const MAX_CANDLES = 500;
 
 const GetCandlestickDataInput = {
+  access_token: z
+    .string()
+    .trim()
+    .min(1, "access_token must not be empty")
+    .describe("Pyth Pro access token. Get one at https://pyth.network/pricing"),
   channel: z
     .string()
     .regex(
@@ -64,7 +73,7 @@ export function registerGetCandlestickData(
         readOnlyHint: true,
       },
       description:
-        "Fetch OHLC candlestick data for a symbol. Use for charting, technical analysis, backtesting. IMPORTANT: The symbol must be the full name from get_symbols including the asset type prefix (e.g. 'Crypto.BTC/USD', 'Equity.US.AAPL', 'FX.EUR/USD') — never use bare names like 'BTC/USD'. Historical data is available from April 2025 onward — do not request timestamps before that. Resolutions: 1/5/15/30/60 minutes, 120/240/360/720 (multi-hour), D (daily), W (weekly), M (monthly). Timestamps are Unix seconds.\n\nTimestamp reference (Unix seconds):\n  2025-04-01 (earliest available) = 1743465600\n  2026-01-01 = 1767225600\n  2026-06-01 = 1780272000\nAlways double-check your timestamp math — year-boundary errors are common.",
+        "Fetch OHLC candlestick data for a symbol. Requires an `access_token` (see https://docs.pyth.network/price-feeds/pro/acquire-api-key). Use for charting, technical analysis, backtesting. IMPORTANT: The symbol must be the full name from get_symbols including the asset type prefix (e.g. 'Crypto.BTC/USD', 'Equity.US.AAPL', 'FX.EUR/USD') — never use bare names like 'BTC/USD'. Historical data is available from April 2025 onward — do not request timestamps before that. Resolutions: 1/5/15/30/60 minutes, 120/240/360/720 (multi-hour), D (daily), W (weekly), M (monthly). Timestamps are Unix seconds.\n\nTimestamp reference (Unix seconds):\n  2025-04-01 (earliest available) = 1743465600\n  2026-01-01 = 1767225600\n  2026-06-01 = 1780272000\nAlways double-check your timestamp math — year-boundary errors are common.",
       inputSchema: GetCandlestickDataInput,
       title: "Get Candlestick Data",
     },
@@ -73,12 +82,12 @@ export function registerGetCandlestickData(
       const start = Date.now();
 
       const baseMetrics = {
-        apiKeyLast4: null as null,
+        apiKeyLast4: getApiKeyLast4(params.access_token),
         clientName: sessionContext.clientName,
         clientVersion: sessionContext.clientVersion,
         requestId: extra.requestId,
         sessionId: extra.sessionId ?? sessionContext.sessionId,
-        tokenHash: null as null,
+        tokenHash: computeTokenHash(params.access_token),
         tool: "get_candlestick_data" as const,
       };
 
@@ -102,6 +111,7 @@ export function registerGetCandlestickData(
             params.resolution,
             params.from,
             params.to,
+            params.access_token,
           );
 
         if (data.s === "no_data") {

--- a/apps/mcp/src/tools/get-historical-price.ts
+++ b/apps/mcp/src/tools/get-historical-price.ts
@@ -8,7 +8,11 @@ import type { SessionContext } from "../server.js";
 import { resolveChannel } from "../utils/channel.js";
 import { addDisplayPrices } from "../utils/display-price.js";
 import { ErrorMessages, toolError } from "../utils/errors.js";
-import { logToolCall } from "../utils/logger.js";
+import {
+  computeTokenHash,
+  getApiKeyLast4,
+  logToolCall,
+} from "../utils/logger.js";
 import {
   alignTimestampToChannel,
   DATA_AVAILABLE_FROM_ISO,
@@ -19,6 +23,11 @@ import {
 } from "../utils/timestamp.js";
 
 const GetHistoricalPriceInput = {
+  access_token: z
+    .string()
+    .trim()
+    .min(1, "access_token must not be empty")
+    .describe("Pyth Pro access token. Get one at https://pyth.network/pricing"),
   channel: z
     .string()
     .regex(
@@ -66,7 +75,7 @@ export function registerGetHistoricalPrice(
         readOnlyHint: true,
       },
       description:
-        "Get price data for specific feeds at a historical timestamp. Use get_symbols first to find feed IDs or symbols. If both price_feed_ids and symbols are provided, only price_feed_ids are used. Accepts Unix seconds, milliseconds, or microseconds (auto-detected). Historical data is available from April 2025 onward — do not request timestamps before that. The timestamp is internally converted to microseconds and aligned (rounded down) to the channel rate — e.g. for fixed_rate@200ms, it must be divisible by 200,000μs. Prices are integers with an exponent field — human-readable price = price * 10^exponent. Pre-computed display_price fields are included for convenience.\n\nTimestamp reference:\n  2025-04-01 (earliest available) = 1743465600\n  2026-01-01 = 1767225600\n  2026-06-01 = 1780272000\nAlways double-check your timestamp math — year-boundary errors are common.",
+        "Get price data for specific feeds at a historical timestamp. Requires an `access_token` (see https://docs.pyth.network/price-feeds/pro/acquire-api-key). Use get_symbols first to find feed IDs or symbols. If both price_feed_ids and symbols are provided, only price_feed_ids are used. Accepts Unix seconds, milliseconds, or microseconds (auto-detected). Historical data is available from April 2025 onward — do not request timestamps before that. The timestamp is internally converted to microseconds and aligned (rounded down) to the channel rate — e.g. for fixed_rate@200ms, it must be divisible by 200,000μs. Prices are integers with an exponent field — human-readable price = price * 10^exponent. Pre-computed display_price fields are included for convenience.\n\nTimestamp reference:\n  2025-04-01 (earliest available) = 1743465600\n  2026-01-01 = 1767225600\n  2026-06-01 = 1780272000\nAlways double-check your timestamp math — year-boundary errors are common.",
       inputSchema: GetHistoricalPriceInput,
       title: "Get Historical Price",
     },
@@ -79,13 +88,13 @@ export function registerGetHistoricalPrice(
         (params.price_feed_ids?.length ?? 0) > 0 ? undefined : params.symbols;
 
       const baseMetrics = {
-        apiKeyLast4: null as null,
+        apiKeyLast4: getApiKeyLast4(params.access_token),
         clientName: sessionContext.clientName,
         clientVersion: sessionContext.clientVersion,
         numFeedsRequested: 0,
         requestId: extra.requestId,
         sessionId: extra.sessionId ?? sessionContext.sessionId,
-        tokenHash: null as null,
+        tokenHash: computeTokenHash(params.access_token),
         tool: "get_historical_price" as const,
       };
 
@@ -144,7 +153,12 @@ export function registerGetHistoricalPrice(
 
         priceEndpointCalled = true;
         const { data: prices, upstreamLatencyMs: priceUpstreamMs } =
-          await historyClient.getHistoricalPrice(channel, ids, timestampUs);
+          await historyClient.getHistoricalPrice(
+            channel,
+            ids,
+            timestampUs,
+            params.access_token,
+          );
 
         const totalUpstreamMs = symbolLookupUpstreamMs + priceUpstreamMs;
         const enriched = prices.map((p) => addDisplayPrices(p));

--- a/apps/mcp/tests/clients/history.test.ts
+++ b/apps/mcp/tests/clients/history.test.ts
@@ -92,6 +92,18 @@ describe("HistoryClient", () => {
       expect(upstreamLatencyMs).toBeGreaterThanOrEqual(0);
     });
 
+    it("does not send an Authorization header", async () => {
+      let auth: string | null = "unset";
+      server.use(
+        http.get(`${HISTORY_URL}/v1/symbols`, ({ request }) => {
+          auth = request.headers.get("authorization");
+          return HttpResponse.json(mockFeeds);
+        }),
+      );
+      await client.getSymbols();
+      expect(auth).toBeNull();
+    });
+
     it("handles 400 error", async () => {
       server.use(
         http.get(`${HISTORY_URL}/v1/symbols`, () =>
@@ -115,6 +127,25 @@ describe("HistoryClient", () => {
       expect(data.t).toHaveLength(2);
       expect(upstreamLatencyMs).toBeGreaterThanOrEqual(0);
     });
+
+    it("sends an Authorization header when an access token is provided", async () => {
+      let auth: string | null = "unset";
+      server.use(
+        http.get(`${HISTORY_URL}/v1/fixed_rate@200ms/history`, ({ request }) => {
+          auth = request.headers.get("authorization");
+          return HttpResponse.json(mockOHLC);
+        }),
+      );
+      await client.getCandlestickData(
+        "fixed_rate@200ms",
+        "BTC/USD",
+        "D",
+        1_708_300_800,
+        1_708_387_200,
+        "test-token",
+      );
+      expect(auth).toBe("Bearer test-token");
+    });
   });
 
   describe("getHistoricalPrice", () => {
@@ -128,6 +159,23 @@ describe("HistoryClient", () => {
       expect(prices).toHaveLength(1);
       expect(prices[0].price_feed_id).toBe(1);
       expect(upstreamLatencyMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("sends an Authorization header when an access token is provided", async () => {
+      let auth: string | null = "unset";
+      server.use(
+        http.get(`${HISTORY_URL}/v1/fixed_rate@200ms/price`, ({ request }) => {
+          auth = request.headers.get("authorization");
+          return HttpResponse.json(mockPrice);
+        }),
+      );
+      await client.getHistoricalPrice(
+        "fixed_rate@200ms",
+        [1],
+        1_708_300_800_000_000,
+        "test-token",
+      );
+      expect(auth).toBe("Bearer test-token");
     });
   });
 });

--- a/apps/mcp/tests/integration/stdio.test.ts
+++ b/apps/mcp/tests/integration/stdio.test.ts
@@ -194,6 +194,7 @@ describe("Integration: MCP server round-trip", () => {
   it("get_candlestick_data returns OHLC", async () => {
     const result = await client.callTool({
       arguments: {
+        access_token: "test-token",
         from: 1_708_300_800,
         resolution: "D",
         symbol: "BTC/USD",
@@ -211,6 +212,7 @@ describe("Integration: MCP server round-trip", () => {
   it("get_historical_price resolves symbols to IDs", async () => {
     const result = await client.callTool({
       arguments: {
+        access_token: "test-token",
         symbols: ["BTC/USD"],
         timestamp: 1_708_300_800,
       },

--- a/apps/mcp/tests/tools/get-candlestick-data.test.ts
+++ b/apps/mcp/tests/tools/get-candlestick-data.test.ts
@@ -86,6 +86,7 @@ describe("get_candlestick_data tool", () => {
   it("returns OHLC data for valid request", async () => {
     const result = await client.callTool({
       arguments: {
+        access_token: "test-token",
         from: 1_708_300_800,
         resolution: "D",
         symbol: "BTC/USD",
@@ -121,6 +122,7 @@ describe("get_candlestick_data tool", () => {
 
     const result = await client.callTool({
       arguments: {
+        access_token: "test-token",
         from: 1_708_300_800,
         resolution: "D",
         symbol: "BTC/USD",
@@ -157,6 +159,7 @@ describe("get_candlestick_data tool", () => {
 
     const result = await client.callTool({
       arguments: {
+        access_token: "test-token",
         from: 1_708_300_800,
         resolution: "1",
         symbol: "BTC/USD",
@@ -173,5 +176,51 @@ describe("get_candlestick_data tool", () => {
     expect(data.returned).toBe(500);
     expect(data.total_available).toBe(600);
     expect(data.t).toHaveLength(500);
+  });
+
+  it("returns validation error when access_token is missing", async () => {
+    const result = await client.callTool({
+      arguments: {
+        from: 1_708_300_800,
+        resolution: "D",
+        symbol: "BTC/USD",
+        to: 1_708_473_600,
+      },
+      name: "get_candlestick_data",
+    });
+
+    expect(result.isError).toBe(true);
+  });
+
+  it("sends Authorization header to the history endpoint", async () => {
+    let historyAuth: string | null = "unset";
+    msw.use(
+      http.get(`${HISTORY_URL}/v1/fixed_rate@200ms/history`, ({ request }) => {
+        historyAuth = request.headers.get("authorization");
+        return HttpResponse.json({
+          c: [51_500],
+          h: [52_000],
+          l: [50_000],
+          o: [51_000],
+          s: "ok",
+          t: [1_708_300_800],
+          v: [100],
+        });
+      }),
+    );
+
+    const result = await client.callTool({
+      arguments: {
+        access_token: "test-token",
+        from: 1_708_300_800,
+        resolution: "D",
+        symbol: "BTC/USD",
+        to: 1_708_473_600,
+      },
+      name: "get_candlestick_data",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(historyAuth).toBe("Bearer test-token");
   });
 });

--- a/apps/mcp/tests/tools/get-historical-price.test.ts
+++ b/apps/mcp/tests/tools/get-historical-price.test.ts
@@ -106,6 +106,7 @@ describe("get_historical_price tool", () => {
   it("returns enriched prices via symbol lookup", async () => {
     const result = await client.callTool({
       arguments: {
+        access_token: "test-token",
         symbols: ["BTC/USD"],
         timestamp: 1_708_300_800,
       },
@@ -134,6 +135,7 @@ describe("get_historical_price tool", () => {
   it("returns enriched prices via feed IDs", async () => {
     const result = await client.callTool({
       arguments: {
+        access_token: "test-token",
         price_feed_ids: [1],
         timestamp: 1_708_300_800,
       },
@@ -151,6 +153,7 @@ describe("get_historical_price tool", () => {
   it("returns error for unknown symbol", async () => {
     const result = await client.callTool({
       arguments: {
+        access_token: "test-token",
         symbols: ["UNKNOWN/USD"],
         timestamp: 1_708_300_800,
       },
@@ -174,6 +177,7 @@ describe("get_historical_price tool", () => {
 
     const result = await client.callTool({
       arguments: {
+        access_token: "test-token",
         price_feed_ids: [1],
         symbols: ["BTC/USD"],
         timestamp: 1_708_300_800,
@@ -219,6 +223,7 @@ describe("get_historical_price tool", () => {
 
     const result = await testClient.callTool({
       arguments: {
+        access_token: "test-token",
         // Duplicates: [1,1,2,2,1] should dedup to [1,2] = count 2
         price_feed_ids: [1, 1, 2, 2, 1],
         timestamp: 1_708_300_800,
@@ -252,6 +257,7 @@ describe("get_historical_price tool", () => {
 
     const result = await client.callTool({
       arguments: {
+        access_token: "test-token",
         price_feed_ids: [1],
         timestamp: futureTimestamp,
       },
@@ -281,6 +287,7 @@ describe("get_historical_price tool", () => {
 
     const result = await client.callTool({
       arguments: {
+        access_token: "test-token",
         price_feed_ids: [1],
         timestamp: pastTimestamp,
       },
@@ -307,6 +314,7 @@ describe("get_historical_price tool", () => {
 
     const result = await client.callTool({
       arguments: {
+        access_token: "test-token",
         price_feed_ids: [999_999],
         timestamp: 1_708_300_800,
       },
@@ -331,6 +339,7 @@ describe("get_historical_price tool", () => {
 
     const result = await client.callTool({
       arguments: {
+        access_token: "test-token",
         symbols: ["BTC/USD"],
         timestamp: 1_708_300_800,
       },
@@ -342,5 +351,45 @@ describe("get_historical_price tool", () => {
       .text;
     // Should get the generic error, not the feed-specific error
     expect(text).toContain("Failed to fetch historical price");
+  });
+
+  it("returns validation error when access_token is missing", async () => {
+    const result = await client.callTool({
+      arguments: {
+        price_feed_ids: [1],
+        timestamp: 1_708_300_800,
+      },
+      name: "get_historical_price",
+    });
+
+    expect(result.isError).toBe(true);
+  });
+
+  it("sends Authorization header to price endpoint but not symbols endpoint", async () => {
+    let priceAuth: string | null = "unset";
+    let symbolsAuth: string | null = "unset";
+    msw.use(
+      http.get(`${HISTORY_URL}/v1/symbols`, ({ request }) => {
+        symbolsAuth = request.headers.get("authorization");
+        return HttpResponse.json(mockFeeds);
+      }),
+      http.get(`${HISTORY_URL}/v1/fixed_rate@200ms/price`, ({ request }) => {
+        priceAuth = request.headers.get("authorization");
+        return HttpResponse.json(mockHistoricalPrice);
+      }),
+    );
+
+    const result = await client.callTool({
+      arguments: {
+        access_token: "test-token",
+        symbols: ["BTC/USD"],
+        timestamp: 1_708_300_800,
+      },
+      name: "get_historical_price",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(priceAuth).toBe("Bearer test-token");
+    expect(symbolsAuth).toBeNull();
   });
 });


### PR DESCRIPTION
## Motivation

Starting **July 24, 2026** the Pyth Pro History API endpoints (`GET /v1/{channel}/history`, `GET /v1/{channel}/price`) require `Authorization: Bearer <PRO_API_KEY>`; unauthenticated access is disabled on that date. The Pyth MCP server (`apps/mcp/`) calls these endpoints anonymously via `HistoryClient`, so `get_historical_price` and `get_candlestick_data` would start returning 401 on July 24 unless the tools accept and forward an access token. `get_latest_price` already handles auth; `/v1/symbols` stays unauthenticated.

Announcement: https://dev-forum.pyth.network/t/action-required-pyth-pro-history-api-auth-required-starting-july-24/808 (parent docs PR: pyth-network/pyth-crosschain#3882).

## Changes

### Server
- `apps/mcp/src/clients/history.ts` — `getHistoricalPrice(...)` and `getCandlestickData(...)` accept an optional `accessToken` and set an `Authorization: Bearer <token>` header when provided. `getSymbols(...)` unchanged (endpoint stays anonymous).
- `apps/mcp/src/tools/get-historical-price.ts` and `get-candlestick-data.ts` — add a **required** `access_token` input (mirrors `get-latest-price.ts`), forward it to the client, mention it in the tool description, and populate `apiKeyLast4` / `tokenHash` log metrics via `getApiKeyLast4` / `computeTokenHash`.

### Tests
- Added `access_token` to existing tool + integration fixtures.
- New negative cases: a missing `access_token` returns a validation error for both tools.
- New header assertions (client + tool level): `Authorization: Bearer <token>` is present on the history/price calls and absent on the symbols call.

### Docs
- `apps/developer-hub/content/docs/price-feeds/pro/mcp.mdx` — accurate token-gating callout, `access_token` rows in the `get_historical_price` / `get_candlestick_data` param tables, broadened auth-error troubleshooting symptom.
- `apps/developer-hub/src/app/llms-price-feeds-pro.txt/route.ts` — token behavior line now names all three token-gated tools.

## Validation
- `pnpm turbo run test:types test:unit --filter=@pythnetwork/mcp` — 139 tests green.
- `pnpm turbo run test:format test:lint test:types --filter=@pythnetwork/developer-hub` (build runs as a dependency) — clean.