### PR TITLE
docs(push-feeds): refresh pro_compatible_status from Hermes (2026-07-17)

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/aptos/aptos-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/aptos/aptos-mainnet.json
@@ -5,161 +5,184 @@
       "id": "03ae4db29ed4ae33d323568895aa00337e658e348b37509f5372ae51f0af00d5",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "BTC/USD",
       "id": "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "ETH/USD",
       "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SOL/USD",
       "id": "ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDC/USD",
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDT/USD",
       "id": "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USD1/USD",
       "id": "0a2425d43486780990d8b63543029e20556be51fd756cca584212f4d539611d4",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "CAKE/USD",
       "id": "2356af9529a1064d41e32d617e2ce1dca5733afa901daba9e2b68dee5d53ecf9",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SUI/USD",
       "id": "23d7315113f5b1d3ba7a83604c44b94d79f4fd69af77f804fc7f920a6dc65744",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "STAPT/APT.RR",
       "id": "2f218a73fb0c46ae8f9f7bb70ffbb232dd0dd65169b6401bfdc9bfb340a66b1a",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "AMI/USD",
       "id": "9074ab34363ea1aada15db169f4678c10117e48f1ad1a8ba9f69c2a939c3a377",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "SUSDE/USDE.RR",
       "id": "271c64ce459937abf721d42552035713b6c58f80eeceab716a624607fda4b10f",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "CETUS/USD",
       "id": "e5b274b2611143df055d6e7cd8d93fe1961716bcd4dca1cad87a83bc1e78c1ef",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "BNB/USD",
       "id": "2f95862b045670cd22bee3114c39763a4a08beeb663b145d283c31d7d1101c4f",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WBTC/USD",
       "id": "c9d8b075a5c69303365ae23633d4e085199bf5c520a3b90fed1322a0342ffc33",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDY/USD",
       "id": "e393449f6aff8a4b6d3e1165a7c9ebec103685f3b41e60db4277b5b6d10e7326",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WETH/USD",
       "id": "9d4294bbcd1174d6f2003ec365831e64cc31d9f6f15a2b85399db8d5000960f6",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "STONE/USD",
       "id": "4dcc2fb96fb89a802ef9712f6bd2246d3607cf95ca5540cb24490d37003f8c46",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "SUSDE/USD",
       "id": "ca3ba9a619a4b3755c10ac7d5e760275aa95e9823d38a84fedd416856cdba37c",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDE/USD",
       "id": "6ec879b1e9963de5ee97e9c8710b742d6228252a5e2ca12d4ae81d7fe5ee8c5d",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "STHAPT/THAPT.RR",
       "id": "ea07fce25d7d716fe6ad10b267451011baadc8f3724b28487026072ddce3ba1b",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "RION/USD",
       "id": "2d8b864599418dc83cb33fe1d91f69e90c8c1c32123d74211950f52a5cef006a",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "KAPT/USD",
       "id": "a44d307a13145b84938740c93155fbea926e9fbdd46d50b67859b8fc47552959",
       "time_difference": 15,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/base-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/base-mainnet.json
@@ -30,7 +30,7 @@
       "time_difference": 3600,
       "price_deviation": 1,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WSTETH/USD",
@@ -62,7 +62,7 @@
       "time_difference": 3600,
       "price_deviation": 1,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/ethereum-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/ethereum-mainnet.json
@@ -22,7 +22,7 @@
       "time_difference": 3600,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SPYX/USD",

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/hyperevm-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/hyperevm-mainnet.json
@@ -110,7 +110,7 @@
       "time_difference": 3600,
       "price_deviation": 1,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "LHYPE/USD",
@@ -174,7 +174,7 @@
       "time_difference": 3600,
       "price_deviation": 1,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "UBTC/USD",
@@ -182,7 +182,7 @@
       "time_difference": 3600,
       "price_deviation": 1,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "CMETH/METH.RR",
@@ -206,7 +206,7 @@
       "time_difference": 3600,
       "price_deviation": 1,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "XAU/USD",
@@ -270,7 +270,7 @@
       "time_difference": 3600,
       "price_deviation": 1,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "KHYPE/USD",
@@ -278,7 +278,7 @@
       "time_difference": 3600,
       "price_deviation": 1,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "HAHYPE/HYPE.RR",
@@ -310,7 +310,7 @@
       "time_difference": 3600,
       "price_deviation": 1,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDN/USD",

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/monad-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/monad-mainnet.json
@@ -86,7 +86,7 @@
       "time_difference": 3600,
       "price_deviation": 0.2,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SUI/USD",
