### PR TITLE
feat(xc-admin-cli): propose integrity-pool reward withdraw

### DIFF
--- a/governance/xc_admin/packages/xc_admin_cli/src/index.ts
+++ b/governance/xc_admin/packages/xc_admin_cli/src/index.ts
@@ -61,6 +61,8 @@ import {
   SYSVAR_CLOCK_PUBKEY,
   SYSVAR_RENT_PUBKEY,
   SystemProgram,
+  TransactionMessage,
+  VersionedTransaction,
 } from "@solana/web3.js";
 import SquadsMesh from "@sqds/mesh";
 import { program } from "commander";
@@ -1107,6 +1109,106 @@ multisigCommand(
         DEFAULT_PRIORITY_FEE_CONFIG,
       );
     }
+  });
+
+multisigCommand(
+  "withdraw-integrity-pool-rewards",
+  "Withdraw PYTH rewards from the Integrity Pool reward custody",
+)
+  .requiredOption(
+    "-d, --destination <pubkey>",
+    "destination PYTH token account that receives the withdrawn rewards",
+  )
+  .option(
+    "-a, --amount <amount>",
+    "amount to withdraw, in raw base units (all digits). If omitted, the full reward custody balance is withdrawn.",
+  )
+  .action(async (options: any) => {
+    const vault = await loadVaultFromOptions(options);
+    const targetCluster: PythCluster = options.cluster;
+    const connection = new Connection(
+      options.rpcUrlOverride ?? getPythClusterApiUrl(targetCluster),
+    );
+
+    const rewardProgramAuthority =
+      await vault.getVaultAuthorityPDA(targetCluster);
+    const destination = new PublicKey(options.destination);
+
+    const poolConfig = PublicKey.findProgramAddressSync(
+      [Buffer.from("pool_config")],
+      INTEGRITY_POOL_PROGRAM_ID,
+    )[0];
+
+    const integrityPoolProgram = new Program(
+      integrityPoolIdl as Idl,
+      INTEGRITY_POOL_PROGRAM_ID,
+      vault.getAnchorProvider(),
+    );
+
+    // Read the reward-custody mint from the on-chain pool config so we derive
+    // the custody account (and default amount) against the real configuration.
+    const poolConfigData =
+      await integrityPoolProgram.account.poolConfig?.fetch(poolConfig);
+    const pythTokenMint = new PublicKey(poolConfigData.pythTokenMint);
+    const poolRewardCustody = await getAssociatedTokenAddress(
+      pythTokenMint,
+      poolConfig,
+      true,
+    );
+
+    // Default to the full reward-custody balance when no amount is provided.
+    let amount: BN;
+    if (options.amount === undefined) {
+      const balance =
+        await connection.getTokenAccountBalance(poolRewardCustody);
+      amount = new BN(balance.value.amount);
+    } else {
+      amount = new BN(options.amount);
+    }
+
+    const withdrawInstruction = await integrityPoolProgram.methods
+      .withdraw?.(amount)
+      .accounts({
+        destination,
+        poolRewardCustody,
+        rewardProgramAuthority,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .instruction();
+
+    if (!withdrawInstruction) {
+      throw new Error("Failed to build the withdraw instruction");
+    }
+
+    // Simulate the withdraw before proposing so we never queue a proposal that
+    // would fail when the multisig executes it. sigVerify is disabled because
+    // the reward_program_authority signature is produced by the vault PDA only
+    // at execution time.
+    const { blockhash } = await connection.getLatestBlockhash();
+    const message = new TransactionMessage({
+      instructions: [withdrawInstruction],
+      payerKey: rewardProgramAuthority,
+      recentBlockhash: blockhash,
+    }).compileToV0Message();
+    const simulation = await connection.simulateTransaction(
+      new VersionedTransaction(message),
+      { replaceRecentBlockhash: true, sigVerify: false },
+    );
+    if (simulation.value.err) {
+      console.error(simulation.value.logs?.join("\n"));
+      throw new Error(
+        `Withdraw simulation failed: ${JSON.stringify(simulation.value.err)}`,
+      );
+    }
+    console.log(
+      `Withdraw simulation succeeded; proposing withdraw of ${amount.toString()} base units to ${destination.toBase58()}.`,
+    );
+
+    await vault.proposeInstructions(
+      [withdrawInstruction],
+      targetCluster,
+      DEFAULT_PRIORITY_FEE_CONFIG,
+    );
   });
 
 multisigCommand("withdraw-er-native-fees", "Withdraw Express Relay native fees")

--- a/governance/xc_admin/packages/xc_admin_cli/src/index.ts
+++ b/governance/xc_admin/packages/xc_admin_cli/src/index.ts
@@ -1148,7 +1148,9 @@ multisigCommand(
     // Read the reward-custody mint from the on-chain pool config so we derive
     // the custody account (and default amount) against the real configuration.
     const poolConfigData =
-      await integrityPoolProgram.account.poolConfig?.fetch(poolConfig);
+      (await integrityPoolProgram.account.poolConfig?.fetch(poolConfig)) as {
+        pythTokenMint: PublicKey;
+      };
     const pythTokenMint = new PublicKey(poolConfigData.pythTokenMint);
     const poolRewardCustody = await getAssociatedTokenAddress(
       pythTokenMint,

--- a/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/idl/integrity-pool.json
+++ b/governance/xc_admin/packages/xc_admin_common/src/multisig_transaction/idl/integrity-pool.json
@@ -1,4 +1,34 @@
 {
+  "accounts": [
+    {
+      "name": "PoolConfig",
+      "type": {
+        "fields": [
+          {
+            "name": "poolData",
+            "type": "publicKey"
+          },
+          {
+            "name": "rewardProgramAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "pythTokenMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "y",
+            "type": "u64"
+          },
+          {
+            "name": "slashCustody",
+            "type": "publicKey"
+          }
+        ],
+        "kind": "struct"
+      }
+    }
+  ],
   "instructions": [
     {
       "accounts": [
@@ -84,6 +114,51 @@
         }
       ],
       "name": "updateY"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": false,
+          "isSigner": true,
+          "name": "rewardProgramAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "poolConfig",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "pool_config"
+              }
+            ]
+          }
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "poolRewardCustody"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "destination"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "tokenProgram"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ],
+      "name": "withdraw"
     }
   ],
   "name": "integrity-pool",


