### PR TITLE
fix(price-pusher): restore info level for EVM success log

### DIFF
--- a/apps/price_pusher/src/evm/evm.ts
+++ b/apps/price_pusher/src/evm/evm.ts
@@ -495,7 +495,7 @@ export class EvmPricePusher implements IPricePusher {
         if (receipt.status === "success") {
           // Keep one non-debug hash line per landed tx: the bundled Grafana
           // "Tx Hash" panel scrapes this message from Loki and extracts {{.hash}}.
-          this.logger.debug({ hash }, "Price update successful");
+          this.logger.info({ hash }, "Price update successful");
         } else {
           this.logger.debug(
             { hash, receipt },


### PR DESCRIPTION
## What

Restores one line in `apps/price_pusher/src/evm/evm.ts` from `logger.debug` back to `logger.info`.

```diff
-          this.logger.debug({ hash }, "Price update successful");
+          this.logger.info({ hash }, "Price update successful");
```

## Why

`main` is red. `@pythnetwork/price-pusher#test:unit` fails with 3 failures in `src/evm/__tests__/receipt-tracking.test.ts` ([run 29835506529](https://github.com/pyth-network/pyth-crosschain/actions/runs/29835506529)).

#3915 downgraded ~20 noisy log lines from `info` to `debug`. Most are fine, but this one is load-bearing, as the comment directly above it notes:

> Keep one non-debug hash line per landed tx: the bundled Grafana "Tx Hash" panel scrapes this message from Loki and extracts `{{.hash}}`.

Pushers run at the default `log-level: info` (`options.ts:72`) and nothing in the deployments repo overrides it, so at `debug` the line is never emitted in production and that panel goes dark on every EVM chain.

The test failures follow from the same thing. `receipt-tracking.test.ts` is the regression suite for the bounded-receipt-tracker fix (#3885), and it uses this log as the observable signal that a tx was detected as landed. The same-nonce escalation case, for example, uses it to prove the original tx's tracker was not cancelled when the old tx wins the mempool race.

## Test

`pnpm run test:unit` in `apps/price_pusher`: 21/21 passing, 2 suites green. Was 18 passed / 3 failed before.

## Note for reviewers

#3915 also bumped `price_pusher` to `12.0.0`. If that image has already rolled out, the Tx Hash panel is dark right now and this fix needs its own bump and deploy rather than just a merge. I left the version alone here to keep the diff to the revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->