@@ -206,7 +206,7 @@
       "time_difference": 3600,
       "price_deviation": 0.2,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "RSETH/USD",
@@ -230,7 +230,7 @@
       "time_difference": 3600,
       "price_deviation": 0.2,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "RSETH/ETH.RR",

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/movement/movement-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/movement/movement-mainnet.json
@@ -5,161 +5,184 @@
       "id": "6bf748c908767baa762a1563d454ebec2d5108f8ee36d806aadacc8f0a075b6d",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "APT/USD",
       "id": "03ae4db29ed4ae33d323568895aa00337e658e348b37509f5372ae51f0af00d5",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDC/USD",
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDT/USD",
       "id": "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SUSDE/USD",
       "id": "ca3ba9a619a4b3755c10ac7d5e760275aa95e9823d38a84fedd416856cdba37c",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WETH/USD",
       "id": "9d4294bbcd1174d6f2003ec365831e64cc31d9f6f15a2b85399db8d5000960f6",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "MOD/USD",
       "id": "9a2a116d85a31d6f1bed19771105557276457094e31791a892758148aa54023d",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "THAPT/USD",
       "id": "b29276972267db5d64ae718fb7f107ad9e72a79cabf9992f0e9bc75ad451a7f6",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "STHAPT/APT.RR",
       "id": "ea07fce25d7d716fe6ad10b267451011baadc8f3724b28487026072ddce3ba1b",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "FRXUSD/USD",
       "id": "7c53208632935ba5122c3cf65a0f4b3e72ba4955b49ad6ba0acf3d9ba405aef3",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "LBTC/USD",
       "id": "8f257aab6e7698bb92b15511915e593d6f8eae914452f781874754b03d0c612b",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "ETH/USD",
       "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "BTC/USD",
       "id": "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WBTC/USD",
       "id": "c9d8b075a5c69303365ae23633d4e085199bf5c520a3b90fed1322a0342ffc33",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WSTETH/USD",
       "id": "6df640f3b8963d8f8358f791f352b8364513f6ab1cca5ed3f1f7b5448980e784",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SOLVBTC/USD",
       "id": "f253cf87dc7d5ed5aa14cba5a6e79aee8bcfaef885a0e1b807035a0bbecc36fa",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "AVALON.USDA/USD",
       "id": "37c307959acbb353e1451bcf7da9d305c8cb8d54c64353588aaf900ffcffdd7d",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "WEETH/USD",
       "id": "9ee4e7c60b940440a261eb54b6d8149c23b580ed7da3139f7f08f4ea29dad395",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "WEETH/ETH.RR",
       "id": "343558e79f587e098c321218ecb34d031ba709ab3e84133126f3c98511b91f64",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "EZETH/USD",
       "id": "06c217a791f5c4f988b36629af4cb88fad827b2485400a358f3b02886b54de92",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "RSETH/USD",
       "id": "0caec284d34d836ca325cf7b3256c078c597bc052fbd3c0283d52b581d68d71f",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "MBTC/USD",
       "id": "6665073f5bc307b97e68654ff11f3d8875abd6181855814d23ab01b8085c0906",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "USDE/USD",
       "id": "6ec879b1e9963de5ee97e9c8710b742d6228252a5e2ca12d4ae81d7fe5ee8c5d",
       "time_difference": 3600,
       "price_deviation": 1,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json
@@ -22,7 +22,7 @@
       "time_difference": 10,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "BNB/USD",
@@ -70,7 +70,7 @@
       "time_difference": 10,
       "price_deviation": 3,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "DOGE/USD",
@@ -102,7 +102,7 @@
       "time_difference": 10,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "HASUI/USD",
@@ -126,7 +126,7 @@
       "time_difference": 10,
       "price_deviation": 3,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "LBTC/USD",
@@ -190,7 +190,7 @@
       "time_difference": 10,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SUI/USD",
@@ -206,7 +206,7 @@
       "time_difference": 10,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "TRX/USD",
@@ -270,7 +270,7 @@
       "time_difference": 10,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "UP/USD",

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/fogo-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/fogo-mainnet.json
@@ -6,7 +6,8 @@
       "id": "245f89fb8084840bd098d661a026032ee21062270003426797c9196d2d8d4e43",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDC/USD",
@@ -14,7 +15,8 @@
       "id": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "SOL/USD",
@@ -22,7 +24,8 @@
       "id": "ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "ETH/USD",
