### PR TITLE
chore(greenlight): auto-approve contract_manager store record JSONs

### DIFF
--- a/.github/greenlight.yml
+++ b/.github/greenlight.yml
@@ -29,3 +29,6 @@ auto_approve_paths:
   # Scaffolding / test-config dev tooling
   - "packages/create-pyth-package/**"
   - "packages/jest-config/**"
+  # Deployment record JSONs (chains, contracts, tokens, vaults) written by
+  # contract_manager tooling; the tooling itself stays behind human review
+  - "contract_manager/src/store/**"


### PR DESCRIPTION
## Summary

Adds `contract_manager/src/store/**` to greenlight's `auto_approve_paths` allowlist so that deployment record PRs (the chains/contracts/tokens/vaults JSONs written by `saveAllContracts` after a deploy, e.g. #3935) are eligible for self-authorized auto-merge.

The contract_manager tooling itself (`src/` code, `scripts/`) remains behind human review — only the store record JSONs are allowlisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->