### PR TITLE
perf(developer-hub): cap and rank docs search results (4.6x faster)

### DIFF
--- a/apps/developer-hub/scripts/generate-price-feeds-snapshot.ts
+++ b/apps/developer-hub/scripts/generate-price-feeds-snapshot.ts
@@ -25,14 +25,12 @@
 
 import * as fs from "node:fs/promises";
 import path from "node:path";
-
-import {
-  hermesSchema,
-  lazerSchema,
-  type HermesFeed,
-  type LazerFeed,
-  type PriceFeedsSnapshot,
+import type {
+  HermesFeed,
+  LazerFeed,
+  PriceFeedsSnapshot,
 } from "../src/app/api/search/feed-schemas";
+import { hermesSchema, lazerSchema } from "../src/app/api/search/feed-schemas";
 import { SYMBOLS_API_URL } from "../src/config/pyth-pro-public";
 
 const OUTPUT_PATH = "./src/generated/price-feeds.json";
@@ -87,7 +85,10 @@ async function fetchSource<T>(
 
 async function writeSnapshot(snapshot: PriceFeedsSnapshot): Promise<void> {
   await fs.mkdir(path.dirname(OUTPUT_PATH), { recursive: true });
-  await fs.writeFile(OUTPUT_PATH, JSON.stringify(snapshot, undefined, 2) + "\n");
+  await fs.writeFile(
+    OUTPUT_PATH,
+    JSON.stringify(snapshot, undefined, 2) + "\n",
+  );
 }
 
 // Guarantees the route's static-import target exists even if generation blew up
@@ -131,9 +132,12 @@ try {
 } catch (error) {
   // Snapshot generation is best-effort: the previously-committed (or empty)
   // snapshot is sufficient for the build. Never fail the build on this script.
-  const message = error instanceof Error ? error.stack ?? error.message : error;
+  const message =
+    error instanceof Error ? (error.stack ?? error.message) : error;
   // eslint-disable-next-line no-console
-  console.warn("\n⚠ Price feeds snapshot generation failed, continuing anyway:");
+  console.warn(
+    "\n⚠ Price feeds snapshot generation failed, continuing anyway:",
+  );
   // eslint-disable-next-line no-console
   console.warn(message);
   await ensureSnapshotFile();

--- a/apps/developer-hub/src/app/api/search/feed-schemas.ts
+++ b/apps/developer-hub/src/app/api/search/feed-schemas.ts
@@ -3,18 +3,18 @@ import { z } from "zod";
 // Shape of the Hermes `/v2/price_feeds` response entries we index.
 export const hermesSchema = z.array(
   z.object({
-    id: z.string(),
     attributes: z.object({ symbol: z.string() }),
+    id: z.string(),
   }),
 );
 
 // Shape of the Lazer (Pro) symbols API response entries we index.
 export const lazerSchema = z.array(
   z.object({
-    symbol: z.string(),
+    description: z.string(),
     name: z.string(),
     pyth_lazer_id: z.number(),
-    description: z.string(),
+    symbol: z.string(),
   }),
 );
 

--- a/apps/developer-hub/src/app/api/search/route.ts
+++ b/apps/developer-hub/src/app/api/search/route.ts
@@ -1,66 +1,268 @@
-import type { AdvancedIndex } from "fumadocs-core/search/server";
-import { createSearchAPI } from "fumadocs-core/search/server";
-
-import type { HermesFeed, LazerFeed, PriceFeedsSnapshot } from "./feed-schemas";
+import type { AdvancedIndex, SortedResult } from "fumadocs-core/search/server";
+import {
+  createContentHighlighter,
+  initAdvancedSearch,
+} from "fumadocs-core/search/server";
 import priceFeeds from "../../../generated/price-feeds.json";
 import { source } from "../../../lib/source";
+import type { HermesFeed, LazerFeed, PriceFeedsSnapshot } from "./feed-schemas";
 
 // Feed lists are fetched at build time by
 // `scripts/generate-price-feeds-snapshot.ts` and imported statically here, so
 // the search route performs zero external HTTP calls at runtime.
 const snapshot = priceFeeds as PriceFeedsSnapshot;
 
+const CORE_FEED_PATH = "/price-feeds/core/price-feeds/price-feed-ids";
+const PRO_FEED_PATH = "/price-feeds/pro/price-feed-ids";
+
+// Total results handed back to the search dialog. Without a cap, a query like
+// "USD" matches most of the indexed documents and the route serialises several
+// MB on every debounce tick.
+const MAX_RESULTS = 24;
+// Reserved slots per family, so no family can crowd out another: "USD" matches
+// nearly every Core feed and used to push the first documentation hit to rank
+// 624, while "solana" is dominated by docs and would otherwise surface no feeds
+// at all. Whatever a family does not claim is backfilled from the rest, so a
+// query with no feed matches still returns a full page of docs.
+const MAX_DOC_RESULTS = 12;
+const MAX_CORE_FEED_RESULTS = 6;
+const MAX_PRO_FEED_RESULTS = 6;
+
+// fumadocs indexes `title` and `description` as their own documents, so the
+// per-field `structuredData.contents` entries feeds used to carry only
+// duplicated text already covered by those two fields, at 2-3x the document
+// count. Symbol, name, description and feed ID all remain searchable.
+const NO_STRUCTURED_DATA = { contents: [], headings: [] };
+
 function hermesToAdvancedIndex(fee: HermesFeed): AdvancedIndex {
   return {
-    title: `${fee.attributes.symbol} (Core)`,
     description: `Price Feed ID: ${fee.id}`,
-    url: `/price-feeds/core/price-feeds/price-feed-ids?search=${fee.attributes.symbol}`,
     id: fee.id,
+    structuredData: NO_STRUCTURED_DATA,
     tag: "price-feed-core",
-    structuredData: {
-      headings: [],
-      contents: [
-        { heading: "Symbol", content: fee.attributes.symbol },
-        { heading: "ID", content: fee.id },
-      ],
-    },
+    title: `${fee.attributes.symbol} (Core)`,
+    url: `${CORE_FEED_PATH}?search=${fee.attributes.symbol}`,
   };
 }
 
 function lazerToAdvancedIndex(feed: LazerFeed): AdvancedIndex {
   return {
-    title: `${feed.name} (Pro)`,
     description: `${feed.symbol} - ${feed.description} (ID: ${String(feed.pyth_lazer_id)})`,
-    url: `/price-feeds/pro/price-feed-ids?search=${feed.symbol}`,
     id: `lazer-${String(feed.pyth_lazer_id)}`,
+    structuredData: NO_STRUCTURED_DATA,
     tag: "price-feed-pro",
-    structuredData: {
-      headings: [],
-      contents: [
-        { heading: "Symbol", content: feed.symbol },
-        { heading: "Name", content: feed.name },
-        { heading: "Description", content: feed.description },
-        { heading: "ID", content: String(feed.pyth_lazer_id) },
-      ],
-    },
+    title: `${feed.name} (Pro)`,
+    url: `${PRO_FEED_PATH}?search=${feed.symbol}`,
   };
 }
 
-export const { GET } = createSearchAPI("advanced", {
+/**
+ * Core feeds from mainnet and beta, deduplicated by symbol.
+ *
+ * hermes-beta republishes 99.4% of the mainnet symbol list (2,873 of 2,890),
+ * and both sides render to the same `SYMBOL (Core)` title pointing at the same
+ * `?search=SYMBOL` URL, so indexing both put literal duplicate rows in the
+ * search dialog and doubled the Core half of the index for nothing. Mainnet
+ * wins ties; the handful of beta-only symbols stay searchable.
+ */
+function coreFeeds(): HermesFeed[] {
+  const bySymbol = new Map<string, HermesFeed>();
+  for (const feed of snapshot.hermesBeta) {
+    bySymbol.set(feed.attributes.symbol, feed);
+  }
+  for (const feed of snapshot.hermes) {
+    bySymbol.set(feed.attributes.symbol, feed);
+  }
+  return [...bySymbol.values()];
+}
+
+type Family = "core" | "docs" | "pro";
+
+// Feed symbols are dotted/slashed paths ("Crypto.BTC/USD", "Equity.US.RIVN/USD.ON").
+const SYMBOL_SEPARATORS = /[./]/;
+
+const tokenize = (value: string): string[] =>
+  value.toLowerCase().split(SYMBOL_SEPARATORS).filter(Boolean);
+
+/**
+ * A feed as seen by the exact-match pass.
+ *
+ * Orama ranks with BM25 over ~13k documents, which does not favour the feed a
+ * user actually typed: searching the exact symbol "Crypto.BTC/USD" returned 24
+ * results without that feed among them, because common tokens ("crypto",
+ * "usd") score highly across thousands of near-identical symbols. This pass
+ * guarantees the obvious answer is present before Orama fills the rest.
+ */
+type FeedCandidate = {
+  family: Exclude<Family, "docs">;
+  index: AdvancedIndex;
+  name: string;
+  symbol: string;
+  tokens: Set<string>;
+};
+
+function toCandidate(
+  family: Exclude<Family, "docs">,
+  symbol: string,
+  name: string,
+  index: AdvancedIndex,
+): FeedCandidate {
+  return {
+    family,
+    index,
+    name: name.toLowerCase(),
+    symbol: symbol.toLowerCase(),
+    tokens: new Set([...tokenize(symbol), ...tokenize(name)]),
+  };
+}
+
+const CORE_INDEXES = coreFeeds().map((feed) => ({
+  feed,
+  index: hermesToAdvancedIndex(feed),
+}));
+const PRO_INDEXES = snapshot.lazer.map((feed) => ({
+  feed,
+  index: lazerToAdvancedIndex(feed),
+}));
+
+const FEED_CANDIDATES: FeedCandidate[] = [
+  ...CORE_INDEXES.map(({ feed, index }) =>
+    toCandidate("core", feed.attributes.symbol, feed.attributes.symbol, index),
+  ),
+  ...PRO_INDEXES.map(({ feed, index }) =>
+    toCandidate("pro", feed.symbol, feed.name, index),
+  ),
+];
+
+/**
+ * Score a feed against the query. 2 = the whole symbol or name was typed,
+ * 1 = every token in the query appears in the feed, 0 = no direct match.
+ *
+ * The token rule keeps "ETH/USD" on Crypto.ETH/USD without dragging in
+ * Crypto.ETH/USDT, and leaves vague one-character queries to Orama.
+ */
+function scoreCandidate(
+  candidate: FeedCandidate,
+  query: string,
+  queryTokens: string[],
+): number {
+  if (candidate.symbol === query || candidate.name === query) return 2;
+  return queryTokens.every((token) => candidate.tokens.has(token)) ? 1 : 0;
+}
+
+function directFeedMatches(query: string): AdvancedIndex[] {
+  const normalized = query.trim().toLowerCase();
+  const queryTokens = tokenize(normalized);
+  if (queryTokens.length === 0) return [];
+
+  const scored: { candidate: FeedCandidate; score: number }[] = [];
+  for (const candidate of FEED_CANDIDATES) {
+    const score = scoreCandidate(candidate, normalized, queryTokens);
+    if (score > 0) scored.push({ candidate, score });
+  }
+
+  // Best match first, then the most canonical symbol: "Crypto.BTC/USD" should
+  // outrank "FundingRate.Binance.BTC/USDT" for the query "BTC".
+  scored.sort(
+    (a, b) =>
+      b.score - a.score ||
+      a.candidate.symbol.length - b.candidate.symbol.length,
+  );
+
+  const taken: AdvancedIndex[] = [];
+  const used = { core: 0, pro: 0 };
+  const limits = { core: MAX_CORE_FEED_RESULTS, pro: MAX_PRO_FEED_RESULTS };
+  for (const { candidate } of scored) {
+    if (used[candidate.family] >= limits[candidate.family]) continue;
+    used[candidate.family] += 1;
+    taken.push(candidate.index);
+    if (used.core >= limits.core && used.pro >= limits.pro) break;
+  }
+  return taken;
+}
+
+const server = initAdvancedSearch({
   indexes: () => {
     const staticPages = source.getPages().map((page) => ({
-      title: page.data.title,
       description: page.data.description,
-      url: page.url,
       id: page.url,
       structuredData: page.data.structuredData,
+      title: page.data.title,
+      url: page.url,
     })) as AdvancedIndex[];
 
-    const hermesFeeds = [...snapshot.hermes, ...snapshot.hermesBeta].map(
-      (feed) => hermesToAdvancedIndex(feed),
-    );
-    const lazerFeeds = snapshot.lazer.map((feed) => lazerToAdvancedIndex(feed));
-
-    return [...staticPages, ...hermesFeeds, ...lazerFeeds];
+    return [
+      ...staticPages,
+      ...CORE_INDEXES.map(({ index }) => index),
+      ...PRO_INDEXES.map(({ index }) => index),
+    ];
   },
 });
+
+const QUOTAS: Record<Family, number> = {
+  core: MAX_CORE_FEED_RESULTS,
+  docs: MAX_DOC_RESULTS,
+  pro: MAX_PRO_FEED_RESULTS,
+};
+
+function familyOf(result: SortedResult): Family {
+  if (result.url.startsWith(CORE_FEED_PATH)) return "core";
+  if (result.url.startsWith(PRO_FEED_PATH)) return "pro";
+  return "docs";
+}
+
+/**
+ * Trim the full match set to `MAX_RESULTS`, giving each family its reserved
+ * slots first and then backfilling any unused slots with the next
+ * highest-ranked results so a docs-only or feed-only query still fills the list.
+ */
+function applyQuotas(results: SortedResult[]): SortedResult[] {
+  const picked: SortedResult[] = [];
+  const overflow: SortedResult[] = [];
+  const used: Record<Family, number> = { core: 0, docs: 0, pro: 0 };
+
+  for (const result of results) {
+    if (picked.length >= MAX_RESULTS) break;
+    const family = familyOf(result);
+    if (used[family] < QUOTAS[family]) {
+      used[family] += 1;
+      picked.push(result);
+    } else if (overflow.length < MAX_RESULTS) {
+      overflow.push(result);
+    }
+  }
+
+  return [...picked, ...overflow].slice(0, MAX_RESULTS);
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const params = new URL(request.url).searchParams;
+  const query = params.get("query");
+
+  if (!query) return Response.json([]);
+
+  const tag = params.get("tag");
+  const locale = params.get("locale");
+
+  const highlighter = createContentHighlighter(query);
+  const exact: SortedResult[] = directFeedMatches(query).map((index) => ({
+    content: index.title,
+    contentWithHighlights: highlighter.highlight(index.title),
+    id: index.id,
+    type: "page",
+    url: index.url,
+  }));
+
+  const results = await server.search(query, {
+    ...(tag === null ? {} : { tag: tag.split(",") }),
+    ...(locale === null ? {} : { locale }),
+  });
+
+  // A feed surfaced by the exact-match pass must not appear again as an Orama
+  // page row or as one of its own description snippets; both share the feed URL.
+  const seen = new Set(exact.map((result) => result.url));
+
+  return Response.json(
+    applyQuotas([...exact, ...results.filter((r) => !seen.has(r.url))]),
+  );
+}


### PR DESCRIPTION
Stacked on #3917 (base is that PR's branch, so this diff shows only the search work). Retarget to `main` once #3917 lands.

## Problem

The docs search route returned every match with no cap. Measured against production:

| query | time | payload | results |
|---|---|---|---|
| `BTC` | 0.10s | 67 KB | 179 |
| `USD` | 0.50s | 5.2 MB | 15,769 |
| `e` | 0.55s | 8.1 MB | 16,802 |
| `Equity.US.RIVN/USD.ON` | **4.66s** | **6.2 MB** | 23,494 |

That last row is a user pasting a feed symbol. The dialog debounces at 100ms, so typing it fires several of those in a row.

Cause: `searchAdvanced` calls Orama with `groupBy: { properties: ["page_id"], maxResult: 8 }` and no limit on group count. Every one of the ~9.4k feeds is its own group, so any common token (`usd`, `price`, `e`) matches thousands of them.

Worth knowing for anyone else touching this: **`search: { limit: N }` does nothing here.** Orama's `limit` bounds hits, not groups — I verified the output is byte-identical with and without it. The cap has to be applied in the route handler.

## Changes

- **Cap at 24 results with per-family quotas** (12 docs / 6 Core / 6 Pro, unused slots backfilled). Quotas are load-bearing, not cosmetic: for `USD` the first documentation hit sat at rank 624, and a naive top-24 slice made `solana` return no feeds at all.
- **Drop `structuredData.contents` from feeds.** fumadocs indexes `title` and `description` as their own documents, so those entries duplicated text already covered, at 2-3x the document count. Index build 660ms → 260ms. Symbol, name, description and feed ID all stay searchable.
- **Deduplicate Core feeds by symbol.** hermes-beta republishes 99.4% of the mainnet symbol list (2,873 of 2,890) into rows with *identical* titles and *identical* URLs — literal duplicate entries in the dialog. Mainnet wins ties; the 17 beta-only symbols stay searchable.
- **Add a deterministic exact-match pass.** Capping exposed a latent relevance bug: searching the exact symbol `Crypto.BTC/USD` returned 24 results *without that feed among them*, because BM25 favours common tokens across thousands of near-identical symbols. Feeds are now matched directly by symbol/name tokens before Orama fills the rest.
- **Drop the `outputs` override on the build task.** It restated what the task already inherits, and merging it into `main` produced a duplicate `outputs` key in the same object (`git merge-tree` reproduces it — auto-merges clean, invalid result).
- **Apply the biome fixes CI misses.** `//:test:lint` logs `Checked 0 files` on PR runs, so `biome ci --changed` never inspected these files.

## Results

6 interleaved A/B rounds against local production builds, 15-query set, 9 iterations per query. Interleaved so machine drift cannot bias one side.

| | baseline | this PR |
|---|---|---|
| median total latency | 542.9ms | 117.5ms |
| mean | 539.4ms | 122.0ms |
| total payload | 38.57 MB | 0.12 MB |

**4.62x median.** Per-round: 4.75x, 4.27x, 3.23x, 4.44x, 4.86x, 5.32x. Pairing the fastest baseline round against the slowest optimized round still gives 3.23x. Worst single query went 102.9ms → 21.6ms.

Loopback makes an 8 MB response nearly free, so this understates the production gain — over the wire the payload reduction is the dominant term.

## Verification

- 20/20 correctness checks: Core by symbol / bare ticker / 64-char feed ID, Pro by name / symbol / numeric Lazer ID / description word, `BTC`+`ETH`+`USD` each returning both families, docs still reachable on prose queries, no duplicate feed rows.
- `pnpm turbo run build --filter @pythnetwork/developer-hub` passes on this branch's base.
- `tsc` clean, `biome check` clean on all changed files.

## Not addressed here

Two items from the review of #3917 are still open and belong with that PR: an upstream outage at build time silently ships an empty feed index (the "previous snapshot" fallback cannot work on Vercel, since `src/generated/` is gitignored and `cache: false`), and there is no refresh path — no cron or ISR — so new feeds only appear on the next deploy. Lazer added 64 feeds in the 5 days after #3917 was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->