### PR TITLE
docs(developer-hub): present-tense pro auth docs, document price range endpoint

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/api/history.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/api/history.mdx
@@ -20,31 +20,19 @@ All `{channel}` path segments refer to a price channel (e.g. `real_time`, `fixed
   connect TradingView charting UIs directly to this API.
 </Callout>
 
-<Callout type="warning" title="API key required starting July 24, 2026">
-  Starting **July 24, 2026**, `GET /{channel}/price` and `GET /{channel}/history`
-  require API-key authentication, and unauthenticated access to them will be
-  disabled. API-key auth is supported today, so add the
-  `Authorization: Bearer <PRO_API_KEY>` header now to stay forward-compatible.
-  See [Authentication](#authentication) for the header format, and
-  [Frontend Authentication](/price-feeds/pro/frontend-auth) for browser apps.
-  See the
-  [announcement](https://dev-forum.pyth.network/t/action-required-pyth-pro-history-api-auth-required-starting-july-24/808)
-  for details.
-</Callout>
-
 ## Endpoints
 
-| Method | Path                   | Auth                       | Description                   |
-| ------ | ---------------------- | -------------------------- | ----------------------------- |
-| GET    | `/live`                | No                         | Health check                  |
-| GET    | `/symbols`             | No                         | List available symbols        |
-| GET    | `/{channel}/price`     | Yes (from July 24, 2026)   | Price at a specific timestamp |
-| GET    | `/{channel}/history`   | Yes (from July 24, 2026)   | OHLC candlestick data         |
-| GET    | `/{channel}/search`    | No                         | Search symbols                |
-| GET    | `/{channel}/symbols`   | No                         | Resolve a single symbol       |
-| GET    | `/{channel}/streaming` | No                         | SSE price stream              |
-| GET    | `/{channel}/config`    | No                         | TradingView configuration     |
-| GET    | `/publisher_updates`   | Yes                        | Raw publisher updates         |
+| Method | Path                   | Auth | Description                   |
+| ------ | ---------------------- | ---- | ----------------------------- |
+| GET    | `/live`                | No   | Health check                  |
+| GET    | `/symbols`             | No   | List available symbols        |
+| GET    | `/{channel}/price`     | Yes  | Price at a specific timestamp |
+| GET    | `/{channel}/history`   | Yes  | OHLC candlestick data         |
+| GET    | `/{channel}/search`    | No   | Search symbols                |
+| GET    | `/{channel}/symbols`   | No   | Resolve a single symbol       |
+| GET    | `/{channel}/streaming` | No   | SSE price stream              |
+| GET    | `/{channel}/config`    | No   | TradingView configuration     |
+| GET    | `/publisher_updates`   | Yes  | Raw publisher updates         |
 
 ---
 
@@ -178,9 +166,8 @@ Returns raw publisher price updates. Requires authentication.
 
 ## Authentication
 
-Starting **July 24, 2026**, `GET /{channel}/price` and `GET /{channel}/history`
-require API-key authentication, and unauthenticated access to them will be
-disabled. Pass your Pro API key as a bearer token:
+`GET /{channel}/price` and `GET /{channel}/history` require API-key
+authentication. Pass your Pro API key as a bearer token:
 
 ```bash copy
 curl -H "Authorization: Bearer $PRO_API_KEY" \

--- a/apps/developer-hub/content/docs/price-feeds/pro/api/history.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/api/history.mdx
@@ -22,17 +22,18 @@ All `{channel}` path segments refer to a price channel (e.g. `real_time`, `fixed
 
 ## Endpoints
 
-| Method | Path                   | Auth | Description                   |
-| ------ | ---------------------- | ---- | ----------------------------- |
-| GET    | `/live`                | No   | Health check                  |
-| GET    | `/symbols`             | No   | List available symbols        |
-| GET    | `/{channel}/price`     | Yes  | Price at a specific timestamp |
-| GET    | `/{channel}/history`   | Yes  | OHLC candlestick data         |
-| GET    | `/{channel}/search`    | No   | Search symbols                |
-| GET    | `/{channel}/symbols`   | No   | Resolve a single symbol       |
-| GET    | `/{channel}/streaming` | No   | SSE price stream              |
-| GET    | `/{channel}/config`    | No   | TradingView configuration     |
-| GET    | `/publisher_updates`   | Yes  | Raw publisher updates         |
+| Method | Path                     | Auth | Description                         |
+| ------ | ------------------------ | ---- | ----------------------------------- |
+| GET    | `/live`                  | No   | Health check                        |
+| GET    | `/symbols`               | No   | List available symbols              |
+| GET    | `/{channel}/price`       | Yes  | Price at a specific timestamp       |
+| GET    | `/{channel}/price/range` | Yes  | Paginated prices over a time window |
+| GET    | `/{channel}/history`     | Yes  | OHLC candlestick data               |
+| GET    | `/{channel}/search`      | No   | Search symbols                      |
+| GET    | `/{channel}/symbols`     | No   | Resolve a single symbol             |
+| GET    | `/{channel}/streaming`   | No   | SSE price stream                    |
+| GET    | `/{channel}/config`      | No   | TradingView configuration           |
+| GET    | `/publisher_updates`     | Yes  | Raw publisher updates               |
 
 ---
 
@@ -59,6 +60,48 @@ Returns price data at a specific historical timestamp.
 | ----------- | ---------- | -------- | ---------------------------------- | ------------------ |
 | `ids`       | `number[]` | Yes      | Price feed IDs                     | `1,2`              |
 | `timestamp` | `number`   | Yes      | Unix timestamp in **microseconds** | `1704067200000000` |
+
+---
+
+### GET /\{channel\}/price/range
+
+Returns paginated price data for a set of feeds over a bounded time window.
+
+**Query Parameters**
+
+| Parameter         | Type       | Required | Description                                                                    | Example            |
+| ----------------- | ---------- | -------- | ------------------------------------------------------------------------------ | ------------------ |
+| `ids`             | `number[]` | Yes      | Price feed IDs (max 100)                                                       | `1,2`              |
+| `start_timestamp` | `number`   | Yes      | Window start, Unix timestamp in **microseconds**, inclusive                    | `1704067200000000` |
+| `end_timestamp`   | `number`   | Yes      | Window end, Unix timestamp in **microseconds**, inclusive; the window may not exceed 60 seconds | `1704067260000000` |
+| `limit`           | `number`   | No       | Max results per page, 1–1000 (default: `100`)                                  | `500`              |
+| `after`           | `string`   | No       | Opaque pagination cursor from a previous response's `next` field               |                    |
+
+**Response Schema**
+
+| Field  | Type       | Description                                          |
+| ------ | ---------- | ---------------------------------------------------- |
+| `data` | `object[]` | Price objects, one per feed and timestamp            |
+| `next` | `string`   | Opaque cursor, present only when another page exists |
+
+Each `data` entry has the same shape as the `GET /{channel}/price` response:
+`channel`, `channel_name`, `price_feed_id`, `price`, `publish_time`,
+`best_bid_price`, `best_ask_price`, `publisher_count`, `exponent`,
+`confidence`, `funding_rate`, `funding_timestamp`, `funding_rate_interval`,
+`market_session`, `ema_price`, `ema_confidence`, `feed_update_timestamp`.
+
+To fetch the next page, pass `next` verbatim as the `after` parameter of the
+following request; stop when `next` is absent. Cursors are opaque and must not
+be constructed by hand.
+
+**Errors**
+
+| Status | Cause                                                                                    |
+| ------ | ---------------------------------------------------------------------------------------- |
+| `400`  | Invalid parameters, window longer than 60 seconds, or feed not ready/unavailable on the channel |
+| `401`  | Missing bearer token                                                                     |
+| `403`  | Token not entitled to a requested feed                                                   |
+| `404`  | Unknown feed ID                                                                          |
 
 ---
 
@@ -166,8 +209,9 @@ Returns raw publisher price updates. Requires authentication.
 
 ## Authentication
 
-`GET /{channel}/price` and `GET /{channel}/history` require API-key
-authentication. Pass your Pro API key as a bearer token:
+`GET /{channel}/price`, `GET /{channel}/price/range`, and
+`GET /{channel}/history` require API-key authentication. Pass your Pro API key
+as a bearer token:
 
 ```bash copy
 curl -H "Authorization: Bearer $PRO_API_KEY" \

--- a/apps/developer-hub/content/docs/price-feeds/pro/api/rest.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/api/rest.mdx
@@ -12,25 +12,12 @@ import { Callout } from "fumadocs-ui/components/callout";
 https://pyth-lazer.dourolabs.app
 ```
 
-<Callout type="warning" title="API key required for POST /v1/price starting July 24, 2026">
-  Starting **July 24, 2026**, `POST /v1/price` requires API-key authentication,
-  and unauthenticated access to it will be disabled. Pass
-  `Authorization: Bearer <PRO_API_KEY>`; API-key auth is supported today, so add
-  the header now to stay forward-compatible. Do not expose the key in browser
-  apps — keep it server-side. See [Authentication](#authentication) for the
-  header format, and
-  [Frontend Authentication](/price-feeds/pro/frontend-auth) for browser apps,
-  and the
-  [announcement](https://dev-forum.pyth.network/t/action-required-pyth-pro-history-api-auth-required-starting-july-24/808)
-  for details.
-</Callout>
-
 ## Endpoints
 
-| Method | Path               | Auth                       | Description                                         |
-| ------ | ------------------ | -------------------------- | --------------------------------------------------- |
-| POST   | `/v1/latest_price` | Yes                        | Fetch the latest price for one or more price feeds  |
-| POST   | `/v1/price`        | Yes (from July 24, 2026)   | Fetch price data at a specific historical timestamp |
+| Method | Path               | Auth | Description                                         |
+| ------ | ------------------ | ---- | --------------------------------------------------- |
+| POST   | `/v1/latest_price` | Yes  | Fetch the latest price for one or more price feeds  |
+| POST   | `/v1/price`        | Yes  | Fetch price data at a specific historical timestamp |
 
 ### POST /v1/latest_price
 
@@ -66,9 +53,8 @@ For the full response schema — including price feed fields, signed payloads, a
 
 ## Authentication
 
-Starting **July 24, 2026**, `POST /v1/price` requires API-key authentication,
-and unauthenticated access to it will be disabled. Pass your Pro API key as a
-bearer token:
+`POST /v1/latest_price` and `POST /v1/price` require API-key authentication.
+Pass your Pro API key as a bearer token:
 
 ```bash copy
 curl -X POST -H "Authorization: Bearer $PRO_API_KEY" \

--- a/apps/developer-hub/content/docs/price-feeds/pro/faq.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/faq.mdx
@@ -123,7 +123,7 @@ https://pyth.dourolabs.app/v1/fixed_rate@200ms/history?symbol=Crypto.BTC/USD&fro
 
 See the [History API](/price-feeds/pro/api/history) for full endpoint details, query parameters, and resolutions.
 
-Starting **July 24, 2026**, `GET /{channel}/history` and `GET /{channel}/price` require the `Authorization: Bearer <PRO_API_KEY>` header, and unauthenticated access to them will be disabled. See the [History API](/price-feeds/pro/api/history#authentication) for the header format and frontend-safe guidance.
+`GET /{channel}/history` and `GET /{channel}/price` require the `Authorization: Bearer <PRO_API_KEY>` header. See the [History API](/price-feeds/pro/api/history#authentication) for the header format and frontend-safe guidance.
 
 #### Q. How do I fetch the latest price via HTTP?
 
@@ -138,7 +138,7 @@ https://pyth-lazer.dourolabs.app
 
 See the [REST API](/price-feeds/pro/api/rest) for request/response schemas and examples.
 
-Starting **July 24, 2026**, `POST /v1/price` will require the `Authorization: Bearer <PRO_API_KEY>` header, and unauthenticated access to it will be disabled. See the [REST API](/price-feeds/pro/api/rest#authentication) for details. `POST /v1/latest_price` is unaffected by this change.
+`POST /v1/price` requires the `Authorization: Bearer <PRO_API_KEY>` header. See the [REST API](/price-feeds/pro/api/rest#authentication) for details.
 
 #### Q. How should I authenticate the History and REST endpoints from a frontend app?
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/mcp.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/mcp.mdx
@@ -26,7 +26,7 @@ The Pyth MCP server gives AI assistants direct, structured access to Pyth market
 Recommended workflow: `get_symbols` → `get_latest_price` / `get_historical_price` → `get_candlestick_data`
 
 <Callout type="warning">
-  `get_latest_price` requires a Pyth Pro API key passed as `access_token`. `get_historical_price` and `get_candlestick_data` require it as of **July 24, 2026** (optional before then). Get one at [acquire API key guide](./acquire-api-key). `get_symbols` and `convert_date_to_timestamp` work without a key.
+  `get_latest_price`, `get_historical_price`, and `get_candlestick_data` require a Pyth Pro API key passed as `access_token`. Get one at [acquire API key guide](./acquire-api-key). `get_symbols` and `convert_date_to_timestamp` work without a key.
 </Callout>
 
 ## Setup
@@ -157,7 +157,7 @@ Get prices at a single historical timestamp.
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `access_token` | string | From Jul 24, 2026 | Pyth Pro API key |
+| `access_token` | string | **Yes** | Pyth Pro API key |
 | `symbols` | string[] | No\* | Full symbols |
 | `price_feed_ids` | number[] | No\* | Feed IDs |
 | `timestamp` | number | **Yes** | Unix seconds, milliseconds, or microseconds |
@@ -179,7 +179,7 @@ Fetch OHLC candlestick data for a single feed.
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `access_token` | string | From Jul 24, 2026 | Pyth Pro API key |
+| `access_token` | string | **Yes** | Pyth Pro API key |
 | `symbol` | string | **Yes** | Full symbol (e.g. `Crypto.BTC/USD`) |
 | `resolution` | string | **Yes** | `1`, `5`, `15`, `30`, `60`, `120`, `240`, `360`, `720`, `D`, `W`, `M` |
 | `from` | number | **Yes** | Start time (Unix seconds) |

--- a/apps/developer-hub/src/app/llms-price-feeds-pro.txt/route.ts
+++ b/apps/developer-hub/src/app/llms-price-feeds-pro.txt/route.ts
@@ -143,8 +143,9 @@ You MUST connect to all three endpoints simultaneously. Any single endpoint may 
 - POST /v1/price — Fetch price at a specific historical timestamp (Unix microseconds)
 
 ### History API (base: https://pyth.dourolabs.app/v1)
-- GET /{channel}/history — OHLC candlestick data
-- GET /{channel}/price — Price at specific timestamp
+- GET /{channel}/history — OHLC candlestick data (requires auth)
+- GET /{channel}/price — Price at specific timestamp (requires auth)
+- GET /{channel}/price/range — Paginated prices over a time window (requires auth)
 - GET /symbols — List available symbols (no auth required)
 - Supports TradingView UDF specification
 

--- a/apps/developer-hub/src/app/llms-price-feeds-pro.txt/route.ts
+++ b/apps/developer-hub/src/app/llms-price-feeds-pro.txt/route.ts
@@ -154,7 +154,7 @@ Pyth Pro also provides an MCP server so agents can discover feeds and fetch pric
 
 - MCP endpoint: https://mcp.pyth.network/mcp
 - Tool workflow: \`get_symbols\` -> \`get_latest_price\` / \`get_historical_price\` -> \`get_candlestick_data\`
-- Token behavior: \`get_latest_price\` requires \`access_token\`; \`get_historical_price\` and \`get_candlestick_data\` require it as of July 24, 2026
+- Token behavior: \`get_latest_price\`, \`get_historical_price\`, and \`get_candlestick_data\` require \`access_token\`
 - 9 pre-built skills for Claude Code: price alerts, cross-asset comparison, volatility analysis, FX conversion, portfolio tracking, funding rate monitoring, data export, time-series snapshots, and integration guidance
 - Skills docs: https://docs.pyth.network/price-feeds/pro/mcp-skills.mdx
 


### PR DESCRIPTION
### Summary

In this PR we remove the stale July 24 auth announcements from the Pyth Pro docs and document the `GET /{channel}/price/range` endpoint on the History API page

### Context

- The auth requirement went live on July 24, 2026, so the warning callouts, future-tense Authentication sections, FAQ answers, MCP callout, and `llms-price-feeds-pro.txt` line now state it as current reality; dev-forum announcement links are dropped
- The new range endpoint section (params, response shape, cursor pagination, limits) was written against the `price_range_handler` in pyth-lazer — worth cross-checking against the live OpenAPI docs at pyth.dourolabs.app/docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
