### PR TITLE
chore(mcp): bump server.json to 0.2.0 for MCP Registry publish

### DIFF
--- a/apps/mcp/server.json
+++ b/apps/mcp/server.json
@@ -14,6 +14,6 @@
     "url": "https://github.com/pyth-network/pyth-crosschain"
   },
   "title": "Pyth Pro MCP Server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "websiteUrl": "https://docs.pyth.network/price-feeds/pro"
 }


### PR DESCRIPTION
Bumps `apps/mcp/server.json` version `0.1.0` → `0.2.0` to match `package.json` and trigger the MCP Registry publish (`publish-mcp.yml` fires on `server.json` changes) for the v0.2.0 release.

This is the registry-metadata half of the PFG-1255 rollout (History-tool auth + History host fix, merged in #3884). The hosted server image (`mcp-server-v0.2.0` tag) and the platform-cyan deployment bump are handled separately.

Refs PFG-1255

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->