### PR TITLE
deploy(lazer): Flow EVM mainnet

### DIFF
--- a/contract_manager/src/store/contracts/EvmExecutorContracts.json
+++ b/contract_manager/src/store/contracts/EvmExecutorContracts.json
@@ -318,5 +318,10 @@
     "address": "0x0708325268dF9F66270F1401206434524814508b",
     "chain": "robinhood_testnet",
     "type": "EvmExecutorContract"
+  },
+  {
+    "address": "0x26DD80569a8B23768A1d80869Ed7339e07595E85",
+    "chain": "flow_mainnet",
+    "type": "EvmExecutorContract"
   }
 ]

--- a/contract_manager/src/store/contracts/EvmLazerContracts.json
+++ b/contract_manager/src/store/contracts/EvmLazerContracts.json
@@ -173,5 +173,10 @@
     "address": "0xACeA761c27A909d4D3895128EBe6370FDE2dF481",
     "chain": "robinhood_testnet",
     "type": "EvmLazerContract"
+  },
+  {
+    "address": "0xACeA761c27A909d4D3895128EBe6370FDE2dF481",
+    "chain": "flow_mainnet",
+    "type": "EvmLazerContract"
   }
 ]


### PR DESCRIPTION
## Summary

Adds the Pyth Pro (Lazer) mainnet deployment on Flow EVM to the contract manager store:

- `PythLazer` (EvmLazerContract): `0xACeA761c27A909d4D3895128EBe6370FDE2dF481`
- `Executor` (EvmExecutorContract): `0x26DD80569a8B23768A1d80869Ed7339e07595E85`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->