### PR TITLE
ci(mcp): fix MCP Registry publish (mcp-publisher v1.8.0 + workflow_dispatch)

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -6,6 +6,7 @@ on:
       - 'apps/mcp/server.json'
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: publish-mcp-registry
@@ -27,7 +28,7 @@ jobs:
 
       - name: Install mcp-publisher
         run: |
-          curl -fL "https://github.com/modelcontextprotocol/registry/releases/download/v1.4.1/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+          curl -fL "https://github.com/modelcontextprotocol/registry/releases/download/v1.8.0/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
           sudo mv mcp-publisher /usr/local/bin/
 
       - name: Authenticate to MCP Registry

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -19,6 +19,10 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Only ever publish from main — including manual dispatch — so a
+    # workflow_dispatch on a branch can't publish an unreviewed manifest
+    # to the io.github.pyth-network/* namespace with the OIDC credentials.
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Problem

The `Publish Pyth MCP to Registry` workflow failed on the #3886 merge ([run](https://github.com/pyth-network/pyth-crosschain/actions/runs/29261566239)) at the `mcp-publisher login github-oidc` step:

```
token exchange failed with status 401: invalid audience:
expected https://registry.modelcontextprotocol.io, got [mcp-registry]
```

The pinned **mcp-publisher v1.4.1** requests an OIDC audience (`mcp-registry`) the registry no longer accepts. (Pre-existing tooling drift — the May run failed too; unrelated to the version bump.)

## Fix

- Bump `mcp-publisher` **v1.4.1 → v1.8.0** (latest; uses the correct audience). The `mcp-publisher_linux_amd64.tar.gz` asset exists for v1.8.0.
- Add a **`workflow_dispatch`** trigger so the publish can be re-run manually — the push trigger only fires on `apps/mcp/server.json` changes, and it's already at 0.2.0.

## After merge

Manually dispatch the workflow (or it will fire on the next `server.json` change) to publish the **0.2.0** registry entry for `io.github.pyth-network/mcp`.

Refs PFG-1255

🤖 Generated with [Claude Code](https://claude.com/claude-code)