### PR TITLE
lazer/sui: add Published.toml file, update mainnet info

### DIFF
--- a/lazer/contracts/sui/Published.toml
+++ b/lazer/contracts/sui/Published.toml
@@ -1,0 +1,5 @@
+[published.mainnet]
+chain-id = "35834a8a"
+published-at = "0xefbfd064480777699fd9c557a5804d72ace7bc82661fdc8d1f1a44ea6d92ee10"
+original-id = "0x7b502c8a7bcb3915892347f11086745570e759fe9708d03c03accf4c90bbf580"
+version = 2

--- a/lazer/contracts/sui/sources/meta.move
+++ b/lazer/contracts/sui/sources/meta.move
@@ -9,7 +9,7 @@ module pyth_lazer::meta;
 /// `UpgradeCap` version, and thus attempts to publish or upgrade the package
 /// using an invalid version will result in the package becoming locked.
 public(package) fun version(): u64 {
-    2
+    1
 }
 
 /// References:

--- a/lazer/contracts/sui/sources/meta.move
+++ b/lazer/contracts/sui/sources/meta.move
@@ -9,7 +9,7 @@ module pyth_lazer::meta;
 /// `UpgradeCap` version, and thus attempts to publish or upgrade the package
 /// using an invalid version will result in the package becoming locked.
 public(package) fun version(): u64 {
-    1
+    2
 }
 
 /// References:


### PR DESCRIPTION
## Summary

Adds mainnet entry to `Published.toml` file.

## Rationale

Our Lazer contract on Sui is using new package format, but is missing `Published.toml` file needed to guide downstream dependents.

## How has this been tested?

- [ ] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

I've run `sui client verify-source` few times, making sure that checks only succeed with correct addresses.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->