### PR TITLE
feat(mcp): authenticate History price & candlestick tools before Lazer auth cutover

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/mcp.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/mcp.mdx
@@ -26,7 +26,7 @@ The Pyth MCP server gives AI assistants direct, structured access to Pyth market
 Recommended workflow: `get_symbols` → `get_latest_price` / `get_historical_price` → `get_candlestick_data`
 
 <Callout type="warning">
-  `get_latest_price` requires a Pyth Pro API key passed as `access_token`. Get one at [acquire API key guide](./acquire-api-key). All other tools work without a key.
+  `get_latest_price` requires a Pyth Pro API key passed as `access_token`. `get_historical_price` and `get_candlestick_data` require it as of **July 24, 2026** (optional before then). Get one at [acquire API key guide](./acquire-api-key). `get_symbols` and `convert_date_to_timestamp` work without a key.
 </Callout>
 
 ## Setup
@@ -157,6 +157,7 @@ Get prices at a single historical timestamp.
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
+| `access_token` | string | From Jul 24, 2026 | Pyth Pro API key |
 | `symbols` | string[] | No\* | Full symbols |
 | `price_feed_ids` | number[] | No\* | Feed IDs |
 | `timestamp` | number | **Yes** | Unix seconds, milliseconds, or microseconds |
@@ -178,6 +179,7 @@ Fetch OHLC candlestick data for a single feed.
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
+| `access_token` | string | From Jul 24, 2026 | Pyth Pro API key |
 | `symbol` | string | **Yes** | Full symbol (e.g. `Crypto.BTC/USD`) |
 | `resolution` | string | **Yes** | `1`, `5`, `15`, `30`, `60`, `120`, `240`, `360`, `720`, `D`, `W`, `M` |
 | `from` | number | **Yes** | Start time (Unix seconds) |
@@ -192,7 +194,7 @@ Fetch OHLC candlestick data for a single feed.
 
 ### Invalid or expired API key
 
-- **Symptom:** `get_latest_price` returns an auth error
+- **Symptom:** `get_latest_price`, `get_historical_price`, or `get_candlestick_data` returns an auth error
 - **Fix:** Verify or regenerate your API key and pass it as `access_token`
 
 ### Symbol not found

--- a/apps/developer-hub/src/app/llms-price-feeds-pro.txt/route.ts
+++ b/apps/developer-hub/src/app/llms-price-feeds-pro.txt/route.ts
@@ -154,7 +154,7 @@ Pyth Pro also provides an MCP server so agents can discover feeds and fetch pric
 
 - MCP endpoint: https://mcp.pyth.network/mcp
 - Tool workflow: \`get_symbols\` -> \`get_latest_price\` / \`get_historical_price\` -> \`get_candlestick_data\`
-- Token behavior: only \`get_latest_price\` requires \`access_token\`
+- Token behavior: \`get_latest_price\` requires \`access_token\`; \`get_historical_price\` and \`get_candlestick_data\` require it as of July 24, 2026
 - 9 pre-built skills for Claude Code: price alerts, cross-asset comparison, volatility analysis, FX conversion, portfolio tracking, funding rate monitoring, data export, time-series snapshots, and integration guidance
 - Skills docs: https://docs.pyth.network/price-feeds/pro/mcp-skills.mdx
 

--- a/apps/mcp/docs/PLAN.md
+++ b/apps/mcp/docs/PLAN.md
@@ -21,9 +21,9 @@ The server wraps two Pyth Pro APIs:
 | Language | **TypeScript** — largest MCP ecosystem, npm distribution, fast to ship |
 | Transport | **Stdio + HTTP** — local dev via stdio, remote deployment via HTTP |
 | Package | **`@pyth-network/mcp-server`** |
-| Auth (v1) | User provides `PYTH_PRO_ACCESS_TOKEN` env var. Required for Router API tools. History API tools work without it. |
+| Auth (v1) | Caller passes their Pyth Pro token per-call via the `access_token` tool parameter. Required for `get_latest_price`. **As of 2026-07-24**, `get_historical_price` and `get_candlestick_data` also require it (History `/{channel}/price` and `/{channel}/history` became auth-gated). `get_symbols` (`/v1/symbols`) stays public. |
 | Auth (v2) | Server holds a shared trial token (never exposed). Rate-limited per session. Falls back when user has no token. |
-| Graceful degradation | History API tools (search, OHLC, historical prices) work **without** a token. Router API tools (latest prices) require a token and return a clear "bring your token" message if missing. |
+| Graceful degradation | `get_symbols` (feed discovery) works **without** a token. `get_latest_price`, and — from 2026-07-24 — `get_historical_price` / `get_candlestick_data`, require a token and return a clear "bring your token" message if missing/invalid. |
 | Channel default | `fixed_rate@200ms` server-wide default via `PYTH_CHANNEL` env var. Per-tool `channel` parameter can override. Note: each feed has a minimum supported channel (most are 200ms, some support real_time). |
 | Feed identifiers | Tools accept **both** `symbols` (string, e.g. `"BTC/USD"`) and `priceFeedIds` (numeric). LLMs will naturally use symbols. |
 | Properties default | `[price, bestBidPrice, bestAskPrice, confidence, exponent, publisherCount]` — overridable per-tool call. |
@@ -165,7 +165,7 @@ process.on("SIGINT", cleanup);
 
 ## Tools (4 tools)
 
-> **Naming convention:** Tool names match the underlying API endpoint names directly. Router API is only used for `get_latest_price` (real-time data requiring a token). All other tools use the History API (public, no token needed).
+> **Naming convention:** Tool names match the underlying API endpoint names directly. Router API is only used for `get_latest_price` (real-time data requiring a token). The other tools use the History API: `get_symbols` is public, while `get_historical_price` and `get_candlestick_data` require a token as of 2026-07-24 (passed per-call via `access_token`).
 
 ### Toolset: `discovery` (public, no token needed)
 
@@ -198,7 +198,7 @@ process.on("SIGINT", cleanup);
 | Field | Value |
 |-------|-------|
 | API | `GET /{channel}/history` (History API) |
-| Auth | None |
+| Auth | Required as of 2026-07-24 (per-call `access_token`) |
 | Read-only | Yes |
 
 **Parameters:**
@@ -222,7 +222,7 @@ process.on("SIGINT", cleanup);
 | Field | Value |
 |-------|-------|
 | API | `GET /{channel}/price` (History API) |
-| Auth | None |
+| Auth | Required as of 2026-07-24 (per-call `access_token`) |
 | Read-only | Yes |
 
 **Parameters:**

--- a/apps/mcp/docs/PLAN.md
+++ b/apps/mcp/docs/PLAN.md
@@ -10,7 +10,7 @@ Pyth Pro delivers low-latency, cross-asset market data (crypto, equities, FX, me
 
 The server wraps two Pyth Pro APIs:
 - **Router API** (`https://pyth-lazer.dourolabs.app`) — real-time/latest prices, requires bearer token
