### PR TITLE
deploy(pro-compatible) Cronos testnet Core contracts

### DIFF
--- a/contract_manager/src/store/contracts/EvmPriceFeedContracts.json
+++ b/contract_manager/src/store/contracts/EvmPriceFeedContracts.json
@@ -1110,5 +1110,11 @@
     "chain": "mezo_testnet",
     "type": "EvmPriceFeedContract",
     "deploymentType": "pro-compatible-production"
+  },
+  {
+    "address": "0xf77705A55aA859A80f60b8d8C4A03D7f69D2D7Ba",
+    "chain": "cronos_testnet",
+    "type": "EvmPriceFeedContract",
+    "deploymentType": "pro-compatible-production"
   }
 ]

--- a/contract_manager/src/store/contracts/EvmWormholeContracts.json
+++ b/contract_manager/src/store/contracts/EvmWormholeContracts.json
@@ -1120,5 +1120,11 @@
     "chain": "mezo_testnet",
     "type": "EvmWormholeContract",
     "deploymentType": "pro-compatible-production"
+  },
+  {
+    "address": "0x0402833A00e734821f74fA4bbdeD2F1759540519",
+    "chain": "cronos_testnet",
+    "type": "EvmWormholeContract",
+    "deploymentType": "pro-compatible-production"
   }
 ]


### PR DESCRIPTION
Deploys the pro-compatible (`pro-compatible-production`) Core price feed contract to Cronos testnet, following the same procedure as the mainnet deployment (#3889) and the Mezo testnet deployment (#3894).

## Deployed contracts

| Chain | Contract | Address |
|---|---|---|
| cronos_testnet | EvmPriceFeedContract (proxy) | `0xf77705A55aA859A80f60b8d8C4A03D7f69D2D7Ba` |
| cronos_testnet | WormholeReceiver (half quorum) | `0x0402833A00e734821f74fA4bbdeD2F1759540519` |

Config: `--single-update-fee-in-wei 0`, valid time period 60s (default), pro-compatible Pythnet data source (emitter chain 26).

Verified on-chain on the proxy:
- `version() == 1.4.5-alpha.1`, `getValidTimePeriod() == 60`, `singleUpdateFeeInWei() == 0`
- `wormhole()` points at the new half-quorum receiver, `validDataSources()` returns the pro-compatible emitter
- Implementation bytecode is byte-identical to the Cronos/Mezo mainnet deployments (modulo the UUPS `__self` immutable)
- A live pro-compatible update executes successfully via `eth_call`; a legacy Core (`hermes.pyth.network`) payload correctly reverts with `InvalidWormholeVaa()`
- A real update has already been pushed on-chain: `getPriceUnsafe(ETH/USD)` returns a live price

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3895" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->