### PR DESCRIPTION
Adds a `withdraw-integrity-pool-rewards` multisig command to xc-admin-cli that proposes the integrity-pool `withdraw` instruction through the Squads vault.

## Details
- Extends the bundled `integrity-pool.json` IDL with the `withdraw` instruction and the `PoolConfig` account so Anchor can build the instruction and read the reward-custody mint on-chain.
- The command takes a required `--destination` (a PYTH token account) and an optional `--amount` in raw base units. When `--amount` is omitted it reads the reward-custody token balance and withdraws the full amount.
- `reward_program_authority` is resolved to the multisig vault authority PDA (same pattern as `set-publisher-stake-account`); `pool_config` is auto-resolved from its PDA seeds and `pool_reward_custody` is derived as the pool_config ATA of the pool's `pyth_token_mint`.
- Before proposing, the built instruction is simulated (`sigVerify: false`, since the authority signature is produced by the vault PDA at execution time) and the command aborts if the simulation fails.

## Verification
Simulated the built instruction against Solana mainnet-beta (pool_config `BE8Xq1iHSQYKG8CZorZsrTnxyeHKQLzCWm4dYKdFkVEL`, reward custody `FbSivnCf6iXfXns6osFih2MgX8icmSKx9iba3gyFpiCT`): the transaction returned `err: null` with program logs showing `Instruction: Withdraw` and a successful SPL token transfer CPI.