### PR TITLE
docs(developer-hub): point Lazer SDK links at pyth-lazer-public

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/api/index.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/api/index.mdx
@@ -17,6 +17,6 @@ For browser or frontend apps, don't embed the API key — mint a short-lived JWT
 ## Resources
 
 - [Examples Repository](https://github.com/pyth-network/pyth-examples/tree/main/lazer) - Code examples for all APIs
-- [SDK Repository](https://github.com/pyth-network/pyth-crosschain/tree/main/lazer/sdk/js) - JavaScript/TypeScript SDK
+- [SDK Repository](https://github.com/pyth-network/pyth-lazer-public/tree/main/sdk/js) - JavaScript/TypeScript SDK
 - [Price Feed IDs](/price-feeds/pro/price-feed-ids) - Complete list of available feeds
 - [Payload Reference](/price-feeds/pro/payload-reference) - Data structure documentation

--- a/apps/developer-hub/content/docs/price-feeds/pro/api/websocket.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/api/websocket.mdx
@@ -28,4 +28,4 @@ The WebSocket API is part of the Pyth Pro Router API. The full OpenAPI specifica
 ## Related
 
 - [Examples Repository](https://github.com/pyth-network/pyth-examples/tree/main/lazer)
-- [SDK Repository](https://github.com/pyth-network/pyth-crosschain/tree/main/lazer/sdk/js)
+- [SDK Repository](https://github.com/pyth-network/pyth-lazer-public/tree/main/sdk/js)

--- a/apps/developer-hub/content/docs/price-feeds/pro/faq.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/faq.mdx
@@ -78,7 +78,7 @@ Pyth Pro can be configured to behave as needed for your use case via **market se
 
 #### Q. Is it mandatory to call `verifyUpdate` to get the payload when using Pyth Pro on-chain?
 
-**No**. You can trim the payload off-chain and extract the data (from byte 71 onwards) without calling `verifyUpdate`. See the [verify function](https://github.com/pyth-network/pyth-crosschain/blob/main/lazer/contracts/evm/src/PythLazer.sol#L70-L106) in the contract or the [Rust SDK protocol module](https://github.com/pyth-network/pyth-crosschain/blob/main/lazer/sdk/rust/protocol/src/message.rs).
+**No**. You can trim the payload off-chain and extract the data (from byte 71 onwards) without calling `verifyUpdate`. See the [verify function](https://github.com/pyth-network/pyth-crosschain/blob/main/lazer/contracts/evm/src/PythLazer.sol#L70-L106) in the contract or the [Rust SDK protocol module](https://github.com/pyth-network/pyth-lazer-public/blob/main/sdk/rust/protocol/src/message.rs).
 
 We strongly discourage using the data on-chain without signature verification, as it poses security risks. If you are using the data on-chain without signature verification, you are responsible for verifying the data yourself.
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/cardano.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/integrate-as-consumer/cardano.mdx
@@ -183,7 +183,6 @@ Pyth Pro supports a wide range of price feeds. Consult the [Price Feed IDs](/pri
 
 ### Contract Sources
 
-{/* TODO: change once merged into `main` */}
-The Cardano contract implementation lives in [`lazer/contracts/cardano`](https://github.com/pyth-network/pyth-crosschain/tree/matej/cardano-governance/lazer/contracts/cardano).
+The Cardano contract implementation lives in [`lazer/contracts/cardano`](https://github.com/pyth-network/pyth-crosschain/tree/main/lazer/contracts/cardano).
 
 The off-chain flow shown above comes from [`fetch-and-verify.ts`](https://github.com/pyth-network/pyth-crosschain/blob/main/lazer/contracts/cardano/sdk/js/src/examples/fetch-and-verify.ts).


### PR DESCRIPTION
The Lazer JS/Rust SDKs were moved out of `pyth-crosschain` into [`pyth-network/pyth-lazer-public`](https://github.com/pyth-network/pyth-lazer-public) (crosschain commit `8ac81e674`, plus symlink cleanup in `fb6c65432`). The developer-hub docs still linked at the old in-repo paths, which now 404.

## Changes

- `price-feeds/pro/api/websocket.mdx` and `price-feeds/pro/api/index.mdx` — "SDK Repository" now points at `pyth-lazer-public/tree/main/sdk/js` instead of `pyth-crosschain/tree/main/lazer/sdk/js`.
- `price-feeds/pro/faq.mdx` — "Rust SDK protocol module" now points at `pyth-lazer-public/blob/main/sdk/rust/protocol/src/message.rs`.
- `price-feeds/pro/integrate-as-consumer/cardano.mdx` — the Cardano contract-sources link pointed at the unmerged `matej/cardano-governance` branch (404, with a `TODO: change once merged into main`). The contracts are on `main` now, so the link points there and the TODO is gone.

## Scope check

I link-checked every `github.com` URL in `apps/developer-hub/{content,src}` (129 unique URLs). The remaining `pyth-crosschain` Lazer links all target `lazer/contracts/{evm,sui,iota,cardano}`, which did **not** move and still resolve. Everything else that references the SDK does so by npm package name or docs.rs/crates.io, which are unaffected.

Four unrelated 404s turned up in the same sweep and are left alone here (tracked separately): two `pyth-network/per` SDK example links, `apps/hermes/client/js/src/HermesClient.ts`, `apps/developer-hub/data/changelog-diffs`, and `target_chains/iota/cli`.

## Verification

`pnpm turbo test --filter=@pythnetwork/developer-hub` — 47/47 tasks pass (build, types, lint). Each replacement URL was confirmed to return 200 with `curl -L`.