### PR TITLE
feat(xc_admin_common): add MigrateGovernanceAndWormhole governance codec

### DIFF
--- a/governance/xc_admin/packages/xc_admin_common/package.json
+++ b/governance/xc_admin/packages/xc_admin_common/package.json
@@ -229,14 +229,14 @@
         "types": "./dist/cjs/governance_payload/SetWormholeAddress.d.ts"
       }
     },
-    "./governance_payload/SetWormholeAddressAndDataSources": {
+    "./governance_payload/MigrateGovernanceAndWormhole": {
       "import": {
-        "default": "./dist/esm/governance_payload/SetWormholeAddressAndDataSources.mjs",
-        "types": "./dist/esm/governance_payload/SetWormholeAddressAndDataSources.d.ts"
+        "default": "./dist/esm/governance_payload/MigrateGovernanceAndWormhole.mjs",
+        "types": "./dist/esm/governance_payload/MigrateGovernanceAndWormhole.d.ts"
       },
       "require": {
-        "default": "./dist/cjs/governance_payload/SetWormholeAddressAndDataSources.cjs",
-        "types": "./dist/cjs/governance_payload/SetWormholeAddressAndDataSources.d.ts"
+        "default": "./dist/cjs/governance_payload/MigrateGovernanceAndWormhole.cjs",
+        "types": "./dist/cjs/governance_payload/MigrateGovernanceAndWormhole.d.ts"
       }
     },
     "./governance_payload/StellarExecutorAction": {

--- a/governance/xc_admin/packages/xc_admin_common/package.json
+++ b/governance/xc_admin/packages/xc_admin_common/package.json
@@ -229,6 +229,16 @@
         "types": "./dist/cjs/governance_payload/SetWormholeAddress.d.ts"
       }
     },
