### PR TITLE
docs(developer-hub): remove GET /{channel}/streaming from history API docs

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/api/history.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/api/history.mdx
@@ -31,7 +31,6 @@ All `{channel}` path segments refer to a price channel (e.g. `real_time`, `fixed
 | GET    | `/{channel}/history`     | Yes  | OHLC candlestick data               |
 | GET    | `/{channel}/search`      | No   | Search symbols                      |
 | GET    | `/{channel}/symbols`     | No   | Resolve a single symbol             |
-| GET    | `/{channel}/streaming`   | No   | SSE price stream                    |
 | GET    | `/{channel}/config`      | No   | TradingView configuration           |
 | GET    | `/publisher_updates`     | Yes  | Raw publisher updates               |
 
@@ -176,12 +175,6 @@ Resolve a single symbol to its full configuration.
 | Parameter | Type     | Required | Description                    |
 | --------- | -------- | -------- | ------------------------------ |
 | `symbol`  | `string` | Yes      | Symbol name (case-insensitive) |
-
----
-
-### GET /\{channel\}/streaming
-
-Server-sent events (SSE) stream of live price updates.
 
 ---
 


### PR DESCRIPTION
Removes the `GET /{channel}/streaming` (SSE price stream) section and its endpoints-table row from the Pro History API page.

`GET /{channel}/config` and all other endpoints are untouched. No other pages or the llms.txt route reference the streaming endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->