### PR TITLE
docs(developer-hub): document both auth credentials on Subscribe to Prices

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/subscribe-to-prices.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/subscribe-to-prices.mdx
@@ -6,6 +6,7 @@ slug: /price-feeds/pro/subscribe-price-updates
 
 import { Callout } from "fumadocs-ui/components/callout";
 import { Step, Steps } from "fumadocs-ui/components/steps";
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 This guide explains how to subscribe to prices from Pyth Pro.
 This guide will also explain various properties and configuration options to customize the prices.
@@ -36,7 +37,19 @@ The websocket servers are available at:
 
   Follow the steps we've outlined in the [Acquire an API key section](./acquire-api-key).
 
-Use the API key to authenticate the websocket connection by passing it as an `Authorization{:bash}` header with the value `Bearer {key}{:bash}`.
+The websocket connection is authenticated with an `Authorization{:bash}` header of the form `Bearer {token}{:bash}`. Two kinds of tokens are accepted:
+
+- Your long-lived **Pro API key**. Prefer this for server-to-server integrations.
+- A **short-lived JWT** minted from that key via `POST /auth/token{:bash}`. Prefer this when the connecting client should not hold the raw key. See [Frontend Authentication](/price-feeds/pro/frontend-auth) for the full flow.
+
+<Tabs items={["Pro API key", "Short-lived JWT"]}>
+  <Tab value="Pro API key">
+
+Pass the API key directly as the bearer value:
+
+```text
+Authorization: Bearer <PRO_API_KEY>
+```
 
 <Callout type="warning">
   **Security Warning**: Never expose your API key in frontend applications
@@ -44,6 +57,28 @@ Use the API key to authenticate the websocket connection by passing it as an `Au
   environments. Exposing keys in frontend code makes them publicly accessible
   and is a violation of our terms of service.
 </Callout>
+
+  </Tab>
+  <Tab value="Short-lived JWT">
+
+Mint a JWT server-side with your API key, then present the JWT in place of the key:
+
+```bash copy
+curl -X POST "https://pyth.dourolabs.app/auth/token" \
+  -H "Authorization: Bearer $PRO_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+# => {"access_token": "<JWT>", "expires_at": "...", "token_type": "Bearer"}
+```
+
+```text
+Authorization: Bearer <JWT>
+```
+
+JWTs live for at most 15 minutes, so mint a fresh one shortly before opening a new connection.
+
+  </Tab>
+</Tabs>
 
 A browser can't set request headers on a WebSocket. For frontend apps, mint a short-lived JWT (see [Frontend Authentication](/price-feeds/pro/frontend-auth)) and pass it through the subprotocol list — the marker `pyth-lazer-auth` immediately followed by the token:
 
@@ -144,7 +179,7 @@ To subscribe to the prices, send a request to the websocket server. The server w
 npm install --save @pythnetwork/pyth-lazer-sdk
 ```
 
-2. Then create a `PythLazerClient` object using both endpoint URLs and the API key obtained in the first step:
+2. Then create a `PythLazerClient` object using the endpoint URLs and a credential from the first step. The `token` field accepts either your Pro API key or a short-lived JWT:
 
 ```js copy
 import { PythLazerClient } from "@pythnetwork/pyth-lazer-sdk";


### PR DESCRIPTION
## Summary

The Subscribe to Prices guide only showed the raw Pro API key as the websocket credential, with the short-lived JWT mentioned solely as a browser workaround. Pyth Pro accepts either token as the `Bearer` value, and integrators migrating for the History auth cutover have been asking how to use each.

- **Step 1**: states the both-credentials rule and adds a **Pro API key** / **Short-lived JWT** tab pair — the JWT tab shows the `POST /auth/token` mint call and presenting the JWT in place of the key, with the 15-minute TTL note. The security callout and the browser `pyth-lazer-auth` subprotocol note are kept.
- **Step 3**: the `PythLazerClient` intro now notes the `token` field accepts either credential.

The full JWT flow (backend token endpoint, caching, refresh) stays on the Frontend Authentication page, which is linked rather than duplicated.

## Verification

- Live-tested against production: REST `latest_price` and the websocket stream accept both the raw Pro API key and a minted JWT via the `Authorization` header, and the JWT via the `pyth-lazer-auth` subprotocol (server echoes the subprotocol back).
- Rendered page verified on the local dev server; both tabs display correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->