### PR TITLE
Rebrand "upgraded" to "Pro-compatible" in Pyth Core upgrade docs

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/contracts.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/contracts.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Upgraded Contract Addresses"
-description: "Per-chain addresses for the upgraded Pyth Core Contract."
+title: "Pro-compatible Contract Addresses"
+description: "Per-chain addresses for the Pro-compatible Pyth Core Contract."
 full: true
 ---
 
@@ -9,7 +9,7 @@ import MigrationContractsTable from "../../../../../src/components/MigrationCont
 import { SponsoredFeedsTable } from "../../../../../src/components/SponsoredFeedsTable";
 import solanaMainnet from "../push-feeds/data/svm/solana-mainnet.json";
 
-These are the **upgraded Pyth Core Contract** addresses for each supported chain. To upgrade your Pyth Core integration, swap your existing Pyth contract address for the one listed below for your chain. The interface is unchanged. No other code changes are needed.
+These are the **Pro-compatible Pyth Core Contract** addresses for each supported chain. To upgrade your Pyth Core integration, swap your existing Pyth contract address for the one listed below for your chain. The interface is unchanged. No other code changes are needed.
 
 See the [upgrade guide](/price-feeds/core/upgrade/preparing) for the full upgrade path.
 
@@ -27,7 +27,7 @@ See the [upgrade guide](/price-feeds/core/upgrade/preparing) for the full upgrad
 
 ### Mainnet
 
