### PR TITLE
docs(developer-hub): move Pyth Core upgrade date to August 18, 2026

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/create-tradingview-charts.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/create-tradingview-charts.mdx
@@ -12,7 +12,7 @@ The TradingView integration allows users to view Pyth prices on their own websit
 <UpgradeCallout chain="index" />
 
 <Callout type="warn">
-  The Benchmarks endpoints below stay at the same URLs after the upgrade, but from **July 31, 2026** every request must include an `Authorization: Bearer $PYTH_API_KEY` header. Get a Pyth API Key on the [billing page](https://app.pyth.com/billing/plans?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=benchmarks-tv-billing).
+  The Benchmarks endpoints below stay at the same URLs after the upgrade, but from **August 18, 2026** every request must include an `Authorization: Bearer $PYTH_API_KEY` header. Get a Pyth API Key on the [billing page](https://app.pyth.com/billing/plans?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=benchmarks-tv-billing).
 </Callout>
 
 ## Choosing an Implementation Method for TradingView Integration

--- a/apps/developer-hub/content/docs/price-feeds/core/create-your-first-pyth-app/evm/part-2.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/create-your-first-pyth-app/evm/part-2.mdx
@@ -113,7 +113,7 @@ curl -s -H "Authorization: Bearer $PYTH_API_KEY" \
 <Tab value="Current endpoint">
 
 ```bash copy
-# Authentication becomes required on July 31, 2026.
+# Authentication becomes required on August 18, 2026.
 curl -s -H "Authorization: Bearer $PYTH_API_KEY" \
   "https://hermes.pyth.network/v2/updates/price/latest?&ids[]=$ETH_USD_ID" | jq -r ".binary.data[0]" > price_update.txt
 ```

--- a/apps/developer-hub/content/docs/price-feeds/core/fetch-price-updates.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/fetch-price-updates.mdx
@@ -51,7 +51,7 @@ curl -X 'GET' \
 <Tab value="Current endpoint">
 
 ```bash copy
-# Authentication becomes required on July 31, 2026.
+# Authentication becomes required on August 18, 2026.
 curl -X 'GET' \
   -H "Authorization: Bearer $PYTH_API_KEY" \
   'https://hermes.pyth.network/v2/updates/price/latest?ids%5B%5D=0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43&ids%5B%5D=0xc96458d393fe9deb7a7d63a0ac41e2898a67a7750dbd166673279e06c868df0a'

--- a/apps/developer-hub/content/docs/price-feeds/core/getting-started.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/getting-started.mdx
@@ -4,7 +4,7 @@ description: Explore key resources to begin integrating Pyth price feeds
 slug: /price-feeds/core/getting-started
 ---
 
-Integrating Pyth price feeds is quick and easy. Pyth price feeds are permissionless on-chain. From **July 31, 2026**, calling the Hermes price API requires a Pyth API Key — see the upgrade callout below.
+Integrating Pyth price feeds is quick and easy. Pyth price feeds are permissionless on-chain. From **August 18, 2026**, calling the Hermes price API requires a Pyth API Key — see the upgrade callout below.
 
 <UpgradeCallout chain="index" />
 

--- a/apps/developer-hub/content/docs/price-feeds/core/how-pyth-works/cross-chain.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/how-pyth-works/cross-chain.mdx
@@ -10,7 +10,7 @@ shows how prices are delivered from Pythnet to target chains.
 <UpgradeCallout chain="index" />
 
 <Callout type="info">
-  The architecture described on this page reflects the **pre-upgrade** cross-chain flow (Wormhole guardians). After **July 31, 2026**, Wormhole is replaced by a 5-router 3-of-5 quorum. See [How the Pyth Core upgrade works](/price-feeds/core/upgrade/how-it-works) for the post-upgrade architecture.
+  The architecture described on this page reflects the **pre-upgrade** cross-chain flow (Wormhole guardians). After **August 18, 2026**, Wormhole is replaced by a 5-router 3-of-5 quorum. See [How the Pyth Core upgrade works](/price-feeds/core/upgrade/how-it-works) for the post-upgrade architecture.
 </Callout>
 
 <figure className="image-container">

--- a/apps/developer-hub/content/docs/price-feeds/core/how-pyth-works/hermes.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/how-pyth-works/hermes.mdx
@@ -38,7 +38,7 @@ $ curl -H "Authorization: Bearer $PYTH_API_KEY" \
 <Tab value="Current endpoint">
 
 ```bash
-# Authentication becomes required on July 31, 2026.
+# Authentication becomes required on August 18, 2026.
 $ curl -H "Authorization: Bearer $PYTH_API_KEY" \
   "https://hermes.pyth.network/api/latest_price_feeds?ids[]=0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace"
 ```

--- a/apps/developer-hub/content/docs/price-feeds/core/schedule-price-updates/using-price-pusher.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/schedule-price-updates/using-price-pusher.mdx
@@ -12,7 +12,7 @@ Anyone can operate this service to keep on-chain Pyth prices current based on co
 
 <UpgradeCallout chain="index" />
 
-From **July 31, 2026** onward the Price Pusher must be configured with a Pyth API Key. Pass it via the `--hermes-access-token <YOUR_KEY>` command-line flag so its Hermes calls can authenticate against the upgraded backend.
+From **August 18, 2026** onward the Price Pusher must be configured with a Pyth API Key. Pass it via the `--hermes-access-token <YOUR_KEY>` command-line flag so its Hermes calls can authenticate against the upgraded backend.
 
 The `--hermes-access-token` flag was added in [Price Pusher v10.5.0](https://github.com/pyth-network/pyth-crosschain/commit/bab960de82fc881fd3c9397627d4e1831aeec934). Make sure you are running v10.5.0 or later. Refer to the project README for setup instructions and configuration details.
 

--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/contracts.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/contracts.mdx
@@ -26,7 +26,7 @@ Pyth has three kinds of on-chain contracts. This page explains how to tell them 
 |                          | What it is                                                                                                                       | Built for                                                                                |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | **Pyth Core (current)**  | The contract you integrated against today. Keeps a **shared price on-chain** that any contract can read                            | Existing integrations                                                                      |
-| **Pyth Core (upgraded)** | The **same interface and feed IDs** at a new address, with richer data and more customization. Still keeps the shared price on-chain | Upgrading your existing integration before July 31: swap the [contract address and the Hermes endpoint together](/price-feeds/core/upgrade/preparing), with an API key |
+| **Pyth Core (upgraded)** | The **same interface and feed IDs** at a new address, with richer data and more customization. Still keeps the shared price on-chain | Upgrading your existing integration before August 18: swap the [contract address and the Hermes endpoint together](/price-feeds/core/upgrade/preparing), with an API key |
 | **Pyth Pro**             | A different model: **no price stored on-chain**. Each transaction carries its own millisecond-fresh signed price, verified on the spot | Latency-critical trading priced per transaction: perps fills, RFQ and quote-based execution |
 
 ## The real difference between upgraded Core and Pro
@@ -50,7 +50,7 @@ Pyth has three kinds of on-chain contracts. This page explains how to tell them 
   If not, take a look at [**Pyth Pro**](/price-feeds/pro).
 </Callout>
 
-## What happens on July 31, 2026
+## What happens on August 18, 2026
 
 - Your **current contract is upgraded in place**. It starts accepting the new data payloads automatically. You keep your address, and your feed IDs don't change; nearly all feeds carry over ([check yours](https://pythdata.app/explore?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=contract-addresses)).\*
 - `hermes.pyth.network` is **redirected to the upgraded backend**. The URL keeps working, but every request needs a [Pyth API Key](https://pythdata.app/signup?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=contract-addresses) from that day on.
@@ -61,7 +61,7 @@ Pyth has three kinds of on-chain contracts. This page explains how to tell them 
 ## The two mistakes this page exists to prevent
 
 1. **Swapping a Core integration to a Pro address.** Pro has a different interface, different feed IDs, and no stored price to read, so it isn't a drop-in replacement for a Core integration. If you're upgrading Core, you want the **upgraded Core** address (listed below).
-2. **Swapping the contract address without moving your data source, or vice versa.** Each endpoint's payloads verify only on its own contract generation. Swap both together, or wait and let July 31 switch both for you (expect a brief switchover window; see the [wait-path guidance](/price-feeds/core/upgrade/preparing#waiting-for-the-automatic-upgrade)).
+2. **Swapping the contract address without moving your data source, or vice versa.** Each endpoint's payloads verify only on its own contract generation. Swap both together, or wait and let August 18 switch both for you (expect a brief switchover window; see the [wait-path guidance](/price-feeds/core/upgrade/preparing#waiting-for-the-automatic-upgrade)).
 
 **Where to go next:** the [upgrade guide](/price-feeds/core/upgrade/preparing) for the how, or the [Pyth Pro docs](/price-feeds/pro) if per-transaction pricing is what you need. All addresses, all three kinds, are below.
 

--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/how-it-works.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/how-it-works.mdx
@@ -95,7 +95,7 @@ Here is a side-by-side comparison of the two architectures:
 
 ## What this means for consumers
 
-Pyth Core will be upgraded on **July 31st**. To avoid potential oracle downtime,
+Pyth Core will be upgraded on **August 18**. To avoid potential oracle downtime,
 make sure you take the appropriate steps by following the [upgrade guide](/price-feeds/core/upgrade/preparing).
 You can also view the [upgraded Pyth Core Contract addresses](/price-feeds/core/upgrade/contracts)
 for the new contract addresses on each supported chain.

--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/index.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/index.mdx
@@ -1,26 +1,26 @@
 ---
 title: "Pyth Core Upgrade"
-description: "Pyth Core is upgrading on July 31, 2026. Prepare your integration."
+description: "Pyth Core is upgrading on August 18, 2026. Prepare your integration."
 full: true
 ---
 
 import { Card, Cards } from "fumadocs-ui/components/card";
 
-Pyth Network is upgrading [Pyth Core](/price-feeds/core) on **July 31, 2026**. This upgrade replaces Pyth Core's underlying data infrastructure with an improved version while preserving the existing Hermes API surface and on-chain contract interface.
+Pyth Network is upgrading [Pyth Core](/price-feeds/core) on **August 18, 2026**. This upgrade replaces Pyth Core's underlying data infrastructure with an improved version while preserving the existing Hermes API surface and on-chain contract interface.
 
 ## What you get
 - **Higher-frequency updates** for faster price moves.
 - **Additional price feeds** beyond the current Core catalog.
 - **Lower latency** across the data path.
 
-Most existing integrations keep working through the cutover. [Prepare for the upgrade](/price-feeds/core/upgrade/preparing) to check whether you're covered. The one new requirement is authentication on Hermes: every Hermes user needs a [Pyth API Key](https://pythdata.app/signup?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=overview) by July 31, 2026.
+Most existing integrations keep working through the cutover. [Prepare for the upgrade](/price-feeds/core/upgrade/preparing) to check whether you're covered. The one new requirement is authentication on Hermes: every Hermes user needs a [Pyth API Key](https://pythdata.app/signup?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=overview) by August 18, 2026.
 
 ## Next steps
 
 <Cards>
   <Card
     title="Prepare for the upgrade"
-    description="Step-by-step migration guide before the July 31 cutover."
+    description="Step-by-step migration guide before the August 18 cutover."
     href="/price-feeds/core/upgrade/preparing"
   />
   <Card

--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/index.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Preparing for the Pyth Core upgrade"
-description: "Everything you need to upgrade your Pyth Core integration before July 31, 2026."
+description: "Everything you need to upgrade your Pyth Core integration before August 18, 2026."
 full: true
 ---
 
@@ -18,12 +18,12 @@ import {
 
 <ActiveStepHighlighter />
 
-Pyth Network is upgrading [Pyth Core](/price-feeds/core) on **July 31, 2026**. Your existing integration keeps working: the on-chain Pyth contract is upgraded by the Pyth DAO on July 31 (except on [Sui](/price-feeds/core/upgrade/preparing/sui), which requires a manual swap), and [Hermes](/api-reference/pyth-core/hermes) requests are redirected to the upgraded backend automatically. The one new requirement is authentication on Hermes: every Hermes user needs a Pyth API Key by **July 31**.
+Pyth Network is upgrading [Pyth Core](/price-feeds/core) on **August 18, 2026**. Your existing integration keeps working: the on-chain Pyth contract is upgraded by the Pyth DAO on August 18 (except on [Sui](/price-feeds/core/upgrade/preparing/sui), which requires a manual swap), and [Hermes](/api-reference/pyth-core/hermes) requests are redirected to the upgraded backend automatically. The one new requirement is authentication on Hermes: every Hermes user needs a Pyth API Key by **August 18**.
 
 For background on what's changing and why, see the [upgrade overview](/price-feeds/core/upgrade). For a walkthrough of the signers, data flow, and contracts behind the upgrade, see [How the Pyth Core upgrade works](/price-feeds/core/upgrade/how-it-works).
 
 <Callout type="warn">
-  **All Hermes users need a Pyth API Key by July 31, 2026** — the upgraded
+  **All Hermes users need a Pyth API Key by August 18, 2026** — the upgraded
   Hermes endpoint requires authentication, even for users who wait for the
   automatic upgrade. [Register at Pyth Terminal →](https://pythdata.app/signup?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=callout-top)
 </Callout>
@@ -76,7 +76,7 @@ After Step 1, choose how and when to move to the upgraded infrastructure. Your c
 
 |                  | Early upgrade (recommended)                | Wait for automatic                                                   |
 | ---------------- | ------------------------------------------ | -------------------------------------------------------------------- |
-| Timing           | You choose                                 | July 31, 2026                                                        |
+| Timing           | You choose                                 | August 18, 2026                                                        |
 | Downtime         | Up to you                                       | Brief, during the switch                                             |
 | Hermes endpoint  | Switch to the new Hermes endpoint now             | Start using `hermes.pyth.network` with an API key before the cutover               |
 | Contract address | You swap to the upgraded Pyth Core Contract       | DAO upgrades the current Pyth Core Contract for you                             |
@@ -85,7 +85,7 @@ After Step 1, choose how and when to move to the upgraded infrastructure. Your c
 
 ## Early upgrade
 
-This is the recommended path, as it makes the **July 31 cutover a non-event for your integration**. Please note that if you swap the endpoint but not the contract address or vice versa you won't be able to verify price updates. 
+This is the recommended path, as it makes the **August 18 cutover a non-event for your integration**. Please note that if you swap the endpoint but not the contract address or vice versa you won't be able to verify price updates. 
 
 <Steps>
 <Step>
@@ -137,7 +137,7 @@ Swap your existing Pyth contract address for the [upgraded Pyth Core Contract](/
 
 View all upgraded [Pyth Core Contract addresses](/price-feeds/core/upgrade/contracts).
 
-After the swap, you're done before the July 31 cutover. 
+After the swap, you're done before the August 18 cutover. 
 
 </Step>
 </Steps>
@@ -168,7 +168,7 @@ After the swap, you're done before the July 31 cutover.
   This path does not apply on Sui. Apps reference the Pyth package by object ID, and the DAO cannot swap that for you. Follow the [Sui upgrade guide](/price-feeds/core/upgrade/preparing/sui) instead.
 </Callout>
 
-At the cutover on July 31, the Pyth DAO upgrades your on-chain contract a few moments *before* `hermes.pyth.network` starts serving the upgraded payload.
+At the cutover on August 18, the Pyth DAO upgrades your on-chain contract a few moments *before* `hermes.pyth.network` starts serving the upgraded payload.
 During that brief gap, the price updates served by `hermes.pyth.network` cannot verify against your upgraded contract, while those served by `pyth.dourolabs.app/hermes` can.
 
 A potential strategy to stay live without timing the switch yourself is to fetch from both URLs every request and submit whichever payload verifies:
@@ -221,19 +221,19 @@ Nearly all current Pyth Core feeds remain available after the upgrade, with new 
     Hermes code breaks at the cutover *if* your client is still pointed at `hermes.pyth.network` without an API key. Please follow the steps mentioned [above](#waiting-for-the-automatic-upgrade).
   </Accordion>
   <Accordion title="When exactly does Hermes redirect?">
-    On July 31, 2026. Exact switch timing is announced closer to the date. From that point, `hermes.pyth.network` serves the upgraded data and requires API key authentication.
+    On August 18, 2026. Exact switch timing is announced closer to the date. From that point, `hermes.pyth.network` serves the upgraded data and requires API key authentication.
   </Accordion>
   <Accordion title="Can I test before upgrading?">
     Yes. The upgraded endpoint (`pyth.dourolabs.app/hermes`) and the upgraded Pyth Core Contract are both available on testnets today. See the upgraded [Pyth Core Contract addresses](/price-feeds/core/upgrade/contracts) for addresses.
   </Accordion>
   <Accordion title="What if my chain isn't supported?">
-    Contact the team. Several chains are in active discussion and may be supported by July 31. For others, custom arrangements are possible. See the [upgraded Pyth Core Contract addresses](/price-feeds/core/upgrade/contracts) for the full list.
+    Contact the team. Several chains are in active discussion and may be supported by August 18. For others, custom arrangements are possible. See the [upgraded Pyth Core Contract addresses](/price-feeds/core/upgrade/contracts) for the full list.
   </Accordion>
   <Accordion title="Are all my feeds available after the upgrade?">
     Nearly all current Pyth Core feeds remain available after the upgrade, with new ones added. Look up your specific feeds on the [feed explorer](https://pythdata.app/explore?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=feed-explorer-faq). If a feed you depend on isn't listed, [contact the team](#get-help).
   </Accordion>
   <Accordion title="I read prices on-chain only (push feeds, no Hermes) — do I need an API key?">
-    No. The API key is only required for Hermes (REST/SSE) requests. If your integration reads prices directly from the Pyth contract on-chain and never calls Hermes, you don't need to register. Your contract will be upgraded automatically on July 31, or you can swap it early (see the [Early upgrade](#early-upgrade) section).
+    No. The API key is only required for Hermes (REST/SSE) requests. If your integration reads prices directly from the Pyth contract on-chain and never calls Hermes, you don't need to register. Your contract will be upgraded automatically on August 18, or you can swap it early (see the [Early upgrade](#early-upgrade) section).
   </Accordion>
   <Accordion title="My code uses the Hermes REST/SSE API directly — what changes for me?">
     Routes and response shapes are unchanged. The upgraded endpoint is a drop-in replacement. The differences are *which URL* you call and *whether you send the `Authorization: Bearer $PYTH_API_KEY` header*:

--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/sui.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/sui.mdx
@@ -19,7 +19,7 @@ These notes complement the [main upgrade guide](/price-feeds/core/upgrade/prepar
     </>
   }
 >
-  There is no automatic upgrade path on Sui. Apps reference the Pyth package by object ID, and the DAO cannot swap that for you. Complete the steps below before **July 31, 2026**.
+  There is no automatic upgrade path on Sui. Apps reference the Pyth package by object ID, and the DAO cannot swap that for you. Complete the steps below before **August 18, 2026**.
 </Callout>
 
 <Steps>

--- a/apps/developer-hub/content/docs/price-feeds/core/use-historical-price-data.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-historical-price-data.mdx
@@ -12,7 +12,7 @@ This guide explains how to integrate **Pyth Benchmarks** to access historical pr
 <UpgradeCallout chain="index" />
 
 <Callout type="warn">
-  The Benchmarks endpoints stay at the same URLs after the upgrade, but from **July 31, 2026** every request must include an `Authorization: Bearer $PYTH_API_KEY` header. Get a Pyth API Key on the [billing page](https://app.pyth.com/billing/plans?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=benchmarks-historical-billing).
+  The Benchmarks endpoints stay at the same URLs after the upgrade, but from **August 18, 2026** every request must include an `Authorization: Bearer $PYTH_API_KEY` header. Get a Pyth API Key on the [billing page](https://app.pyth.com/billing/plans?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=benchmarks-historical-billing).
 </Callout>
 
 <Callout type="info" title="Benchmarks Terminology">

--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/solana.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/solana.mdx
@@ -157,7 +157,7 @@ To use price update accounts, the frontend code needs to perform two different t
 
 #### Fetch price updates
 
-Use `HermesClient` from `@pythnetwork/hermes-client` to fetch Pyth price updates from Hermes. The new endpoint `pyth.dourolabs.app/hermes` is the upgraded backend (recommended); the current `hermes.pyth.network` keeps working until cutover and requires an API key from July 31, 2026:
+Use `HermesClient` from `@pythnetwork/hermes-client` to fetch Pyth price updates from Hermes. The new endpoint `pyth.dourolabs.app/hermes` is the upgraded backend (recommended); the current `hermes.pyth.network` keeps working until cutover and requires an API key from August 18, 2026:
 
 <Tabs items={["Upgraded endpoint", "Current endpoint"]}>
 <Tab value="Upgraded endpoint">
@@ -177,7 +177,7 @@ const priceServiceConnection = new HermesClient(
 ```typescript copy
 import { HermesClient } from "@pythnetwork/hermes-client";
 
-// Authentication becomes required on July 31, 2026.
+// Authentication becomes required on August 18, 2026.
 const priceServiceConnection = new HermesClient(
   "https://hermes.pyth.network",
   { accessToken: process.env.PYTH_API_KEY },

--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/sui.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/sui.mdx
@@ -12,7 +12,7 @@ This guide explains how to use real-time Pyth data in Sui applications.
 <UpgradeCallout chain="sui" />
 
 <Callout type="info">
-  After **July 31, 2026**, replace the Pyth package `rev` below with
+  After **August 18, 2026**, replace the Pyth package `rev` below with
   `sui-pro-compatible-contract-mainnet` (or `sui-pro-compatible-contract-testnet`)
   and update the Pyth State / Wormhole State IDs to the [upgraded Sui addresses](/price-feeds/core/upgrade/contracts#sui).
   See the [upgrade guide](/price-feeds/core/upgrade/preparing) for details.
@@ -146,7 +146,7 @@ import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 /// Step 1: Get the off-chain data.
 const connection = new SuiPriceServiceConnection(
   "https://pyth.dourolabs.app/hermes", // upgraded endpoint
-  // Or: "https://hermes.pyth.network" — auth required from July 31, 2026
+  // Or: "https://hermes.pyth.network" — auth required from August 18, 2026
   {
     accessToken: process.env.PYTH_API_KEY,
     // Provide this option to retrieve signed price updates for on-chain contracts!
@@ -255,7 +255,7 @@ npm run example-relay -- --feed-id "5a035d5440f5c163069af66062bac6c79377bf88396f
 
 ### Contract Addresses
 
-Consult [Sui Contract Addresses](../../contract-addresses/sui) to find the current package IDs, or the [upgraded Sui addresses](/price-feeds/core/upgrade/contracts#sui) for the post-July 31, 2026 upgrade.
+Consult [Sui Contract Addresses](../../contract-addresses/sui) to find the current package IDs, or the [upgraded Sui addresses](/price-feeds/core/upgrade/contracts#sui) for the post-August 18, 2026 upgrade.
 
 ### Pyth Price Feed IDs
 

--- a/apps/developer-hub/src/components/MigrationBanner/index.tsx
+++ b/apps/developer-hub/src/components/MigrationBanner/index.tsx
@@ -22,7 +22,7 @@ export const MigrationBanner = () => {
         href="/price-feeds/core/upgrade/preparing"
         className="hover:underline"
       >
-        Pyth Core upgrade July 31, 2026. Every Core user will need an API Key.
+        Pyth Core upgrade August 18, 2026. Every Core user will need an API Key.
         Learn more →
       </Link>
     </Banner>

--- a/apps/developer-hub/src/components/MigrationFlow/BranchToggle.tsx
+++ b/apps/developer-hub/src/components/MigrationFlow/BranchToggle.tsx
@@ -22,7 +22,7 @@ const OPTIONS: Option[] = [
   {
     value: "wait",
     title: "Wait for automatic",
-    caption: "DAO upgrades contract on July 31",
+    caption: "DAO upgrades contract on August 18",
   },
 ];
 

--- a/apps/developer-hub/src/components/MigrationFlow/UpgradeCallout.tsx
+++ b/apps/developer-hub/src/components/MigrationFlow/UpgradeCallout.tsx
@@ -36,7 +36,7 @@ const SUPPORTED_PARTIAL = new Set<Chain>(["evm"]);
 
 type Props = { chain: Chain };
 
-const TITLE = "Pyth Core upgrades on July 31, 2026";
+const TITLE = "Pyth Core upgrades on August 18, 2026";
 
 export const UpgradeCallout = ({ chain }: Props) => {
   const upgradeGuide = "/price-feeds/core/upgrade/preparing";
@@ -56,7 +56,7 @@ export const UpgradeCallout = ({ chain }: Props) => {
           </li>
           <li>
             Existing integrations using the current addresses will be
-            automatically upgraded by the DAO on <strong>July 31, 2026</strong>.
+            automatically upgraded by the DAO on <strong>August 18, 2026</strong>.
             See the <Link href={upgradeGuide}>upgrade guide</Link> for details.
           </li>
         </ul>
@@ -71,7 +71,7 @@ export const UpgradeCallout = ({ chain }: Props) => {
     return (
       <Callout
         type="warn"
-        title={`Pyth Core on ${label} is upgrading on July 31, 2026`}
+        title={`Pyth Core on ${label} is upgrading on August 18, 2026`}
       >
         <ul className="list-disc pl-5 my-0! space-y-1">
           <li>
@@ -80,7 +80,7 @@ export const UpgradeCallout = ({ chain }: Props) => {
           </li>
           <li>
             Existing integrations using the current addresses will be
-            automatically upgraded by the DAO on <strong>July 31, 2026</strong>.
+            automatically upgraded by the DAO on <strong>August 18, 2026</strong>.
             See the <Link href={upgradeGuide}>upgrade guide</Link> for details.
           </li>
         </ul>
@@ -92,7 +92,7 @@ export const UpgradeCallout = ({ chain }: Props) => {
     return (
       <Callout
         type="warn"
-        title={`Pyth Core on ${label} chains is upgrading on July 31, 2026`}
+        title={`Pyth Core on ${label} chains is upgrading on August 18, 2026`}
       >
         <ul className="list-disc pl-5 my-0! space-y-1">
           <li>
@@ -101,7 +101,7 @@ export const UpgradeCallout = ({ chain }: Props) => {
           </li>
           <li>
             Existing integrations on {label} chains in the upgrade will be
-            automatically upgraded by the DAO on <strong>July 31, 2026</strong>.
+            automatically upgraded by the DAO on <strong>August 18, 2026</strong>.
             See the <Link href={upgradeGuide}>upgrade guide</Link> for details.
           </li>
           <li>
@@ -116,7 +116,7 @@ export const UpgradeCallout = ({ chain }: Props) => {
   return (
     <Callout
       type="warn"
-      title={`Pyth Core will no longer support ${label} after July 31, 2026`}
+      title={`Pyth Core will no longer support ${label} after August 18, 2026`}
     >
       <ul className="list-disc pl-5 my-0! space-y-1">
         <li>

--- a/apps/developer-hub/src/components/Pages/Homepage/index.tsx
+++ b/apps/developer-hub/src/components/Pages/Homepage/index.tsx
@@ -25,7 +25,7 @@ export const Homepage = () => {
         <div className={styles.migrationFeature}>
           <div className={styles.migrationFeatureText}>
             <h2 className={styles.migrationFeatureTitle}>
-              Pyth Core is upgrading on July 31, 2026
+              Pyth Core is upgrading on August 18, 2026
             </h2>
             <p className={styles.migrationFeatureBody}>
               All Pyth Core users must register for an API Key


### PR DESCRIPTION
## Summary

The Pyth Core upgrade cutover moved from **July 31** to **August 18, 2026**, per the official announcement: https://dev-forum.pyth.network/t/update-pyth-core-upgrade-date-moved-to-august-18-2026/811

This is a complete sweep of every date reference in the developer hub — 42 replacements across 19 files:

- Upgrade section: overview, preparing guide, per-chain guides (EVM/Solana/Sui), All Contract Addresses page (#3898)
- Auth deadline callouts: Hermes endpoints, Benchmarks (historical data, TradingView), getting started, fetch-price-updates, price-pusher scheduling
- Code-sample comments (Hermes clients in the EVM/Solana/Sui tutorials)
- Components: `MigrationBanner`, `MigrationFlow` (`UpgradeCallout` titles and bodies, `BranchToggle` caption), homepage hero

`grep -rn "July 31"` over `content/` and `src/` returns zero hits after the sweep.

## Notes

The announcement also names **Aptos** as newly supported by the upgrade. That is deliberately *not* part of this PR: the contract-manager registry has no Aptos `pro-compatible` entries yet, so there are no addresses to publish. Docs follow once the registry has them.

## Test plan

Verified in the dev server: upgrade overview, preparing guide, and All Contract Addresses all render with the new date and zero remaining July 31 references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->