### PR TITLE
docs(developer-hub): repoint three 404ing GitHub links

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/fetch-price-updates.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/fetch-price-updates.mdx
@@ -142,7 +142,7 @@ data:{"binary":{"encoding":"hex","data":["504e41550100000003b801000000040d00c225
 ## SDK
 
 Pyth provides a typescript SDK for Hermes to fetch price updates.
-The [`HermesClient`](https://github.com/pyth-network/pyth-crosschain/blob/main/apps/hermes/client/js/src/HermesClient.ts#L41) class in this [SDK](https://github.com/pyth-network/pyth-crosschain/tree/main/apps/hermes/client/js) connects to Hermes to fetch and stream price updates.
+The [`HermesClient`](https://github.com/pyth-network/pyth-crosschain/blob/main/apps/hermes/client/js/src/hermes-client.ts#L52) class in this [SDK](https://github.com/pyth-network/pyth-crosschain/tree/main/apps/hermes/client/js) connects to Hermes to fetch and stream price updates.
 
 ```typescript copy
 const connection = new HermesClient("https://pyth.dourolabs.app/hermes", {

--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/iota.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/iota.mdx
@@ -185,20 +185,18 @@ You may find these additional resources helpful for developing your IOTA applica
 
 ### CLI Example
 
-[This example](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/iota/cli) shows how to update prices on a IOTA network. It does the following:
+[This example](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/sui/cli-iota) shows how to update prices on a IOTA network. It does the following:
 
 1. Fetches update data from Hermes for the given price feeds.
 1. Call the Pyth IOTA contract with a price update.
 
-You can run this example with `npm run example-relay`. A full command that updates prices on the IOTA testnet looks like this:
+You can run this example with `npm run cli -- update-feeds`. A full command that updates prices on the IOTA testnet looks like this:
 
 ```bash
-export IOTA_KEY=YOUR_PRIV_KEY;
-npm run example-relay -- --feed-id "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace" \
---hermes "https://hermes.pyth.network" \
---full-node "https://api.testnet.iota.cafe" \
---pyth-state-id "0x68dda579251917b3db28e35c4df495c6e664ccc085ede867a9b773c8ebedc2c1" \
---wormhole-state-id "0x8bc490f69520a97ca1b3de864c96aa2265a0cf5d90f5f3f016b2eddf0cf2af2b"
+npm run cli -- update-feeds --feed-id "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace" \
+--endpoint "https://hermes.pyth.network" \
+--contract "iota_testnet_0x68dda579251917b3db28e35c4df495c6e664ccc085ede867a9b773c8ebedc2c1" \
+--private-key YOUR_PRIV_KEY
 ```
 
 ### Contract Addresses

--- a/apps/developer-hub/src/components/ChangeLog/ChangeLogView.tsx
+++ b/apps/developer-hub/src/components/ChangeLog/ChangeLogView.tsx
@@ -25,7 +25,7 @@ const Footer = () => (
     <span className={styles.footerSpacer} />
     <a
       className={styles.footerEdit}
-      href="https://github.com/pyth-network/pyth-crosschain/tree/main/apps/developer-hub/data/changelog-diffs"
+      href="https://github.com/pyth-network/pyth-crosschain/tree/changelog-data/apps/developer-hub/data/changelog-diffs"
       rel="noopener noreferrer"
       target="_blank"
     >


### PR DESCRIPTION
Five `github.com` URLs under `apps/developer-hub/{content,src}` returned 404. Two of them lived on the Express Relay searcher page, which has since been deleted upstream by the Express Relay docs sunset (OP-PIP-124) — those links are gone with it. The remaining three are repointed at where the content actually lives now.

## Changes

**`price-feeds/core/fetch-price-updates.mdx`** — `apps/hermes/client/js/src/HermesClient.ts` was renamed to `hermes-client.ts`. The `#L41` anchor is bumped to `#L52`, where `export class HermesClient` now sits.

**`ChangeLogView.tsx`** — the "View source data on GitHub" footer link pointed at `tree/main/apps/developer-hub/data/changelog-diffs`. Those diffs are gitignored on `main` and only exist on the `changelog-data` branch, which is where `scripts/pull-changelog-data.sh` hydrates them from at build time. Link now points at that branch.

**`price-feeds/core/use-real-time-data/pull-integration/iota.mdx`** — `target_chains/iota/cli` has never existed in this repo (the section was copied from `sui.mdx`). The IOTA CLI lives at `target_chains/sui/cli-iota`. Its `update-feeds` command does exactly what the surrounding prose describes — fetch update data from Hermes for the given feed ids, then call the Pyth IOTA contract with the update — so the example invocation is also corrected: the package exposes `cli`, not `example-relay`, and takes `--contract <chain>_<stateId>` (resolved from the contract-manager store) plus `--endpoint`, rather than `--full-node` / `--pyth-state-id` / `--wormhole-state-id`. The state ids in the old command match the `iota_testnet` store entry, so the contract id is derived from it and the feed id is unchanged.

## Verification

- Re-ran the full sweep over every unique `github.com` URL in `apps/developer-hub/{content,src}` on the rebased tree: 118 URLs, all 200. No 404s remain.
- `pnpm turbo test --filter=@pythnetwork/developer-hub` — 47/47 tasks pass (build, `test:types`, lint).
- `git merge-tree origin/main HEAD` — no conflicts.