### PR TITLE
fix(ci): skip native builds for eccrypto and ssh2 under Node 24

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -184,6 +184,8 @@ engineStrict: true
 
 ignoredBuiltDependencies:
   - "@stellar/stellar-sdk"
+  - eccrypto
+  - ssh2
 
 managePackageManagerVersions: true
 
@@ -204,7 +206,6 @@ onlyBuiltDependencies:
   - core-js
   - core-js-pure
   - cpu-features
-  - eccrypto
   - es5-ext
   - esbuild
   - keccak
@@ -216,7 +217,6 @@ onlyBuiltDependencies:
   - protobufjs
   - secp256k1
   - sharp
-  - ssh2
   - tiny-secp256k1
   - truffle
   - usb


### PR DESCRIPTION
## Problem

The `publish-js.yml` workflow fails during `pnpm install` on Node 24. Two transitive dev-tooling dependencies ship native addons pinned to old `nan` versions that no longer compile against V8 in Node 24:

- `eccrypto@1.1.6` → `nan@2.14.0` (`SetAccessor is not a member of v8::ObjectTemplate`, etc.)
- `ssh2@1.16.0` → `nan@2.22.2` (`v8::FunctionCallbackInfo<v8::Value> has no member named 'Holder'`)

Both were listed in `onlyBuiltDependencies`, so their install scripts ran during `pnpm install` and the failure killed the install step before `turbo build` or `pnpm publish` could run.

Neither native addon is a runtime dependency of any published package:

- `eccrypto` (pulled in via `@ethereumjs/tx`) reverts to its pure-JS browser implementation when the native `secp256k1` binding is absent — the repo already patches its entrypoint to make that fallback clean.
- `ssh2` (pulled in via `dockerode` → `docker-modem`) is dev-only tooling.

## Fix

Move `eccrypto` and `ssh2` from `onlyBuiltDependencies` to `ignoredBuiltDependencies` in `pnpm-workspace.yaml`. This makes pnpm skip their install scripts (the JS entrypoints still install, they just don't build the native C++ addons). Because `strictDepBuilds: true` is set, they must be *moved* to `ignoredBuiltDependencies` rather than simply deleted — a plain deletion would leave packages with build scripts that are neither allowed nor explicitly ignored, which `strictDepBuilds` rejects. The native addons we actually need (`secp256k1`, `sharp`, `node-hid`, etc.) are untouched, so `--ignore-scripts` is deliberately avoided.

## Validation (local, Node 24.12.0, pnpm 10.28.0)

- `pnpm install` succeeds — no eccrypto/ssh2 native-build failures, `strictDepBuilds` does not fire, `secp256k1` and the other allowed addons still build.
- `pnpm run turbo build --filter=@pythnetwork/price-pusher --filter=@pythnetwork/pyth-sui-js` succeeds (22/22 tasks). `price-pusher` is the package that transitively depends on `eccrypto`, confirming the browser fallback works with no native addon.
- The full `turbo build` was not run to completion locally only because `@pythnetwork/pyth-evm-contract:install-forge-deps` requires git submodules absent from the sandbox bundle — unrelated to this change; CI sets up Foundry/forge deps separately.