### PR TITLE
feat(evm): add MigrateGovernanceAndWormhole governance action

### DIFF
--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernance.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernance.sol
@@ -260,8 +260,9 @@ abstract contract PythGovernance is
         emit WormholeAddressSet(oldWormholeAddress, address(wormhole()));
     }
 
-    /// @dev Sets wormhole address, data sources, and fee without dual-VAA re-verify.
+    /// @dev Sets wormhole address and data sources without dual-VAA re-verify.
     /// Used for legacy → pro-compatible migration where guardian sets do not overlap.
+    /// Fee is set separately via SetFee before migration.
     function setWormholeAddressAndDataSources(
         SetWormholeAddressAndDataSourcesPayload memory payload
     ) internal {
@@ -282,7 +283,6 @@ abstract contract PythGovernance is
         setDataSources(
             SetDataSourcesPayload({dataSources: payload.dataSources})
         );
-        setFee(SetFeePayload({newFee: payload.newFee}));
     }
 
     function setTransactionFee(

--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernance.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernance.sol
@@ -106,12 +106,12 @@ abstract contract PythGovernance is
         } else if (gi.action == GovernanceAction.WithdrawFee) {
             withdrawFee(parseWithdrawFeePayload(gi.payload));
         } else if (
-            gi.action == GovernanceAction.SetWormholeAddressAndDataSources
+            gi.action == GovernanceAction.MigrateGovernanceAndWormhole
         ) {
             if (gi.targetChainId == 0)
                 revert PythErrors.InvalidGovernanceTarget();
-            setWormholeAddressAndDataSources(
-                parseSetWormholeAddressAndDataSourcesPayload(gi.payload)
+            migrateGovernanceAndWormhole(
+                parseMigrateGovernanceAndWormholePayload(gi.payload)
             );
         } else {
             revert PythErrors.InvalidGovernanceMessage();
@@ -260,11 +260,12 @@ abstract contract PythGovernance is
         emit WormholeAddressSet(oldWormholeAddress, address(wormhole()));
     }
 
-    /// @dev Sets wormhole address and data sources without dual-VAA re-verify.
-    /// Used for legacy → pro-compatible migration where guardian sets do not overlap.
+    /// @dev Atomically migrates wormhole address, valid data sources, and
+    /// governance emitter without dual-VAA re-verify. Resets the last executed
+    /// governance sequence so the new emitter can start from sequence 0.
     /// Fee is set separately via SetFee before migration.
-    function setWormholeAddressAndDataSources(
-        SetWormholeAddressAndDataSourcesPayload memory payload
+    function migrateGovernanceAndWormhole(
+        MigrateGovernanceAndWormholePayload memory payload
     ) internal {
         if (payload.newWormholeAddress == address(0))
             revert PythErrors.InvalidWormholeAddressToSet();
@@ -276,12 +277,33 @@ abstract contract PythGovernance is
         }
         if (codeSize == 0) revert PythErrors.InvalidWormholeAddressToSet();
 
+        if (payload.governanceDataSource.emitterAddress == bytes32(0))
+            revert PythErrors.InvalidGovernanceDataSource();
+
         address oldWormholeAddress = address(wormhole());
         setWormhole(payload.newWormholeAddress);
         emit WormholeAddressSet(oldWormholeAddress, address(wormhole()));
 
         setDataSources(
             SetDataSourcesPayload({dataSources: payload.dataSources})
+        );
+
+        // Governance data source index must strictly increase to prevent replay.
+        if (
+            payload.governanceDataSourceIndex <= governanceDataSourceIndex()
+        ) revert PythErrors.OldGovernanceMessage();
+
+        PythInternalStructs.DataSource
+            memory oldGovernanceDataSource = governanceDataSource();
+
+        setGovernanceDataSourceIndex(payload.governanceDataSourceIndex);
+        setGovernanceDataSource(payload.governanceDataSource);
+        setLastExecutedGovernanceSequence(0);
+
+        emit GovernanceDataSourceSet(
+            oldGovernanceDataSource,
+            governanceDataSource(),
+            lastExecutedGovernanceSequence()
         );
     }
 

--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernance.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernance.sol
@@ -105,6 +105,14 @@ abstract contract PythGovernance is
             setTransactionFee(parseSetTransactionFeePayload(gi.payload));
         } else if (gi.action == GovernanceAction.WithdrawFee) {
             withdrawFee(parseWithdrawFeePayload(gi.payload));
+        } else if (
+            gi.action == GovernanceAction.SetWormholeAddressAndDataSources
+        ) {
+            if (gi.targetChainId == 0)
+                revert PythErrors.InvalidGovernanceTarget();
+            setWormholeAddressAndDataSources(
+                parseSetWormholeAddressAndDataSourcesPayload(gi.payload)
+            );
         } else {
             revert PythErrors.InvalidGovernanceMessage();
         }