@@ -30,7 +33,8 @@
       "id": "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "USDT/USD",
@@ -38,7 +42,8 @@
       "id": "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "IFOGO/FOGO",
@@ -46,7 +51,8 @@
       "id": "73cb634654bb300aa53ad8e2c60e31eb897eb0af317f8313ca13caad34f75f02",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     },
     {
       "alias": "STFOGO/FOGO",
@@ -54,7 +60,8 @@
       "id": "98601fdcfe6c4600f0788380e87631c3d4488c737991aeea27737ec31676f55d",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/fogo-testnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/fogo-testnet.json
@@ -6,7 +6,8 @@
       "id": "d3cd2bae6315f4f940cbd3a4a915f675f8fba85e33bd6aa5f7b727a15a9c812f",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "fUSD/USD",
@@ -14,7 +15,8 @@
       "id": "8d940f7b53df8dd4b3c33a84c3ba043214c3cdcd5243c03b7cb4b0b22746efd8",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "USDC/USD",
@@ -22,7 +24,8 @@
       "id": "41f3625971ca2ed2263e78573fe5ce23e13d2558ed3f2e47ab0f84fb9e7ae722",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     },
     {
       "alias": "USDT/USD",
@@ -30,7 +33,8 @@
       "id": "1fc18861232290221461220bd4e2acd1dcdfbc89c84092c93c18bdc7756c1588",
       "time_difference": 60,
       "price_deviation": 0.5,
-      "confidence_ratio": 100
+      "confidence_ratio": 100,
+      "pro_compatible_status": "coming_soon"
     }
   ]
 }

--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/solana-mainnet.json
@@ -169,7 +169,7 @@
       "time_difference": 60,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "NEON/USD",
@@ -340,7 +340,7 @@
       "time_difference": 60,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "NTBILL/USD.RR",
@@ -349,7 +349,7 @@
       "time_difference": 60,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "NBASIS/USD.RR",
@@ -358,7 +358,7 @@
       "time_difference": 60,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "NWISDOM/USD.RR",
@@ -367,7 +367,7 @@
       "time_difference": 60,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "NALPHA/USD.RR",
@@ -376,7 +376,7 @@
       "time_difference": 60,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "NFALCON/USD.RR",
@@ -385,7 +385,7 @@
       "time_difference": 60,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "CASH/RD.RR",
@@ -421,7 +421,7 @@
       "time_difference": 60,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     }
   ]
 }

--- a/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
+++ b/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
@@ -25,7 +25,7 @@ const PRO_COMPATIBLE_DOCS_URL = "/price-feeds/core/upgrade/preparing";
  *   2. For each feed, set "available" if its `id` is present in that listing,
  *      otherwise "coming_soon".
  *
- * Last refreshed 2026-07-03. To refresh, re-run the steps above.
+ * Last refreshed 2026-07-17. To refresh, re-run the steps above.
  */
 type ProCompatibleStatus = "available" | "coming_soon";
 


### PR DESCRIPTION
## Summary

- Re-derives `pro_compatible_status` on every push-feed data JSON from a fresh fetch of `https://pyth.dourolabs.app/hermes/v2/price_feeds`.
- Bumps SponsoredFeedsTable JSDoc `Last refreshed` date from `2026-07-03` to `2026-07-17`.
- Rule applied uniformly (Avalanche included): `available` iff the feed `id` is in the Hermes set, otherwise `coming_soon`.

## Hermes fetch summary

- Endpoint: `https://pyth.dourolabs.app/hermes/v2/price_feeds`
- Fetched at: `2026-07-17T13:05:17Z`
- Unique lowercase 64-hex ids returned: **1376** (from 1378 entries; the endpoint returned three copies of one id, which does not affect membership).

## Before/after status counts

`available/coming_soon` per file.

