### PR TITLE
cardano: Fix Wormhole guardian set VAAs CSV URL

### DIFF
--- a/lazer/contracts/cardano/cli/js/src/wormhole.ts
+++ b/lazer/contracts/cardano/cli/js/src/wormhole.ts
@@ -9,7 +9,7 @@ import type { VAA } from "@wormhole-foundation/sdk-definitions";
 import * as wormhole from "@wormhole-foundation/sdk-definitions";
 
 const GUARDIAN_SET_VAAS_URL =
-  "https://raw.githubusercontent.com/wormhole-foundation/wormhole/refs/heads/main/deployments/mainnet/guardianSetVAAs.csv";
+  "https://raw.githubusercontent.com/wormhole-foundation/wormhole/refs/heads/main/guardianset/mainnetv2/canonical_sets/guardianSetVAAs.csv";
 
 export type PreparedVAA = {
   vaa: Uint8Array;


### PR DESCRIPTION
## Rationale

CSV with guardian set VAAs was moved to a different location in upstream repo.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->