### PR TITLE
deploy(pro-compatible) Cronos and Mezo Core contracts

### DIFF
--- a/contract_manager/src/store/contracts/EvmPriceFeedContracts.json
+++ b/contract_manager/src/store/contracts/EvmPriceFeedContracts.json
@@ -1092,5 +1092,17 @@
     "chain": "injective_evm",
     "type": "EvmPriceFeedContract",
     "deploymentType": "pro-compatible-production"
+  },
+  {
+    "address": "0x6E7D74FA7d5c90FEF9F0512987605a6d546181Bb",
+    "chain": "cronos",
+    "type": "EvmPriceFeedContract",
+    "deploymentType": "pro-compatible-production"
+  },
+  {
+    "address": "0x5D289Ad1CE59fCC25b6892e7A303dfFf3a9f7167",
+    "chain": "mezo",
+    "type": "EvmPriceFeedContract",
+    "deploymentType": "pro-compatible-production"
   }
 ]

--- a/contract_manager/src/store/contracts/EvmWormholeContracts.json
+++ b/contract_manager/src/store/contracts/EvmWormholeContracts.json
@@ -1102,5 +1102,17 @@
     "chain": "injective_evm",
     "type": "EvmWormholeContract",
     "deploymentType": "pro-compatible-production"
+  },
+  {
+    "address": "0xf0a1b566B55e0A0CB5BeF52Eb2a57142617Bee67",
+    "chain": "cronos",
+    "type": "EvmWormholeContract",
+    "deploymentType": "pro-compatible-production"
+  },
+  {
+    "address": "0x5f3c61944CEb01B3eAef861251Fb1E0f14b848fb",
+    "chain": "mezo",
+    "type": "EvmWormholeContract",
+    "deploymentType": "pro-compatible-production"
   }
 ]


### PR DESCRIPTION
Deploys the pro-compatible (`pro-compatible-production`) Core price feed contracts to Cronos and Mezo mainnets, following the same procedure as the recent Injective deployment (114716012).

## Deployed contracts

| Chain | Contract | Address |
|---|---|---|
| cronos | EvmPriceFeedContract (proxy) | `0x6E7D74FA7d5c90FEF9F0512987605a6d546181Bb` |
| cronos | WormholeReceiver (half quorum) | `0xf0a1b566B55e0A0CB5BeF52Eb2a57142617Bee67` |
| mezo | EvmPriceFeedContract (proxy) | `0x5D289Ad1CE59fCC25b6892e7A303dfFf3a9f7167` |
| mezo | WormholeReceiver (half quorum) | `0x5f3c61944CEb01B3eAef861251Fb1E0f14b848fb` |

Config: `--single-update-fee-in-wei 0`, valid time period 60s (defaults), pro-compatible Pythnet data source (emitter chain 26).

Verified on-chain on both proxies: `getValidTimePeriod() == 60`, `singleUpdateFeeInWei() == 0`, `wormhole()` points at the new receiver, `validDataSources()` returns the pro-compatible emitter.

Note: Mezo required `--gas-multiplier 1.5` because the default 2x exceeded its 10M block gas limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->