### PR TITLE
docs(pro): document JWT auth option for History API

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/api/history.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/api/history.mdx
@@ -201,7 +201,7 @@ solution is also available. To use this option:
 
 1. A browser client needs to ask its backend for a JWT.
 2. If the client backend doesn't already have a valid JWT cached, it calls
-   `POST /auth/token` on the API service, using its actual (secret) API key.
+   `POST /auth/token`, using its actual (secret) API key.
 3. The backend returns this JWT to the frontend.
 4. The frontend uses this JWT as a bearer token (i.e., as an
    `Authorization: Bearer ...` header, just like backend clients do with API keys)
@@ -209,6 +209,10 @@ solution is also available. To use this option:
 
 Note that JWT tokens are short-lived. Clients should inspect the token's expiration time
 and periodically refresh their tokens.
+
+Backends should protect their own token-providing endpoint against abuse, e.g. by
+requiring their own authentication or with rate limits. API usage via JWTs counts
+against the usage limit of the API key used to mint the JWT.
 
 See [/auth/token](https://pyth.dourolabs.app/docs/?urls.primaryName=Auth+API#/Auth/mint-token)
 for details on how to call the mint token endpoint.

--- a/apps/developer-hub/content/docs/price-feeds/pro/api/history.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/api/history.mdx
@@ -189,10 +189,29 @@ curl -H "Authorization: Bearer $PRO_API_KEY" \
 **Do not embed your Pro API key in frontend or browser applications.** The key
 must stay server-side. Route requests through your own backend, which injects
 the `Authorization` header before forwarding to this API. A client-safe JWT
-authentication option is planned for teams that do not want to run their own
+authentication option is available for teams that do not want to run their own
 proxy.
 
 See [Acquire an API Key](/price-feeds/pro/acquire-api-key) to obtain a key.
+
+### JWT Authentication
+
+While routing requests through your own backend is the preferred approach, a JWT-based
+solution is also available. To use this option:
+
+1. A browser client needs to ask its backend for a JWT.
+2. If the client backend doesn't already have a valid JWT cached, it calls
+   `POST /auth/token` on the API service, using its actual (secret) API key.
+3. The backend returns this JWT to the frontend.
+4. The frontend uses this JWT as a bearer token (i.e., as an
+   `Authorization: Bearer ...` header, just like backend clients do with API keys)
+   to perform authenticated calls to the Pyth API service.
+
+Note that JWT tokens are short-lived. Clients should inspect the token's expiration time
+and periodically refresh their tokens.
+
+See [/auth/token](https://pyth.dourolabs.app/docs/?urls.primaryName=Auth+API#/Auth/mint-token)
+for details on how to call the mint token endpoint.
 
 ## OpenAPI Schema
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/api/rest.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/api/rest.mdx
@@ -78,8 +78,9 @@ curl -X POST -H "Authorization: Bearer $PRO_API_KEY" \
 **Do not embed your Pro API key in frontend or browser applications.** The key
 must stay server-side. Route requests through your own backend, which injects
 the `Authorization` header before forwarding to this API. A client-safe JWT
-authentication option is planned for teams that do not want to run their own
-proxy.
+authentication option is available for teams that do not want to run their own
+proxy. See the [History API](/price-feeds/pro/api/history#jwt-authentication)
+for details.
 
 See [Acquire an API Key](/price-feeds/pro/acquire-api-key) to obtain a key.
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/faq.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/faq.mdx
@@ -142,7 +142,7 @@ Starting **July 24, 2026**, `POST /v1/price` will require the `Authorization: Be
 
 #### Q. How should I authenticate the History and REST endpoints from a frontend app?
 
-Do not embed your Pro access token in browsers or frontend apps. Route requests through your own backend or proxy that injects the `Authorization: Bearer <PRO_API_KEY>` header before forwarding. A client-safe JWT authentication option is planned for teams that do not want to run their own proxy.
+Do not embed your Pro access token in browsers or frontend apps. Route requests through your own backend or proxy that injects the `Authorization: Bearer <PRO_API_KEY>` header before forwarding. A client-safe JWT authentication option is available for teams that do not want to run their own proxy.
 
 ## Access Tokens & Permissions
 


### PR DESCRIPTION
- Note JWT auth is available (not just planned) as a proxy alternative
- Add JWT Authentication section with mint-token flow and refresh guidance

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->