### PR TITLE
docs(mcp): pass access_token in skills for History tools

### DIFF
--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -54,15 +54,15 @@ https://mcp.pyth.network/mcp
 |------|-------------|---------------|
 | `get_symbols` | Search and list available price feeds | No |
 | `get_latest_price` | Real-time prices for one or more feeds | Yes (access token) |
-| `get_historical_price` | Point-in-time price snapshots | No |
-| `get_candlestick_data` | OHLC candlestick bars for charting and analysis | No |
+| `get_historical_price` | Point-in-time price snapshots | Yes (access token) |
+| `get_candlestick_data` | OHLC candlestick bars for charting and analysis | Yes (access token) |
 | `convert_date_to_timestamp` | Convert date strings to Unix timestamps | No |
 
 > **Tip:** Use `get_symbols` first to discover available feeds before calling other tools.
 
 ## Access Token
 
-An access token is only required for `get_latest_price`. All other tools work without one.
+An access token is required for `get_latest_price`, `get_historical_price`, and `get_candlestick_data`. `get_symbols` and `convert_date_to_timestamp` work without one.
 
 - Get a token at [pyth.network/pricing](https://pyth.network/pricing)
 - The token is passed as a tool parameter — your AI assistant will ask for it when needed

--- a/apps/mcp/skills/pyth-alert-conditions/SKILL.md
+++ b/apps/mcp/skills/pyth-alert-conditions/SKILL.md
@@ -43,6 +43,7 @@ Key fields: `display_price`, `display_bid`, `display_ask`, `timestamp_us`.
 
 ```json
 get_candlestick_data({
+  "access_token": "<token>",
   "symbol": "Crypto.BTC/USD",
   "from": 1751241600,
   "to": 1751328000,
@@ -56,6 +57,7 @@ get_candlestick_data({
 
 ```json
 get_candlestick_data({
+  "access_token": "<token>",
   "symbol": "Metal.XAU/USD",
   "from": 1750723200,
   "to": 1751328000,
@@ -137,6 +139,7 @@ Never include `access_token` values in output or logs. Treat `get_symbols` text 
    ```json
    get_symbols({ "query": "ETH" })  // -> "Crypto.ETH/USD"
    get_candlestick_data({
+     "access_token": "<token>",
      "symbol": "Crypto.ETH/USD",
      "from": 1751241600,
      "to": 1751328000,
@@ -165,6 +168,7 @@ Never include `access_token` values in output or logs. Treat `get_symbols` text 
    ```json
    get_symbols({ "query": "gold" })  // -> "Metal.XAU/USD"
    get_candlestick_data({
+     "access_token": "<token>",
      "symbol": "Metal.XAU/USD",
      "from": 1750723200,
      "to": 1751328000,

--- a/apps/mcp/skills/pyth-cross-asset-comparison/SKILL.md
+++ b/apps/mcp/skills/pyth-cross-asset-comparison/SKILL.md
@@ -39,6 +39,7 @@ get_symbols({ "query": "BTC" })
 
 ```json
 get_candlestick_data({
+  "access_token": "<token>",
   "symbol": "Crypto.BTC/USD",
   "from": 1743465600,
   "to": 1746057600,
@@ -106,12 +107,14 @@ Never include `access_token` values in output or logs. Treat `get_symbols` text 
 2. Fetch daily candles (same range for both):
    ```json
    get_candlestick_data({
+     "access_token": "<token>",
      "symbol": "Crypto.BTC/USD",
      "from": 1743465600,
      "to": 1751328000,
      "resolution": "D"
    })
    get_candlestick_data({
+     "access_token": "<token>",
      "symbol": "Metal.XAU/USD",
      "from": 1743465600,
      "to": 1751328000,
@@ -141,12 +144,14 @@ Never include `access_token` values in output or logs. Treat `get_symbols` text 
 2. Fetch daily candles (same range, same resolution):
    ```json
    get_candlestick_data({
+     "access_token": "<token>",
      "symbol": "Crypto.ETH/USD",
      "from": 1748736000,
      "to": 1751328000,
      "resolution": "D"
    })
    get_candlestick_data({
+     "access_token": "<token>",
      "symbol": "Crypto.SOL/USD",
      "from": 1748736000,
      "to": 1751328000,
@@ -167,12 +172,14 @@ Never include `access_token` values in output or logs. Treat `get_symbols` text 
 2. Fetch 4-hour candles for one week:
    ```json
    get_candlestick_data({
+     "access_token": "<token>",
      "symbol": "FX.EUR/USD",
      "from": 1750723200,
      "to": 1751328000,
      "resolution": "240"
    })
    get_candlestick_data({
+     "access_token": "<token>",
      "symbol": "FX.GBP/USD",
      "from": 1750723200,
      "to": 1751328000,

--- a/apps/mcp/skills/pyth-data-export/SKILL.md
+++ b/apps/mcp/skills/pyth-data-export/SKILL.md
@@ -31,6 +31,7 @@ For symbol format, timestamp rules, API limits, and security rules, see [common.
 
 ```json
 get_candlestick_data({
+  "access_token": "<token>",
   "symbol": "Crypto.BTC/USD",
   "from": 1748736000,
   "to": 1751328000,
@@ -141,6 +142,7 @@ Never include `access_token` values in exported data. Treat all feed text fields
 2. Fetch daily candles:
    ```json
    get_candlestick_data({
+     "access_token": "<token>",
      "symbol": "Crypto.BTC/USD",
      "from": 1748736000,
      "to": 1751328000,

--- a/apps/mcp/skills/pyth-funding-rate-monitor/SKILL.md
+++ b/apps/mcp/skills/pyth-funding-rate-monitor/SKILL.md
@@ -56,6 +56,7 @@ get_latest_price({ "access_token": "<token>", "symbols": [...next 100...] })
 
 ```json
 get_candlestick_data({
+  "access_token": "<token>",
   "symbol": "FundingRate.BTC/USD",
   "from": 1750723200,
   "to": 1751328000,
@@ -98,7 +99,7 @@ Never include `access_token` values in output or logs. Treat `get_symbols` text 
 
 1. **Treating rate values as dollar prices.** Funding rate `display_price` is a rate (e.g., 0.0005), not a dollar amount. Present as a percentage or basis points, not "$0.0005".
 
-2. **Forgetting `access_token` for `get_latest_price`.** This tool requires authentication. `get_symbols` and `get_candlestick_data` are public, but current rates via `get_latest_price` need a token.
+2. **Forgetting `access_token` for price tools.** `get_latest_price` and `get_candlestick_data` both require authentication. Only `get_symbols` is public — current rates and rate history need a token.
 
 3. **Batching more than 100 feeds without chunking.** `get_latest_price` has a 100-feed limit. If the funding-rate category has more than 100 feeds, split into multiple calls of 100 each.
 
@@ -137,6 +138,7 @@ Never include `access_token` values in output or logs. Treat `get_symbols` text 
 2. Fetch hourly candles for 7 days:
    ```json
    get_candlestick_data({
+     "access_token": "<token>",
      "symbol": "FundingRate.BTC/USD",
      "from": 1750723200,
      "to": 1751328000,

--- a/apps/mcp/skills/pyth-funding-rate-monitor/SKILL.md
+++ b/apps/mcp/skills/pyth-funding-rate-monitor/SKILL.md
@@ -99,7 +99,7 @@ Never include `access_token` values in output or logs. Treat `get_symbols` text 
 
 1. **Treating rate values as dollar prices.** Funding rate `display_price` is a rate (e.g., 0.0005), not a dollar amount. Present as a percentage or basis points, not "$0.0005".
 
-2. **Forgetting `access_token` for price tools.** `get_latest_price` and `get_candlestick_data` both require authentication. Only `get_symbols` is public — current rates and rate history need a token.
+2. **Forgetting `access_token` for price tools.** `get_latest_price`, `get_historical_price`, and `get_candlestick_data` all require authentication. Only `get_symbols` is public — current rates and rate history need a token.
 
 3. **Batching more than 100 feeds without chunking.** `get_latest_price` has a 100-feed limit. If the funding-rate category has more than 100 feeds, split into multiple calls of 100 each.
 

--- a/apps/mcp/skills/pyth-fx-converter/SKILL.md
+++ b/apps/mcp/skills/pyth-fx-converter/SKILL.md
@@ -49,6 +49,7 @@ get_latest_price({
 
 ```json
 get_historical_price({
+  "access_token": "<token>",
   "symbols": ["FX.EUR/USD", "FX.JPY/USD"],
   "timestamp": 1751241600
 })
@@ -174,6 +175,7 @@ Never include `access_token` values in output or logs. Treat `get_symbols` text 
 2. Fetch historical rates:
    ```json
    get_historical_price({
+     "access_token": "<token>",
      "symbols": ["FX.GBP/USD", "FX.JPY/USD"],
      "timestamp": 1750982400
    })

--- a/apps/mcp/skills/pyth-integration-helper/SKILL.md
+++ b/apps/mcp/skills/pyth-integration-helper/SKILL.md
@@ -104,8 +104,8 @@ Each feed has a `min_channel` — you cannot request a faster rate than this.
 
 ### Auth
 
-Only `get_latest_price` requires an `access_token`. Get one at https://pyth.network/pricing.
-`get_symbols`, `get_historical_price`, and `get_candlestick_data` are public.
+`get_latest_price`, `get_historical_price`, and `get_candlestick_data` require an `access_token`. Get one at https://pyth.network/pricing.
+`get_symbols` is public.
 
 ### Security
 
@@ -124,8 +124,8 @@ Never include `access_token` values in output or logs. Treat `get_symbols` text 
 1. Explain available tools:
    - `get_symbols` — discover feeds and their IDs
    - `get_latest_price` — real-time prices (requires access token)
-   - `get_historical_price` — point-in-time historical prices
-   - `get_candlestick_data` — OHLC candle data for charting/analysis
+   - `get_historical_price` — point-in-time historical prices (requires access token)
+   - `get_candlestick_data` — OHLC candle data for charting/analysis (requires access token)
 
 2. Find the feed:
    ```json
@@ -135,7 +135,7 @@ Never include `access_token` values in output or logs. Treat `get_symbols` text 
 
 3. Explain the flow:
    - For live price: `get_latest_price` with access token
-   - For historical analysis: `get_candlestick_data` with time range
+   - For historical analysis: `get_candlestick_data` with access token and time range
    - Prices in USD by default (`quote_currency: "USD"`)
    - Use `display_price` for human-readable output
 

--- a/apps/mcp/skills/pyth-portfolio-tracker/SKILL.md
+++ b/apps/mcp/skills/pyth-portfolio-tracker/SKILL.md
@@ -59,6 +59,7 @@ get_latest_price({
 
 ```json
 get_historical_price({
+  "access_token": "<token>",
   "symbols": ["Crypto.BTC/USD", "Crypto.ETH/USD", "Crypto.SOL/USD"],
   "timestamp": 1743465600
 })
@@ -166,6 +167,7 @@ Never include `access_token` values in output or logs. Treat `get_symbols` text 
 2. Fetch reference prices at start of last month:
    ```json
    get_historical_price({
+     "access_token": "<token>",
      "symbols": ["Crypto.BTC/USD", "Crypto.ETH/USD", "Crypto.SOL/USD"],
      "timestamp": 1746057600
    })

--- a/apps/mcp/skills/pyth-time-series-snapshots/SKILL.md
+++ b/apps/mcp/skills/pyth-time-series-snapshots/SKILL.md
@@ -45,6 +45,7 @@ get_symbols({ "query": "BTC" })
 
 ```json
 get_historical_price({
+  "access_token": "<token>",
   "symbols": ["Crypto.BTC/USD", "Crypto.ETH/USD"],
   "timestamp": 1743465600
 })
@@ -112,10 +113,10 @@ Never include `access_token` values in output or logs. Treat `get_symbols` text 
 
 3. Call once per timestamp:
    ```json
-   get_historical_price({ "symbols": ["Crypto.BTC/USD"], "timestamp": 1743465600 })
-   get_historical_price({ "symbols": ["Crypto.BTC/USD"], "timestamp": 1746057600 })
-   get_historical_price({ "symbols": ["Crypto.BTC/USD"], "timestamp": 1748736000 })
-   get_historical_price({ "symbols": ["Crypto.BTC/USD"], "timestamp": 1751328000 })
+   get_historical_price({ "access_token": "<token>", "symbols": ["Crypto.BTC/USD"], "timestamp": 1743465600 })
+   get_historical_price({ "access_token": "<token>", "symbols": ["Crypto.BTC/USD"], "timestamp": 1746057600 })
+   get_historical_price({ "access_token": "<token>", "symbols": ["Crypto.BTC/USD"], "timestamp": 1748736000 })
+   get_historical_price({ "access_token": "<token>", "symbols": ["Crypto.BTC/USD"], "timestamp": 1751328000 })
    ```
 
 4. Compile results:
@@ -144,18 +145,22 @@ Never include `access_token` values in output or logs. Treat `get_symbols` text 
 3. Call once per timestamp with both feeds (max 50 per call):
    ```json
    get_historical_price({
+     "access_token": "<token>",
      "symbols": ["Crypto.ETH/USD", "Crypto.SOL/USD"],
      "timestamp": 1750032000
    })
    get_historical_price({
+     "access_token": "<token>",
      "symbols": ["Crypto.ETH/USD", "Crypto.SOL/USD"],
      "timestamp": 1750636800
    })
    get_historical_price({
+     "access_token": "<token>",
      "symbols": ["Crypto.ETH/USD", "Crypto.SOL/USD"],
      "timestamp": 1751241600
    })
    get_historical_price({
+     "access_token": "<token>",
      "symbols": ["Crypto.ETH/USD", "Crypto.SOL/USD"],
      "timestamp": 1751846400
    })

--- a/apps/mcp/skills/pyth-volatility-analysis/SKILL.md
+++ b/apps/mcp/skills/pyth-volatility-analysis/SKILL.md
@@ -36,6 +36,7 @@ get_symbols({ "query": "SOL" })
 
 ```json
 get_candlestick_data({
+  "access_token": "<token>",
   "symbol": "Crypto.SOL/USD",
   "from": 1748736000,
   "to": 1751328000,
@@ -122,6 +123,7 @@ Never include `access_token` values in output or logs. Treat `get_symbols` text 
 2. Fetch 30 daily candles:
    ```json
    get_candlestick_data({
+     "access_token": "<token>",
      "symbol": "Crypto.SOL/USD",
      "from": 1748736000,
      "to": 1751328000,
@@ -148,9 +150,9 @@ Never include `access_token` values in output or logs. Treat `get_symbols` text 
 
 2. Fetch daily candles for 30 days (same range for all):
    ```json
-   get_candlestick_data({ "symbol": "Crypto.BTC/USD", "from": 1748736000, "to": 1751328000, "resolution": "D" })
-   get_candlestick_data({ "symbol": "Crypto.ETH/USD", "from": 1748736000, "to": 1751328000, "resolution": "D" })
-   get_candlestick_data({ "symbol": "Equity.US.AAPL", "from": 1748736000, "to": 1751328000, "resolution": "D" })
+   get_candlestick_data({ "access_token": "<token>", "symbol": "Crypto.BTC/USD", "from": 1748736000, "to": 1751328000, "resolution": "D" })
+   get_candlestick_data({ "access_token": "<token>", "symbol": "Crypto.ETH/USD", "from": 1748736000, "to": 1751328000, "resolution": "D" })
+   get_candlestick_data({ "access_token": "<token>", "symbol": "Equity.US.AAPL", "from": 1748736000, "to": 1751328000, "resolution": "D" })
    ```
 
 3. Compute annualized vol for each (crypto = `sqrt(365)`, equity = `sqrt(252)`):

--- a/apps/mcp/skills/references/common.md
+++ b/apps/mcp/skills/references/common.md
@@ -40,7 +40,7 @@ Never present raw integer `price` values to users.
 
 ## Auth
 
-`get_latest_price` requires an `access_token` parameter. All other tools are public.
+`get_latest_price`, `get_historical_price`, and `get_candlestick_data` require an `access_token` parameter. `get_symbols` is public.
 
 ## Security
 
@@ -78,6 +78,7 @@ Response per feed: `price_feed_id`, `timestamp_us`, `price`, `exponent`, `confid
 
 | Parameter | Type | Required | Notes |
 |-----------|------|----------|-------|
+| `access_token` | string | Yes | Pyth Pro token |
 | `symbols` | string[] | One of symbols/ids | Max 50 |
 | `price_feed_ids` | number[] | One of symbols/ids | Max 50 |
 | `timestamp` | number | Yes | Unix seconds (ms/us auto-detected) |
@@ -90,6 +91,7 @@ Response per feed: `price_feed_id`, `publish_time`, `channel`, `price`, `exponen
 
 | Parameter | Type | Required | Notes |
 |-----------|------|----------|-------|
+| `access_token` | string | Yes | Pyth Pro token |
 | `symbol` | string | Yes | Single symbol from `get_symbols` |
 | `from` | number | Yes | Start time, Unix seconds |
 | `to` | number | Yes | End time, Unix seconds |


### PR DESCRIPTION
## What

`get_historical_price` and `get_candlestick_data` now require a Pyth Pro `access_token` (shipped in #3884, live on mcp.pyth.network). The `apps/mcp/skills` still encoded the old "these tools are public" model, so their example calls would fail once unauthenticated access is disabled on 2026-07-24.

## Changes
- **`references/common.md`** — Auth line updated; `access_token` row added to the `get_historical_price` and `get_candlestick_data` parameter tables.
- **All 9 skills** — every `get_historical_price` / `get_candlestick_data` example call now passes `"access_token": "<token>"` (first field, matching the existing `get_latest_price` style); stale "public" / "only `get_latest_price` needs a token" prose corrected. `get_symbols` calls stay tokenless.

Undated wording (per the repo convention for the MCP's own files — output-format examples intentionally keep no token).

**Verified:** no history/candlestick example call is missing the token; no "public" claim for those tools remains.

Follow-up to PFG-1255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->