### PR TITLE
Add .github/greenlight.yml (opt into greenlight)

### DIFF
--- a/.github/greenlight.yml
+++ b/.github/greenlight.yml
@@ -1,0 +1,31 @@
+enabled: true
+required_reviewer_checks: []
+# auto_approve_paths is an allowlist: only PR files matching one of these
+# patterns are eligible for self-authorized auto-merge. Everything else
+# (all on-chain contracts, price-service/hermes, publisher/pusher & keeper
+# services, wormhole/quorum, pythnet programs, governance & deployment
+# tooling) stays behind human review. Fail-safe: when in doubt, leave out.
+auto_approve_paths:
+  # Documentation — inert markdown at any depth (READMEs, guides, SECURITY.md, etc.)
+  - "**/*.md"
+  # Repo-wide coding standards / contributor guides (no runtime surface)
+  - "standards/**"
+  # CI / build tooling scripts
+  - "scripts/**"
+  # Documentation sites
+  - "apps/api-reference/**"
+  - "apps/developer-hub/**"
+  # Read-only consumer frontends (consume prices, never produce them)
+  - "apps/entropy-explorer/**"
+  - "apps/insights/**"
+  # Off-chain market-data recorders (ingest external data into ClickHouse for
+  # research; not on the price-delivery wire)
+  - "apps/binance-recorder/**"
+  - "apps/hyperliquid-recorder/**"
+  - "apps/ondo-recorder/**"
+  # Presentational UI packages (not imported by any critical-path tool)
+  - "packages/component-library/**"
+  - "packages/known-publishers/**"
+  # Scaffolding / test-config dev tooling
+  - "packages/create-pyth-package/**"
+  - "packages/jest-config/**"


### PR DESCRIPTION
Adds `.github/greenlight.yml` opting pyth-crosschain into the greenlight service (AI-review + WebAuthn self-authorized auto-merge). Greenlight reads this per-repo config at the PR head sha; a repo without the file is fail-safe opted out.

- `enabled: true` — mandatory opt-in switch.
- `required_reviewer_checks: []` — empty list opts out of the reviewer-gate stage; file-diff eligibility + WebAuthn is the only merge gate.
- `auto_approve_paths` is set on a project basis to only non-critical projects. There is also a server-wide `hard_default_paths` floor (which already blocks workflows, lockfiles, `.env`, Dockerfiles, `CODEOWNERS`, etc.).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->