### PR TITLE
deploy(pro-compatible) Mezo testnet Core contracts

### DIFF
--- a/contract_manager/src/store/contracts/EvmPriceFeedContracts.json
+++ b/contract_manager/src/store/contracts/EvmPriceFeedContracts.json
@@ -1104,5 +1104,11 @@
     "chain": "mezo",
     "type": "EvmPriceFeedContract",
     "deploymentType": "pro-compatible-production"
+  },
+  {
+    "address": "0x933aDeC2C7624b11E4B2b80ACE15BF9a71a31315",
+    "chain": "mezo_testnet",
+    "type": "EvmPriceFeedContract",
+    "deploymentType": "pro-compatible-production"
   }
 ]

--- a/contract_manager/src/store/contracts/EvmWormholeContracts.json
+++ b/contract_manager/src/store/contracts/EvmWormholeContracts.json
@@ -1114,5 +1114,11 @@
     "chain": "mezo",
     "type": "EvmWormholeContract",
     "deploymentType": "pro-compatible-production"
+  },
+  {
+    "address": "0x876A4e56A51386aBb1a5ab5d62f77E814372f0C7",
+    "chain": "mezo_testnet",
+    "type": "EvmWormholeContract",
+    "deploymentType": "pro-compatible-production"
   }
 ]


### PR DESCRIPTION
Deploys the pro-compatible (`pro-compatible-production`) Core price feed contract to Mezo testnet, following the same procedure as the Cronos/Mezo mainnet deployment (#3889).

## Deployed contracts

| Chain | Contract | Address |
|---|---|---|
| mezo_testnet | EvmPriceFeedContract (proxy) | `0x933aDeC2C7624b11E4B2b80ACE15BF9a71a31315` |
| mezo_testnet | WormholeReceiver (half quorum) | `0x876A4e56A51386aBb1a5ab5d62f77E814372f0C7` |

Config: `--single-update-fee-in-wei 0`, valid time period 60s (default), pro-compatible Pythnet data source (emitter chain 26). Used `--gas-multiplier 1.5` since Mezo testnet has the same 10M block gas limit as mainnet.

Verified on-chain on the proxy:
- `version() == 1.4.5-alpha.1`, `getValidTimePeriod() == 60`, `singleUpdateFeeInWei() == 0`
- `wormhole()` points at the new half-quorum receiver, `validDataSources()` returns the pro-compatible emitter
- Implementation bytecode is byte-identical to the Cronos/Mezo mainnet deployments (modulo the UUPS `__self` immutable)
- A live pro-compatible update (calldata from the Optimism pro contract) executes successfully against the proxy via `eth_call`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->