-- **History API** (`https://pyth.dourolabs.app`) — symbols (public), plus OHLC and historical prices (token-gated from 2026-07-24)
+- **History API** (`https://pyth.dourolabs.app`) — symbols (public), plus OHLC and historical prices (token-gated)
 
 ---
 
@@ -21,9 +21,9 @@ The server wraps two Pyth Pro APIs:
 | Language | **TypeScript** — largest MCP ecosystem, npm distribution, fast to ship |
 | Transport | **Stdio + HTTP** — local dev via stdio, remote deployment via HTTP |
 | Package | **`@pyth-network/mcp-server`** |
-| Auth (v1) | Caller passes their Pyth Pro token per-call via the `access_token` tool parameter. Required for `get_latest_price`. **As of 2026-07-24**, `get_historical_price` and `get_candlestick_data` also require it (History `/{channel}/price` and `/{channel}/history` became auth-gated). `get_symbols` (`/v1/symbols`) stays public. |
+| Auth (v1) | Caller passes their Pyth Pro token per-call via the `access_token` tool parameter. Required for `get_latest_price`, `get_historical_price`, and `get_candlestick_data` (History `/{channel}/price` and `/{channel}/history` are auth-gated). `get_symbols` (`/v1/symbols`) stays public. |
 | Auth (v2) | Server holds a shared trial token (never exposed). Rate-limited per session. Falls back when user has no token. |
-| Graceful degradation | `get_symbols` (feed discovery) works **without** a token. `get_latest_price`, and — from 2026-07-24 — `get_historical_price` / `get_candlestick_data`, require a token and return a clear "bring your token" message if missing/invalid. |
+| Graceful degradation | `get_symbols` (feed discovery) works **without** a token. `get_latest_price`, `get_historical_price`, and `get_candlestick_data` require a token and return a clear "bring your token" message if missing/invalid. |
 | Channel default | `fixed_rate@200ms` server-wide default via `PYTH_CHANNEL` env var. Per-tool `channel` parameter can override. Note: each feed has a minimum supported channel (most are 200ms, some support real_time). |
 | Feed identifiers | Tools accept **both** `symbols` (string, e.g. `"BTC/USD"`) and `priceFeedIds` (numeric). LLMs will naturally use symbols. |
 | Properties default | `[price, bestBidPrice, bestAskPrice, confidence, exponent, publisherCount]` — overridable per-tool call. |
@@ -165,7 +165,7 @@ process.on("SIGINT", cleanup);
 
 ## Tools (4 tools)
 
-> **Naming convention:** Tool names match the underlying API endpoint names directly. Router API is only used for `get_latest_price` (real-time data requiring a token). The other tools use the History API: `get_symbols` is public, while `get_historical_price` and `get_candlestick_data` require a token as of 2026-07-24 (passed per-call via `access_token`).
+> **Naming convention:** Tool names match the underlying API endpoint names directly. Router API is only used for `get_latest_price` (real-time data requiring a token). The other tools use the History API: `get_symbols` is public, while `get_historical_price` and `get_candlestick_data` require a token (passed per-call via `access_token`).
 
 ### Toolset: `discovery` (public, no token needed)
 
@@ -198,7 +198,7 @@ process.on("SIGINT", cleanup);
 | Field | Value |
 |-------|-------|
 | API | `GET /{channel}/history` (History API) |
-| Auth | Required as of 2026-07-24 (per-call `access_token`) |
+| Auth | Required (per-call `access_token`) |
 | Read-only | Yes |
 
 **Parameters:**
@@ -222,7 +222,7 @@ process.on("SIGINT", cleanup);
 | Field | Value |
 |-------|-------|
 | API | `GET /{channel}/price` (History API) |
-| Auth | Required as of 2026-07-24 (per-call `access_token`) |
+| Auth | Required (per-call `access_token`) |
 | Read-only | Yes |
 
 **Parameters:**