| File | Before | After |
| --- | --- | --- |
| `aptos/aptos-mainnet.json` | 0/0 | 17/6 |
| `evm/abstract-mainnet.json` | 4/0 | 4/0 |
| `evm/arbitrum-mainnet.json` | 0/1 | 0/1 |
| `evm/avalanche-mainnet.json` | 0/1 | 0/1 |
| `evm/base-mainnet.json` | 6/2 | 8/0 |
| `evm/berachain-mainnet.json` | 7/2 | 7/2 |
| `evm/ethereum-mainnet.json` | 3/1 | 4/0 |
| `evm/hyperevm-mainnet.json` | 16/27 | 23/20 |
| `evm/linea-mainnet.json` | 1/0 | 1/0 |
| `evm/monad-mainnet.json` | 48/12 | 51/9 |
| `evm/optimism-mainnet.json` | 5/0 | 5/0 |
| `evm/soneium-mainnet.json` | 7/0 | 7/0 |
| `evm/sonic-mainnet.json` | 7/4 | 7/4 |
| `movement/movement-mainnet.json` | 0/0 | 14/9 |
| `sui/sui-mainnet.json` | 18/18 | 25/11 |
| `svm/fogo-mainnet.json` | 0/0 | 7/0 |
| `svm/fogo-testnet.json` | 0/0 | 0/4 |
| `svm/solana-mainnet.json` | 33/14 | 41/6 |
| **TOTAL** | **155/82** | **221/73** |

Net delta: **+66 available**, **-9 coming_soon**.

## Flips reported in the parent-issue drift report

The parent-issue description headline said "26 reported flips" but the itemized list under it contains **28** entries (hyperevm has 7 and solana has 8 — the headline is a miscount). All 28 itemized flips are applied by this PR.

| File | Alias | Id | Old -> New |
| --- | --- | --- | --- |
| `evm/base-mainnet.json` | CBETH/USD | `15ecddd2…` | `coming_soon` -> `available` |
| `evm/base-mainnet.json` | WEETH/USD | `9ee4e7c6…` | `coming_soon` -> `available` |
| `evm/ethereum-mainnet.json` | BOLD/USD | `d6134dbb…` | `coming_soon` -> `available` |
| `evm/hyperevm-mainnet.json` | WSTHYPE/STHYPE.RR | `1a78b582…` | `coming_soon` -> `available` |
| `evm/hyperevm-mainnet.json` | UETH/USD | `08c73e18…` | `coming_soon` -> `available` |
| `evm/hyperevm-mainnet.json` | UBTC/USD | `42bfb267…` | `coming_soon` -> `available` |
| `evm/hyperevm-mainnet.json` | USOL/USD | `974c7a77…` | `coming_soon` -> `available` |
| `evm/hyperevm-mainnet.json` | KHYPE/HYPE.RR | `983b7cab…` | `coming_soon` -> `available` |
| `evm/hyperevm-mainnet.json` | KHYPE/USD | `2837a61a…` | `coming_soon` -> `available` |
| `evm/hyperevm-mainnet.json` | USDT0/USD | `cfc1303e…` | `coming_soon` -> `available` |
| `evm/monad-mainnet.json` | STETH/ETH.RR | `cf40822c…` | `coming_soon` -> `available` |
| `evm/monad-mainnet.json` | WEETH/USD | `9ee4e7c6…` | `coming_soon` -> `available` |
| `evm/monad-mainnet.json` | WEETH/EETH.RR | `343558e7…` | `coming_soon` -> `available` |
| `sui/sui-mainnet.json` | BLUE/USD | `04cfeb7b…` | `coming_soon` -> `available` |
| `sui/sui-mainnet.json` | DMC/USD | `8abfa63a…` | `coming_soon` -> `available` |
| `sui/sui-mainnet.json` | HAEDAL/USD | `e67d98cc…` | `coming_soon` -> `available` |
| `sui/sui-mainnet.json` | IKA/USD | `2b529621…` | `coming_soon` -> `available` |
| `sui/sui-mainnet.json` | STSUI/USD | `0b3eae8c…` | `coming_soon` -> `available` |
| `sui/sui-mainnet.json` | SUIUSDE/USD | `8cead549…` | `coming_soon` -> `available` |
| `sui/sui-mainnet.json` | XAUM/USD.RR | `d7db0679…` | `coming_soon` -> `available` |
| `svm/solana-mainnet.json` | MNDE/USD | `3607bf4d…` | `coming_soon` -> `available` |
| `svm/solana-mainnet.json` | NOPAL/USD.RR | `8858dfaa…` | `coming_soon` -> `available` |
| `svm/solana-mainnet.json` | NTBILL/USD.RR | `f03015f2…` | `coming_soon` -> `available` |
| `svm/solana-mainnet.json` | NBASIS/USD.RR | `fd9397e6…` | `coming_soon` -> `available` |
| `svm/solana-mainnet.json` | NWISDOM/USD.RR | `384986c9…` | `coming_soon` -> `available` |
| `svm/solana-mainnet.json` | NALPHA/USD.RR | `57d1e11b…` | `coming_soon` -> `available` |
| `svm/solana-mainnet.json` | NFALCON/USD.RR | `32364732…` | `coming_soon` -> `available` |
| `svm/solana-mainnet.json` | JUPUSD/USD | `8ed858a2…` | `coming_soon` -> `available` |

