### PR TITLE
fix(price_pusher): bound the EVM receipt tracker to stop the getTransactionByHash leak

### DIFF
--- a/apps/price_pusher/package.json
+++ b/apps/price_pusher/package.json
@@ -226,5 +226,5 @@
   },
   "type": "module",
   "types": "./dist/index.d.ts",
-  "version": "11.2.2"
+  "version": "11.3.0"
 }

--- a/apps/price_pusher/src/evm/__tests__/receipt-tracking.test.ts
+++ b/apps/price_pusher/src/evm/__tests__/receipt-tracking.test.ts
@@ -203,73 +203,72 @@ describe("EvmPricePusher receipt tracking (leak fix)", () => {
     expect(chain.calls.getTransactionByHash).toBe(0);
   });
 
-  it("superseded nonce (gas escalation): single-flight, old tracker is cancelled", async () => {
+  it("same-nonce escalation: both hashes stay watched; the OLD tx winning the race is still logged (Codex)", async () => {
+    // On a same-nonce gas escalation the original and repriced tx compete for
+    // the nonce, and a miner may include the OLD one over the replacement. The
+    // original's tracker must NOT be cancelled, or its landing is never logged
+    // and the Grafana Tx-Hash panel misses a tx that actually landed.
     const chain = new MockChain();
-    chain.defaultPolicy = "pending"; // both stuck so the escalation path is taken
-    const { logger } = makeLogger();
-    // Long timeout so tracker A cannot self-terminate within the window — the
-    // ONLY thing that can stop A here is the abort, so this genuinely proves
-    // single-flight (with a short shared timeout, A stopping would be ambiguous
-    // between abort and its own deadline).
+    chain.defaultPolicy = "pending"; // both pending -> same-nonce escalation path
+    const { logger, logs } = makeLogger();
     const pusher = makePusher(chain, logger, 10_000, 30);
 
-    // First push -> tx A (nonce 5), tracker A starts polling.
+    // Push A (nonce 5), then push B — same nonce (A not landed), escalated gas.
     await pusher.updatePriceFeed(PRICE_IDS, PUB_TIMES);
-    await sleep(90);
+    await sleep(60);
     const hashA = chain.sentHashes[0] as Hash;
-    expect(chain.receiptCallsByHash.get(hashA) ?? 0).toBeGreaterThan(0);
-
-    // Second push -> same nonce (not landed), escalated gas, tx B; tracker B
-    // must abort tracker A.
     await pusher.updatePriceFeed(PRICE_IDS, PUB_TIMES);
     await sleep(60);
     const hashB = chain.sentHashes[1] as Hash;
     expect(hashB).not.toEqual(hashA);
 
-    const aCallsAfterSupersede = chain.receiptCallsByHash.get(hashA) ?? 0;
-    await sleep(150);
-    const aCallsLater = chain.receiptCallsByHash.get(hashA) ?? 0;
-    const bCallsLater = chain.receiptCallsByHash.get(hashB) ?? 0;
+    // Both are still polled after the escalation — A was NOT cancelled.
+    const aBefore = chain.receiptCallsByHash.get(hashA) ?? 0;
+    await sleep(90);
+    expect(
+      (chain.receiptCallsByHash.get(hashA) ?? 0) - aBefore,
+    ).toBeGreaterThan(0);
+    expect(chain.receiptCallsByHash.get(hashB) ?? 0).toBeGreaterThan(0);
 
-    // A stopped being polled (at most one in-flight call straddling the abort).
-    // Without the abort, A's 10s deadline is far away, so it would keep polling
-    // and this delta would be many — i.e. this assertion fails if abort breaks.
-    expect(aCallsLater - aCallsAfterSupersede).toBeLessThanOrEqual(1);
-    // B is the live tracker and keeps polling.
-    expect(bCallsLater).toBeGreaterThan(0);
+    // The OLD tx wins the mempool race and lands after being superseded.
+    chain.policyByHash.set(hashA, "success");
+    await sleep(90);
 
-    // Tear down the live tracker so its (10s) timer does not outlive the test.
+    const successHashes = hashLogs(logs.info).map((entry) => entry.hash);
+    expect(successHashes).toContain(hashA); // A's landing IS logged
+    expect(successHashes).not.toContain(hashB); // B never lands
+    expect(hashLogs(logs.info)).toHaveLength(1);
+
     pusher.dispose();
     await sleep(20);
   });
 
-  it("superseded-but-landed: a cancelled tracker STILL logs its tx once it lands", async () => {
-    // Regression guard: on a normal next-nonce advance the prior tx has landed
-    // (that is why the nonce advanced), and the next push aborts its tracker.
-    // The aborted tracker must not drop the "Price update successful" log for a
-    // tx that actually landed, or the Grafana Tx-Hash panel silently under-reports.
+  it("nonce advance: the resolved nonce's stragglers are aborted (bounded) but its landed tx is still logged", async () => {
     const chain = new MockChain();
     chain.defaultPolicy = "pending";
     const { logger, logs } = makeLogger();
     const pusher = makePusher(chain, logger, 10_000, 30);
 
-    // Push A -> tracker A, tx A pending.
+    // Push A (nonce 5), pending.
     await pusher.updatePriceFeed(PRICE_IDS, PUB_TIMES);
     await sleep(60);
     const hashA = chain.sentHashes[0] as Hash;
 
-    // Tx A lands, then a new push (B) supersedes and aborts tracker A.
+    // A lands and the on-chain nonce advances; the next push uses nonce 6, a
+    // DIFFERENT nonce, which aborts A's straggler while still logging A.
     chain.policyByHash.set(hashA, "success");
+    chain.minedTxCount = 6;
     await pusher.updatePriceFeed(PRICE_IDS, PUB_TIMES);
-    await sleep(120);
-    const hashB = chain.sentHashes[1] as Hash;
+    await sleep(90);
 
-    // A's success must still be logged despite A being superseded.
+    // A's landing is logged via the final lookup on abort.
     const successHashes = hashLogs(logs.info).map((entry) => entry.hash);
     expect(successHashes).toContain(hashA);
-    // B never lands, so it does not (yet) log — exactly one success line.
-    expect(successHashes).not.toContain(hashB);
-    expect(hashLogs(logs.info)).toHaveLength(1);
+
+    // A is then aborted -> no longer polled (bounded across the nonce boundary).
+    const aAfter = chain.receiptCallsByHash.get(hashA) ?? 0;
+    await sleep(120);
+    expect(chain.receiptCallsByHash.get(hashA) ?? 0).toBe(aAfter);
 
     pusher.dispose();
     await sleep(20);

--- a/apps/price_pusher/src/evm/__tests__/receipt-tracking.test.ts
+++ b/apps/price_pusher/src/evm/__tests__/receipt-tracking.test.ts
@@ -1,0 +1,306 @@
+import type { HermesClient, UnixTimestamp } from "@pythnetwork/hermes-client";
+import type { Logger } from "pino";
+
+import { EvmPricePusher } from "../evm.js";
+import type { GasPriceConfig } from "../gas-price.js";
+import type { PythContract } from "../pyth-contract.js";
+import type { SuperWalletClient } from "../super-wallet.js";
+
+type Hash = `0x${string}`;
+
+// A receipt is absent (viem throws TransactionReceiptNotFoundError while a tx is
+// unmined — modelled here as a throw) or a landed receipt.
+type ReceiptPolicy = "pending" | "success" | "reverted";
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+// Instrumented mock of the pieces EvmPricePusher.updatePriceFeed touches. It
+// counts RPC calls per method (and, crucially, per tx hash for receipt lookups)
+// and lets each scenario drive the on-chain nonce and per-hash receipt state.
+class MockChain {
+  calls = {
+    getTransactionByHash: 0,
+    getTransactionCount: 0,
+    getTransactionReceipt: 0,
+    waitForTransactionReceipt: 0,
+    writeContract: 0,
+  };
+  receiptCallsByHash = new Map<string, number>();
+  policyByHash = new Map<string, ReceiptPolicy>();
+  defaultPolicy: ReceiptPolicy = "pending";
+  // On-chain mined-tx count returned by getTransactionCount (the nonce source).
+  minedTxCount = 5;
+  sentHashes: Hash[] = [];
+  private hashCounter = 0;
+
+  private nextHash(): Hash {
+    this.hashCounter += 1;
+    return `0x${this.hashCounter.toString(16).padStart(64, "0")}` as Hash;
+  }
+
+  get client(): SuperWalletClient {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this;
+    return {
+      account: { address: "0x1111111111111111111111111111111111111111" },
+      estimateMaxPriorityFeePerGas: () => Promise.resolve(1_000_000_000n),
+      getBlock: () => Promise.resolve({ baseFeePerGas: 1_000_000_000n }),
+      // Leak-prone methods the OLD code used. They MUST never be called now.
+      getTransaction: () => {
+        self.calls.getTransactionByHash += 1;
+        return Promise.reject(
+          new Error("eth_getTransactionByHash must not be called"),
+        );
+      },
+      getTransactionCount: () => {
+        self.calls.getTransactionCount += 1;
+        return Promise.resolve(self.minedTxCount);
+      },
+      // The ONLY method the receipt tracker should call.
+      getTransactionReceipt: ({ hash }: { hash: Hash }) => {
+        self.calls.getTransactionReceipt += 1;
+        self.receiptCallsByHash.set(
+          hash,
+          (self.receiptCallsByHash.get(hash) ?? 0) + 1,
+        );
+        const policy = self.policyByHash.get(hash) ?? self.defaultPolicy;
+        if (policy === "pending") {
+          // viem throws while the tx is not yet mined.
+          return Promise.reject(new Error("TransactionReceiptNotFoundError"));
+        }
+        return Promise.resolve({ status: policy, transactionHash: hash });
+      },
+      waitForTransactionReceipt: () => {
+        self.calls.waitForTransactionReceipt += 1;
+        return Promise.reject(
+          new Error("client.waitForTransactionReceipt must not be called"),
+        );
+      },
+      writeContract: () => {
+        self.calls.writeContract += 1;
+        const hash = self.nextHash();
+        self.sentHashes.push(hash);
+        if (!self.policyByHash.has(hash)) {
+          self.policyByHash.set(hash, self.defaultPolicy);
+        }
+        return Promise.resolve(hash);
+      },
+    } as unknown as SuperWalletClient;
+  }
+
+  get pythContract(): PythContract {
+    return {
+      read: { getUpdateFee: () => Promise.resolve(1n) },
+      simulate: {
+        updatePriceFeedsIfNecessary: () => Promise.resolve({ request: {} }),
+      },
+    } as unknown as PythContract;
+  }
+}
+
+const hermesClient = {
+  getLatestPriceUpdates: () => Promise.resolve({ binary: { data: ["abcd"] } }),
+} as unknown as HermesClient;
+
+const gasPriceConfig: GasPriceConfig = {
+  baseFeeMultiplier: 1.2,
+  priorityFeeMultiplier: 1,
+  strategy: "eip1559",
+};
+
+type LogEntry = { hash?: Hash };
+
+const makeLogger = (): {
+  logger: Logger;
+  logs: { info: LogEntry[]; debug: LogEntry[]; warn: LogEntry[] };
+} => {
+  const logs = {
+    debug: [] as LogEntry[],
+    info: [] as LogEntry[],
+    warn: [] as LogEntry[],
+  };
+  const record = (arr: LogEntry[]) => (obj: unknown) => {
+    arr.push((obj ?? {}) as LogEntry);
+  };
+  const logger = {
+    debug: record(logs.debug),
+    error: record(logs.debug),
+    info: record(logs.info),
+    warn: record(logs.warn),
+  } as unknown as Logger;
+  return { logger, logs };
+};
+
+const makePusher = (
+  chain: MockChain,
+  logger: Logger,
+  timeoutMs: number,
+  intervalMs: number,
+): EvmPricePusher =>
+  new EvmPricePusher(
+    hermesClient,
+    chain.client,
+    chain.pythContract,
+    logger,
+    1.1, // overrideGasPriceMultiplier
+    5, // overrideGasPriceMultiplierCap
+    1, // updateFeeMultiplier
+    gasPriceConfig,
+    undefined, // gasLimit
+    timeoutMs, // receiptWaitTimeoutMs
+    intervalMs, // receiptPollIntervalMs
+  );
+
+const PRICE_IDS = [
+  "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
+];
+const PUB_TIMES: UnixTimestamp[] = [1000];
+const hashLogs = (entries: LogEntry[]): LogEntry[] =>
+  entries.filter((entry) => entry.hash !== undefined);
+
+describe("EvmPricePusher receipt tracking (leak fix)", () => {
+  it("happy path: logs success once, polls only getTransactionReceipt, never getTransactionByHash", async () => {
+    const chain = new MockChain();
+    chain.defaultPolicy = "success"; // lands on first poll
+    const { logger, logs } = makeLogger();
+    const pusher = makePusher(chain, logger, 500, 20);
+
+    await pusher.updatePriceFeed(PRICE_IDS, PUB_TIMES);
+    await sleep(120);
+
+    const successLogs = hashLogs(logs.info).filter(
+      (entry) =>
+        entry.hash !== undefined && chain.sentHashes.includes(entry.hash),
+    );
+    expect(successLogs).toHaveLength(1);
+    expect(chain.calls.getTransactionByHash).toBe(0);
+    expect(chain.calls.waitForTransactionReceipt).toBe(0);
+    expect(chain.calls.getTransactionReceipt).toBeLessThanOrEqual(2);
+  });
+
+  it("never-lands: the receipt poll is BOUNDED and stops (no leak)", async () => {
+    const chain = new MockChain();
+    chain.defaultPolicy = "pending"; // never lands
+    const { logger, logs } = makeLogger();
+    const timeoutMs = 200;
+    const intervalMs = 40;
+    const pusher = makePusher(chain, logger, timeoutMs, intervalMs);
+
+    await pusher.updatePriceFeed(PRICE_IDS, PUB_TIMES);
+    await sleep(timeoutMs + 150);
+
+    const bound = Math.ceil(timeoutMs / intervalMs) + 2;
+    // It must actually have polled (not a dead tracker) AND stayed bounded.
+    expect(chain.calls.getTransactionReceipt).toBeGreaterThan(1);
+    expect(chain.calls.getTransactionReceipt).toBeLessThanOrEqual(bound);
+    const countAtDeadline = chain.calls.getTransactionReceipt;
+
+    // After the deadline, polling must have fully stopped.
+    await sleep(200);
+    expect(chain.calls.getTransactionReceipt).toBe(countAtDeadline);
+    expect(hashLogs(logs.info)).toHaveLength(0);
+    expect(chain.calls.getTransactionByHash).toBe(0);
+  });
+
+  it("superseded nonce (gas escalation): single-flight, old tracker is cancelled", async () => {
+    const chain = new MockChain();
+    chain.defaultPolicy = "pending"; // both stuck so the escalation path is taken
+    const { logger } = makeLogger();
+    // Long timeout so tracker A cannot self-terminate within the window — the
+    // ONLY thing that can stop A here is the abort, so this genuinely proves
+    // single-flight (with a short shared timeout, A stopping would be ambiguous
+    // between abort and its own deadline).
+    const pusher = makePusher(chain, logger, 10_000, 30);
+
+    // First push -> tx A (nonce 5), tracker A starts polling.
+    await pusher.updatePriceFeed(PRICE_IDS, PUB_TIMES);
+    await sleep(90);
+    const hashA = chain.sentHashes[0] as Hash;
+    expect(chain.receiptCallsByHash.get(hashA) ?? 0).toBeGreaterThan(0);
+
+    // Second push -> same nonce (not landed), escalated gas, tx B; tracker B
+    // must abort tracker A.
+    await pusher.updatePriceFeed(PRICE_IDS, PUB_TIMES);
+    await sleep(60);
+    const hashB = chain.sentHashes[1] as Hash;
+    expect(hashB).not.toEqual(hashA);
+
+    const aCallsAfterSupersede = chain.receiptCallsByHash.get(hashA) ?? 0;
+    await sleep(150);
+    const aCallsLater = chain.receiptCallsByHash.get(hashA) ?? 0;
+    const bCallsLater = chain.receiptCallsByHash.get(hashB) ?? 0;
+
+    // A stopped being polled (at most one in-flight call straddling the abort).
+    // Without the abort, A's 10s deadline is far away, so it would keep polling
+    // and this delta would be many — i.e. this assertion fails if abort breaks.
+    expect(aCallsLater - aCallsAfterSupersede).toBeLessThanOrEqual(1);
+    // B is the live tracker and keeps polling.
+    expect(bCallsLater).toBeGreaterThan(0);
+
+    // Tear down the live tracker so its (10s) timer does not outlive the test.
+    pusher.dispose();
+    await sleep(20);
+  });
+
+  it("superseded-but-landed: a cancelled tracker STILL logs its tx once it lands", async () => {
+    // Regression guard: on a normal next-nonce advance the prior tx has landed
+    // (that is why the nonce advanced), and the next push aborts its tracker.
+    // The aborted tracker must not drop the "Price update successful" log for a
+    // tx that actually landed, or the Grafana Tx-Hash panel silently under-reports.
+    const chain = new MockChain();
+    chain.defaultPolicy = "pending";
+    const { logger, logs } = makeLogger();
+    const pusher = makePusher(chain, logger, 10_000, 30);
+
+    // Push A -> tracker A, tx A pending.
+    await pusher.updatePriceFeed(PRICE_IDS, PUB_TIMES);
+    await sleep(60);
+    const hashA = chain.sentHashes[0] as Hash;
+
+    // Tx A lands, then a new push (B) supersedes and aborts tracker A.
+    chain.policyByHash.set(hashA, "success");
+    await pusher.updatePriceFeed(PRICE_IDS, PUB_TIMES);
+    await sleep(120);
+    const hashB = chain.sentHashes[1] as Hash;
+
+    // A's success must still be logged despite A being superseded.
+    const successHashes = hashLogs(logs.info).map((entry) => entry.hash);
+    expect(successHashes).toContain(hashA);
+    // B never lands, so it does not (yet) log — exactly one success line.
+    expect(successHashes).not.toContain(hashB);
+    expect(hashLogs(logs.info)).toHaveLength(1);
+
+    pusher.dispose();
+    await sleep(20);
+  });
+
+  it("reverted tx: no success log, tracker stops", async () => {
+    const chain = new MockChain();
+    chain.defaultPolicy = "reverted";
+    const { logger, logs } = makeLogger();
+    const pusher = makePusher(chain, logger, 500, 20);
+
+    await pusher.updatePriceFeed(PRICE_IDS, PUB_TIMES);
+    await sleep(120);
+
+    expect(hashLogs(logs.info)).toHaveLength(0);
+    expect(chain.calls.getTransactionReceipt).toBeLessThanOrEqual(2);
+    expect(chain.calls.getTransactionByHash).toBe(0);
+  });
+
+  it("pushes stop: the last un-landing tracker self-terminates at the deadline", async () => {
+    const chain = new MockChain();
+    chain.defaultPolicy = "pending";
+    const { logger } = makeLogger();
+    const timeoutMs = 150;
+    const pusher = makePusher(chain, logger, timeoutMs, 30);
+
+    await pusher.updatePriceFeed(PRICE_IDS, PUB_TIMES);
+    // Controller goes idle (no more pushes). The tracker must not poll forever.
+    await sleep(timeoutMs + 200);
+    const finalCount = chain.calls.getTransactionReceipt;
+    await sleep(200);
+    expect(chain.calls.getTransactionReceipt).toBe(finalCount);
+  });
+});

--- a/apps/price_pusher/src/evm/command.ts
+++ b/apps/price_pusher/src/evm/command.ts
@@ -95,6 +95,23 @@ export default {
       required: false,
       type: "number",
     } as Options,
+    "receipt-poll-interval": {
+      default: 2,
+      description:
+        "How often (in seconds) to poll for a sent transaction's receipt while waiting for " +
+        "it to land. Default to 2",
+      required: false,
+      type: "number",
+    } as Options,
+    "receipt-wait-timeout": {
+      default: 60,
+      description:
+        "Maximum time (in seconds) to poll for a sent transaction's receipt before giving " +
+        "up. Bounds the wait so a transaction that never lands cannot be polled forever. " +
+        "Default to 60",
+      required: false,
+      type: "number",
+    } as Options,
     "tx-speed": {
       choices: ["slow", "standard", "fast"],
       description:
@@ -145,6 +162,8 @@ export default {
       baseFeeMultiplier,
       priorityFeeMultiplier,
       updateFeeMultiplier,
+      receiptPollInterval,
+      receiptWaitTimeout,
       logLevel,
       controllerLogLevel,
       enableMetrics,
@@ -246,6 +265,11 @@ export default {
       updateFeeMultiplier,
       gasPriceConfig,
       gasLimit,
+      // CLI values are in seconds; the pusher expects milliseconds. Defaults
+      // (60s / 2s) reproduce the pre-flag behaviour, so existing deployments
+      // that don't set these flags are unaffected.
+      receiptWaitTimeout * 1000,
+      receiptPollInterval * 1000,
     );
 
     const controller = new Controller(

--- a/apps/price_pusher/src/evm/evm.ts
+++ b/apps/price_pusher/src/evm/evm.ts
@@ -146,6 +146,15 @@ export class EvmPriceListener extends ChainPriceListener {
 export class EvmPricePusher implements IPricePusher {
   private pusherAddress: `0x${string}` | undefined;
   private lastPushAttempt: PushAttempt | undefined;
+  // Single-flight, bounded receipt tracker. At most one receipt wait runs at a
+  // time; it is cancelled and replaced whenever a newer push supersedes the tx
+  // (e.g. a same-nonce gas escalation), and it stops at `receiptWaitTimeoutMs`.
+  // This replaces viem's `waitForTransactionReceipt`, whose timeout (on the
+  // pinned version) rejects without tearing down its internal
+  // `eth_getTransactionByHash` / block-number poll — so a fire-and-forget wait
+  // for a tx that never becomes findable leaked a detached poller that ran for
+  // the pod's whole lifetime and accumulated one per push.
+  private receiptTracker: AbortController | undefined;
 
   constructor(
     private hermesClient: HermesClient,
@@ -157,6 +166,11 @@ export class EvmPricePusher implements IPricePusher {
     private updateFeeMultiplier: number,
     private gasPriceConfig: GasPriceConfig,
     private gasLimit?: number,
+    // Upper bound on how long to poll for a tx receipt before giving up. Keeps a
+    // tx that never lands from polling forever. Defaults to ~2 push cycles.
+    private receiptWaitTimeoutMs = 60_000,
+    // How often to poll `eth_getTransactionReceipt` while waiting.
+    private receiptPollIntervalMs = 2000,
   ) {}
 
   // The pubTimes are passed here to use the values that triggered the push.
@@ -280,7 +294,7 @@ export class EvmPricePusher implements IPricePusher {
 
       this.logger.debug({ hash }, "Price update sent");
 
-      void this.waitForTransactionReceipt(hash);
+      this.trackTransactionReceipt(hash);
     } catch (error: any) {
       this.logger.debug(
         { err: error },
@@ -410,32 +424,113 @@ export class EvmPricePusher implements IPricePusher {
     }
   }
 
-  private async waitForTransactionReceipt(hash: `0x${string}`): Promise<void> {
-    try {
-      const receipt = await this.client.waitForTransactionReceipt({
-        hash: hash,
-      });
+  // Stop the in-flight receipt tracker (graceful shutdown / tests). Safe to call
+  // at any time; leaves no pending poll behind.
+  public dispose(): void {
+    this.receiptTracker?.abort();
+    this.receiptTracker = undefined;
+  }
 
-      switch (receipt.status) {
-        case "success": {
-          this.logger.debug({ hash, receipt }, "Price update successful");
+  // Start (or replace) the single-flight receipt tracker for a freshly-sent tx.
+  // Fire-and-forget by design — the receipt is observational (it only produces
+  // the "Price update successful" log the Grafana Tx-Hash panel scrapes); the
+  // controller never blocks on it, and the re-send/nonce/gas decision is driven
+  // by a fresh `getTransactionCount` each cycle, not by the receipt. Cancels any
+  // prior tracker so only the latest tx is polled, capping concurrent waiters at
+  // one (a superseded poller may issue at most one more in-flight lookup before
+  // it observes the abort, which also lets it still log a tx that just landed).
+  private trackTransactionReceipt(hash: `0x${string}`): void {
+    this.receiptTracker?.abort();
+    const controller = new AbortController();
+    this.receiptTracker = controller;
+    void this.pollTransactionReceipt(hash, controller).finally(() => {
+      // Only clear if we are still the active tracker (a newer push may have
+      // already replaced us).
+      if (this.receiptTracker === controller) {
+        this.receiptTracker = undefined;
+      }
+    });
+  }
+
+  // Poll `eth_getTransactionReceipt` (one call per interval) until the tx lands,
+  // the tracker is superseded, or the deadline elapses. Unlike viem's
+  // `waitForTransactionReceipt` this issues no `eth_getTransactionByHash` and no
+  // per-block full-block fetch, and its teardown is guaranteed by the bound +
+  // AbortController — so an un-landing tx cannot leak a poller.
+  private async pollTransactionReceipt(
+    hash: `0x${string}`,
+    controller: AbortController,
+  ): Promise<void> {
+    const deadline = Date.now() + this.receiptWaitTimeoutMs;
+
+    for (;;) {
+      let receipt;
+      try {
+        receipt = await this.client.getTransactionReceipt({ hash });
+      } catch {
+        // viem throws TransactionReceiptNotFoundError while the tx is unmined.
+        // Treat any lookup failure as "not landed yet" and keep polling.
+        receipt = undefined;
+      }
+
+      // A fetched receipt means the tx actually landed — it is never stale, so
+      // log it even if this tracker was superseded (otherwise the Grafana panel
+      // would miss the hash of a tx that landed just as the next push started).
+      if (receipt !== undefined) {
+        if (receipt.status === "success") {
           // Keep one non-debug hash line per landed tx: the bundled Grafana
           // "Tx Hash" panel scrapes this message from Loki and extracts {{.hash}}.
-          // Demoting it to debug hides successful hashes under the default log level.
           this.logger.info({ hash }, "Price update successful");
-          break;
-        }
-        default: {
+        } else {
           this.logger.debug(
             { hash, receipt },
             "Price update did not succeed or its transaction did not land. " +
               "This is an expected behaviour in high frequency or multi-instance setup.",
           );
         }
+        return;
       }
-    } catch (error: any) {
-      this.logger.warn({ err: error }, "Failed to get transaction receipt");
+
+      // Not landed yet: stop if this tracker was superseded, or if we ran out
+      // of time (only these bounded paths end the loop, so it cannot leak).
+      if (controller.signal.aborted) {
+        return;
+      }
+      if (Date.now() >= deadline) {
+        this.logger.debug(
+          { hash },
+          "Gave up waiting for the transaction receipt within the timeout. " +
+            "This is expected when a tx does not land; the next push re-derives " +
+            "the nonce from the chain and replaces it if needed.",
+        );
+        return;
+      }
+
+      await this.interruptibleSleep(
+        this.receiptPollIntervalMs,
+        controller.signal,
+      );
     }
+  }
+
+  // Sleep that resolves early if the signal aborts, so a superseded tracker
+  // stops promptly instead of waiting out its poll interval.
+  private interruptibleSleep(ms: number, signal: AbortSignal): Promise<void> {
+    return new Promise((resolve) => {
+      if (signal.aborted) {
+        resolve();
+        return;
+      }
+      const onAbort = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(() => {
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      }, ms);
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
   }
 
   private async getPriceFeedsUpdateData(

--- a/apps/price_pusher/src/evm/evm.ts
+++ b/apps/price_pusher/src/evm/evm.ts
@@ -146,15 +146,21 @@ export class EvmPriceListener extends ChainPriceListener {
 export class EvmPricePusher implements IPricePusher {
   private pusherAddress: `0x${string}` | undefined;
   private lastPushAttempt: PushAttempt | undefined;
-  // Single-flight, bounded receipt tracker. At most one receipt wait runs at a
-  // time; it is cancelled and replaced whenever a newer push supersedes the tx
-  // (e.g. a same-nonce gas escalation), and it stops at `receiptWaitTimeoutMs`.
-  // This replaces viem's `waitForTransactionReceipt`, whose timeout (on the
-  // pinned version) rejects without tearing down its internal
-  // `eth_getTransactionByHash` / block-number poll — so a fire-and-forget wait
-  // for a tx that never becomes findable leaked a detached poller that ran for
-  // the pod's whole lifetime and accumulated one per push.
-  private receiptTracker: AbortController | undefined;
+  // Bounded, per-nonce receipt trackers. Each poll self-terminates on landing or
+  // at `receiptWaitTimeoutMs`. Same-nonce gas escalations ADD a tracker rather
+  // than replacing the previous one: the original and the repriced tx compete
+  // for the nonce and EITHER can land (a miner may include the old tx over the
+  // replacement), so all competing hashes stay watched and whichever lands is
+  // logged. A nonce advance means the previous nonce already resolved, so its
+  // now-doomed stragglers are aborted. This replaces viem's
+  // `waitForTransactionReceipt`, whose timeout (on the pinned version) rejects
+  // without tearing down its internal `eth_getTransactionByHash` / block-number
+  // poll — so a fire-and-forget wait for a tx that never becomes findable leaked
+  // a detached poller that ran for the pod's whole lifetime, one per push. Here
+  // the count is bounded: at most one nonce is tracked at a time, and each of
+  // its trackers self-terminates at the deadline.
+  private receiptTrackers = new Set<AbortController>();
+  private trackedNonce: number | undefined;
 
   constructor(
     private hermesClient: HermesClient,
@@ -294,7 +300,7 @@ export class EvmPricePusher implements IPricePusher {
 
       this.logger.debug({ hash }, "Price update sent");
 
-      this.trackTransactionReceipt(hash);
+      this.trackTransactionReceipt(hash, txNonce);
     } catch (error: any) {
       this.logger.debug(
         { err: error },
@@ -424,31 +430,40 @@ export class EvmPricePusher implements IPricePusher {
     }
   }
 
-  // Stop the in-flight receipt tracker (graceful shutdown / tests). Safe to call
-  // at any time; leaves no pending poll behind.
+  // Stop all in-flight receipt trackers (graceful shutdown / tests). Safe to
+  // call at any time; leaves no pending poll behind.
   public dispose(): void {
-    this.receiptTracker?.abort();
-    this.receiptTracker = undefined;
+    for (const controller of this.receiptTrackers) {
+      controller.abort();
+    }
+    this.receiptTrackers.clear();
+    this.trackedNonce = undefined;
   }
 
-  // Start (or replace) the single-flight receipt tracker for a freshly-sent tx.
-  // Fire-and-forget by design — the receipt is observational (it only produces
-  // the "Price update successful" log the Grafana Tx-Hash panel scrapes); the
-  // controller never blocks on it, and the re-send/nonce/gas decision is driven
-  // by a fresh `getTransactionCount` each cycle, not by the receipt. Cancels any
-  // prior tracker so only the latest tx is polled, capping concurrent waiters at
-  // one (a superseded poller may issue at most one more in-flight lookup before
-  // it observes the abort, which also lets it still log a tx that just landed).
-  private trackTransactionReceipt(hash: `0x${string}`): void {
-    this.receiptTracker?.abort();
-    const controller = new AbortController();
-    this.receiptTracker = controller;
-    void this.pollTransactionReceipt(hash, controller).finally(() => {
-      // Only clear if we are still the active tracker (a newer push may have
-      // already replaced us).
-      if (this.receiptTracker === controller) {
-        this.receiptTracker = undefined;
+  // Start a receipt tracker for a freshly-sent tx. Fire-and-forget by design —
+  // the receipt is observational (it only produces the "Price update successful"
+  // log the Grafana Tx-Hash panel scrapes); the controller never blocks on it,
+  // and the re-send/nonce/gas decision is driven by a fresh `getTransactionCount`
+  // each cycle, not by the receipt.
+  private trackTransactionReceipt(hash: `0x${string}`, nonce: number): void {
+    // A new nonce means the previous nonce already resolved (a tx for it landed,
+    // advancing the on-chain count), so abort the stragglers still polling the
+    // old nonce's hashes. They each do one final lookup on abort, so the hash
+    // that actually landed is still logged before they stop. Same-nonce
+    // escalations fall through and ADD a tracker so every competing hash for the
+    // live nonce stays watched.
+    if (this.trackedNonce !== undefined && nonce !== this.trackedNonce) {
+      for (const controller of this.receiptTrackers) {
+        controller.abort();
       }
+      this.receiptTrackers.clear();
+    }
+    this.trackedNonce = nonce;
+
+    const controller = new AbortController();
+    this.receiptTrackers.add(controller);
+    void this.pollTransactionReceipt(hash, controller).finally(() => {
+      this.receiptTrackers.delete(controller);
     });
   }
 


### PR DESCRIPTION
## What
Replace the EVM pusher's fire-and-forget `waitForTransactionReceipt` with a **bounded, per-nonce, cancellable** `getTransactionReceipt` poller.

## Why
On viem 2.24.3, `waitForTransactionReceipt`'s timeout rejects without tearing down its internal `eth_getTransactionByHash` / block poll, so a tx that never becomes findable leaks a detached poller — one per push, forever. Measured: **~1,157 `getTransactionByHash`/s on Soneium (green), ~197M/day fleet-wide**.

## Fix
- Polls `getTransactionReceipt` only (**zero `getTransactionByHash`**), bounded by a deadline and torn down via `AbortController` — no accumulation.
- **Per-nonce**: same-nonce escalations keep every competing hash watched (whichever lands is logged, incl. the original winning the race); a nonce advance aborts the resolved nonce's stragglers.
- Preserves the `Price update successful` `{hash}` log; no hot-path change (nonce/gas still driven by `getTransactionCount`).
- Timeout/interval are CLI-configurable (`--receipt-wait-timeout` / `--receipt-poll-interval`); defaults reproduce prior behavior.

## Tests
6-scenario suite driving the real `EvmPricePusher`; also verified end-to-end against anvil.

Pairs with deployments#5120 (eRPC hedge-off) — independent, either order.