--- a/apps/mcp/docs/PLAN.md
+++ b/apps/mcp/docs/PLAN.md
@@ -10,7 +10,7 @@ Pyth Pro delivers low-latency, cross-asset market data (crypto, equities, FX, me
 
 The server wraps two Pyth Pro APIs:
 - **Router API** (`https://pyth-lazer.dourolabs.app`) — real-time/latest prices, requires bearer token
-- **History API** (`https://history.pyth-lazer.dourolabs.app`) — symbols, OHLC, historical prices, mostly public
+- **History API** (`https://pyth.dourolabs.app`) — symbols (public), plus OHLC and historical prices (token-gated from 2026-07-24)
 
 ---
 
@@ -466,7 +466,7 @@ interface ToolInvocationLog {
 | `PYTH_PRO_ACCESS_TOKEN` | `--token` | — | Pyth Pro bearer token. Required for Router API tools. |
 | `PYTH_CHANNEL` | `--channel` | `fixed_rate@200ms` | Default price channel |
 | `PYTH_ROUTER_URL` | `--router-url` | `https://pyth-lazer.dourolabs.app` | Router API base URL |
-| `PYTH_HISTORY_URL` | `--history-url` | `https://history.pyth-lazer.dourolabs.app` | History API base URL |
+| `PYTH_HISTORY_URL` | `--history-url` | `https://pyth.dourolabs.app` | History API base URL |
 | `PYTH_LOG_LEVEL` | `--log-level` | `info` | Log level: debug, info, warn, error |
 | `PYTH_LOG_FILE` | `--log-file` | stderr | Log output file (stdio mode logs to stderr to avoid polluting JSON-RPC) |
 | `PYTH_REQUEST_TIMEOUT_MS` | `--timeout` | `10000` | HTTP request timeout in milliseconds |

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -39,5 +39,5 @@
     "test:unit": "test-unit"
   },
   "type": "module",
-  "version": "0.1.0"
+  "version": "0.2.0"
 }

--- a/apps/mcp/src/clients/history.ts
+++ b/apps/mcp/src/clients/history.ts
@@ -9,6 +9,15 @@ import {
   OHLCResponseSchema,
 } from "./types.js";
 
