### PR TITLE
aptos: route contract-upgrade hash consumption through a friend-only accessor

### DIFF
--- a/target_chains/aptos/contracts/sources/governance/contract_upgrade.move
+++ b/target_chains/aptos/contracts/sources/governance/contract_upgrade.move
@@ -37,7 +37,7 @@ module pyth::contract_upgrade {
     ) {
         // Check to see if the hash of the given code and metadata matches the authorized hash.
         // The aptos framework does no validation of the metadata, so we include it in the hash.
-        assert!(matches_hash(code, metadata_serialized, state::get_contract_upgrade_authorized_hash()), error::invalid_upgrade_hash());
+        assert!(matches_hash(code, metadata_serialized, state::take_contract_upgrade_authorized_hash()), error::invalid_upgrade_hash());
         // Perform the upgrade
         let pyth = state::pyth_signer();
         code::publish_package_txn(&pyth, metadata_serialized, code);

--- a/target_chains/aptos/contracts/sources/governance/governance.move
+++ b/target_chains/aptos/contracts/sources/governance/governance.move
@@ -199,7 +199,7 @@ module pyth::governance_test {
         governance::execute_governance_instruction(vaa_bytes);
         assert!(state::get_last_executed_governance_sequence() == 5, 1);
 
-        assert!(state::get_contract_upgrade_authorized_hash() ==
+        assert!(state::take_contract_upgrade_authorized_hash() ==
             contract_upgrade_hash::from_byte_vec(x"a381a47fd0e97f34c71ef491c82208f58cd0080e784c697e65966d2a25d20d56"), 1);
     }
 
@@ -223,7 +223,7 @@ module pyth::governance_test {
         governance::execute_governance_instruction(vaa_bytes);
         assert!(state::get_last_executed_governance_sequence() == 5, 1);
 
-        assert!(state::get_contract_upgrade_authorized_hash() ==
+        assert!(state::take_contract_upgrade_authorized_hash() ==
             contract_upgrade_hash::from_byte_vec(x"a381a47fd0e97f34c71ef491c82208f58cd0080e784c697e65966d2a25d20d56"), 1);
     }
 

--- a/target_chains/aptos/contracts/sources/state.move
+++ b/target_chains/aptos/contracts/sources/state.move
@@ -134,7 +134,15 @@ module pyth::state {
         *table::borrow(&latest_price_info.info, price_identifier)
     }
 
-    public fun get_contract_upgrade_authorized_hash(): Hash acquires ContractUpgradeAuthorized {
+    /// Deprecated. Retained only to preserve the module's public ABI under the
+    /// `compatible` upgrade policy, which forbids removing or narrowing a
+    /// `public fun`. It is disabled and aborts; the upgrade path uses the
+    /// friend-only `take_contract_upgrade_authorized_hash`.
+    public fun get_contract_upgrade_authorized_hash(): Hash {
+        abort error::unauthorized_upgrade()
+    }
+
+    public(friend) fun take_contract_upgrade_authorized_hash(): Hash acquires ContractUpgradeAuthorized {
         assert!(exists<ContractUpgradeAuthorized>(@pyth), error::unauthorized_upgrade());
         let ContractUpgradeAuthorized { hash } = move_from<ContractUpgradeAuthorized>(@pyth);
         hash


### PR DESCRIPTION
Move consumption of the pending contract-upgrade authorization into a new friend-only accessor `pyth::state::take_contract_upgrade_authorized_hash`, and reduce the pre-existing public `get_contract_upgrade_authorized_hash` to a disabled stub.

The Aptos package sets `upgrade_policy = "compatible"`, so each on-chain upgrade must stay backward-compatible: the framework's compatibility checker rejects removing a `public fun` or narrowing it to `public(friend)` at publish time. To respect that, the public function keeps its exact signature but its body now aborts, and the destructive `move_from` logic lives in the new `public(friend)` accessor. All in-package callers (`pyth::contract_upgrade` and the `pyth::governance_test` tests, both already friends of `pyth::state`) are updated to the new accessor.

## Testing

- `aptos move lint --check-test-code --dev` — clean; `aptos move test` — 80/80 pass (CI-pinned Aptos CLI 6.1.1).
- Verified upgrade compatibility on Aptos devnet: published a module with the original `public` accessor, then upgraded under `compatible` policy to the new shape (public abort stub + new `public(friend)` accessor) — accepted (`Executed successfully`). A control upgrade that instead narrowed the accessor to `public(friend)` was rejected with `BACKWARD_INCOMPATIBLE_MODULE_UPDATE`.