## Additional drift found beyond the parent-issue report

Two categories:

1. **Files that previously had no `pro_compatible_status` field at all** (`aptos/aptos-mainnet.json`, `movement/movement-mainnet.json`, `svm/fogo-mainnet.json`, `svm/fogo-testnet.json`). The load-bearing data-source rule requires every feed to have `pro_compatible_status` derived from Hermes, so the field is now populated on these too. These MDX pages (`aptos.mdx`, `movement.mdx`, `fogo.mdx`) don't currently pass `showProCompatibleStatus` so this addition is not user-visible today, but it satisfies the acceptance criteria "Fresh `hermes/v2/price_feeds` fetch drives every JSON's `pro_compatible_status` field".
2. **Genuine additional drift**: none — every JSON that already had `pro_compatible_status` set had its values match Hermes exactly _outside_ of the 28 flips listed above.

| File | Alias | Id | Old -> New |
| --- | --- | --- | --- |
| `aptos/aptos-mainnet.json` | APT/USD | `03ae4db2…` | `(unset)` -> `available` |
| `aptos/aptos-mainnet.json` | BTC/USD | `e62df6c8…` | `(unset)` -> `available` |
| `aptos/aptos-mainnet.json` | ETH/USD | `ff61491a…` | `(unset)` -> `available` |
| `aptos/aptos-mainnet.json` | SOL/USD | `ef0d8b6f…` | `(unset)` -> `available` |
| `aptos/aptos-mainnet.json` | USDC/USD | `eaa020c6…` | `(unset)` -> `available` |
| `aptos/aptos-mainnet.json` | USDT/USD | `2b89b9dc…` | `(unset)` -> `available` |
| `aptos/aptos-mainnet.json` | USD1/USD | `0a2425d4…` | `(unset)` -> `available` |
| `aptos/aptos-mainnet.json` | CAKE/USD | `2356af95…` | `(unset)` -> `available` |
| `aptos/aptos-mainnet.json` | SUI/USD | `23d73151…` | `(unset)` -> `available` |
| `aptos/aptos-mainnet.json` | STAPT/APT.RR | `2f218a73…` | `(unset)` -> `coming_soon` |
| `aptos/aptos-mainnet.json` | AMI/USD | `9074ab34…` | `(unset)` -> `coming_soon` |
| `aptos/aptos-mainnet.json` | SUSDE/USDE.RR | `271c64ce…` | `(unset)` -> `available` |
| `aptos/aptos-mainnet.json` | CETUS/USD | `e5b274b2…` | `(unset)` -> `available` |
| `aptos/aptos-mainnet.json` | BNB/USD | `2f95862b…` | `(unset)` -> `available` |
| `aptos/aptos-mainnet.json` | WBTC/USD | `c9d8b075…` | `(unset)` -> `available` |
| `aptos/aptos-mainnet.json` | USDY/USD | `e393449f…` | `(unset)` -> `available` |
| `aptos/aptos-mainnet.json` | WETH/USD | `9d4294bb…` | `(unset)` -> `available` |
| `aptos/aptos-mainnet.json` | STONE/USD | `4dcc2fb9…` | `(unset)` -> `coming_soon` |
| `aptos/aptos-mainnet.json` | SUSDE/USD | `ca3ba9a6…` | `(unset)` -> `available` |
| `aptos/aptos-mainnet.json` | USDE/USD | `6ec879b1…` | `(unset)` -> `available` |
| `aptos/aptos-mainnet.json` | STHAPT/THAPT.RR | `ea07fce2…` | `(unset)` -> `coming_soon` |
| `aptos/aptos-mainnet.json` | RION/USD | `2d8b8645…` | `(unset)` -> `coming_soon` |
| `aptos/aptos-mainnet.json` | KAPT/USD | `a44d307a…` | `(unset)` -> `coming_soon` |
| `movement/movement-mainnet.json` | MOVE/USD | `6bf748c9…` | `(unset)` -> `available` |
| `movement/movement-mainnet.json` | APT/USD | `03ae4db2…` | `(unset)` -> `available` |
| `movement/movement-mainnet.json` | USDC/USD | `eaa020c6…` | `(unset)` -> `available` |
| `movement/movement-mainnet.json` | USDT/USD | `2b89b9dc…` | `(unset)` -> `available` |
| `movement/movement-mainnet.json` | SUSDE/USD | `ca3ba9a6…` | `(unset)` -> `available` |
| `movement/movement-mainnet.json` | WETH/USD | `9d4294bb…` | `(unset)` -> `available` |
| `movement/movement-mainnet.json` | MOD/USD | `9a2a116d…` | `(unset)` -> `coming_soon` |
| `movement/movement-mainnet.json` | THAPT/USD | `b2927697…` | `(unset)` -> `coming_soon` |
| `movement/movement-mainnet.json` | STHAPT/APT.RR | `ea07fce2…` | `(unset)` -> `coming_soon` |
| `movement/movement-mainnet.json` | FRXUSD/USD | `7c532086…` | `(unset)` -> `coming_soon` |
| `movement/movement-mainnet.json` | LBTC/USD | `8f257aab…` | `(unset)` -> `available` |
| `movement/movement-mainnet.json` | ETH/USD | `ff61491a…` | `(unset)` -> `available` |
| `movement/movement-mainnet.json` | BTC/USD | `e62df6c8…` | `(unset)` -> `available` |
| `movement/movement-mainnet.json` | WBTC/USD | `c9d8b075…` | `(unset)` -> `available` |
| `movement/movement-mainnet.json` | WSTETH/USD | `6df640f3…` | `(unset)` -> `available` |
| `movement/movement-mainnet.json` | SOLVBTC/USD | `f253cf87…` | `(unset)` -> `coming_soon` |
| `movement/movement-mainnet.json` | AVALON.USDA/USD | `37c30795…` | `(unset)` -> `coming_soon` |
| `movement/movement-mainnet.json` | WEETH/USD | `9ee4e7c6…` | `(unset)` -> `available` |
| `movement/movement-mainnet.json` | WEETH/ETH.RR | `343558e7…` | `(unset)` -> `available` |
| `movement/movement-mainnet.json` | EZETH/USD | `06c217a7…` | `(unset)` -> `coming_soon` |
| `movement/movement-mainnet.json` | RSETH/USD | `0caec284…` | `(unset)` -> `coming_soon` |
| `movement/movement-mainnet.json` | MBTC/USD | `6665073f…` | `(unset)` -> `coming_soon` |
| `movement/movement-mainnet.json` | USDE/USD | `6ec879b1…` | `(unset)` -> `available` |
| `svm/fogo-mainnet.json` | FOGO/USD | `245f89fb…` | `(unset)` -> `available` |
| `svm/fogo-mainnet.json` | USDC/USD | `eaa020c6…` | `(unset)` -> `available` |
| `svm/fogo-mainnet.json` | SOL/USD | `ef0d8b6f…` | `(unset)` -> `available` |
| `svm/fogo-mainnet.json` | ETH/USD | `ff61491a…` | `(unset)` -> `available` |
| `svm/fogo-mainnet.json` | USDT/USD | `2b89b9dc…` | `(unset)` -> `available` |
| `svm/fogo-mainnet.json` | IFOGO/FOGO | `73cb6346…` | `(unset)` -> `available` |
| `svm/fogo-mainnet.json` | STFOGO/FOGO | `98601fdc…` | `(unset)` -> `available` |
| `svm/fogo-testnet.json` | FOGO/USD | `d3cd2bae…` | `(unset)` -> `coming_soon` |
| `svm/fogo-testnet.json` | fUSD/USD | `8d940f7b…` | `(unset)` -> `coming_soon` |
| `svm/fogo-testnet.json` | USDC/USD | `41f36259…` | `(unset)` -> `coming_soon` |
| `svm/fogo-testnet.json` | USDT/USD | `1fc18861…` | `(unset)` -> `coming_soon` |

## Verification

- `pnpm turbo run test:format test:types test:lint --filter=@pythnetwork/developer-hub` — **46 tasks passed** (includes the developer-hub Next.js `build` as a dependency, which prerenders all 197 MDX pages using the updated JSONs).
- Post-write scan: iterated every feed in every JSON and confirmed `pro_compatible_status` matches Hermes-set membership. Mismatches: **0**. Missing `pro_compatible_status`: **0**.
- Confirmed Avalanche `_comment` field is absent from `data/evm/avalanche-mainnet.json` and no Avalanche clause is present in the SponsoredFeedsTable JSDoc — nothing to remove.
- No id/alias/time_difference/price_deviation/confidence_ratio/account_address values changed; no entries added or reordered; the `PRO_COMPATIBLE_DOCS_URL` and column-header link constants are untouched.