+    "./governance_payload/SetWormholeAddressAndDataSources": {
+      "import": {
+        "default": "./dist/esm/governance_payload/SetWormholeAddressAndDataSources.mjs",
+        "types": "./dist/esm/governance_payload/SetWormholeAddressAndDataSources.d.ts"
+      },
+      "require": {
+        "default": "./dist/cjs/governance_payload/SetWormholeAddressAndDataSources.cjs",
+        "types": "./dist/cjs/governance_payload/SetWormholeAddressAndDataSources.d.ts"
+      }
+    },
     "./governance_payload/StellarExecutorAction": {
       "import": {
         "default": "./dist/esm/governance_payload/StellarExecutorAction.mjs",

--- a/governance/xc_admin/packages/xc_admin_common/src/__tests__/GovernancePayload.test.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/__tests__/GovernancePayload.test.ts
@@ -31,6 +31,7 @@ import { SetDataSources } from "../governance_payload/SetDataSources";
 import { SetFee, SetFeeInToken } from "../governance_payload/SetFee";
 import { SetTransactionFee } from "../governance_payload/SetTransactionFee";
 import { SetValidPeriod } from "../governance_payload/SetValidPeriod";
+import { SetWormholeAddressAndDataSources } from "../governance_payload/SetWormholeAddressAndDataSources";
 import {
   CosmosUpgradeContract,
   EvmUpgradeContract,
@@ -271,6 +272,90 @@ test("GovernancePayload ser/de", () => {
     ),
   ).toBeTruthy();
 
+  const setWormholeAddressAndDataSources =
+    new SetWormholeAddressAndDataSources(
+      "ethereum",
+      "0102030405060708090a0b0c0d0e0f1011121314",
+      [
+        {
+          emitterAddress:
+            "6bb14509a612f01fbbc4cffeebd4bbfb492a86df717ebe92eb6df432a3f00a25",
+          emitterChain: 1,
+        },
+        {
+          emitterAddress:
+            "000000000000000000000000000000000000000000000000000000000000012d",
+          emitterChain: 3,
+        },
+      ],
+      42n,
+      8n,
+    );
+  const setWormholeAddressAndDataSourcesBuffer =
+    setWormholeAddressAndDataSources.encode();
+  console.log(setWormholeAddressAndDataSourcesBuffer.toJSON());
+  expect(
+    setWormholeAddressAndDataSourcesBuffer.equals(
+      Buffer.from([
+        // header: PTGM | module=1 | action=10 | ethereum chain id
+        80, 84, 71, 77, 1, 10, 0, 2,
+        // wormhole address (20 bytes)
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        // numSources = 2
+        2,
+        // data source 1
+        0, 1, 107, 177, 69, 9, 166, 18, 240, 31, 187, 196, 207, 254, 235, 212,
+        187, 251, 73, 42, 134, 223, 113, 126, 190, 146, 235, 109, 244, 50, 163,
+        240, 10, 37,
+        // data source 2
+        0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 1, 45,
+        // fee value = 42, expo = 8
+        0, 0, 0, 0, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0, 8,
+      ]),
+    ),
+  ).toBeTruthy();
+  const decodedSetWormholeAddressAndDataSources =
+    SetWormholeAddressAndDataSources.decode(
+      setWormholeAddressAndDataSourcesBuffer,
+    );
+  expect(decodedSetWormholeAddressAndDataSources?.targetChainId).toBe(
+    "ethereum",
+  );
+  expect(decodedSetWormholeAddressAndDataSources?.address).toBe(
+    "0102030405060708090a0b0c0d0e0f1011121314",
+  );
+  expect(decodedSetWormholeAddressAndDataSources?.dataSources).toEqual([
+    {
+      emitterAddress:
+        "6bb14509a612f01fbbc4cffeebd4bbfb492a86df717ebe92eb6df432a3f00a25",
+      emitterChain: 1,
+    },
+    {
+      emitterAddress:
+        "000000000000000000000000000000000000000000000000000000000000012d",
+      emitterChain: 3,
+    },
+  ]);
+  expect(decodedSetWormholeAddressAndDataSources?.newFeeValue).toBe(42n);
+  expect(decodedSetWormholeAddressAndDataSources?.newFeeExpo).toBe(8n);
+  expect(
+    decodeGovernancePayload(setWormholeAddressAndDataSourcesBuffer),
+  ).toBeInstanceOf(SetWormholeAddressAndDataSources);
+
+  // Fee fields are always present even when zero (migrate path).
+  const migratePayload = new SetWormholeAddressAndDataSources(
+    "ethereum",
+    "0102030405060708090a0b0c0d0e0f1011121314",
+    [],
+    0n,
+    0n,
+  );
+  const migrateBuffer = migratePayload.encode();
+  expect(migrateBuffer.length).toBe(8 + 20 + 1 + 16);
+  expect(migrateBuffer.subarray(-16).equals(Buffer.alloc(16))).toBeTruthy();
+  expect(migrateBuffer[5]).toBe(10);
+
   const upgradeContract = new UpgradeContract256Bit(
     "starknet",
     "043d0ed8155263af0862372df3af9403c502358661f317f62fbdc026d03beaee",
@@ -483,6 +568,23 @@ function governanceActionArb(): Arbitrary<PythGovernanceAction> {
         },
       );
       return fc.oneof(evmArb, starknetArb);
+    } else if (header.action === "SetWormholeAddressAndDataSources") {
+      return fc
+        .record({
+          address: hexBytesArb({ maxLength: 20, minLength: 20 }),
+          dataSources: fc.array(dataSourceArb()),
+          newFeeExpo: fc.bigUintN(64),
+          newFeeValue: fc.bigUintN(64),
+        })
+        .map(({ address, dataSources, newFeeValue, newFeeExpo }) => {
+          return new SetWormholeAddressAndDataSources(
+            header.targetChainId,
+            address,
+            dataSources,
+            newFeeValue,
+            newFeeExpo,
+          );
+        });
     } else if (header.action === "Execute") {
       return fc
         .record({

--- a/governance/xc_admin/packages/xc_admin_common/src/__tests__/GovernancePayload.test.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/__tests__/GovernancePayload.test.ts
@@ -31,7 +31,7 @@ import { SetDataSources } from "../governance_payload/SetDataSources";
 import { SetFee, SetFeeInToken } from "../governance_payload/SetFee";
 import { SetTransactionFee } from "../governance_payload/SetTransactionFee";
 import { SetValidPeriod } from "../governance_payload/SetValidPeriod";
-import { SetWormholeAddressAndDataSources } from "../governance_payload/SetWormholeAddressAndDataSources";
+import { MigrateGovernanceAndWormhole } from "../governance_payload/MigrateGovernanceAndWormhole";
 import {
   CosmosUpgradeContract,
   EvmUpgradeContract,
@@ -272,28 +272,33 @@ test("GovernancePayload ser/de", () => {
     ),
   ).toBeTruthy();
 
-  const setWormholeAddressAndDataSources =
-    new SetWormholeAddressAndDataSources(
-      "ethereum",
-      "0102030405060708090a0b0c0d0e0f1011121314",
-      [
-        {
-          emitterAddress:
-            "6bb14509a612f01fbbc4cffeebd4bbfb492a86df717ebe92eb6df432a3f00a25",
-          emitterChain: 1,
-        },
-        {
-          emitterAddress:
-            "000000000000000000000000000000000000000000000000000000000000012d",
-          emitterChain: 3,
-        },
-      ],
-    );
-  const setWormholeAddressAndDataSourcesBuffer =
-    setWormholeAddressAndDataSources.encode();
-  console.log(setWormholeAddressAndDataSourcesBuffer.toJSON());
+  const migrateGovernanceAndWormhole = new MigrateGovernanceAndWormhole(
+    "ethereum",
+    "0102030405060708090a0b0c0d0e0f1011121314",
+    [
+      {
+        emitterAddress:
+          "6bb14509a612f01fbbc4cffeebd4bbfb492a86df717ebe92eb6df432a3f00a25",
+        emitterChain: 1,
+      },
+      {
+        emitterAddress:
+          "000000000000000000000000000000000000000000000000000000000000012d",
+        emitterChain: 3,
+      },
+    ],
+    {
+      emitterAddress:
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      emitterChain: 1,
+    },
+    2,
+  );
+  const migrateGovernanceAndWormholeBuffer =
+    migrateGovernanceAndWormhole.encode();
+  console.log(migrateGovernanceAndWormholeBuffer.toJSON());
   expect(
-    setWormholeAddressAndDataSourcesBuffer.equals(
+    migrateGovernanceAndWormholeBuffer.equals(
       Buffer.from([
         // header: PTGM | module=1 | action=10 | ethereum chain id
         80, 84, 71, 77, 1, 10, 0, 2,
@@ -308,20 +313,22 @@ test("GovernancePayload ser/de", () => {
         // data source 2
         0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 1, 45,
+        // governance emitter
+        0, 1, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170,
+        170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170,
+        170, 170, 170, 170, 170,
+        // governanceDataSourceIndex = 2
+        0, 0, 0, 2,
       ]),
     ),
   ).toBeTruthy();
-  const decodedSetWormholeAddressAndDataSources =
-    SetWormholeAddressAndDataSources.decode(
-      setWormholeAddressAndDataSourcesBuffer,
-    );
-  expect(decodedSetWormholeAddressAndDataSources?.targetChainId).toBe(
-    "ethereum",
-  );
-  expect(decodedSetWormholeAddressAndDataSources?.address).toBe(
+  const decodedMigrateGovernanceAndWormhole =
+    MigrateGovernanceAndWormhole.decode(migrateGovernanceAndWormholeBuffer);
+  expect(decodedMigrateGovernanceAndWormhole?.targetChainId).toBe("ethereum");
+  expect(decodedMigrateGovernanceAndWormhole?.address).toBe(
     "0102030405060708090a0b0c0d0e0f1011121314",
   );
-  expect(decodedSetWormholeAddressAndDataSources?.dataSources).toEqual([
+  expect(decodedMigrateGovernanceAndWormhole?.dataSources).toEqual([
     {
       emitterAddress:
         "6bb14509a612f01fbbc4cffeebd4bbfb492a86df717ebe92eb6df432a3f00a25",
@@ -333,18 +340,33 @@ test("GovernancePayload ser/de", () => {
       emitterChain: 3,
     },
   ]);
+  expect(decodedMigrateGovernanceAndWormhole?.governanceDataSource).toEqual({
+    emitterAddress:
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    emitterChain: 1,
+  });
+  expect(decodedMigrateGovernanceAndWormhole?.governanceDataSourceIndex).toBe(
+    2,
+  );
   expect(
-    decodeGovernancePayload(setWormholeAddressAndDataSourcesBuffer),
-  ).toBeInstanceOf(SetWormholeAddressAndDataSources);
+    decodeGovernancePayload(migrateGovernanceAndWormholeBuffer),
+  ).toBeInstanceOf(MigrateGovernanceAndWormhole);
 
-  // Empty data sources is a valid payload (header + address + numSources=0).
-  const migratePayload = new SetWormholeAddressAndDataSources(
+  // Empty data sources is a valid payload
+  // (header + address + numSources=0 + governance emitter + index).
+  const migratePayload = new MigrateGovernanceAndWormhole(
     "ethereum",
     "0102030405060708090a0b0c0d0e0f1011121314",
     [],
+    {
+      emitterAddress:
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      emitterChain: 1,
+    },
+    2,
   );
   const migrateBuffer = migratePayload.encode();
-  expect(migrateBuffer.length).toBe(8 + 20 + 1);
+  expect(migrateBuffer.length).toBe(8 + 20 + 1 + 34 + 4);
   expect(migrateBuffer[5]).toBe(10);
 
   const upgradeContract = new UpgradeContract256Bit(
@@ -559,19 +581,30 @@ function governanceActionArb(): Arbitrary<PythGovernanceAction> {
         },
       );
       return fc.oneof(evmArb, starknetArb);
-    } else if (header.action === "SetWormholeAddressAndDataSources") {
+    } else if (header.action === "MigrateGovernanceAndWormhole") {
       return fc
         .record({
           address: hexBytesArb({ maxLength: 20, minLength: 20 }),
           dataSources: fc.array(dataSourceArb()),
+          governanceDataSource: dataSourceArb(),
+          governanceDataSourceIndex: fc.nat({ max: 0xffff_ffff }),
         })
-        .map(({ address, dataSources }) => {
-          return new SetWormholeAddressAndDataSources(
-            header.targetChainId,
+        .map(
+          ({
             address,
             dataSources,
-          );
-        });
+            governanceDataSource,
+            governanceDataSourceIndex,
+          }) => {
+            return new MigrateGovernanceAndWormhole(
+              header.targetChainId,
+              address,
+              dataSources,
+              governanceDataSource,
+              governanceDataSourceIndex,
+            );
+          },
+        );
     } else if (header.action === "Execute") {
       return fc
         .record({

--- a/governance/xc_admin/packages/xc_admin_common/src/__tests__/GovernancePayload.test.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/__tests__/GovernancePayload.test.ts
@@ -288,8 +288,6 @@ test("GovernancePayload ser/de", () => {
           emitterChain: 3,
         },
       ],
-      42n,
-      8n,
     );
   const setWormholeAddressAndDataSourcesBuffer =
     setWormholeAddressAndDataSources.encode();
@@ -310,8 +308,6 @@ test("GovernancePayload ser/de", () => {
         // data source 2
         0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 1, 45,
-        // fee value = 42, expo = 8
-        0, 0, 0, 0, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0, 8,
       ]),
     ),
   ).toBeTruthy();
@@ -337,23 +333,18 @@ test("GovernancePayload ser/de", () => {
       emitterChain: 3,
     },
   ]);
-  expect(decodedSetWormholeAddressAndDataSources?.newFeeValue).toBe(42n);
-  expect(decodedSetWormholeAddressAndDataSources?.newFeeExpo).toBe(8n);
   expect(
     decodeGovernancePayload(setWormholeAddressAndDataSourcesBuffer),
   ).toBeInstanceOf(SetWormholeAddressAndDataSources);
 
-  // Fee fields are always present even when zero (migrate path).
+  // Empty data sources is a valid payload (header + address + numSources=0).
   const migratePayload = new SetWormholeAddressAndDataSources(
     "ethereum",
     "0102030405060708090a0b0c0d0e0f1011121314",
     [],
-    0n,
-    0n,
   );
   const migrateBuffer = migratePayload.encode();
-  expect(migrateBuffer.length).toBe(8 + 20 + 1 + 16);
-  expect(migrateBuffer.subarray(-16).equals(Buffer.alloc(16))).toBeTruthy();
+  expect(migrateBuffer.length).toBe(8 + 20 + 1);
   expect(migrateBuffer[5]).toBe(10);
 
   const upgradeContract = new UpgradeContract256Bit(
@@ -573,16 +564,12 @@ function governanceActionArb(): Arbitrary<PythGovernanceAction> {
         .record({
           address: hexBytesArb({ maxLength: 20, minLength: 20 }),
           dataSources: fc.array(dataSourceArb()),
-          newFeeExpo: fc.bigUintN(64),
-          newFeeValue: fc.bigUintN(64),
         })
-        .map(({ address, dataSources, newFeeValue, newFeeExpo }) => {
+        .map(({ address, dataSources }) => {
           return new SetWormholeAddressAndDataSources(
             header.targetChainId,
             address,
             dataSources,
-            newFeeValue,
-            newFeeExpo,
           );
         });
     } else if (header.action === "Execute") {

--- a/governance/xc_admin/packages/xc_admin_common/src/governance_payload/MigrateGovernanceAndWormhole.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/governance_payload/MigrateGovernanceAndWormhole.ts
@@ -13,27 +13,33 @@ const DataSourceLayout: BufferLayout.Structure<DataSource> =
   ]);
 
 /**
- * Set the wormhole address and data sources on the target chain.
+ * Migrate the wormhole address, price data sources, and governance emitter
+ * on the target chain.
  *
  * Wire format after the governance header:
- *   newWormholeAddress(20) | numSources(u8) | dataSources*
+ *   newWormholeAddress(20) |
+ *   numSources(u8) | [emitterChain(u16be) | emitterAddress(32)]* |
+ *   governanceEmitterChain(u16be) | governanceEmitterAddress(32) |
+ *   governanceDataSourceIndex(u32be)
  *
  * Fee is not included; set fee separately via SetFee before migration.
  */
-export class SetWormholeAddressAndDataSources implements PythGovernanceAction {
+export class MigrateGovernanceAndWormhole implements PythGovernanceAction {
   readonly actionName: ActionName;
 
   constructor(
     readonly targetChainId: ChainName,
     readonly address: string,
     readonly dataSources: DataSource[],
+    readonly governanceDataSource: DataSource,
+    readonly governanceDataSourceIndex: number,
   ) {
-    this.actionName = "SetWormholeAddressAndDataSources";
+    this.actionName = "MigrateGovernanceAndWormhole";
   }
 
-  static decode(data: Buffer): SetWormholeAddressAndDataSources | undefined {
+  static decode(data: Buffer): MigrateGovernanceAndWormhole | undefined {
     const header = PythGovernanceHeader.decode(data);
-    if (!header || header.action !== "SetWormholeAddressAndDataSources") {
+    if (!header || header.action !== "MigrateGovernanceAndWormhole") {
       return undefined;
     }
 
@@ -49,21 +55,29 @@ export class SetWormholeAddressAndDataSources implements PythGovernanceAction {
       index += DataSourceLayout.span;
     }
 
+    const governanceDataSource = DataSourceLayout.decode(data, index);
+    index += DataSourceLayout.span;
+
+    const governanceDataSourceIndex = BufferLayout.u32be().decode(data, index);
+    index += 4;
+
     if (index !== data.length) {
       return undefined;
     }
 
-    return new SetWormholeAddressAndDataSources(
+    return new MigrateGovernanceAndWormhole(
       header.targetChainId,
       address,
       dataSources,
+      governanceDataSource,
+      governanceDataSourceIndex,
     );
   }
 
   encode(): Buffer {
     const headerBuffer = new PythGovernanceHeader(
       this.targetChainId,
-      "SetWormholeAddressAndDataSources",
+      "MigrateGovernanceAndWormhole",
     ).encode();
 
     const addressBuf = Buffer.alloc(20);
@@ -78,11 +92,25 @@ export class SetWormholeAddressAndDataSources implements PythGovernanceAction {
       return buf;
     });
 
+    const governanceDataSourceBuf = Buffer.alloc(DataSourceLayout.span);
+    DataSourceLayout.encode(
+      this.governanceDataSource,
+      governanceDataSourceBuf,
+    );
+
+    const governanceDataSourceIndexBuf = Buffer.alloc(4);
+    BufferLayout.u32be().encode(
+      this.governanceDataSourceIndex,
+      governanceDataSourceIndexBuf,
+    );
+
     return safeBufferConcat([
       headerBuffer,
       addressBuf,
       numSourcesBuf,
       ...dataSourceBufs,
+      governanceDataSourceBuf,
+      governanceDataSourceIndexBuf,
     ]);
   }
 }

--- a/governance/xc_admin/packages/xc_admin_common/src/governance_payload/PythGovernanceAction.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/governance_payload/PythGovernanceAction.ts
@@ -21,6 +21,7 @@ export const TargetAction = {
   SetFeeInToken: 7,
   SetTransactionFee: 8,
   WithdrawFee: 9,
+  SetWormholeAddressAndDataSources: 10,
 } as const;
 
 export const EvmExecutorAction = {
@@ -74,6 +75,8 @@ export function toActionName(
         return "SetTransactionFee";
       case 9:
         return "WithdrawFee";
+      case 10:
+        return "SetWormholeAddressAndDataSources";
     }
   } else if (
     deserialized.moduleId == MODULE_EVM_EXECUTOR &&

--- a/governance/xc_admin/packages/xc_admin_common/src/governance_payload/PythGovernanceAction.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/governance_payload/PythGovernanceAction.ts
@@ -21,7 +21,7 @@ export const TargetAction = {
   SetFeeInToken: 7,
   SetTransactionFee: 8,
   WithdrawFee: 9,
-  SetWormholeAddressAndDataSources: 10,
+  MigrateGovernanceAndWormhole: 10,
 } as const;
 
 export const EvmExecutorAction = {
@@ -76,7 +76,7 @@ export function toActionName(
       case 9:
         return "WithdrawFee";
       case 10:
-        return "SetWormholeAddressAndDataSources";
+        return "MigrateGovernanceAndWormhole";
     }
   } else if (
     deserialized.moduleId == MODULE_EVM_EXECUTOR &&

--- a/governance/xc_admin/packages/xc_admin_common/src/governance_payload/SetWormholeAddressAndDataSources.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/governance_payload/SetWormholeAddressAndDataSources.ts
@@ -12,18 +12,13 @@ const DataSourceLayout: BufferLayout.Structure<DataSource> =
     BufferLayoutExt.hexBytes(32, "emitterAddress"),
   ]);
 
-const FeeLayout: BufferLayout.Structure<
-  Readonly<{ newFeeValue: bigint; newFeeExpo: bigint }>
-> = BufferLayout.struct([
-  BufferLayoutExt.u64be("newFeeValue"),
-  BufferLayoutExt.u64be("newFeeExpo"),
-]);
-
 /**
- * Set the wormhole address, data sources, and fee on the target chain.
+ * Set the wormhole address and data sources on the target chain.
  *
  * Wire format after the governance header:
- *   newWormholeAddress(20) | numSources(u8) | dataSources* | newFeeValue(u64be) | newFeeExpo(u64be)
+ *   newWormholeAddress(20) | numSources(u8) | dataSources*
+ *
+ * Fee is not included; set fee separately via SetFee before migration.
  */
 export class SetWormholeAddressAndDataSources implements PythGovernanceAction {
   readonly actionName: ActionName;
@@ -32,8 +27,6 @@ export class SetWormholeAddressAndDataSources implements PythGovernanceAction {
     readonly targetChainId: ChainName,
     readonly address: string,
     readonly dataSources: DataSource[],
-    readonly newFeeValue: bigint,
-    readonly newFeeExpo: bigint,
   ) {
     this.actionName = "SetWormholeAddressAndDataSources";
   }
@@ -56,14 +49,14 @@ export class SetWormholeAddressAndDataSources implements PythGovernanceAction {
       index += DataSourceLayout.span;
     }
 
-    const fee = FeeLayout.decode(data, index);
+    if (index !== data.length) {
+      return undefined;
+    }
 
     return new SetWormholeAddressAndDataSources(
       header.targetChainId,
       address,
       dataSources,
-      fee.newFeeValue,
-      fee.newFeeExpo,
     );
   }
 
@@ -85,21 +78,11 @@ export class SetWormholeAddressAndDataSources implements PythGovernanceAction {
       return buf;
     });
 
-    const feeBuf = Buffer.alloc(FeeLayout.span);
-    FeeLayout.encode(
-      {
-        newFeeExpo: this.newFeeExpo,
-        newFeeValue: this.newFeeValue,
-      },
-      feeBuf,
-    );
-
     return safeBufferConcat([
       headerBuffer,
       addressBuf,
       numSourcesBuf,
       ...dataSourceBufs,
-      feeBuf,
     ]);
   }
 }

--- a/governance/xc_admin/packages/xc_admin_common/src/governance_payload/SetWormholeAddressAndDataSources.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/governance_payload/SetWormholeAddressAndDataSources.ts
@@ -1,0 +1,105 @@
+import * as BufferLayout from "@solana/buffer-layout";
+import type { ChainName } from "../chains";
+import { safeBufferConcat } from "../utils/buffer";
+import * as BufferLayoutExt from "./BufferLayoutExt";
+import type { ActionName, PythGovernanceAction } from "./PythGovernanceAction";
+import { PythGovernanceHeader } from "./PythGovernanceAction";
+import type { DataSource } from "./SetDataSources";
+
+const DataSourceLayout: BufferLayout.Structure<DataSource> =
+  BufferLayout.struct([
+    BufferLayout.u16be("emitterChain"),
+    BufferLayoutExt.hexBytes(32, "emitterAddress"),
+  ]);
+
+const FeeLayout: BufferLayout.Structure<
+  Readonly<{ newFeeValue: bigint; newFeeExpo: bigint }>
+> = BufferLayout.struct([
+  BufferLayoutExt.u64be("newFeeValue"),
+  BufferLayoutExt.u64be("newFeeExpo"),
+]);
+
+/**
+ * Set the wormhole address, data sources, and fee on the target chain.
+ *
+ * Wire format after the governance header:
+ *   newWormholeAddress(20) | numSources(u8) | dataSources* | newFeeValue(u64be) | newFeeExpo(u64be)
+ */
+export class SetWormholeAddressAndDataSources implements PythGovernanceAction {
+  readonly actionName: ActionName;
+
+  constructor(
+    readonly targetChainId: ChainName,
+    readonly address: string,
+    readonly dataSources: DataSource[],
+    readonly newFeeValue: bigint,
+    readonly newFeeExpo: bigint,
+  ) {
+    this.actionName = "SetWormholeAddressAndDataSources";
+  }
+
+  static decode(data: Buffer): SetWormholeAddressAndDataSources | undefined {
+    const header = PythGovernanceHeader.decode(data);
+    if (!header || header.action !== "SetWormholeAddressAndDataSources") {
+      return undefined;
+    }
+
+    let index = PythGovernanceHeader.span;
+    const address = BufferLayoutExt.hexBytes(20).decode(data, index);
+    index += 20;
+
+    const numSources = BufferLayout.u8().decode(data, index);
+    index += 1;
+    const dataSources = [];
+    for (let i = 0; i < numSources; i++) {
+      dataSources.push(DataSourceLayout.decode(data, index));
+      index += DataSourceLayout.span;
+    }
+
+    const fee = FeeLayout.decode(data, index);
+
+    return new SetWormholeAddressAndDataSources(
+      header.targetChainId,
+      address,
+      dataSources,
+      fee.newFeeValue,
+      fee.newFeeExpo,
+    );
+  }
+
+  encode(): Buffer {
+    const headerBuffer = new PythGovernanceHeader(
+      this.targetChainId,
+      "SetWormholeAddressAndDataSources",
+    ).encode();
+
+    const addressBuf = Buffer.alloc(20);
+    BufferLayoutExt.hexBytes(20).encode(this.address, addressBuf);
+
+    const numSourcesBuf = Buffer.alloc(1);
+    BufferLayout.u8().encode(this.dataSources.length, numSourcesBuf);
+
+    const dataSourceBufs = this.dataSources.map((source) => {
+      const buf = Buffer.alloc(DataSourceLayout.span);
+      DataSourceLayout.encode(source, buf);
+      return buf;
+    });
+
+    const feeBuf = Buffer.alloc(FeeLayout.span);
+    FeeLayout.encode(
+      {
+        newFeeExpo: this.newFeeExpo,
+        newFeeValue: this.newFeeValue,
+      },
+      feeBuf,
+    );
+
+    return safeBufferConcat([
+      headerBuffer,
+      addressBuf,
+      numSourcesBuf,
+      ...dataSourceBufs,
+      feeBuf,
+    ]);
+  }
+}

--- a/governance/xc_admin/packages/xc_admin_common/src/governance_payload/index.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/governance_payload/index.ts
@@ -14,7 +14,7 @@ import {
   EvmSetWormholeAddress,
   StarknetSetWormholeAddress,
 } from "./SetWormholeAddress";
-import { SetWormholeAddressAndDataSources } from "./SetWormholeAddressAndDataSources";
+import { MigrateGovernanceAndWormhole } from "./MigrateGovernanceAndWormhole";
 import {
   CallStellarExecutor,
   UpgradeStellarExecutor,
@@ -85,8 +85,8 @@ export function decodeGovernancePayload(
         return undefined;
       }
     }
-    case "SetWormholeAddressAndDataSources":
-      return SetWormholeAddressAndDataSources.decode(data);
+    case "MigrateGovernanceAndWormhole":
+      return MigrateGovernanceAndWormhole.decode(data);
     case "Execute":
       return EvmExecute.decode(data);
     case "SetTransactionFee":
@@ -128,7 +128,7 @@ export * from "./SetFee";
 export * from "./SetTransactionFee";
 export * from "./SetValidPeriod";
 export * from "./SetWormholeAddress";
-export * from "./SetWormholeAddressAndDataSources";
+export * from "./MigrateGovernanceAndWormhole";
 export * from "./StellarExecutorAction";
 export * from "./UpdateTrustedSigner";
 export * from "./UpgradeContract";

--- a/governance/xc_admin/packages/xc_admin_common/src/governance_payload/index.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/governance_payload/index.ts
@@ -14,6 +14,7 @@ import {
   EvmSetWormholeAddress,
   StarknetSetWormholeAddress,
 } from "./SetWormholeAddress";
+import { SetWormholeAddressAndDataSources } from "./SetWormholeAddressAndDataSources";
 import {
   CallStellarExecutor,
   UpgradeStellarExecutor,
@@ -84,6 +85,8 @@ export function decodeGovernancePayload(
         return undefined;
       }
     }
+    case "SetWormholeAddressAndDataSources":
+      return SetWormholeAddressAndDataSources.decode(data);
     case "Execute":
       return EvmExecute.decode(data);
     case "SetTransactionFee":
@@ -125,6 +128,7 @@ export * from "./SetFee";
 export * from "./SetTransactionFee";
 export * from "./SetValidPeriod";
 export * from "./SetWormholeAddress";
+export * from "./SetWormholeAddressAndDataSources";
 export * from "./StellarExecutorAction";
 export * from "./UpdateTrustedSigner";
 export * from "./UpgradeContract";

--- a/governance/xc_admin/packages/xc_admin_frontend/components/tabs/Proposals/utils.ts
+++ b/governance/xc_admin/packages/xc_admin_frontend/components/tabs/Proposals/utils.ts
@@ -6,6 +6,7 @@ import {
   MultisigParser,
   PythGovernanceActionImpl,
   SetDataSources,
+  MigrateGovernanceAndWormhole,
   WormholeMultisigInstruction,
 } from "@pythnetwork/xc-admin-common";
 import type { PublicKey } from "@solana/web3.js";
@@ -88,7 +89,10 @@ const getInstructionSummary = (
       );
     } else if (governanceAction instanceof PythGovernanceActionImpl) {
       return [{ name: governanceAction.action } as const];
-    } else if (governanceAction instanceof SetDataSources) {
+    } else if (
+      governanceAction instanceof SetDataSources ||
+      governanceAction instanceof MigrateGovernanceAndWormhole
+    ) {
       return [{ name: governanceAction.actionName } as const];
     } else {
       return [{ name: "unknown" } as const];


### PR DESCRIPTION
## Summary
- Adds `MigrateGovernanceAndWormhole` (Target action **10**) encode/decode in `@pythnetwork/xc-admin-common`.
- Wire format (after PTGM header): `wormhole(20) | dataSources* | governanceEmitter(chain u16 + addr 32) | governanceDataSourceIndex(u32)` — **no fee**.
- Atomic cutover codec for legacy → pro-compatible migrate (wormhole + price data sources + new governance emitter).
- Frontend proposal utils updated so action 10 is recognized.
- Roundtrip coverage in `GovernancePayload.test.ts`.

Sibling PRs:
- EVM Solidity handler
- contract_manager migrate tooling (depends on this export)

## Test plan
- [ ] Run `xc_admin_common` governance payload tests
- [ ] Decode a sample migrate payload and confirm action id byte is `10`
- [ ] Confirm body includes governance emitter + index and has no fee trailer
- [ ] Confirm frontend proposal summary does not show action 10 as unknown