### PR TITLE
deploy(pro-compatible) Polygon and Polygon Amoy Core contracts

### DIFF
--- a/contract_manager/src/store/chains/EvmChains.json
+++ b/contract_manager/src/store/chains/EvmChains.json
@@ -793,7 +793,7 @@
     "id": "polygon_amoy",
     "mainnet": false,
     "networkId": 80002,
-    "rpcUrl": "https://polygon-amoy-bor-rpc.publicnode.com",
+    "rpcUrl": "https://polygon-amoy.drpc.org",
     "type": "EvmChain"
   },
   {

--- a/contract_manager/src/store/contracts/EvmPriceFeedContracts.json
+++ b/contract_manager/src/store/contracts/EvmPriceFeedContracts.json
@@ -1116,5 +1116,17 @@
     "chain": "cronos_testnet",
     "type": "EvmPriceFeedContract",
     "deploymentType": "pro-compatible-production"
+  },
+  {
+    "address": "0x6E7D74FA7d5c90FEF9F0512987605a6d546181Bb",
+    "chain": "polygon",
+    "type": "EvmPriceFeedContract",
+    "deploymentType": "pro-compatible-production"
+  },
+  {
+    "address": "0x0708325268dF9F66270F1401206434524814508b",
+    "chain": "polygon_amoy",
+    "type": "EvmPriceFeedContract",
+    "deploymentType": "pro-compatible-production"
   }
 ]

--- a/contract_manager/src/store/contracts/EvmWormholeContracts.json
+++ b/contract_manager/src/store/contracts/EvmWormholeContracts.json
@@ -1126,5 +1126,17 @@
     "chain": "cronos_testnet",
     "type": "EvmWormholeContract",
     "deploymentType": "pro-compatible-production"
+  },
+  {
+    "address": "0xf0a1b566B55e0A0CB5BeF52Eb2a57142617Bee67",
+    "chain": "polygon",
+    "type": "EvmWormholeContract",
+    "deploymentType": "pro-compatible-production"
+  },
+  {
+    "address": "0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509",
+    "chain": "polygon_amoy",
+    "type": "EvmWormholeContract",
+    "deploymentType": "pro-compatible-production"
   }
 ]


### PR DESCRIPTION
Deploys the pro-compatible (`pro-compatible-production`) Core price feed contracts to Polygon mainnet and Polygon Amoy, following the same procedure as #3889 / #3894 / #3895.

## Deployed contracts

| Chain | Contract | Address |
|---|---|---|
| polygon | EvmPriceFeedContract (proxy) | `0x6E7D74FA7d5c90FEF9F0512987605a6d546181Bb` |
| polygon | WormholeReceiver (half quorum) | `0xf0a1b566B55e0A0CB5BeF52Eb2a57142617Bee67` |
| polygon_amoy | EvmPriceFeedContract (proxy) | `0x0708325268dF9F66270F1401206434524814508b` |
| polygon_amoy | WormholeReceiver (half quorum) | `0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509` |

Config: `--single-update-fee-in-wei 0`, valid time period 60s (default), pro-compatible Pythnet data source (emitter chain 26).

Also switches the `polygon_amoy` RPC in the chain store from `polygon-amoy-bor-rpc.publicnode.com` to `polygon-amoy.drpc.org` (used for this deployment; verified working).

Verified on-chain on both proxies:
- `version() == 1.4.5-alpha.1`, `getValidTimePeriod() == 60`, `singleUpdateFeeInWei() == 0`
- `wormhole()` points at the respective new half-quorum receiver, `validDataSources()` returns the pro-compatible emitter
- Implementation bytecode is byte-identical to the existing pro-compatible fleet (modulo the UUPS `__self` immutable); Polygon mainnet reuses the same deterministic addresses as Cronos mainnet
- A live pro-compatible update executes successfully via `eth_call` on both; a legacy Core (`hermes.pyth.network`) payload correctly reverts with `InvalidWormholeVaa()` on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->