@@ -250,6 +258,31 @@ abstract contract PythGovernance is
             revert PythErrors.InvalidWormholeAddressToSet();
 
         emit WormholeAddressSet(oldWormholeAddress, address(wormhole()));
+    }
+
+    /// @dev Sets wormhole address, data sources, and fee without dual-VAA re-verify.
+    /// Used for legacy → pro-compatible migration where guardian sets do not overlap.
+    function setWormholeAddressAndDataSources(
+        SetWormholeAddressAndDataSourcesPayload memory payload
+    ) internal {
+        if (payload.newWormholeAddress == address(0))
+            revert PythErrors.InvalidWormholeAddressToSet();
+
+        uint256 codeSize;
+        address newWormholeAddress = payload.newWormholeAddress;
+        assembly {
+            codeSize := extcodesize(newWormholeAddress)
+        }
+        if (codeSize == 0) revert PythErrors.InvalidWormholeAddressToSet();
+
+        address oldWormholeAddress = address(wormhole());
+        setWormhole(payload.newWormholeAddress);
+        emit WormholeAddressSet(oldWormholeAddress, address(wormhole()));
+
+        setDataSources(
+            SetDataSourcesPayload({dataSources: payload.dataSources})
+        );
+        setFee(SetFeePayload({newFee: payload.newFee}));
     }
 
     function setTransactionFee(

--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
@@ -98,7 +98,6 @@ contract PythGovernanceInstructions {
     struct SetWormholeAddressAndDataSourcesPayload {
         address newWormholeAddress;
         PythInternalStructs.DataSource[] dataSources;
-        uint newFee;
     }
 
     /// @dev Parse a GovernanceInstruction
@@ -313,14 +312,6 @@ contract PythGovernanceInstructions {
             );
             index += 32;
         }
-
-        uint64 val = encodedPayload.toUint64(index);
-        index += 8;
-
-        uint64 expo = encodedPayload.toUint64(index);
-        index += 8;
-
-        payload.newFee = uint256(val) * uint256(10) ** uint256(expo);
 
         if (encodedPayload.length != index)
             revert PythErrors.InvalidGovernanceMessage();

--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
@@ -42,7 +42,7 @@ contract PythGovernanceInstructions {
         SetFeeInToken, // 7 - No-op for EVM chains
         SetTransactionFee, // 8
         WithdrawFee, // 9
-        SetWormholeAddressAndDataSources // 10
+        MigrateGovernanceAndWormhole // 10
     }
 
     struct GovernanceInstruction {
@@ -95,9 +95,11 @@ contract PythGovernanceInstructions {
         uint256 fee;
     }
 
-    struct SetWormholeAddressAndDataSourcesPayload {
+    struct MigrateGovernanceAndWormholePayload {
         address newWormholeAddress;
         PythInternalStructs.DataSource[] dataSources;
+        PythInternalStructs.DataSource governanceDataSource;
+        uint32 governanceDataSourceIndex;
     }
 
     /// @dev Parse a GovernanceInstruction
@@ -283,13 +285,13 @@ contract PythGovernanceInstructions {
             revert PythErrors.InvalidGovernanceMessage();
     }
 
-    /// @dev Parse a SetWormholeAddressAndDataSourcesPayload (action 10) with minimal validation
-    function parseSetWormholeAddressAndDataSourcesPayload(
+    /// @dev Parse a MigrateGovernanceAndWormholePayload (action 10) with minimal validation
+    function parseMigrateGovernanceAndWormholePayload(
         bytes memory encodedPayload
     )
         public
         pure
-        returns (SetWormholeAddressAndDataSourcesPayload memory payload)
+        returns (MigrateGovernanceAndWormholePayload memory payload)
     {
         uint index = 0;
 
@@ -312,6 +314,17 @@ contract PythGovernanceInstructions {
             );
             index += 32;
         }
+
+        payload.governanceDataSource.chainId = encodedPayload.toUint16(index);
+        index += 2;
+
+        payload.governanceDataSource.emitterAddress = encodedPayload.toBytes32(
+            index
+        );
+        index += 32;
+
+        payload.governanceDataSourceIndex = encodedPayload.toUint32(index);
+        index += 4;
 
         if (encodedPayload.length != index)
             revert PythErrors.InvalidGovernanceMessage();

--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
@@ -41,7 +41,8 @@ contract PythGovernanceInstructions {
         SetWormholeAddress, // 6
         SetFeeInToken, // 7 - No-op for EVM chains
         SetTransactionFee, // 8
-        WithdrawFee // 9
+        WithdrawFee, // 9
+        SetWormholeAddressAndDataSources // 10
     }
 
     struct GovernanceInstruction {
@@ -92,6 +93,12 @@ contract PythGovernanceInstructions {
         address targetAddress;
         // Fee in wei, matching the native uint256 type used for address.balance in EVM
         uint256 fee;
+    }
+
+    struct SetWormholeAddressAndDataSourcesPayload {
+        address newWormholeAddress;
+        PythInternalStructs.DataSource[] dataSources;
+        uint newFee;
     }
 
     /// @dev Parse a GovernanceInstruction
@@ -272,6 +279,48 @@ contract PythGovernanceInstructions {
         index += 8;
 
         wf.fee = uint256(val) * uint256(10) ** uint256(expo);
+
+        if (encodedPayload.length != index)
+            revert PythErrors.InvalidGovernanceMessage();
+    }
+
+    /// @dev Parse a SetWormholeAddressAndDataSourcesPayload (action 10) with minimal validation
+    function parseSetWormholeAddressAndDataSourcesPayload(
+        bytes memory encodedPayload
+    )
+        public
+        pure
+        returns (SetWormholeAddressAndDataSourcesPayload memory payload)
+    {
+        uint index = 0;
+
+        payload.newWormholeAddress = address(encodedPayload.toAddress(index));
+        index += 20;
+
+        uint8 dataSourcesLength = encodedPayload.toUint8(index);
+        index += 1;
+
+        payload.dataSources = new PythInternalStructs.DataSource[](
+            dataSourcesLength
+        );
+
+        for (uint i = 0; i < dataSourcesLength; i++) {
+            payload.dataSources[i].chainId = encodedPayload.toUint16(index);
+            index += 2;
+
+            payload.dataSources[i].emitterAddress = encodedPayload.toBytes32(
+                index
+            );
+            index += 32;
+        }
+
+        uint64 val = encodedPayload.toUint64(index);
+        index += 8;
+
+        uint64 expo = encodedPayload.toUint64(index);
+        index += 8;
+
+        payload.newFee = uint256(val) * uint256(10) ** uint256(expo);
 
         if (encodedPayload.length != index)
             revert PythErrors.InvalidGovernanceMessage();

--- a/target_chains/ethereum/contracts/test/PythGovernance.t.sol
+++ b/target_chains/ethereum/contracts/test/PythGovernance.t.sol
@@ -647,21 +647,29 @@ contract PythGovernanceTest is
         PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
     }
 
-    function testSetWormholeAddressAndDataSources() public {
+    function testMigrateGovernanceAndWormhole() public {
         address newWormhole = address(setUpWormholeReceiver(1));
         bytes32 newEmitter = bytes32(
             0x0000000000000000000000000000000000000000000000000000000000002222
         );
+        uint16 newGovernanceChain = 3;
+        bytes32 newGovernanceEmitter = bytes32(
+            0x0000000000000000000000000000000000000000000000000000000000003333
+        );
+        uint32 newGovernanceIndex = 1;
 
         bytes memory data = abi.encodePacked(
             MAGIC,
             uint8(GovernanceModule.Target),
-            uint8(GovernanceAction.SetWormholeAddressAndDataSources),
+            uint8(GovernanceAction.MigrateGovernanceAndWormhole),
             TARGET_CHAIN_ID,
             newWormhole,
             uint8(1), // Number of data sources
             uint16(26), // Chain ID
-            newEmitter
+            newEmitter,
+            newGovernanceChain,
+            newGovernanceEmitter,
+            newGovernanceIndex
         );
 
         bytes memory vaa = encodeAndSignMessage(
@@ -675,16 +683,30 @@ contract PythGovernanceTest is
         PythInternalStructs.DataSource[] memory oldDataSources = PythGetters(
             address(pyth)
         ).validDataSources();
+        PythInternalStructs.DataSource
+            memory oldGovernanceDataSource = PythGetters(address(pyth))
+                .governanceDataSource();
         uint feeBefore = PythGetters(address(pyth)).singleUpdateFeeInWei();
 
         PythInternalStructs.DataSource[]
             memory newDataSources = new PythInternalStructs.DataSource[](1);
         newDataSources[0] = PythInternalStructs.DataSource(26, newEmitter);
+        PythInternalStructs.DataSource
+            memory newGovernanceDataSource = PythInternalStructs.DataSource(
+                newGovernanceChain,
+                newGovernanceEmitter
+            );
 
         vm.expectEmit(true, true, true, true);
         emit WormholeAddressSet(oldWormhole, newWormhole);
         vm.expectEmit(true, true, true, true);
         emit DataSourcesSet(oldDataSources, newDataSources);
+        vm.expectEmit(true, true, true, true);
+        emit GovernanceDataSourceSet(
+            oldGovernanceDataSource,
+            newGovernanceDataSource,
+            0
+        );
 
         PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
 
@@ -698,71 +720,32 @@ contract PythGovernanceTest is
         assertTrue(
             PythGetters(address(pyth)).isValidDataSource(26, newEmitter)
         );
+
+        PythInternalStructs.DataSource
+            memory governanceDataSource = PythGetters(address(pyth))
+                .governanceDataSource();
+        assertEq(governanceDataSource.chainId, newGovernanceChain);
+        assertEq(governanceDataSource.emitterAddress, newGovernanceEmitter);
+        assertEq(
+            PythGetters(address(pyth)).governanceDataSourceIndex(),
+            newGovernanceIndex
+        );
+        assertEq(
+            PythGetters(address(pyth)).lastExecutedGovernanceSequence(),
+            0
+        );
         // Fee is unchanged — set separately via SetFee before migration.
         assertEq(PythGetters(address(pyth)).singleUpdateFeeInWei(), feeBefore);
     }
 
-    function testSetWormholeAddressAndDataSourcesRejectsZeroAddress() public {
-        bytes memory data = abi.encodePacked(
-            MAGIC,
-            uint8(GovernanceModule.Target),
-            uint8(GovernanceAction.SetWormholeAddressAndDataSources),
-            TARGET_CHAIN_ID,
-            address(0),
-            uint8(1),
-            uint16(26),
-            bytes32(
-                0x0000000000000000000000000000000000000000000000000000000000002222
-            )
-        );
-
-        bytes memory vaa = encodeAndSignMessage(
-            data,
-            TEST_GOVERNANCE_CHAIN_ID,
-            TEST_GOVERNANCE_EMITTER,
-            1
-        );
-
-        vm.expectRevert(PythErrors.InvalidWormholeAddressToSet.selector);
-        PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
-    }
-
-    function testSetWormholeAddressAndDataSourcesRejectsNoCode() public {
-        address noCode = makeAddr("noCodeWormhole");
-
-        bytes memory data = abi.encodePacked(
-            MAGIC,
-            uint8(GovernanceModule.Target),
-            uint8(GovernanceAction.SetWormholeAddressAndDataSources),
-            TARGET_CHAIN_ID,
-            noCode,
-            uint8(1),
-            uint16(26),
-            bytes32(
-                0x0000000000000000000000000000000000000000000000000000000000002222
-            )
-        );
-
-        bytes memory vaa = encodeAndSignMessage(
-            data,
-            TEST_GOVERNANCE_CHAIN_ID,
-            TEST_GOVERNANCE_EMITTER,
-            1
-        );
-
-        vm.expectRevert(PythErrors.InvalidWormholeAddressToSet.selector);
-        PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
-    }
-
-    function testSetWormholeAddressAndDataSourcesRejectsTrailingBytes()
-        public
-    {
+    function testMigrateGovernanceAndWormholeRejectsStaleIndex() public {
         address newWormhole = address(setUpWormholeReceiver(1));
 
+        // Initial governanceDataSourceIndex is 0; index must strictly increase.
         bytes memory data = abi.encodePacked(
             MAGIC,
             uint8(GovernanceModule.Target),
-            uint8(GovernanceAction.SetWormholeAddressAndDataSources),
+            uint8(GovernanceAction.MigrateGovernanceAndWormhole),
             TARGET_CHAIN_ID,
             newWormhole,
             uint8(1),
@@ -770,6 +753,105 @@ contract PythGovernanceTest is
             bytes32(
                 0x0000000000000000000000000000000000000000000000000000000000002222
             ),
+            uint16(3),
+            bytes32(
+                0x0000000000000000000000000000000000000000000000000000000000003333
+            ),
+            uint32(0)
+        );
+
+        bytes memory vaa = encodeAndSignMessage(
+            data,
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            1
+        );
+
+        vm.expectRevert(PythErrors.OldGovernanceMessage.selector);
+        PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
+    }
+
+    function testMigrateGovernanceAndWormholeRejectsZeroWormhole() public {
+        bytes memory data = abi.encodePacked(
+            MAGIC,
+            uint8(GovernanceModule.Target),
+            uint8(GovernanceAction.MigrateGovernanceAndWormhole),
+            TARGET_CHAIN_ID,
+            address(0),
+            uint8(1),
+            uint16(26),
+            bytes32(
+                0x0000000000000000000000000000000000000000000000000000000000002222
+            ),
+            uint16(3),
+            bytes32(
+                0x0000000000000000000000000000000000000000000000000000000000003333
+            ),
+            uint32(1)
+        );
+
+        bytes memory vaa = encodeAndSignMessage(
+            data,
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            1
+        );
+
+        vm.expectRevert(PythErrors.InvalidWormholeAddressToSet.selector);
+        PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
+    }
+
+    function testMigrateGovernanceAndWormholeRejectsNoCode() public {
+        address noCode = makeAddr("noCodeWormhole");
+
+        bytes memory data = abi.encodePacked(
+            MAGIC,
+            uint8(GovernanceModule.Target),
+            uint8(GovernanceAction.MigrateGovernanceAndWormhole),
+            TARGET_CHAIN_ID,
+            noCode,
+            uint8(1),
+            uint16(26),
+            bytes32(
+                0x0000000000000000000000000000000000000000000000000000000000002222
+            ),
+            uint16(3),
+            bytes32(
+                0x0000000000000000000000000000000000000000000000000000000000003333
+            ),
+            uint32(1)
+        );
+
+        bytes memory vaa = encodeAndSignMessage(
+            data,
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            1
+        );
+
+        vm.expectRevert(PythErrors.InvalidWormholeAddressToSet.selector);
+        PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
+    }
+
+    function testMigrateGovernanceAndWormholeRejectsTrailingBytes() public {
+        address newWormhole = address(setUpWormholeReceiver(1));
+
+        bytes memory data = abi.encodePacked(
+            MAGIC,
+            uint8(GovernanceModule.Target),
+            uint8(GovernanceAction.MigrateGovernanceAndWormhole),
+            TARGET_CHAIN_ID,
+            newWormhole,
+            uint8(1),
+            uint16(26),
+            bytes32(
+                0x0000000000000000000000000000000000000000000000000000000000002222
+            ),
+            uint16(3),
+            bytes32(
+                0x0000000000000000000000000000000000000000000000000000000000003333
+            ),
+            uint32(1),
             uint8(0xff) // Trailing byte
         );
 
@@ -784,16 +866,16 @@ contract PythGovernanceTest is
         PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
     }
 
-    function testSetWormholeAddressAndDataSourcesRejectsTruncatedPayload()
+    function testMigrateGovernanceAndWormholeRejectsTruncatedPayload()
         public
     {
         address newWormhole = address(setUpWormholeReceiver(1));
 
-        // Missing emitter address (truncated after chain id)
+        // Truncated after data-source chain id (missing emitter + governance fields)
         bytes memory data = abi.encodePacked(
             MAGIC,
             uint8(GovernanceModule.Target),
-            uint8(GovernanceAction.SetWormholeAddressAndDataSources),
+            uint8(GovernanceAction.MigrateGovernanceAndWormhole),
             TARGET_CHAIN_ID,
             newWormhole,
             uint8(1),
@@ -811,20 +893,25 @@ contract PythGovernanceTest is
         PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
     }
 
-    function testSetWormholeAddressAndDataSourcesRejectsChainIdZero() public {
+    function testMigrateGovernanceAndWormholeRejectsChainIdZero() public {
         address newWormhole = address(setUpWormholeReceiver(1));
 
         bytes memory data = abi.encodePacked(
             MAGIC,
             uint8(GovernanceModule.Target),
-            uint8(GovernanceAction.SetWormholeAddressAndDataSources),
+            uint8(GovernanceAction.MigrateGovernanceAndWormhole),
             uint16(0), // Chain ID 0 (unset)
             newWormhole,
             uint8(1),
             uint16(26),
             bytes32(
                 0x0000000000000000000000000000000000000000000000000000000000002222
-            )
+            ),
+            uint16(3),
+            bytes32(
+                0x0000000000000000000000000000000000000000000000000000000000003333
+            ),
+            uint32(1)
         );
 
         bytes memory vaa = encodeAndSignMessage(
@@ -835,6 +922,38 @@ contract PythGovernanceTest is
         );
 
         vm.expectRevert(PythErrors.InvalidGovernanceTarget.selector);
+        PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
+    }
+
+    function testMigrateGovernanceAndWormholeRejectsZeroGovernanceEmitter()
+        public
+    {
+        address newWormhole = address(setUpWormholeReceiver(1));
+
+        bytes memory data = abi.encodePacked(
+            MAGIC,
+            uint8(GovernanceModule.Target),
+            uint8(GovernanceAction.MigrateGovernanceAndWormhole),
+            TARGET_CHAIN_ID,
+            newWormhole,
+            uint8(1),
+            uint16(26),
+            bytes32(
+                0x0000000000000000000000000000000000000000000000000000000000002222
+            ),
+            uint16(3),
+            bytes32(0), // Zero governance emitter
+            uint32(1)
+        );
+
+        bytes memory vaa = encodeAndSignMessage(
+            data,
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            1
+        );
+
+        vm.expectRevert(PythErrors.InvalidGovernanceDataSource.selector);
         PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
     }
 

--- a/target_chains/ethereum/contracts/test/PythGovernance.t.sol
+++ b/target_chains/ethereum/contracts/test/PythGovernance.t.sol
@@ -661,9 +661,7 @@ contract PythGovernanceTest is
             newWormhole,
             uint8(1), // Number of data sources
             uint16(26), // Chain ID
-            newEmitter,
-            uint64(0), // fee value
-            uint64(0) // fee expo
+            newEmitter
         );
 
         bytes memory vaa = encodeAndSignMessage(
@@ -677,7 +675,7 @@ contract PythGovernanceTest is
         PythInternalStructs.DataSource[] memory oldDataSources = PythGetters(
             address(pyth)
         ).validDataSources();
-        uint oldFee = PythGetters(address(pyth)).singleUpdateFeeInWei();
+        uint feeBefore = PythGetters(address(pyth)).singleUpdateFeeInWei();
 
         PythInternalStructs.DataSource[]
             memory newDataSources = new PythInternalStructs.DataSource[](1);
@@ -687,8 +685,6 @@ contract PythGovernanceTest is
         emit WormholeAddressSet(oldWormhole, newWormhole);
         vm.expectEmit(true, true, true, true);
         emit DataSourcesSet(oldDataSources, newDataSources);
-        vm.expectEmit(true, true, true, true);
-        emit FeeSet(oldFee, 0);
 
         PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
 
@@ -702,7 +698,8 @@ contract PythGovernanceTest is
         assertTrue(
             PythGetters(address(pyth)).isValidDataSource(26, newEmitter)
         );
-        assertEq(PythGetters(address(pyth)).singleUpdateFeeInWei(), 0);
+        // Fee is unchanged — set separately via SetFee before migration.
+        assertEq(PythGetters(address(pyth)).singleUpdateFeeInWei(), feeBefore);
     }
 
     function testSetWormholeAddressAndDataSourcesRejectsZeroAddress() public {
@@ -716,9 +713,7 @@ contract PythGovernanceTest is
             uint16(26),
             bytes32(
                 0x0000000000000000000000000000000000000000000000000000000000002222
-            ),
-            uint64(0),
-            uint64(0)
+            )
         );
 
         bytes memory vaa = encodeAndSignMessage(
@@ -745,9 +740,7 @@ contract PythGovernanceTest is
             uint16(26),
             bytes32(
                 0x0000000000000000000000000000000000000000000000000000000000002222
-            ),
-            uint64(0),
-            uint64(0)
+            )
         );
 
         bytes memory vaa = encodeAndSignMessage(
@@ -777,8 +770,6 @@ contract PythGovernanceTest is
             bytes32(
                 0x0000000000000000000000000000000000000000000000000000000000002222
             ),
-            uint64(0),
-            uint64(0),
             uint8(0xff) // Trailing byte
         );
 
@@ -798,7 +789,7 @@ contract PythGovernanceTest is
     {
         address newWormhole = address(setUpWormholeReceiver(1));
 
-        // Missing fee expo (truncated after fee value)
+        // Missing emitter address (truncated after chain id)
         bytes memory data = abi.encodePacked(
             MAGIC,
             uint8(GovernanceModule.Target),
@@ -806,11 +797,7 @@ contract PythGovernanceTest is
             TARGET_CHAIN_ID,
             newWormhole,
             uint8(1),
-            uint16(26),
-            bytes32(
-                0x0000000000000000000000000000000000000000000000000000000000002222
-            ),
-            uint64(0) // fee value only — missing expo
+            uint16(26)
         );
 
         bytes memory vaa = encodeAndSignMessage(
@@ -837,9 +824,7 @@ contract PythGovernanceTest is
             uint16(26),
             bytes32(
                 0x0000000000000000000000000000000000000000000000000000000000002222
-            ),
-            uint64(0),
-            uint64(0)
+            )
         );
 
         bytes memory vaa = encodeAndSignMessage(
@@ -851,37 +836,6 @@ contract PythGovernanceTest is
 
         vm.expectRevert(PythErrors.InvalidGovernanceTarget.selector);
         PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
-    }
-
-    function testSetWormholeAddressAndDataSourcesSetsNonZeroFee() public {
-        address newWormhole = address(setUpWormholeReceiver(1));
-        bytes32 newEmitter = bytes32(
-            0x0000000000000000000000000000000000000000000000000000000000003333
-        );
-
-        // fee = 5 * 10^3 = 5000
-        bytes memory data = abi.encodePacked(
-            MAGIC,
-            uint8(GovernanceModule.Target),
-            uint8(GovernanceAction.SetWormholeAddressAndDataSources),
-            TARGET_CHAIN_ID,
-            newWormhole,
-            uint8(1),
-            uint16(26),
-            newEmitter,
-            uint64(5),
-            uint64(3)
-        );
-
-        bytes memory vaa = encodeAndSignMessage(
-            data,
-            TEST_GOVERNANCE_CHAIN_ID,
-            TEST_GOVERNANCE_EMITTER,
-            1
-        );
-
-        PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
-        assertEq(PythGetters(address(pyth)).singleUpdateFeeInWei(), 5000);
     }
 
     function encodeAndSignWormholeMessage(

--- a/target_chains/ethereum/contracts/test/PythGovernance.t.sol
+++ b/target_chains/ethereum/contracts/test/PythGovernance.t.sol
@@ -647,6 +647,243 @@ contract PythGovernanceTest is
         PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
     }
 
+    function testSetWormholeAddressAndDataSources() public {
+        address newWormhole = address(setUpWormholeReceiver(1));
+        bytes32 newEmitter = bytes32(
+            0x0000000000000000000000000000000000000000000000000000000000002222
+        );
+
+        bytes memory data = abi.encodePacked(
+            MAGIC,
+            uint8(GovernanceModule.Target),
+            uint8(GovernanceAction.SetWormholeAddressAndDataSources),
+            TARGET_CHAIN_ID,
+            newWormhole,
+            uint8(1), // Number of data sources
+            uint16(26), // Chain ID
+            newEmitter,
+            uint64(0), // fee value
+            uint64(0) // fee expo
+        );
+
+        bytes memory vaa = encodeAndSignMessage(
+            data,
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            1
+        );
+
+        address oldWormhole = address(PythGetters(address(pyth)).wormhole());
+        PythInternalStructs.DataSource[] memory oldDataSources = PythGetters(
+            address(pyth)
+        ).validDataSources();
+        uint oldFee = PythGetters(address(pyth)).singleUpdateFeeInWei();
+
+        PythInternalStructs.DataSource[]
+            memory newDataSources = new PythInternalStructs.DataSource[](1);
+        newDataSources[0] = PythInternalStructs.DataSource(26, newEmitter);
+
+        vm.expectEmit(true, true, true, true);
+        emit WormholeAddressSet(oldWormhole, newWormhole);
+        vm.expectEmit(true, true, true, true);
+        emit DataSourcesSet(oldDataSources, newDataSources);
+        vm.expectEmit(true, true, true, true);
+        emit FeeSet(oldFee, 0);
+
+        PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
+
+        assertEq(address(PythGetters(address(pyth)).wormhole()), newWormhole);
+        assertFalse(
+            PythGetters(address(pyth)).isValidDataSource(
+                TEST_PYTH2_WORMHOLE_CHAIN_ID,
+                TEST_PYTH2_WORMHOLE_EMITTER
+            )
+        );
+        assertTrue(
+            PythGetters(address(pyth)).isValidDataSource(26, newEmitter)
+        );
+        assertEq(PythGetters(address(pyth)).singleUpdateFeeInWei(), 0);
+    }
+
+    function testSetWormholeAddressAndDataSourcesRejectsZeroAddress() public {
+        bytes memory data = abi.encodePacked(
+            MAGIC,
+            uint8(GovernanceModule.Target),
+            uint8(GovernanceAction.SetWormholeAddressAndDataSources),
+            TARGET_CHAIN_ID,
+            address(0),
+            uint8(1),
+            uint16(26),
+            bytes32(
+                0x0000000000000000000000000000000000000000000000000000000000002222
+            ),
+            uint64(0),
+            uint64(0)
+        );
+
+        bytes memory vaa = encodeAndSignMessage(
+            data,
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            1
+        );
+
+        vm.expectRevert(PythErrors.InvalidWormholeAddressToSet.selector);
+        PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
+    }
+
+    function testSetWormholeAddressAndDataSourcesRejectsNoCode() public {
+        address noCode = makeAddr("noCodeWormhole");
+
+        bytes memory data = abi.encodePacked(
+            MAGIC,
+            uint8(GovernanceModule.Target),
+            uint8(GovernanceAction.SetWormholeAddressAndDataSources),
+            TARGET_CHAIN_ID,
+            noCode,
+            uint8(1),
+            uint16(26),
+            bytes32(
+                0x0000000000000000000000000000000000000000000000000000000000002222
+            ),
+            uint64(0),
+            uint64(0)
+        );
+
+        bytes memory vaa = encodeAndSignMessage(
+            data,
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            1
+        );
+
+        vm.expectRevert(PythErrors.InvalidWormholeAddressToSet.selector);
+        PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
+    }
+
+    function testSetWormholeAddressAndDataSourcesRejectsTrailingBytes()
+        public
+    {
+        address newWormhole = address(setUpWormholeReceiver(1));
+
+        bytes memory data = abi.encodePacked(
+            MAGIC,
+            uint8(GovernanceModule.Target),
+            uint8(GovernanceAction.SetWormholeAddressAndDataSources),
+            TARGET_CHAIN_ID,
+            newWormhole,
+            uint8(1),
+            uint16(26),
+            bytes32(
+                0x0000000000000000000000000000000000000000000000000000000000002222
+            ),
+            uint64(0),
+            uint64(0),
+            uint8(0xff) // Trailing byte
+        );
+
+        bytes memory vaa = encodeAndSignMessage(
+            data,
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            1
+        );
+
+        vm.expectRevert(PythErrors.InvalidGovernanceMessage.selector);
+        PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
+    }
+
+    function testSetWormholeAddressAndDataSourcesRejectsTruncatedPayload()
+        public
+    {
+        address newWormhole = address(setUpWormholeReceiver(1));
+
+        // Missing fee expo (truncated after fee value)
+        bytes memory data = abi.encodePacked(
+            MAGIC,
+            uint8(GovernanceModule.Target),
+            uint8(GovernanceAction.SetWormholeAddressAndDataSources),
+            TARGET_CHAIN_ID,
+            newWormhole,
+            uint8(1),
+            uint16(26),
+            bytes32(
+                0x0000000000000000000000000000000000000000000000000000000000002222
+            ),
+            uint64(0) // fee value only — missing expo
+        );
+
+        bytes memory vaa = encodeAndSignMessage(
+            data,
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            1
+        );
+
+        vm.expectRevert();
+        PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
+    }
+
+    function testSetWormholeAddressAndDataSourcesRejectsChainIdZero() public {
+        address newWormhole = address(setUpWormholeReceiver(1));
+
+        bytes memory data = abi.encodePacked(
+            MAGIC,
+            uint8(GovernanceModule.Target),
+            uint8(GovernanceAction.SetWormholeAddressAndDataSources),
+            uint16(0), // Chain ID 0 (unset)
+            newWormhole,
+            uint8(1),
+            uint16(26),
+            bytes32(
+                0x0000000000000000000000000000000000000000000000000000000000002222
+            ),
+            uint64(0),
+            uint64(0)
+        );
+
+        bytes memory vaa = encodeAndSignMessage(
+            data,
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            1
+        );
+
+        vm.expectRevert(PythErrors.InvalidGovernanceTarget.selector);
+        PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
+    }
+
+    function testSetWormholeAddressAndDataSourcesSetsNonZeroFee() public {
+        address newWormhole = address(setUpWormholeReceiver(1));
+        bytes32 newEmitter = bytes32(
+            0x0000000000000000000000000000000000000000000000000000000000003333
+        );
+
+        // fee = 5 * 10^3 = 5000
+        bytes memory data = abi.encodePacked(
+            MAGIC,
+            uint8(GovernanceModule.Target),
+            uint8(GovernanceAction.SetWormholeAddressAndDataSources),
+            TARGET_CHAIN_ID,
+            newWormhole,
+            uint8(1),
+            uint16(26),
+            newEmitter,
+            uint64(5),
+            uint64(3)
+        );
+
+        bytes memory vaa = encodeAndSignMessage(
+            data,
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            1
+        );
+
+        PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
+        assertEq(PythGetters(address(pyth)).singleUpdateFeeInWei(), 5000);
+    }
+
     function encodeAndSignWormholeMessage(
         bytes memory data,
         uint16 emitterChainId,


### PR DESCRIPTION
## Summary
- Adds Target governance action **10** `MigrateGovernanceAndWormhole` for legacy → pro-compatible in-place cutover.
- Atomically sets wormhole (no dual-VAA re-verify), replaces valid data sources, sets the **new** governance emitter, bumps `governanceDataSourceIndex`, and resets `lastExecutedGovernanceSequence` to `0`.
- Fee is **not** part of this action — set to `0` beforehand via existing `SetFee`.
- Leaves `SetWormholeAddress` dual-verify and `AuthorizeGovernanceDataSourceTransfer` unchanged (handoff cannot cross mismatched attestor sets).

Wire format (after PTGM header):
`wormhole(20) | dataSources* | governanceEmitter(chain u16 + addr 32) | governanceDataSourceIndex(u32)`

Sibling PRs:
- xc_admin_common codec
- contract_manager migrate tooling

## Test plan
- [ ] `forge test --match-contract PythGovernance`
- [ ] Happy path: wormhole, data sources, governance DS/index, sequence `0`; fee unchanged
- [ ] Reverts: zero/no-code wormhole, zero governance emitter, stale index, chainId `0`, trailing/truncated payload
- [ ] Confirm actions 6 and authorize-transfer behavior unchanged