-|                     | Current                                                                                                                                                                | Upgraded                                                             |
+|                     | Current                                                                                                                                                                | Pro-compatible                                                             |
 | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
 | Pyth State ID       | [`0x1f9310238ee9298fb703c3419030b35b22bb1cc37113e3bb5007c99aec79e5b8`](https://suiscan.xyz/mainnet/object/0x1f9310238ee9298fb703c3419030b35b22bb1cc37113e3bb5007c99aec79e5b8) | [`0x03719fae774ddab3cfcaa53bbc046f0cbe21410019b6280811bf3f9f4b05839d`](https://suiscan.xyz/mainnet/object/0x03719fae774ddab3cfcaa53bbc046f0cbe21410019b6280811bf3f9f4b05839d) |
 | Pyth Package ID     | [`0x04e20ddf36af412a4096f9014f4a565af9e812db9a05cc40254846cf6ed0ad91`](https://suiscan.xyz/mainnet/object/0x04e20ddf36af412a4096f9014f4a565af9e812db9a05cc40254846cf6ed0ad91) | [`0x55300367a2d40813727ccac4ecee977a39fb9cdb46f2e6b2c354b9798f5de2c0`](https://suiscan.xyz/mainnet/object/0x55300367a2d40813727ccac4ecee977a39fb9cdb46f2e6b2c354b9798f5de2c0) |
@@ -36,7 +36,7 @@ See the [upgrade guide](/price-feeds/core/upgrade/preparing) for the full upgrad
 
 ### Testnet
 
-|                     | Current                                                                                                                                                                                  | Upgraded                                                             |
+|                     | Current                                                                                                                                                                                  | Pro-compatible                                                             |
 | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
 | Pyth State ID       | [`0x243759059f4c3111179da5878c12f68d612c21a8d54d85edc86164bb18be1c7c`](https://suiscan.xyz/testnet/object/0x243759059f4c3111179da5878c12f68d612c21a8d54d85edc86164bb18be1c7c) | [`0x3c48fe392912de6c18087a2b3f5fdbfbfdb4598e180947feff1f12f8e9ea073e`](https://suiscan.xyz/testnet/object/0x3c48fe392912de6c18087a2b3f5fdbfbfdb4598e180947feff1f12f8e9ea073e) |
 | Pyth Package ID     | [`0xabf837e98c26087cba0883c0a7a28326b1fa3c5e1e2c5abdb486f9e8f594c837`](https://suiscan.xyz/testnet/object/0xabf837e98c26087cba0883c0a7a28326b1fa3c5e1e2c5abdb486f9e8f594c837) | [`0xd1ac23e1582080e2e5d43dbad1cf463ea2337cdbbb1a9ca669e470cefb74d8fd`](https://suiscan.xyz/testnet/object/0xd1ac23e1582080e2e5d43dbad1cf463ea2337cdbbb1a9ca669e470cefb74d8fd) |
@@ -47,7 +47,7 @@ See the [upgrade guide](/price-feeds/core/upgrade/preparing) for the full upgrad
 
 ### Programs (Mainnet and Testnet)
 
-| Program           | Current                                                                                                                              | Upgraded                                       |
+| Program           | Current                                                                                                                              | Pro-compatible                                       |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
 | Wormhole receiver | [`HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ`](https://explorer.solana.com/address/HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ)   | [`HDw2E7P8X1SkCyjvoGsfBGAVUutKcj874bXjHrpVYrVL`](https://explorer.solana.com/address/HDw2E7P8X1SkCyjvoGsfBGAVUutKcj874bXjHrpVYrVL) |
 | Solana receiver   | [`rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ`](https://explorer.solana.com/address/rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ)   | [`rec2HHDDnjLfj4kE7VyEtFA1HPGQLK33259532cRyHp`](https://explorer.solana.com/address/rec2HHDDnjLfj4kE7VyEtFA1HPGQLK33259532cRyHp) |
@@ -55,7 +55,7 @@ See the [upgrade guide](/price-feeds/core/upgrade/preparing) for the full upgrad
 
 ### Push Feed Accounts (Mainnet)
 
-Each Solana push feed lives at a PDA derived from the Price Feed program ID and the price feed ID. The Price Feed program ID changes at the upgrade, so every per-feed account address changes too. Below are the upgraded account addresses (shard 0) for every sponsored feed. For the current (pre-upgrade) addresses, see the [push feeds on Solana](/price-feeds/core/push-feeds/solana) page.
+Each Solana push feed lives at a PDA derived from the Price Feed program ID and the price feed ID. The Price Feed program ID changes at the upgrade, so every per-feed account address changes too. Below are the Pro-compatible account addresses (shard 0) for every sponsored feed. For the current (pre-upgrade) addresses, see the [push feeds on Solana](/price-feeds/core/push-feeds/solana) page.
 
 <SponsoredFeedsTable
   feeds={solanaMainnet.feeds}

--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/how-it-works.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/how-it-works.mdx
@@ -27,7 +27,7 @@ graph LR
   end
 
   subgraph OnChain ["<span style='color:#71717a'>On-Chain</span>"]
-    P[Upgraded Pyth Core Contract]
+    P[Pro-compatible Pyth Core Contract]
   end
 
   R1 --> H
@@ -52,8 +52,8 @@ graph LR
 2. **Data Collection**: The upgraded Hermes endpoint gathers the signed roots and
    price messages from all routers.
 3. **Update Submission**: Consumers fetch the signed root and Merkle proofs from
-   Hermes and submit them to the upgraded contract.
-4. **On-Chain Verification**: The upgraded contracts verify that the router
+   Hermes and submit them to the Pro-compatible contract.
+4. **On-Chain Verification**: The Pro-compatible contracts verify that the router
    signatures meet the quorum and validate the requested price aggregate against the Merkle
    root.
 
@@ -70,7 +70,7 @@ The upgraded Hermes endpoint is hosted at a new URL but remains completely
 backward-compatible with standard Hermes. It exposes the identical HTTP and
 WebSocket API endpoints and returns the same payload structures.
 
-### Upgraded Pyth Core Contract
+### Pro-compatible Pyth Core Contract
 
 These are newly deployed contracts on each supported blockchain. They share
 the exact same ABI and interface as the legacy contracts, eliminating the
@@ -97,5 +97,5 @@ Here is a side-by-side comparison of the two architectures:
 
 Pyth Core will be upgraded on **July 31st**. To avoid potential oracle downtime,
 make sure you take the appropriate steps by following the [upgrade guide](/price-feeds/core/upgrade/preparing).
-You can also view the [upgraded Pyth Core Contract addresses](/price-feeds/core/upgrade/contracts)
+You can also view the [Pro-compatible Pyth Core Contract addresses](/price-feeds/core/upgrade/contracts)
 for the new contract addresses on each supported chain.

--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/index.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/index.mdx
@@ -24,8 +24,8 @@ Most existing integrations keep working through the cutover. [Prepare for the up
     href="/price-feeds/core/upgrade/preparing"
   />
   <Card
-    title="See the upgraded contract addresses"
-    description="Per-chain addresses for the upgraded Pyth Core contract."
+    title="See the Pro-compatible contract addresses"
+    description="Per-chain addresses for the Pro-compatible Pyth Core Contract."
     href="/price-feeds/core/upgrade/contracts"
   />
   <Card

--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/evm.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/evm.mdx
@@ -47,6 +47,6 @@ const hermes = new HermesClient(
 
 The contract call itself follows your ABI library. Use `pythContract.write.updatePriceFeeds(...)` in viem, `pythContract.updatePriceFeeds(...)` in ethers.
 
-## Upgraded EVM Addresses
+## Pro-compatible EVM Addresses
 
 [View on the contract addresses page →](/price-feeds/core/upgrade/contracts#evm)

--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/index.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/index.mdx
@@ -79,13 +79,13 @@ After Step 1, choose how and when to move to the upgraded infrastructure. Your c
 | Timing           | You choose                                 | July 31, 2026                                                        |
 | Downtime         | Up to you                                       | Brief, during the switch                                             |
 | Hermes endpoint  | Switch to the new Hermes endpoint now             | Start using `hermes.pyth.network` with an API key before the cutover               |
-| Contract address | You swap to the upgraded Pyth Core Contract       | DAO upgrades the current Pyth Core Contract for you                             |
+| Contract address | You swap to the Pro-compatible Pyth Core Contract       | DAO upgrades the current Pyth Core Contract for you                             |
 
 <BranchSection path="now">
 
 ## Early upgrade
 
-This is the recommended path, as it makes the **July 31 cutover a non-event for your integration**. Please note that if you swap the endpoint but not the contract address or vice versa you won't be able to verify price updates. 
+This is the recommended path, as it makes the **July 31 cutover a non-event for your integration**. Please note that if you swap the endpoint but not the contract address or vice versa you won't be able to verify price updates.
 
 <Steps>
 <Step>
@@ -123,7 +123,7 @@ Per-chain availability: see the **Pro-compatible** column on the [EVM](/price-fe
 
 <Callout type="warn">
   **Deploy 1 and 2 in the same release.**
-  The upgraded endpoint serves payloads only the upgraded Pyth Core Contract verifies.
+  The upgraded endpoint serves payloads only the Pro-compatible Pyth Core Contract verifies.
   If you ship these separately, **price updates can fail until both changes are live**.
   If you cannot deploy both together, use a forward-compatible strategy like the one in the [Automatic Upgrade section](#waiting-for-the-automatic-upgrade).
 </Callout>
@@ -133,11 +133,11 @@ Per-chain availability: see the **Pro-compatible** column on the [EVM](/price-fe
 
 ### Swap your contract address
 
-Swap your existing Pyth contract address for the [upgraded Pyth Core Contract](/price-feeds/core/upgrade/contracts) on your chain. The upgraded Pyth Core Contract preserves the Pyth Core interface. No other code changes are needed.
+Swap your existing Pyth contract address for the [Pro-compatible Pyth Core Contract](/price-feeds/core/upgrade/contracts) on your chain. The Pro-compatible Pyth Core Contract preserves the Pyth Core interface. No other code changes are needed.
 
-View all upgraded [Pyth Core Contract addresses](/price-feeds/core/upgrade/contracts).
+View all Pro-compatible [Pyth Core Contract addresses](/price-feeds/core/upgrade/contracts).
 
-After the swap, you're done before the July 31 cutover. 
+After the swap, you're done before the July 31 cutover.
 
 </Step>
 </Steps>
@@ -169,7 +169,7 @@ After the swap, you're done before the July 31 cutover.
 </Callout>
 
 At the cutover on July 31, the Pyth DAO upgrades your on-chain contract a few moments *before* `hermes.pyth.network` starts serving the upgraded payload.
-During that brief gap, the price updates served by `hermes.pyth.network` cannot verify against your upgraded contract, while those served by `pyth.dourolabs.app/hermes` can.
+During that brief gap, the price updates served by `hermes.pyth.network` cannot verify against your Pro-compatible contract, while those served by `pyth.dourolabs.app/hermes` can.
 
 A potential strategy to stay live without timing the switch yourself is to fetch from both URLs every request and submit whichever payload verifies:
 
@@ -203,7 +203,7 @@ for (const update of [newUpdate, oldUpdate]) {
 
 ## Chain support
 
-Pyth Core will be supported on major EVM chains, Solana and Sui. See the [upgraded Pyth Core contract addresses page](/price-feeds/core/upgrade/contracts) for more details.
+Pyth Core will be supported on major EVM chains, Solana and Sui. See the [Pro-compatible Pyth Core Contract addresses page](/price-feeds/core/upgrade/contracts) for more details.
 
 ### Feed support
 
@@ -216,7 +216,7 @@ Nearly all current Pyth Core feeds remain available after the upgrade, with new 
     If you sign up for a Pyth API Key and start using authenticated Hermes now, nothing should break. You may still see a brief oracle downtime window at cutover if you do not take proactive steps to handle the transition; follow the guidance [above](#waiting-for-the-automatic-upgrade).
   </Accordion>
   <Accordion title="Will my existing code break?">
-    On-chain code is fine: the upgrade is fully backward-compatible with the existing Pyth Core interface via the upgraded Pyth Core Contract.
+    On-chain code is fine: the upgrade is fully backward-compatible with the existing Pyth Core interface via the Pro-compatible Pyth Core Contract.
 
     Hermes code breaks at the cutover *if* your client is still pointed at `hermes.pyth.network` without an API key. Please follow the steps mentioned [above](#waiting-for-the-automatic-upgrade).
   </Accordion>
@@ -224,10 +224,10 @@ Nearly all current Pyth Core feeds remain available after the upgrade, with new 
     On July 31, 2026. Exact switch timing is announced closer to the date. From that point, `hermes.pyth.network` serves the upgraded data and requires API key authentication.
   </Accordion>
   <Accordion title="Can I test before upgrading?">
-    Yes. The upgraded endpoint (`pyth.dourolabs.app/hermes`) and the upgraded Pyth Core Contract are both available on testnets today. See the upgraded [Pyth Core Contract addresses](/price-feeds/core/upgrade/contracts) for addresses.
+    Yes. The upgraded endpoint (`pyth.dourolabs.app/hermes`) and the Pro-compatible Pyth Core Contract are both available on testnets today. See the Pro-compatible [Pyth Core Contract addresses](/price-feeds/core/upgrade/contracts) for addresses.
   </Accordion>
   <Accordion title="What if my chain isn't supported?">
-    Contact the team. Several chains are in active discussion and may be supported by July 31. For others, custom arrangements are possible. See the [upgraded Pyth Core Contract addresses](/price-feeds/core/upgrade/contracts) for the full list.
+    Contact the team. Several chains are in active discussion and may be supported by July 31. For others, custom arrangements are possible. See the [Pro-compatible Pyth Core Contract addresses](/price-feeds/core/upgrade/contracts) for the full list.
   </Accordion>
   <Accordion title="Are all my feeds available after the upgrade?">
     Nearly all current Pyth Core feeds remain available after the upgrade, with new ones added. Look up your specific feeds on the [feed explorer](https://pythdata.app/explore?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=feed-explorer-faq). If a feed you depend on isn't listed, [contact the team](#get-help).

--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/solana.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/solana.mdx
@@ -48,7 +48,7 @@ const hermes = new HermesClient(
 
 ### Swap your contract address
 
-On Solana, swapping the Pyth Core contract address means pointing your program and TS SDK at the upgraded program IDs. The full mapping is on the [contract addresses page](/price-feeds/core/upgrade/contracts#solana). 
+On Solana, swapping the Pyth Core contract address means pointing your program and TS SDK at the Pro-compatible program IDs. The full mapping is on the [contract addresses page](/price-feeds/core/upgrade/contracts#solana).
 If your app reads push feeds directly, the per-feed account addresses also change; see the [push feed accounts table](/price-feeds/core/upgrade/contracts#push-feed-accounts-mainnet) for the full mapping.
 
 #### On-chain program (Rust)
@@ -61,7 +61,7 @@ pyth-solana-receiver-sdk = { version = "1.2.0", features = ["pro-compatible"] }
 
 #### TypeScript client
 
-The TS SDK [`@pythnetwork/pyth-solana-receiver`](https://www.npmjs.com/package/@pythnetwork/pyth-solana-receiver) defaults to the current program IDs. Point it at the upgraded ones instead:
+The TS SDK [`@pythnetwork/pyth-solana-receiver`](https://www.npmjs.com/package/@pythnetwork/pyth-solana-receiver) defaults to the current program IDs. Point it at the Pro-compatible ones instead:
 
 ```ts
 import {
@@ -82,12 +82,12 @@ const pythSolanaReceiver = new PythSolanaReceiver({
 ```
 
 <Callout type="warn">
-  Replace any additional reference to the current Core program IDs with the upgraded program IDs in your codebase. See the [contract addresses page](/price-feeds/core/upgrade/contracts#solana) for the full mapping.
+  Replace any additional reference to the current Core program IDs with the Pro-compatible program IDs in your codebase. See the [contract addresses page](/price-feeds/core/upgrade/contracts#solana) for the full mapping.
 </Callout>
 
 </Step>
 </Steps>
 
-## Upgraded Solana Addresses
+## Pro-compatible Solana Addresses
 
 [View on the contract addresses page →](/price-feeds/core/upgrade/contracts#solana)

--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/sui.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/sui.mdx
@@ -64,7 +64,7 @@ const connection = new SuiPriceServiceConnection(
 
 ### Swap your contract address
 
-On Sui, swapping the Pyth Core contract address means updating the Pyth package `rev` in your `Move.toml`. The full list of upgraded Pyth State, Pyth Package, Wormhole State, and Wormhole Package IDs is on the [contract addresses page](/price-feeds/core/upgrade/contracts#sui).
+On Sui, swapping the Pyth Core contract address means updating the Pyth package `rev` in your `Move.toml`. The full list of Pro-compatible Pyth State, Pyth Package, Wormhole State, and Wormhole Package IDs is on the [contract addresses page](/price-feeds/core/upgrade/contracts#sui).
 
 Current Pyth Core users reference the Pyth package in their `Move.toml`:
 
@@ -75,7 +75,7 @@ subdir = "target_chains/sui/contracts"
 rev = "sui-contract-mainnet"
 ```
 
-The upgraded Pyth Core package is available at a new `rev`:
+The Pro-compatible Pyth Core package is available at a new `rev`:
 
 ```toml
 [dependencies.pyth]
@@ -85,7 +85,7 @@ rev = "sui-pro-compatible-contract-mainnet"  # or sui-pro-compatible-contract-te
 ```
 
 <Callout type="warn">
-  **Sui package compatibility may force you to keep both.** Per Sui's [custom package upgrade policies](https://docs.sui.io/develop/publish-upgrade-packages/custom-policies), you may need to keep the original Pyth package alongside the upgraded one in your `Move.toml`. Rename one to avoid a naming conflict:
+  **Sui package compatibility may force you to keep both.** Per Sui's [custom package upgrade policies](https://docs.sui.io/develop/publish-upgrade-packages/custom-policies), you may need to keep the original Pyth package alongside the Pro-compatible one in your `Move.toml`. Rename one to avoid a naming conflict:
 
   ```toml
   [dependencies.pyth]
@@ -110,6 +110,6 @@ rev = "sui-pro-compatible-contract-mainnet"  # or sui-pro-compatible-contract-te
 </Step>
 </Steps>
 
-## Upgraded Sui Addresses
+## Pro-compatible Sui Addresses
 
 [View on the contract addresses page →](/price-feeds/core/upgrade/contracts#sui)

--- a/apps/developer-hub/src/components/MigrationContractsTable/index.tsx
+++ b/apps/developer-hub/src/components/MigrationContractsTable/index.tsx
@@ -99,7 +99,7 @@ const MigrationContractsTable = async ({
       <thead>
         <tr>
           <th>Network</th>
-          <th>Upgraded Pyth Core Contract</th>
+          <th>Pro-compatible Pyth Core Contract</th>
         </tr>
       </thead>
       <tbody>

--- a/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
+++ b/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
@@ -166,7 +166,7 @@ export const SponsoredFeedsTable = ({
         ? [
             {
               id: "upgradedAccountAddress",
-              name: "Upgraded Account Address",
+              name: "Pro-compatible Account Address",
               alignment: "left" as const,
             },
           ]


### PR DESCRIPTION
## Summary

Updated documentation terminology throughout the Pyth Core upgrade guides to consistently use "Pro-compatible" instead of "upgraded" when referring to the new Pyth Core Contract and related infrastructure. This includes updates to page titles, descriptions, table headers, section headings, and inline references across multiple documentation files.

## Rationale

This change standardizes the naming convention used in the upgrade documentation to align with the product branding for the new contract version. Using "Pro-compatible" consistently throughout the docs improves clarity and maintains alignment with the official product terminology.

## How has this been tested?

- No testing needed - this is a documentation-only change consisting of terminology updates and minor whitespace fixes (trailing whitespace removal)

https://claude.ai/code/session_01VPJKxGeKAuM7kkfcX4hqoe
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3893" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->