### PR TITLE
feat(developer-hub): search Pyth Pro feeds by hermes_id / nasdaq_symbol / cmc_id

### DIFF
--- a/apps/developer-hub/src/components/PriceFeedIdsProTable/index.tsx
+++ b/apps/developer-hub/src/components/PriceFeedIdsProTable/index.tsx
@@ -16,10 +16,10 @@ import styles from "./index.module.scss";
 import { filterFeedsBySearch } from "./search";
 
 const CHANNELS = [
-  { id: "real_time", label: "RT", fullName: "Real Time" },
-  { id: "fixed_rate@50ms", label: "50ms", fullName: "fixed_rate@50ms" },
-  { id: "fixed_rate@200ms", label: "200ms", fullName: "fixed_rate@200ms" },
-  { id: "fixed_rate@1000ms", label: "1s", fullName: "fixed_rate@1000ms" },
+  { fullName: "Real Time", id: "real_time", label: "RT" },
+  { fullName: "fixed_rate@50ms", id: "fixed_rate@50ms", label: "50ms" },
+  { fullName: "fixed_rate@200ms", id: "fixed_rate@200ms", label: "200ms" },
+  { fullName: "fixed_rate@1000ms", id: "fixed_rate@1000ms", label: "1s" },
 ] as const;
 
 const normalizeChannelId = (channelId: string) =>