+/**
+ * Bearer auth header for the token-gated History endpoints (`/{channel}/price`
+ * and `/{channel}/history`, which require authentication from 2026-07-24).
+ * Returns undefined when no token is set so unauthenticated callers are unchanged.
+ */
+function authHeaders(token?: string): Record<string, string> | undefined {
+  return token ? { Authorization: `Bearer ${token}` } : undefined;
+}
+
 export class HistoryClient {
   private readonly baseUrl: string;
   private readonly timeoutMs: number;
@@ -54,6 +63,7 @@ export class HistoryClient {
     resolution: string,
     from: number,
     to: number,
+    token?: string,
   ): Promise<UpstreamResult<OHLCResponse>> {
     const url = new URL(`/v1/${channel}/history`, this.baseUrl);
     url.searchParams.set("symbol", symbol);
@@ -65,6 +75,7 @@ export class HistoryClient {
     const data = await withSingleRetry(async () => {
       this.logger.debug({ url: url.toString() }, "GET candlestick data");
       const res = await fetch(url, {
+        headers: authHeaders(token),
         signal: AbortSignal.timeout(this.timeoutMs),
       });
       if (!res.ok) {
@@ -84,6 +95,7 @@ export class HistoryClient {
     channel: string,
     ids: number[],
     timestampUs: number,
+    token?: string,
   ): Promise<UpstreamResult<HistoricalPriceResponse[]>> {
     const url = new URL(`/v1/${channel}/price`, this.baseUrl);
     for (const id of ids) {
@@ -95,6 +107,7 @@ export class HistoryClient {
     const data = await withSingleRetry(async () => {
       this.logger.debug({ url: url.toString() }, "GET historical price");
       const res = await fetch(url, {
+        headers: authHeaders(token),
         signal: AbortSignal.timeout(this.timeoutMs),
       });
       if (!res.ok) {

--- a/apps/mcp/src/clients/history.ts
+++ b/apps/mcp/src/clients/history.ts
@@ -11,8 +11,8 @@ import {
 
 /**
  * Bearer auth header for the token-gated History endpoints (`/{channel}/price`
- * and `/{channel}/history`, which require authentication from 2026-07-24).
- * Returns undefined when no token is set so unauthenticated callers are unchanged.
+ * and `/{channel}/history`). Returns undefined when no token is set so
+ * unauthenticated callers are unchanged.
  */
 function authHeaders(token?: string): Record<string, string> | undefined {
   return token ? { Authorization: `Bearer ${token}` } : undefined;

--- a/apps/mcp/src/config.ts
+++ b/apps/mcp/src/config.ts
@@ -7,7 +7,9 @@ const ConfigSchema = z.object({
   historyUrl: z
     .string()
     .url()
-    .default("https://history.pyth-lazer.dourolabs.app")
+    // History API base. Serves /v1/symbols and the token-gated
+    // /v1/{channel}/price and /v1/{channel}/history routes.
+    .default("https://pyth.dourolabs.app")
     .refine((u) => u.startsWith("https://"), "URL must use HTTPS"),
   logLevel: z.enum(["debug", "info", "warn", "error"]).default("info"),
   requestTimeoutMs: z.coerce.number().int().positive().default(10_000),

--- a/apps/mcp/src/tools/get-candlestick-data.ts
+++ b/apps/mcp/src/tools/get-candlestick-data.ts
@@ -2,12 +2,17 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Logger } from "pino";
 import { z } from "zod";
 import type { HistoryClient } from "../clients/history.js";
+import { HttpError } from "../clients/retry.js";
 import type { Config } from "../config.js";
 import { RESOLUTIONS } from "../constants.js";
 import type { SessionContext } from "../server.js";
 import { resolveChannel } from "../utils/channel.js";
-import { toolError } from "../utils/errors.js";
-import { logToolCall } from "../utils/logger.js";
+import { ErrorMessages, toolError } from "../utils/errors.js";
+import {
+  computeTokenHash,
+  getApiKeyLast4,
+  logToolCall,
+} from "../utils/logger.js";
 import {
   DATA_AVAILABLE_FROM_ISO,
   DATA_AVAILABLE_FROM_UNIX,
@@ -18,6 +23,14 @@ import {
 const MAX_CANDLES = 500;
 
 const GetCandlestickDataInput = {
+  access_token: z
+    .string()
+    .trim()
+    .min(1, "access_token must not be empty")
+    .optional()
+    .describe(
+      "Pyth Pro access token. Required as of July 24, 2026 — requests without it are rejected after that date. Get one at https://docs.pyth.network/price-feeds/pro/acquire-access-token",
+    ),
   channel: z
     .string()
     .regex(
@@ -64,7 +77,7 @@ export function registerGetCandlestickData(
         readOnlyHint: true,
       },
       description:
-        "Fetch OHLC candlestick data for a symbol. Use for charting, technical analysis, backtesting. IMPORTANT: The symbol must be the full name from get_symbols including the asset type prefix (e.g. 'Crypto.BTC/USD', 'Equity.US.AAPL', 'FX.EUR/USD') — never use bare names like 'BTC/USD'. Historical data is available from April 2025 onward — do not request timestamps before that. Resolutions: 1/5/15/30/60 minutes, 120/240/360/720 (multi-hour), D (daily), W (weekly), M (monthly). Timestamps are Unix seconds.\n\nTimestamp reference (Unix seconds):\n  2025-04-01 (earliest available) = 1743465600\n  2026-01-01 = 1767225600\n  2026-06-01 = 1780272000\nAlways double-check your timestamp math — year-boundary errors are common.",
+        "Fetch OHLC candlestick data for a symbol. Pass your Pyth Pro `access_token` (required as of July 24, 2026). Use for charting, technical analysis, backtesting. IMPORTANT: The symbol must be the full name from get_symbols including the asset type prefix (e.g. 'Crypto.BTC/USD', 'Equity.US.AAPL', 'FX.EUR/USD') — never use bare names like 'BTC/USD'. Historical data is available from April 2025 onward — do not request timestamps before that. Resolutions: 1/5/15/30/60 minutes, 120/240/360/720 (multi-hour), D (daily), W (weekly), M (monthly). Timestamps are Unix seconds.\n\nTimestamp reference (Unix seconds):\n  2025-04-01 (earliest available) = 1743465600\n  2026-01-01 = 1767225600\n  2026-06-01 = 1780272000\nAlways double-check your timestamp math — year-boundary errors are common.",
       inputSchema: GetCandlestickDataInput,
       title: "Get Candlestick Data",
     },
@@ -73,12 +86,12 @@ export function registerGetCandlestickData(
       const start = Date.now();
 
       const baseMetrics = {
-        apiKeyLast4: null as null,
+        apiKeyLast4: getApiKeyLast4(params.access_token),
         clientName: sessionContext.clientName,
         clientVersion: sessionContext.clientVersion,
         requestId: extra.requestId,
         sessionId: extra.sessionId ?? sessionContext.sessionId,
-        tokenHash: null as null,
+        tokenHash: computeTokenHash(params.access_token),
         tool: "get_candlestick_data" as const,
       };
 
@@ -102,6 +115,7 @@ export function registerGetCandlestickData(
             params.resolution,
             params.from,
             params.to,
+            params.access_token,
           );
 
         if (data.s === "no_data") {
@@ -210,6 +224,23 @@ export function registerGetCandlestickData(
           content: [{ text: responseText, type: "text" as const }],
         };
       } catch (err) {
+        if (
+          err instanceof HttpError &&
+          (err.status === 401 || err.status === 403)
+        ) {
+          logToolCall(logger, {
+            ...baseMetrics,
+            errorType: "auth",
+            latencyMs: Date.now() - start,
+            status: "error",
+          });
+          return toolError(
+            params.access_token
+              ? ErrorMessages.INVALID_TOKEN
+              : ErrorMessages.MISSING_TOKEN,
+          );
+        }
+
         logger.warn({ err }, "get_candlestick_data upstream error");
         logToolCall(logger, {
           ...baseMetrics,

--- a/apps/mcp/src/tools/get-candlestick-data.ts
+++ b/apps/mcp/src/tools/get-candlestick-data.ts
@@ -29,7 +29,7 @@ const GetCandlestickDataInput = {
     .min(1, "access_token must not be empty")
     .optional()
     .describe(
-      "Pyth Pro access token. Required as of July 24, 2026 — requests without it are rejected after that date. Get one at https://docs.pyth.network/price-feeds/pro/acquire-access-token",
+      "Pyth Pro access token used to authenticate the request. Get one at https://docs.pyth.network/price-feeds/pro/acquire-access-token",
     ),
   channel: z
     .string()
@@ -77,7 +77,7 @@ export function registerGetCandlestickData(
         readOnlyHint: true,
       },
       description:
-        "Fetch OHLC candlestick data for a symbol. Pass your Pyth Pro `access_token` (required as of July 24, 2026). Use for charting, technical analysis, backtesting. IMPORTANT: The symbol must be the full name from get_symbols including the asset type prefix (e.g. 'Crypto.BTC/USD', 'Equity.US.AAPL', 'FX.EUR/USD') — never use bare names like 'BTC/USD'. Historical data is available from April 2025 onward — do not request timestamps before that. Resolutions: 1/5/15/30/60 minutes, 120/240/360/720 (multi-hour), D (daily), W (weekly), M (monthly). Timestamps are Unix seconds.\n\nTimestamp reference (Unix seconds):\n  2025-04-01 (earliest available) = 1743465600\n  2026-01-01 = 1767225600\n  2026-06-01 = 1780272000\nAlways double-check your timestamp math — year-boundary errors are common.",
+        "Fetch OHLC candlestick data for a symbol. Pass your Pyth Pro `access_token` to authenticate the request. Use for charting, technical analysis, backtesting. IMPORTANT: The symbol must be the full name from get_symbols including the asset type prefix (e.g. 'Crypto.BTC/USD', 'Equity.US.AAPL', 'FX.EUR/USD') — never use bare names like 'BTC/USD'. Historical data is available from April 2025 onward — do not request timestamps before that. Resolutions: 1/5/15/30/60 minutes, 120/240/360/720 (multi-hour), D (daily), W (weekly), M (monthly). Timestamps are Unix seconds.\n\nTimestamp reference (Unix seconds):\n  2025-04-01 (earliest available) = 1743465600\n  2026-01-01 = 1767225600\n  2026-06-01 = 1780272000\nAlways double-check your timestamp math — year-boundary errors are common.",
       inputSchema: GetCandlestickDataInput,
       title: "Get Candlestick Data",
     },

--- a/apps/mcp/src/tools/get-historical-price.ts
+++ b/apps/mcp/src/tools/get-historical-price.ts
@@ -8,7 +8,11 @@ import type { SessionContext } from "../server.js";
 import { resolveChannel } from "../utils/channel.js";
 import { addDisplayPrices } from "../utils/display-price.js";
 import { ErrorMessages, toolError } from "../utils/errors.js";
-import { logToolCall } from "../utils/logger.js";
+import {
+  computeTokenHash,
+  getApiKeyLast4,
+  logToolCall,
+} from "../utils/logger.js";
 import {
   alignTimestampToChannel,
   DATA_AVAILABLE_FROM_ISO,
@@ -19,6 +23,14 @@ import {
 } from "../utils/timestamp.js";
 
 const GetHistoricalPriceInput = {
+  access_token: z
+    .string()
+    .trim()
+    .min(1, "access_token must not be empty")
+    .optional()
+    .describe(
+      "Pyth Pro access token. Required as of July 24, 2026 — requests without it are rejected after that date. Get one at https://docs.pyth.network/price-feeds/pro/acquire-access-token",
+    ),
   channel: z
     .string()
     .regex(
@@ -66,7 +78,7 @@ export function registerGetHistoricalPrice(
         readOnlyHint: true,
       },
       description:
-        "Get price data for specific feeds at a historical timestamp. Use get_symbols first to find feed IDs or symbols. If both price_feed_ids and symbols are provided, only price_feed_ids are used. Accepts Unix seconds, milliseconds, or microseconds (auto-detected). Historical data is available from April 2025 onward — do not request timestamps before that. The timestamp is internally converted to microseconds and aligned (rounded down) to the channel rate — e.g. for fixed_rate@200ms, it must be divisible by 200,000μs. Prices are integers with an exponent field — human-readable price = price * 10^exponent. Pre-computed display_price fields are included for convenience.\n\nTimestamp reference:\n  2025-04-01 (earliest available) = 1743465600\n  2026-01-01 = 1767225600\n  2026-06-01 = 1780272000\nAlways double-check your timestamp math — year-boundary errors are common.",
+        "Get price data for specific feeds at a historical timestamp. Pass your Pyth Pro `access_token` (required as of July 24, 2026). Use get_symbols first to find feed IDs or symbols. If both price_feed_ids and symbols are provided, only price_feed_ids are used. Accepts Unix seconds, milliseconds, or microseconds (auto-detected). Historical data is available from April 2025 onward — do not request timestamps before that. The timestamp is internally converted to microseconds and aligned (rounded down) to the channel rate — e.g. for fixed_rate@200ms, it must be divisible by 200,000μs. Prices are integers with an exponent field — human-readable price = price * 10^exponent. Pre-computed display_price fields are included for convenience.\n\nTimestamp reference:\n  2025-04-01 (earliest available) = 1743465600\n  2026-01-01 = 1767225600\n  2026-06-01 = 1780272000\nAlways double-check your timestamp math — year-boundary errors are common.",
       inputSchema: GetHistoricalPriceInput,
       title: "Get Historical Price",
     },
@@ -79,13 +91,13 @@ export function registerGetHistoricalPrice(
         (params.price_feed_ids?.length ?? 0) > 0 ? undefined : params.symbols;
 
       const baseMetrics = {
-        apiKeyLast4: null as null,
+        apiKeyLast4: getApiKeyLast4(params.access_token),
         clientName: sessionContext.clientName,
         clientVersion: sessionContext.clientVersion,
         numFeedsRequested: 0,
         requestId: extra.requestId,
         sessionId: extra.sessionId ?? sessionContext.sessionId,
-        tokenHash: null as null,
+        tokenHash: computeTokenHash(params.access_token),
         tool: "get_historical_price" as const,
       };
 
@@ -144,7 +156,12 @@ export function registerGetHistoricalPrice(
 
         priceEndpointCalled = true;
         const { data: prices, upstreamLatencyMs: priceUpstreamMs } =
-          await historyClient.getHistoricalPrice(channel, ids, timestampUs);
+          await historyClient.getHistoricalPrice(
+            channel,
+            ids,
+            timestampUs,
+            params.access_token,
+          );
 
         const totalUpstreamMs = symbolLookupUpstreamMs + priceUpstreamMs;
         const enriched = prices.map((p) => addDisplayPrices(p));
@@ -211,6 +228,27 @@ export function registerGetHistoricalPrice(
           content: [{ text: responseText, type: "text" as const }],
         };
       } catch (err) {
+        // Only the token-gated /price call can be an auth failure — the internal
+        // getSymbols() lookup hits the public /v1/symbols, so guard on
+        // priceEndpointCalled (mirrors the 400/404 branch below).
+        if (
+          priceEndpointCalled &&
+          err instanceof HttpError &&
+          (err.status === 401 || err.status === 403)
+        ) {
+          logToolCall(logger, {
+            ...baseMetrics,
+            errorType: "auth",
+            latencyMs: Date.now() - start,
+            status: "error",
+          });
+          return toolError(
+            params.access_token
+              ? ErrorMessages.INVALID_TOKEN
+              : ErrorMessages.MISSING_TOKEN,
+          );
+        }
+
         if (
           priceEndpointCalled &&
           err instanceof HttpError &&

--- a/apps/mcp/src/tools/get-historical-price.ts
+++ b/apps/mcp/src/tools/get-historical-price.ts
@@ -29,7 +29,7 @@ const GetHistoricalPriceInput = {
     .min(1, "access_token must not be empty")
     .optional()
     .describe(
-      "Pyth Pro access token. Required as of July 24, 2026 — requests without it are rejected after that date. Get one at https://docs.pyth.network/price-feeds/pro/acquire-access-token",
+      "Pyth Pro access token used to authenticate the request. Get one at https://docs.pyth.network/price-feeds/pro/acquire-access-token",
     ),
   channel: z
     .string()
@@ -78,7 +78,7 @@ export function registerGetHistoricalPrice(
         readOnlyHint: true,
       },
       description:
-        "Get price data for specific feeds at a historical timestamp. Pass your Pyth Pro `access_token` (required as of July 24, 2026). Use get_symbols first to find feed IDs or symbols. If both price_feed_ids and symbols are provided, only price_feed_ids are used. Accepts Unix seconds, milliseconds, or microseconds (auto-detected). Historical data is available from April 2025 onward — do not request timestamps before that. The timestamp is internally converted to microseconds and aligned (rounded down) to the channel rate — e.g. for fixed_rate@200ms, it must be divisible by 200,000μs. Prices are integers with an exponent field — human-readable price = price * 10^exponent. Pre-computed display_price fields are included for convenience.\n\nTimestamp reference:\n  2025-04-01 (earliest available) = 1743465600\n  2026-01-01 = 1767225600\n  2026-06-01 = 1780272000\nAlways double-check your timestamp math — year-boundary errors are common.",
+        "Get price data for specific feeds at a historical timestamp. Pass your Pyth Pro `access_token` to authenticate the request. Use get_symbols first to find feed IDs or symbols. If both price_feed_ids and symbols are provided, only price_feed_ids are used. Accepts Unix seconds, milliseconds, or microseconds (auto-detected). Historical data is available from April 2025 onward — do not request timestamps before that. The timestamp is internally converted to microseconds and aligned (rounded down) to the channel rate — e.g. for fixed_rate@200ms, it must be divisible by 200,000μs. Prices are integers with an exponent field — human-readable price = price * 10^exponent. Pre-computed display_price fields are included for convenience.\n\nTimestamp reference:\n  2025-04-01 (earliest available) = 1743465600\n  2026-01-01 = 1767225600\n  2026-06-01 = 1780272000\nAlways double-check your timestamp math — year-boundary errors are common.",
       inputSchema: GetHistoricalPriceInput,
       title: "Get Historical Price",
     },

--- a/apps/mcp/tests/clients/history.test.ts
+++ b/apps/mcp/tests/clients/history.test.ts
@@ -130,4 +130,89 @@ describe("HistoryClient", () => {
       expect(upstreamLatencyMs).toBeGreaterThanOrEqual(0);
     });
   });
+
+  describe("authentication", () => {
+    it("sends Authorization: Bearer on getCandlestickData when a token is set", async () => {
+      let authHeader: string | null = "unset";
+      server.use(
+        http.get(
+          `${HISTORY_URL}/v1/fixed_rate@200ms/history`,
+          ({ request }) => {
+            authHeader = request.headers.get("authorization");
+            return HttpResponse.json(mockOHLC);
+          },
+        ),
+      );
+      await client.getCandlestickData(
+        "fixed_rate@200ms",
+        "BTC/USD",
+        "D",
+        1_708_300_800,
+        1_708_387_200,
+        "secret-token",
+      );
+      expect(authHeader).toBe("Bearer secret-token");
+    });
+
+    it("sends Authorization: Bearer on getHistoricalPrice when a token is set", async () => {
+      let authHeader: string | null = "unset";
+      server.use(
+        http.get(`${HISTORY_URL}/v1/fixed_rate@200ms/price`, ({ request }) => {
+          authHeader = request.headers.get("authorization");
+          return HttpResponse.json(mockPrice);
+        }),
+      );
+      await client.getHistoricalPrice(
+        "fixed_rate@200ms",
+        [1],
+        1_708_300_800_000_000,
+        "secret-token",
+      );
+      expect(authHeader).toBe("Bearer secret-token");
+    });
+
+    it("omits the Authorization header when no token is passed", async () => {
+      let priceAuth: string | null = "unset";
+      let ohlcAuth: string | null = "unset";
+      server.use(
+        http.get(`${HISTORY_URL}/v1/fixed_rate@200ms/price`, ({ request }) => {
+          priceAuth = request.headers.get("authorization");
+          return HttpResponse.json(mockPrice);
+        }),
+        http.get(
+          `${HISTORY_URL}/v1/fixed_rate@200ms/history`,
+          ({ request }) => {
+            ohlcAuth = request.headers.get("authorization");
+            return HttpResponse.json(mockOHLC);
+          },
+        ),
+      );
+      await client.getHistoricalPrice(
+        "fixed_rate@200ms",
+        [1],
+        1_708_300_800_000_000,
+      );
+      await client.getCandlestickData(
+        "fixed_rate@200ms",
+        "BTC/USD",
+        "D",
+        1_708_300_800,
+        1_708_387_200,
+      );
+      expect(priceAuth).toBeNull();
+      expect(ohlcAuth).toBeNull();
+    });
+
+    it("never sends an Authorization header on the public getSymbols endpoint", async () => {
+      let authHeader: string | null = "unset";
+      server.use(
+        http.get(`${HISTORY_URL}/v1/symbols`, ({ request }) => {
+          authHeader = request.headers.get("authorization");
+          return HttpResponse.json(mockFeeds);
+        }),
+      );
+      await client.getSymbols();
+      expect(authHeader).toBeNull();
+    });
+  });
 });

--- a/apps/mcp/tests/config.test.ts
+++ b/apps/mcp/tests/config.test.ts
@@ -19,7 +19,7 @@ describe("loadConfig", () => {
     const config = loadConfig();
     expect(config.channel).toBe("fixed_rate@200ms");
     expect(config.routerUrl).toBe("https://pyth-lazer.dourolabs.app");
-    expect(config.historyUrl).toBe("https://history.pyth-lazer.dourolabs.app");
+    expect(config.historyUrl).toBe("https://pyth.dourolabs.app");
     expect(config.logLevel).toBe("info");
     expect(config.requestTimeoutMs).toBe(10_000);
   });

--- a/apps/mcp/tests/tools/get-candlestick-data.test.ts
+++ b/apps/mcp/tests/tools/get-candlestick-data.test.ts
@@ -174,4 +174,85 @@ describe("get_candlestick_data tool", () => {
     expect(data.total_available).toBe(600);
     expect(data.t).toHaveLength(500);
   });
+
+  it("forwards access_token as a Bearer header to the history endpoint", async () => {
+    let authHeader: string | null = "unset";
+    msw.use(
+      http.get(`${HISTORY_URL}/v1/fixed_rate@200ms/history`, ({ request }) => {
+        authHeader = request.headers.get("authorization");
+        return HttpResponse.json({
+          c: [51_500],
+          h: [52_000],
+          l: [50_000],
+          o: [51_000],
+          s: "ok",
+          t: [1_708_300_800],
+          v: [100],
+        });
+      }),
+    );
+
+    const result = await client.callTool({
+      arguments: {
+        access_token: "pro-token-123",
+        from: 1_708_300_800,
+        resolution: "D",
+        symbol: "BTC/USD",
+        to: 1_708_473_600,
+      },
+      name: "get_candlestick_data",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(authHeader).toBe("Bearer pro-token-123");
+  });
+
+  it("maps upstream 401 without a token to the missing-token message", async () => {
+    msw.use(
+      http.get(
+        `${HISTORY_URL}/v1/fixed_rate@200ms/history`,
+        () => new HttpResponse(null, { status: 401 }),
+      ),
+    );
+
+    const result = await client.callTool({
+      arguments: {
+        from: 1_708_300_800,
+        resolution: "D",
+        symbol: "BTC/USD",
+        to: 1_708_473_600,
+      },
+      name: "get_candlestick_data",
+    });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      .text;
+    expect(text).toContain("requires a Pyth Pro access token");
+  });
+
+  it("maps upstream 403 with a token to the invalid-token message", async () => {
+    msw.use(
+      http.get(
+        `${HISTORY_URL}/v1/fixed_rate@200ms/history`,
+        () => new HttpResponse(null, { status: 403 }),
+      ),
+    );
+
+    const result = await client.callTool({
+      arguments: {
+        access_token: "bad-token",
+        from: 1_708_300_800,
+        resolution: "D",
+        symbol: "BTC/USD",
+        to: 1_708_473_600,
+      },
+      name: "get_candlestick_data",
+    });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      .text;
+    expect(text).toContain("invalid or expired");
+  });
 });

--- a/apps/mcp/tests/tools/get-historical-price.test.ts
+++ b/apps/mcp/tests/tools/get-historical-price.test.ts
@@ -343,4 +343,95 @@ describe("get_historical_price tool", () => {
     // Should get the generic error, not the feed-specific error
     expect(text).toContain("Failed to fetch historical price");
   });
+
+  it("forwards access_token as a Bearer header to the price endpoint", async () => {
+    let authHeader: string | null = "unset";
+    msw.use(
+      http.get(`${HISTORY_URL}/v1/fixed_rate@200ms/price`, ({ request }) => {
+        authHeader = request.headers.get("authorization");
+        return HttpResponse.json(mockHistoricalPrice);
+      }),
+    );
+
+    const result = await client.callTool({
+      arguments: {
+        access_token: "pro-token-123",
+        price_feed_ids: [1],
+        timestamp: 1_708_300_800,
+      },
+      name: "get_historical_price",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(authHeader).toBe("Bearer pro-token-123");
+  });
+
+  it("maps upstream 401 without a token to the missing-token message", async () => {
+    msw.use(
+      http.get(
+        `${HISTORY_URL}/v1/fixed_rate@200ms/price`,
+        () => new HttpResponse(null, { status: 401 }),
+      ),
+    );
+
+    const result = await client.callTool({
+      arguments: { price_feed_ids: [1], timestamp: 1_708_300_800 },
+      name: "get_historical_price",
+    });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      .text;
+    expect(text).toContain("requires a Pyth Pro access token");
+  });
+
+  it("maps upstream 403 with a token to the invalid-token message", async () => {
+    msw.use(
+      http.get(
+        `${HISTORY_URL}/v1/fixed_rate@200ms/price`,
+        () => new HttpResponse(null, { status: 403 }),
+      ),
+    );
+
+    const result = await client.callTool({
+      arguments: {
+        access_token: "bad-token",
+        price_feed_ids: [1],
+        timestamp: 1_708_300_800,
+      },
+      name: "get_historical_price",
+    });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      .text;
+    expect(text).toContain("invalid or expired");
+  });
+
+  it("does not mislabel a 403 from the public getSymbols lookup as a token error", async () => {
+    // The symbol->id lookup hits the public /v1/symbols. If it 403s, that is an
+    // upstream failure, NOT an auth problem — the token was never sent there.
+    msw.use(
+      http.get(
+        `${HISTORY_URL}/v1/symbols`,
+        () => new HttpResponse(null, { status: 403 }),
+      ),
+    );
+
+    const result = await client.callTool({
+      arguments: {
+        access_token: "some-token",
+        symbols: ["BTC/USD"],
+        timestamp: 1_708_300_800,
+      },
+      name: "get_historical_price",
+    });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      .text;
+    expect(text).toContain("Failed to fetch historical price");
+    expect(text).not.toContain("invalid or expired");
+    expect(text).not.toContain("requires a Pyth Pro access token");
+  });
 });

--- a/apps/mcp/tests/tools/get-symbols.test.ts
+++ b/apps/mcp/tests/tools/get-symbols.test.ts
@@ -10,7 +10,7 @@ import type { SessionContext } from "../../src/server.js";
 import { registerAllTools } from "../../src/tools/index.js";
 import { createTestClient } from "../helpers.js";
 
-const HISTORY_URL = "https://history.pyth-lazer.dourolabs.app";
+const HISTORY_URL = "https://pyth.dourolabs.app";
 
 const mockFeeds = Array.from({ length: 100 }, (_, i) => ({
   asset_type: i < 50 ? "crypto" : "equity",


### PR DESCRIPTION
## What

Authenticate the two MCP History tools before the Pyth Pro (Lazer) auth cutover on **2026-07-24**, when `GET /v1/{channel}/price` and `GET /v1/{channel}/history` start requiring `Authorization: Bearer <token>` ([announcement](https://dev-forum.pyth.network/t/action-required-pyth-pro-history-api-auth-required-starting-july-24/808), documented in #3882).

Without this, `get_historical_price` and `get_candlestick_data` 401/403 on that date. (`get_symbols` stays public; `get_latest_price` already authenticates.)

Closes PFG-1255.

## Changes

- **`clients/history.ts`**: `getCandlestickData` / `getHistoricalPrice` take an optional `token` and attach `Authorization: Bearer` via a small `authHeaders()` helper; `getSymbols` untouched (stays public — including the internal symbol→id lookup).
- **`tools/get-historical-price.ts` + `get-candlestick-data.ts`**: optional `access_token` param (mirrors `get_latest_price`), forwarded to the client; `apiKeyLast4`/`tokenHash` metrics populated; upstream 401/403 mapped to `INVALID_TOKEN` (token present) / `MISSING_TOKEN` (absent). The historical-price auth branch is guarded by `priceEndpointCalled` so a failure of the public `getSymbols` lookup isn't mislabeled as a token error.
- **Optional, not required** — existing tokenless callers keep working until the cutover; afterward a clear token error surfaces. Avoids a premature hard break of the published `@pyth-network/mcp-server` package.
- `docs/PLAN.md` updated to reflect the auth change; version bumped `0.1.0 → 0.2.0`.

## Testing

- `test:types` ✅ · `test:unit` ✅ **143 tests** · `build` ✅.
- New auth tests: client-level Bearer attach/omit + `getSymbols` stays public; tool-level token forwarding, `401 → missing-token`, `403 → invalid-token`, and a guard test that a public `/symbols` 403 isn't mislabeled.
- Multi-agent verification: adversarial correctness review (found & fixed the `priceEndpointCalled` guard gap), a standalone fetch-stub edge probe (6/6 — Bearer verbatim, header omitted when absent, token re-attached on retry, 500 stays a server error), and a live MCP `tools/list` JSON-RPC check confirming `access_token` is exposed as **optional** on both history tools and **absent** on `get_symbols`.

## Rollout

Publish a new npm version of `@pyth-network/mcp-server` and redeploy the hosted HTTP MCP before **2026-07-24**. No server config change (per-call token).

## Follow-up (separate)

External skills repo `aditya520/pyth-mcp` (`pyth-price-lookup`, `pyth-market-analysis`) should be updated to pass `access_token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
