### PR TITLE
fix(xc-admin-frontend): render u64 instruction args as decimal

### DIFF
--- a/governance/xc_admin/packages/xc_admin_frontend/components/tabs/Proposals/Proposal.tsx
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/tabs/Proposals/Proposal.tsx
@@ -7,6 +7,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable no-console */
 import type { Wallet } from "@coral-xyz/anchor";
+import { BN } from "@coral-xyz/anchor";
 import type { PythCluster } from "@pythnetwork/client";
 import { getPythProgramKeyForCluster } from "@pythnetwork/client";
 import {
@@ -559,7 +560,9 @@ export const Proposal = ({
                                   ? instruction.args[key].toString()
                                   : typeof instruction.args[key] === "bigint"
                                     ? instruction.args[key].toString()
-                                    : JSON.stringify(instruction.args[key])}
+                                    : BN.isBN(instruction.args[key])
+                                      ? instruction.args[key].toString()
+                                      : JSON.stringify(instruction.args[key])}
                             </div>
                           )}
                         </div>


### PR DESCRIPTION
The proposal argument renderer in `Proposal.tsx` had no branch for `BN` values. Anchor's `BorshCoder` decodes `u64`/`i64` instruction args into `BN` instances, which are not `PublicKey`/`string`/`Uint8Array`/`bigint`, so they fell through to `JSON.stringify(...)`. `JSON.stringify` calls `BN.prototype.toJSON()`, which returns `toString(16)` — so numeric args were displayed in hexadecimal (e.g. the integrity-pool `withdraw` amount rendered as `c5b8ba0168`).

This adds a `BN.isBN(...)` branch that renders the value with `BN.toString()` (base-10). Fixes the display for every program's numeric args, not just the new withdraw instruction.

Verified: `test:types` (tsc) passes for `@pythnetwork/xc-admin-frontend`; `biome format` clean; `biome lint` introduces no new violation class (the one added `noNestedTernary` warning matches the file's 6 pre-existing warnings of the same kind).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->