@@ -53,26 +53,26 @@ const ChannelSupportIndicator = ({ minChannel }: { minChannel: string }) => {
   const label = `Fastest channel: ${minChannelLabel}. Supported channels: ${supportedChannels}.`;
 
   return (
-    <div className={styles.channelIndicator} role="img" aria-label={label}>
-      <div className={styles.channelTrack} aria-hidden="true">
+    <div aria-label={label} className={styles.channelIndicator} role="img">
+      <div aria-hidden="true" className={styles.channelTrack}>
         {CHANNELS.map((channel, index) => (
           <span
-            key={channel.id}
             className={[
               styles.channelSegment,
               index >= minChannelIndex ? styles.channelSegmentActive : "",
             ].join(" ")}
+            key={channel.id}
           />
         ))}
       </div>
-      <div className={styles.channelLabels} aria-hidden="true">
+      <div aria-hidden="true" className={styles.channelLabels}>
         {CHANNELS.map((channel, index) => (
           <span
-            key={channel.id}
             className={[
               styles.channelLabel,
               index >= minChannelIndex ? styles.channelLabelActive : "",
             ].join(" ")}
+            key={channel.id}
             title={channel.fullName}
           >
             {channel.label}
@@ -84,14 +84,14 @@ const ChannelSupportIndicator = ({ minChannel }: { minChannel: string }) => {
 };
 
 const LEGEND_DESCRIPTIONS: Record<(typeof CHANNELS)[number]["id"], string> = {
-  real_time:
-    "Minimum channel: Real Time. Published on Real Time, fixed_rate@50ms, fixed_rate@200ms, and fixed_rate@1000ms.",
   "fixed_rate@50ms":
     "Minimum channel: fixed_rate@50ms. Published on fixed_rate@50ms, fixed_rate@200ms, and fixed_rate@1000ms.",
   "fixed_rate@200ms":
     "Minimum channel: fixed_rate@200ms. Published on fixed_rate@200ms and fixed_rate@1000ms.",
   "fixed_rate@1000ms":
     "Minimum channel: fixed_rate@1000ms. Published on fixed_rate@1000ms only.",
+  real_time:
+    "Minimum channel: Real Time. Published on Real Time, fixed_rate@50ms, fixed_rate@200ms, and fixed_rate@1000ms.",
 };
 
 export const ChannelLegend = () => (
@@ -103,7 +103,7 @@ export const ChannelLegend = () => (
     </p>
     <ul className={styles.legendRows}>
       {CHANNELS.map((channel) => (
-        <li key={channel.id} className={styles.legendRow}>
+        <li className={styles.legendRow} key={channel.id}>
           <ChannelSupportIndicator minChannel={channel.id} />
           <span className={styles.legendText}>
             {LEGEND_DESCRIPTIONS[channel.id]}
@@ -118,18 +118,18 @@ const FEED_STATES = ["stable", "coming_soon", "inactive"] as const;
 type FeedState = (typeof FEED_STATES)[number];
 
 const FEED_STATE_LABELS: Record<FeedState, string> = {
-  stable: "Stable",
   coming_soon: "Coming Soon",
   inactive: "Inactive",
+  stable: "Stable",
 };
 
 const FEED_STATE_BADGE_VARIANT: Record<
   FeedState,
   "success" | "warning" | "neutral"
 > = {
-  stable: "success",
   coming_soon: "warning",
   inactive: "neutral",
+  stable: "success",
 };
 
 export const PriceFeedIdsProTable = () => {
@@ -168,7 +168,7 @@ export const PriceFeedIdsProTable = () => {
     { id: "description", name: "Description" },
     { id: "name", name: "Name" },
     { id: "symbol", name: "Symbol" },
-    { id: "pyth_lazer_id", name: "Pyth Pro ID", isRowHeader: true },
+    { id: "pyth_lazer_id", isRowHeader: true, name: "Pyth Pro ID" },
     { id: "exponent", name: "Exponent" },
     { id: "state", name: "Status" },
     { id: "channels", name: "Channels" },
@@ -199,9 +199,9 @@ export const PriceFeedIdsProTable = () => {
     },
     filterFeedsBySearch,
     {
-      defaultSort: "pyth_lazer_id",
-      defaultPageSize: 10,
       defaultDescending: false,
+      defaultPageSize: 10,
+      defaultSort: "pyth_lazer_id",
     },
   );
 
@@ -246,50 +246,50 @@ export const PriceFeedIdsProTable = () => {
   const allSelected = selectedStates.size === FEED_STATES.length;
 
   const rows = paginatedItems.map((feed) => ({
-    id: feed.pyth_lazer_id,
     data: {
       asset_type: feed.asset_type,
+      channels: <ChannelSupportIndicator minChannel={feed.min_channel} />,
       description: (
         <div className={styles.descriptionContent}>{feed.description}</div>
       ),
-      name: feed.name,
-      symbol: feed.symbol,
-      pyth_lazer_id: feed.pyth_lazer_id,
       exponent: feed.exponent,
+      name: feed.name,
+      pyth_lazer_id: feed.pyth_lazer_id,
       state: (
-        <Badge variant={FEED_STATE_BADGE_VARIANT[feed.state]} size="xs">
+        <Badge size="xs" variant={FEED_STATE_BADGE_VARIANT[feed.state]}>
           {FEED_STATE_LABELS[feed.state]}
         </Badge>
       ),
-      channels: <ChannelSupportIndicator minChannel={feed.min_channel} />,
+      symbol: feed.symbol,
     },
+    id: feed.pyth_lazer_id,
   }));
 
   return (
     <>
       <SearchInput
+        className={styles.searchInput ?? ""}
         label="Search price feeds"
+        onChange={updateSearch}
         placeholder="Search by symbol, name, ID, or hex feed ID"
         value={search}
-        onChange={updateSearch}
-        className={styles.searchInput ?? ""}
       />
 
       {statusCounts && (
         <div
+          aria-label="Filter by status"
           className={styles.statusFilters}
           role="group"
-          aria-label="Filter by status"
         >
           <button
-            type="button"
             className={styles.filterButton}
             onClick={toggleAll}
+            type="button"
           >
             <Badge
-              variant={allSelected ? "info" : "neutral"}
-              style="outline"
               size="md"
+              style="outline"
+              variant={allSelected ? "info" : "neutral"}
             >
               {allSelected && <Check className={styles.checkIcon} />}
               All ({statusCounts.all})
@@ -299,19 +299,19 @@ export const PriceFeedIdsProTable = () => {
             const isSelected = selectedStates.has(feedState);
             return (
               <button
-                key={feedState}
-                type="button"
                 className={styles.filterButton}
+                key={feedState}
                 onClick={() => {
                   toggleState(feedState);
                 }}
+                type="button"
               >
                 <Badge
+                  size="md"
+                  style="outline"
                   variant={
                     isSelected ? FEED_STATE_BADGE_VARIANT[feedState] : "neutral"
                   }
-                  style="outline"
-                  size="md"
                 >
                   {isSelected && <Check className={styles.checkIcon} />}
                   {FEED_STATE_LABELS[feedState]} ({statusCounts[feedState]})
@@ -325,23 +325,23 @@ export const PriceFeedIdsProTable = () => {
       <div className={styles.tableWrapper}>
         <Table<Col>
           {...(isLoading ? { isLoading: true } : { isLoading: false, rows })}
-          label="Pyth Pro price feed ids"
           columns={columns}
+          fill
+          label="Pyth Pro price feed ids"
           onSortChange={updateSortDescriptor}
+          rounded
           sortDescriptor={sortDescriptor}
           stickyHeader="top"
-          fill
-          rounded
         />
       </div>
       <Paginator
-        numPages={numPages}
-        currentPage={page}
-        onPageChange={updatePage}
-        pageSize={pageSize}
-        onPageSizeChange={updatePageSize}
-        mkPageLink={mkPageLink}
         className={styles.paginator ?? ""}
+        currentPage={page}
+        mkPageLink={mkPageLink}
+        numPages={numPages}
+        onPageChange={updatePage}
+        onPageSizeChange={updatePageSize}
+        pageSize={pageSize}
       />
     </>
   );
@@ -355,13 +355,13 @@ enum StateType {
 }
 
 const State = {
-  NotLoaded: () => ({ type: StateType.NotLoaded as const }),
-  Loading: () => ({ type: StateType.Loading as const }),
+  Failed: (error: unknown) => ({ error, type: StateType.Error as const }),
   Loaded: (feeds: Awaited<ReturnType<typeof getPythProFeeds>>) => ({
-    type: StateType.Loaded as const,
     feeds,
+    type: StateType.Loaded as const,
   }),
-  Failed: (error: unknown) => ({ type: StateType.Error as const, error }),
+  Loading: () => ({ type: StateType.Loading as const }),
+  NotLoaded: () => ({ type: StateType.NotLoaded as const }),
 };
 type State = ReturnType<(typeof State)[keyof typeof State]>;
 
@@ -380,16 +380,16 @@ const getPythProFeeds = async () => {
 const pythProSchema = z.array(
   z.object({
     asset_type: z.string(),
-    description: z.string(),
-    name: z.string(),
-    symbol: z.string(),
-    pyth_lazer_id: z.number().int().positive(),
-    exponent: z.number(),
-    state: z.enum(["stable", "coming_soon", "inactive"]),
-    min_channel: z.string(),
-    hermes_id: z.string().nullable().optional(),
-    nasdaq_symbol: z.string().nullable().optional(),
     cmc_id: z.number().int().nullable().optional(),
+    description: z.string(),
+    exponent: z.number(),
+    hermes_id: z.string().nullable().optional(),
+    min_channel: z.string(),
+    name: z.string(),
+    nasdaq_symbol: z.string().nullable().optional(),
+    pyth_lazer_id: z.number().int().positive(),
+    state: z.enum(["stable", "coming_soon", "inactive"]),
+    symbol: z.string(),
   }),
 );
 

--- a/apps/developer-hub/src/components/PriceFeedIdsProTable/index.tsx
+++ b/apps/developer-hub/src/components/PriceFeedIdsProTable/index.tsx
@@ -8,12 +8,12 @@ import type { ColumnConfig } from "@pythnetwork/component-library/Table";
 import { Table } from "@pythnetwork/component-library/Table";
 import { useQueryParamFilterPagination } from "@pythnetwork/component-library/useQueryParamsPagination";
 import { Callout } from "fumadocs-ui/components/callout";
-import { matchSorter } from "match-sorter";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { z } from "zod";
 
 import { SYMBOLS_API_URL } from "../../config/pyth-pro-public";
 import styles from "./index.module.scss";
+import { filterFeedsBySearch } from "./search";
 
 const CHANNELS = [
   { id: "real_time", label: "RT", fullName: "Real Time" },
@@ -197,85 +197,7 @@ export const PriceFeedIdsProTable = () => {
       }
       return 0;
     },
-    (items, searchString) => {
-      if (!searchString) {
-        return items;
-      }
-      // Split by commas or spaces to support multiple search terms
-      const searchTerms = searchString
-        .split(/[,\s]+/)
-        .map((term) => term.trim().toLowerCase())
-        .filter((term) => term.length > 0);
-
-      if (searchTerms.length === 0) {
-        return items;
-      }
-
-      // For single term, use matchSorter directly for better ranking
-      const firstTerm = searchTerms[0];
-      if (searchTerms.length === 1 && firstTerm !== undefined) {
-        return matchSorter(items, firstTerm, {
-          keys: ["pyth_lazer_id", "symbol", "name", "description"],
-        });
-      }
-
-      // For multiple terms, use exact/substring matching with OR logic
-      // This ensures each term finds its specific matches
-      const termMatchesItem = (
-        item: (typeof items)[number],
-        term: string,
-      ): boolean => {
-        // Numeric ID match - exact match for numeric terms
-        if (/^\d+$/.test(term)) {
-          return String(item.pyth_lazer_id) === term;
-        }
-
-        // String match - case-insensitive substring match
-        const symbol = item.symbol.toLowerCase();
-        const name = item.name.toLowerCase();
-        const description = item.description.toLowerCase();
-
-        return (
-          symbol.includes(term) ||
-          name.includes(term) ||
-          description.includes(term)
-        );
-      };
-
-      // Collect matches with priority: exact ID matches first, then others
-      const exactIdMatches: (typeof items)[number][] = [];
-      const otherMatches = new Map<number, (typeof items)[number]>();
-
-      for (const term of searchTerms) {
-        const isNumericTerm = /^\d+$/.test(term);
-        for (const item of items) {
-          if (termMatchesItem(item, term)) {
-            // Exact ID matches get priority
-            if (isNumericTerm && String(item.pyth_lazer_id) === term) {
-              if (
-                !exactIdMatches.some(
-                  (m) => m.pyth_lazer_id === item.pyth_lazer_id,
-                )
-              ) {
-                exactIdMatches.push(item);
-              }
-            } else if (
-              !exactIdMatches.some(
-                (m) => m.pyth_lazer_id === item.pyth_lazer_id,
-              )
-            ) {
-              otherMatches.set(item.pyth_lazer_id, item);
-            }
-          }
-        }
-      }
-
-      // Return exact ID matches first, then other matches sorted by ID
-      const otherMatchesArray = [...otherMatches.values()].sort(
-        (a, b) => a.pyth_lazer_id - b.pyth_lazer_id,
-      );
-      return [...exactIdMatches, ...otherMatchesArray];
-    },
+    filterFeedsBySearch,
     {
       defaultSort: "pyth_lazer_id",
       defaultPageSize: 10,
@@ -347,7 +269,7 @@ export const PriceFeedIdsProTable = () => {
     <>
       <SearchInput
         label="Search price feeds"
-        placeholder="Search by symbol, name, or ID (comma/space separated)"
+        placeholder="Search by symbol, name, ID, or hex feed ID"
         value={search}
         onChange={updateSearch}
         className={styles.searchInput ?? ""}
@@ -465,6 +387,9 @@ const pythProSchema = z.array(
     exponent: z.number(),
     state: z.enum(["stable", "coming_soon", "inactive"]),
     min_channel: z.string(),
+    hermes_id: z.string().nullable().optional(),
+    nasdaq_symbol: z.string().nullable().optional(),
+    cmc_id: z.number().int().nullable().optional(),
   }),
 );
 

--- a/apps/developer-hub/src/components/PriceFeedIdsProTable/search.test.ts
+++ b/apps/developer-hub/src/components/PriceFeedIdsProTable/search.test.ts
@@ -1,0 +1,159 @@
+import type { SearchableFeed } from "./search";
+import { filterFeedsBySearch } from "./search";
+
+type TestFeed = SearchableFeed;
+
+const btc: TestFeed = {
+  pyth_lazer_id: 1,
+  symbol: "Crypto.BTC/USD",
+  name: "BTC/USD",
+  description: "Bitcoin / US Dollar",
+  hermes_id: "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
+  nasdaq_symbol: null,
+  cmc_id: 1,
+};
+
+const eth: TestFeed = {
+  pyth_lazer_id: 2,
+  symbol: "Crypto.ETH/USD",
+  name: "ETH/USD",
+  description: "Ether / US Dollar",
+  hermes_id: "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
+  nasdaq_symbol: null,
+  cmc_id: 1027,
+};
+
+const bkng: TestFeed = {
+  pyth_lazer_id: 100,
+  symbol: "Equity.US.BKNG/USD",
+  name: "Booking Holdings",
+  description: "Booking Holdings Inc.",
+  hermes_id: null,
+  nasdaq_symbol: "BKNG",
+  cmc_id: null,
+};
+
+// A decoy feed whose hermes_id happens to contain the digit "1" as a substring
+// (nearly every hex hermes_id does). Used to prove pyth_lazer_id=1 wins.
+const decoy: TestFeed = {
+  pyth_lazer_id: 500,
+  symbol: "Crypto.FAKE/USD",
+  name: "FAKE/USD",
+  description: "Decoy asset",
+  hermes_id: "1111111111111111111111111111111111111111111111111111111111111111",
+  nasdaq_symbol: null,
+  cmc_id: null,
+};
+
+const nullish: TestFeed = {
+  pyth_lazer_id: 999,
+  symbol: "Crypto.NUL/USD",
+  name: "NUL/USD",
+  description: "Feed with null identifiers",
+  hermes_id: null,
+  nasdaq_symbol: null,
+  cmc_id: null,
+};
+
+const allFeeds = [btc, eth, bkng, decoy, nullish];
+
+describe("filterFeedsBySearch", () => {
+  it("returns items unchanged when the search string is empty", () => {
+    expect(filterFeedsBySearch(allFeeds, "")).toBe(allFeeds);
+  });
+
+  it("returns items unchanged when the search string is whitespace only", () => {
+    expect(filterFeedsBySearch(allFeeds, "   ")).toStrictEqual(allFeeds);
+  });
+
+  it("matches a raw hex hermes_id", () => {
+    const result = filterFeedsBySearch(
+      allFeeds,
+      "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
+    );
+    expect(result.map((f) => f.pyth_lazer_id)).toContain(btc.pyth_lazer_id);
+    expect(result[0]).toBe(btc);
+  });
+
+  it("matches a hex hermes_id with a 0x prefix", () => {
+    const result = filterFeedsBySearch(
+      allFeeds,
+      "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
+    );
+    expect(result[0]).toBe(btc);
+  });
+
+  it("matches a hex hermes_id with a 0X (upper-case) prefix", () => {
+    const result = filterFeedsBySearch(
+      allFeeds,
+      "0Xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
+    );
+    expect(result[0]).toBe(btc);
+  });
+
+  it("puts an exact pyth_lazer_id match ahead of a hermes_id substring collision (single-term)", () => {
+    // Single-term path uses matchSorter, which ranks EQUAL matches (btc's
+    // pyth_lazer_id === '1') above CONTAINS matches (decoy's hermes_id
+    // '1111...1111' contains '1').
+    const result = filterFeedsBySearch(allFeeds, "1");
+    expect(result[0]).toBe(btc);
+    expect(result).toContain(decoy);
+    expect(result.indexOf(btc)).toBeLessThan(result.indexOf(decoy));
+  });
+
+  it("puts an exact pyth_lazer_id match ahead of other matches in the multi-term path", () => {
+    // Numeric term "1" → exact pyth_lazer_id match for btc. String term "usd"
+    // → substring match for many. btc must come first.
+    const result = filterFeedsBySearch(allFeeds, "1 usd");
+    expect(result[0]).toBe(btc);
+  });
+
+  it("matches a nasdaq_symbol on an equity feed", () => {
+    const result = filterFeedsBySearch(allFeeds, "BKNG");
+    expect(result).toContain(bkng);
+  });
+
+  it("matches a nasdaq_symbol in the multi-term path", () => {
+    const result = filterFeedsBySearch(allFeeds, "BKNG, ZZZ");
+    expect(result).toContain(bkng);
+  });
+
+  it("matches a cmc_id numerically (single-term)", () => {
+    const result = filterFeedsBySearch(allFeeds, "1027");
+    expect(result.map((f) => f.pyth_lazer_id)).toContain(eth.pyth_lazer_id);
+  });
+
+  it("matches a cmc_id numerically in the multi-term path", () => {
+    // Two terms → multi-term path. "1027" is only a cmc_id match for ETH.
+    const result = filterFeedsBySearch(allFeeds, "1027, ZZZ");
+    expect(result).toContain(eth);
+  });
+
+  it("supports multi-term OR across mixed identifiers", () => {
+    const result = filterFeedsBySearch(allFeeds, "BKNG, 1027");
+    expect(result).toContain(bkng);
+    expect(result).toContain(eth);
+  });
+
+  it("does not blow up on feeds with null hermes_id / nasdaq_symbol / cmc_id", () => {
+    // Single-term path
+    expect(() => filterFeedsBySearch([nullish], "abc")).not.toThrow();
+    // Multi-term path with numeric and string terms
+    expect(() => filterFeedsBySearch([nullish], "abc, 42")).not.toThrow();
+    // Multi-term hex-ish term (would hit hermes_id branch if not null-guarded)
+    expect(() =>
+      filterFeedsBySearch([nullish], "0xdeadbeef, foo"),
+    ).not.toThrow();
+  });
+
+  it("preserves symbol / name / description matching (single-term)", () => {
+    expect(filterFeedsBySearch(allFeeds, "BTC")).toContain(btc);
+    expect(filterFeedsBySearch(allFeeds, "Ether")).toContain(eth);
+    expect(filterFeedsBySearch(allFeeds, "Booking")).toContain(bkng);
+  });
+
+  it("preserves exact pyth_lazer_id single-term match", () => {
+    const result = filterFeedsBySearch(allFeeds, "2");
+    expect(result).toContain(eth);
+  });
+});

--- a/apps/developer-hub/src/components/PriceFeedIdsProTable/search.test.ts
+++ b/apps/developer-hub/src/components/PriceFeedIdsProTable/search.test.ts
@@ -4,55 +4,55 @@ import { filterFeedsBySearch } from "./search";
 type TestFeed = SearchableFeed;
 
 const btc: TestFeed = {
-  pyth_lazer_id: 1,
-  symbol: "Crypto.BTC/USD",
-  name: "BTC/USD",
+  cmc_id: 1,
   description: "Bitcoin / US Dollar",
   hermes_id: "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
+  name: "BTC/USD",
   nasdaq_symbol: null,
-  cmc_id: 1,
+  pyth_lazer_id: 1,
+  symbol: "Crypto.BTC/USD",
 };
 
 const eth: TestFeed = {
-  pyth_lazer_id: 2,
-  symbol: "Crypto.ETH/USD",
-  name: "ETH/USD",
+  cmc_id: 1027,
   description: "Ether / US Dollar",
   hermes_id: "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
+  name: "ETH/USD",
   nasdaq_symbol: null,
-  cmc_id: 1027,
+  pyth_lazer_id: 2,
+  symbol: "Crypto.ETH/USD",
 };
 
 const bkng: TestFeed = {
-  pyth_lazer_id: 100,
-  symbol: "Equity.US.BKNG/USD",
-  name: "Booking Holdings",
+  cmc_id: null,
   description: "Booking Holdings Inc.",
   hermes_id: null,
+  name: "Booking Holdings",
   nasdaq_symbol: "BKNG",
-  cmc_id: null,
+  pyth_lazer_id: 100,
+  symbol: "Equity.US.BKNG/USD",
 };
 
 // A decoy feed whose hermes_id happens to contain the digit "1" as a substring
 // (nearly every hex hermes_id does). Used to prove pyth_lazer_id=1 wins.
 const decoy: TestFeed = {
-  pyth_lazer_id: 500,
-  symbol: "Crypto.FAKE/USD",
-  name: "FAKE/USD",
+  cmc_id: null,
   description: "Decoy asset",
   hermes_id: "1111111111111111111111111111111111111111111111111111111111111111",
+  name: "FAKE/USD",
   nasdaq_symbol: null,
-  cmc_id: null,
+  pyth_lazer_id: 500,
+  symbol: "Crypto.FAKE/USD",
 };
 
 const nullish: TestFeed = {
-  pyth_lazer_id: 999,
-  symbol: "Crypto.NUL/USD",
-  name: "NUL/USD",
+  cmc_id: null,
   description: "Feed with null identifiers",
   hermes_id: null,
+  name: "NUL/USD",
   nasdaq_symbol: null,
-  cmc_id: null,
+  pyth_lazer_id: 999,
+  symbol: "Crypto.NUL/USD",
 };
 
 const allFeeds = [btc, eth, bkng, decoy, nullish];

--- a/apps/developer-hub/src/components/PriceFeedIdsProTable/search.ts
+++ b/apps/developer-hub/src/components/PriceFeedIdsProTable/search.ts
@@ -56,7 +56,12 @@ export const filterFeedsBySearch = <T extends SearchableFeed>(
     // Numeric ID match - exact match for numeric terms against pyth_lazer_id or cmc_id
     if (/^\d+$/.test(term)) {
       if (String(item.pyth_lazer_id) === term) return true;
-      if (item.cmc_id != null && String(item.cmc_id) === term) return true;
+      if (
+        item.cmc_id !== null &&
+        item.cmc_id !== undefined &&
+        String(item.cmc_id) === term
+      )
+        return true;
       return false;
     }
 
@@ -75,7 +80,7 @@ export const filterFeedsBySearch = <T extends SearchableFeed>(
 
     if (item.nasdaq_symbol?.toLowerCase().includes(term)) return true;
 
-    if (item.hermes_id != null) {
+    if (item.hermes_id !== null && item.hermes_id !== undefined) {
       const hermesTerm = stripHexPrefix(term);
       if (hermesTerm && item.hermes_id.toLowerCase().includes(hermesTerm)) {
         return true;

--- a/apps/developer-hub/src/components/PriceFeedIdsProTable/search.ts
+++ b/apps/developer-hub/src/components/PriceFeedIdsProTable/search.ts
@@ -1,0 +1,119 @@
+import { matchSorter } from "match-sorter";
+
+export type SearchableFeed = {
+  pyth_lazer_id: number;
+  symbol: string;
+  name: string;
+  description: string;
+  hermes_id?: string | null | undefined;
+  nasdaq_symbol?: string | null | undefined;
+  cmc_id?: number | null | undefined;
+};
+
+const stripHexPrefix = (value: string): string =>
+  value.startsWith("0x") || value.startsWith("0X") ? value.slice(2) : value;
+
+export const filterFeedsBySearch = <T extends SearchableFeed>(
+  items: T[],
+  searchString: string,
+): T[] => {
+  if (!searchString) {
+    return items;
+  }
+
+  // Split by commas or spaces to support multiple search terms
+  const searchTerms = searchString
+    .split(/[,\s]+/)
+    .map((term) => term.trim().toLowerCase())
+    .filter((term) => term.length > 0);
+
+  if (searchTerms.length === 0) {
+    return items;
+  }
+
+  // For single term, use matchSorter directly for better ranking
+  const firstTerm = searchTerms[0];
+  if (searchTerms.length === 1 && firstTerm !== undefined) {
+    // Strip a leading 0x so users can paste a hermes_id in either form.
+    // Non-hermes fields won't spuriously match a 64-char hex string.
+    const normalizedTerm = stripHexPrefix(firstTerm);
+    return matchSorter(items, normalizedTerm, {
+      keys: [
+        "pyth_lazer_id",
+        "symbol",
+        "name",
+        "description",
+        "hermes_id",
+        "nasdaq_symbol",
+        "cmc_id",
+      ],
+    });
+  }
+
+  // For multiple terms, use exact/substring matching with OR logic
+  // This ensures each term finds its specific matches
+  const termMatchesItem = (item: T, term: string): boolean => {
+    // Numeric ID match - exact match for numeric terms against pyth_lazer_id or cmc_id
+    if (/^\d+$/.test(term)) {
+      if (String(item.pyth_lazer_id) === term) return true;
+      if (item.cmc_id != null && String(item.cmc_id) === term) return true;
+      return false;
+    }
+
+    // String match - case-insensitive substring match
+    const symbol = item.symbol.toLowerCase();
+    const name = item.name.toLowerCase();
+    const description = item.description.toLowerCase();
+
+    if (
+      symbol.includes(term) ||
+      name.includes(term) ||
+      description.includes(term)
+    ) {
+      return true;
+    }
+
+    if (item.nasdaq_symbol != null) {
+      if (item.nasdaq_symbol.toLowerCase().includes(term)) return true;
+    }
+
+    if (item.hermes_id != null) {
+      const hermesTerm = stripHexPrefix(term);
+      if (hermesTerm && item.hermes_id.toLowerCase().includes(hermesTerm)) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+
+  // Collect matches with priority: exact pyth_lazer_id matches first, then others
+  const exactIdMatches: T[] = [];
+  const otherMatches = new Map<number, T>();
+
+  for (const term of searchTerms) {
+    const isNumericTerm = /^\d+$/.test(term);
+    for (const item of items) {
+      if (termMatchesItem(item, term)) {
+        // Exact pyth_lazer_id matches get priority
+        if (isNumericTerm && String(item.pyth_lazer_id) === term) {
+          if (
+            !exactIdMatches.some((m) => m.pyth_lazer_id === item.pyth_lazer_id)
+          ) {
+            exactIdMatches.push(item);
+          }
+        } else if (
+          !exactIdMatches.some((m) => m.pyth_lazer_id === item.pyth_lazer_id)
+        ) {
+          otherMatches.set(item.pyth_lazer_id, item);
+        }
+      }
+    }
+  }
+
+  // Return exact pyth_lazer_id matches first, then other matches sorted by ID
+  const otherMatchesArray = [...otherMatches.values()].sort(
+    (a, b) => a.pyth_lazer_id - b.pyth_lazer_id,
+  );
+  return [...exactIdMatches, ...otherMatchesArray];
+};

--- a/apps/developer-hub/src/components/PriceFeedIdsProTable/search.ts
+++ b/apps/developer-hub/src/components/PriceFeedIdsProTable/search.ts
@@ -112,8 +112,9 @@ export const filterFeedsBySearch = <T extends SearchableFeed>(
   }
 
   // Return exact pyth_lazer_id matches first, then other matches sorted by ID
-  const otherMatchesArray = [...otherMatches.values()].sort(
-    (a, b) => a.pyth_lazer_id - b.pyth_lazer_id,
-  );
+  const exactIds = new Set(exactIdMatches.map((m) => m.pyth_lazer_id));
+  const otherMatchesArray = [...otherMatches.values()]
+    .filter((item) => !exactIds.has(item.pyth_lazer_id))
+    .sort((a, b) => a.pyth_lazer_id - b.pyth_lazer_id);
   return [...exactIdMatches, ...otherMatchesArray];
 };

--- a/apps/developer-hub/src/components/PriceFeedIdsProTable/search.ts
+++ b/apps/developer-hub/src/components/PriceFeedIdsProTable/search.ts
@@ -73,9 +73,7 @@ export const filterFeedsBySearch = <T extends SearchableFeed>(
       return true;
     }
 
-    if (item.nasdaq_symbol != null) {
-      if (item.nasdaq_symbol.toLowerCase().includes(term)) return true;
-    }
+    if (item.nasdaq_symbol?.toLowerCase().includes(term)) return true;
 
     if (item.hermes_id != null) {
       const hermesTerm = stripHexPrefix(term);


### PR DESCRIPTION
## Summary

Extends the Pyth Pro **Price Feed IDs** page search box so users can find a feed by pasting any of the three additional identifiers that the Symbology API returns per feed:

- `hermes_id` (nullable hex string) — pasting `e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43` now surfaces the BTC/USD row, and the `0x`-prefixed form works too.
- `nasdaq_symbol` (nullable) — pasting `BKNG` surfaces the BKNG equity feed.
- `cmc_id` (nullable numeric) — pasting a CoinMarketCap ID matches. The existing exact-`pyth_lazer_id` priority still wins ties.

## Changes

- `PriceFeedIdsProTable/index.tsx`: extend `pythProSchema` with the three new nullable/optional identifier fields; replace the inline search predicate with an imported `filterFeedsBySearch`; update the `SearchInput` placeholder to `"Search by symbol, name, ID, or hex feed ID"`.
- `PriceFeedIdsProTable/search.ts` (new): module-scoped, module-tested `filterFeedsBySearch(items, searchString)`. Adds `hermes_id` / `nasdaq_symbol` / `cmc_id` to the `matchSorter` keys in the single-term path, and to the multi-term `termMatchesItem` — substring match for `hermes_id` (with leading `0x`/`0X` stripped from the term) and `nasdaq_symbol`; exact match for `cmc_id` on numeric terms. Skips fields that are `null` / `undefined`. Preserves exact-`pyth_lazer_id` priority in the multi-term path.
- `PriceFeedIdsProTable/search.test.ts` (new): 15 cases covering hex `hermes_id` (raw / `0x` / `0X`), `nasdaq_symbol` on an equity, `cmc_id` numeric, multi-term OR across mixed identifiers, priority of exact `pyth_lazer_id` over `hermes_id` substring collision, null-identifier feed doesn't blow up, and existing symbol / name / description matching regressions.

## Test plan

- [x] `pnpm turbo run test:types --filter @pythnetwork/developer-hub` — pass (includes `next build`)
- [x] `pnpm turbo run test:lint test:format --filter @pythnetwork/developer-hub` — pass
- [x] `NODE_OPTIONS=--experimental-vm-modules pnpm jest PriceFeedIdsProTable` — 15/15 pass
- [x] Verified against live API (`https://pyth.dourolabs.app/v1/symbols`): the three new fields are present on every row, BKNG's `nasdaq_symbol` is `"BKNG"`, BTC's `hermes_id` is `e62df6...`.