### PR TITLE
fix(developer-hub): hide deprecated Entropy chains from chainlist

### DIFF
--- a/apps/developer-hub/src/components/EntropyTable/entropy-api-data-fetcher.tsx
+++ b/apps/developer-hub/src/components/EntropyTable/entropy-api-data-fetcher.tsx
@@ -54,7 +54,24 @@ const apiChainConfigToEntrySchema = ApiChainConfigSchema.transform((chain) => {
 
 const entropyDeploymentsSchema = z.array(apiChainConfigToEntrySchema);
 
-const HIDDEN_CHAINS = new Set(["taiko"]);
+// Entropy support ends August 15, 2026 for the chains below; see
+// https://dev-forum.pyth.network/t/deprecation-notice-pyth-entropy-deprecation-for-selected-chains-august-15-2026/816
+const HIDDEN_CHAINS = new Set([
+  "blast",
+  "blast-testnet",
+  "etherlink",
+  "etherlink-testnet",
+  "sei-evm",
+  "sei-evm-testnet",
+  "story",
+  "story-testnet",
+  "tabi-testnet",
+  "taiko",
+  "unichain",
+  "unichain-sepolia",
+  "zetachain",
+  "zetachain-testnet",
+]);
 
 export async function fetchEntropyDeployments(
   url: string,


### PR DESCRIPTION
## Summary

Entropy support ends on August 15, 2026 for eight chains — ZetaChain, Unichain, Taiko, Tabi, Story, Blast, Etherlink, and Sei EVM — on both testnet and mainnet, per the [deprecation notice](https://dev-forum.pyth.network/t/deprecation-notice-pyth-entropy-deprecation-for-selected-chains-august-15-2026/816).

The Developer Hub's Entropy chainlist page (`content/docs/entropy/chainlist.mdx`) renders `<EntropyTable />`, which lists every chain returned by the Fortuna `/v1/chains/configs` endpoint minus a `HIDDEN_CHAINS` filter. This PR adds all sixteen deprecated-chain identifiers (mainnet + testnet variants, using Fortuna's exact `name` values) to that set so the chainlist page no longer advertises them.

Only chains explicitly named in the deprecation notice are removed. Giwa, Kaia, and other chains that were speculatively discussed but are not in the notice are left untouched. `taiko` was already hidden and is preserved.

## Changes

- `apps/developer-hub/src/components/EntropyTable/entropy-api-data-fetcher.tsx`: extend `HIDDEN_CHAINS` to include the mainnet and testnet names for the eight deprecated chains, with a comment linking the deprecation notice.

## Validation

Ran from the repo root with Node 24 / pnpm 10.28:

- `pnpm turbo run test:types --filter=@pythnetwork/developer-hub` — passed
- `pnpm turbo run test:lint --filter=@pythnetwork/developer-hub` — passed (includes the developer-hub production build)
- `pnpm turbo run test:format --filter=@pythnetwork/developer-hub` — passed

The chain filter is applied on each request to Fortuna, so once deployed the mainnet and testnet tables on the chainlist page will drop the eight deprecated chains. Grepped `apps/developer-hub/content` and `apps/developer-hub/src` for the affected chain names — no other Entropy-specific companion references need to change in this PR.