### PR TITLE
ci: bump deprecated `actions/checkout` v2/v3 to v4

### DIFF
--- a/.github/workflows/ci-aptos-contract.yml
+++ b/.github/workflows/ci-aptos-contract.yml
@@ -17,7 +17,7 @@ jobs:
       run:
         working-directory: target_chains/aptos/contracts/
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download CLI
         run: wget https://github.com/aptos-labs/aptos-core/releases/download/aptos-cli-v6.1.1/aptos-cli-6.1.1-Ubuntu-22.04-x86_64.zip

--- a/.github/workflows/ci-ethereum-contract.yml
+++ b/.github/workflows/ci-ethereum-contract.yml
@@ -18,7 +18,7 @@ jobs:
       run:
         working-directory: target_chains/ethereum/contracts/
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version-file: "package.json"

--- a/.github/workflows/ci-fuel-contract.yml
+++ b/.github/workflows/ci-fuel-contract.yml
@@ -18,7 +18,7 @@ jobs:
       run:
         working-directory: target_chains/fuel/contracts/
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           cache-workspaces: "target_chains/fuel/contracts -> target"
       - name: Install Fuel toolchain

--- a/.github/workflows/ci-hermes-server.yml
+++ b/.github/workflows/ci-hermes-server.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         working-directory: apps/hermes/server
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-workspaces: "apps/hermes/server -> target"

--- a/.github/workflows/ci-hip-3-pusher.yml
+++ b/.github/workflows/ci-hip-3-pusher.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         working-directory: apps/hip-3-pusher
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci-lazer-aptos-contract.yml
+++ b/.github/workflows/ci-lazer-aptos-contract.yml
@@ -16,7 +16,7 @@ jobs:
       run:
         working-directory: lazer/contracts/aptos/
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download CLI
         run: wget https://github.com/aptos-labs/aptos-core/releases/download/aptos-cli-v6.1.1/aptos-cli-6.1.1-Ubuntu-22.04-x86_64.zip

--- a/.github/workflows/ci-near-contract.yml
+++ b/.github/workflows/ci-near-contract.yml
@@ -21,7 +21,7 @@ jobs:
       run:
         working-directory: target_chains/near/receiver
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-workspaces: "target_chains/near/receiver -> target"
@@ -34,7 +34,7 @@ jobs:
       run:
         working-directory: target_chains/near/receiver
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-workspaces: "target_chains/near/receiver -> target"

--- a/.github/workflows/ci-pyth-lazer-pusher.yml
+++ b/.github/workflows/ci-pyth-lazer-pusher.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         working-directory: apps/pyth-lazer-pusher
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Format check
         run: cargo fmt --all -- --check

--- a/.github/workflows/ci-remote-executor.yml
+++ b/.github/workflows/ci-remote-executor.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         working-directory: governance/remote_executor
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v2
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/ci-solana-contract.yml
+++ b/.github/workflows/ci-solana-contract.yml
@@ -29,7 +29,7 @@ jobs:
       run:
         working-directory: target_chains/solana
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           cache-workspaces: "target_chains/solana -> target"
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/ci-starknet-contract-release.yml
+++ b/.github/workflows/ci-starknet-contract-release.yml
@@ -12,7 +12,7 @@ jobs:
       run:
         working-directory: target_chains/starknet/contracts/
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Verify version
         run: |
           version1=$(grep version Scarb.toml | cut -d '"' -f 2)

--- a/.github/workflows/docker-bulk-trade-pusher.yml
+++ b/.github/workflows/docker-bulk-trade-pusher.yml
@@ -23,7 +23,7 @@ jobs:
   bulk-trade-pusher-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set image tag to version of the git tag
         if: ${{ startsWith(github.ref, 'refs/tags/bulk-trade-pusher-v') }}
         run: |

--- a/.github/workflows/docker-entropy-tester.yml
+++ b/.github/workflows/docker-entropy-tester.yml
@@ -25,7 +25,7 @@ jobs:
   entropy-tester-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set image tag to version of the git tag
         if: ${{ startsWith(github.ref, 'refs/tags/entropy-tester-v') }}
         run: |

--- a/.github/workflows/docker-fortuna.yml
+++ b/.github/workflows/docker-fortuna.yml
@@ -23,7 +23,7 @@ jobs:
   fortuna-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set image tag to version of the git tag
         if: ${{ startsWith(github.ref, 'refs/tags/fortuna-v') }}
         run: |

--- a/.github/workflows/docker-hermes.yml
+++ b/.github/workflows/docker-hermes.yml
@@ -19,7 +19,7 @@ jobs:
   hermes-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set image tag to version of the git tag
         if: ${{ startsWith(github.ref, 'refs/tags/hermes-v') }}
         run: |

--- a/.github/workflows/docker-hip-3-pusher.yml
+++ b/.github/workflows/docker-hip-3-pusher.yml
@@ -23,7 +23,7 @@ jobs:
   hip-3-pusher-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set image tag to version of the git tag
         if: ${{ startsWith(github.ref, 'refs/tags/hip-3-pusher-v') }}
         run: |

--- a/.github/workflows/docker-price-pusher.yml
+++ b/.github/workflows/docker-price-pusher.yml
@@ -20,7 +20,7 @@ jobs:
   price-pusher-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set image tag to version of the git tag
         if: ${{ startsWith(github.ref, 'refs/tags/pyth-price-pusher-v') }}
         run: |

--- a/.github/workflows/docker-xc-admin-frontend.yml
+++ b/.github/workflows/docker-xc-admin-frontend.yml
@@ -16,7 +16,7 @@ jobs:
   xc-admin-frontend-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set image tag to timestamp and shortened commit hash
         run: |
           SHORT_HASH=$(echo ${{ github.sha }} | cut -c1-7)

--- a/.github/workflows/publish-pyth-price-store.yml
+++ b/.github/workflows/publish-pyth-price-store.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Publish
         run: cargo publish --token ${CARGO_REGISTRY_TOKEN}

--- a/.github/workflows/publish-pyth-sdk-cw.yml
+++ b/.github/workflows/publish-pyth-sdk-cw.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
         env:

--- a/.github/workflows/publish-pyth-solana-receiver-state.yml
+++ b/.github/workflows/publish-pyth-solana-receiver-state.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
         env:

--- a/.github/workflows/publish-pythnet-sdk.yml
+++ b/.github/workflows/publish-pythnet-sdk.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
         env:

--- a/.github/workflows/publish-pythnet-stylus-sdk.yml
+++ b/.github/workflows/publish-pythnet-stylus-sdk.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
         env:

--- a/.github/workflows/publish-rust-hermes-client.yml
+++ b/.github/workflows/publish-rust-hermes-client.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
         env:

--- a/.github/workflows/push-xc-admin-images.yml
+++ b/.github/workflows/push-xc-admin-images.yml
@@ -13,7 +13,7 @@ jobs:
   xc-admin-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set image tag to version of the git tag
         if: ${{ startsWith(github.ref, 'refs/tags/xc-admin-v') }}
         run: |

--- a/.github/workflows/release-pyth-cosmwasm-contract.yml
+++ b/.github/workflows/release-pyth-cosmwasm-contract.yml
@@ -12,7 +12,7 @@ jobs:
       run:
         working-directory: target_chains/cosmwasm/deploy-scripts
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup tool
         run: pnpm i
       - name: Build generic cosmwasm contract


### PR DESCRIPTION
## Problem

`.github/workflows/` currently spans four `actions/checkout` majors:

| Version | Workflows |
|---|---|
| v2 | 22 |
| v3 | 4 |
| v4 | 21 |
| v5 | 5 |
| pinned SHA | 1 |

`actions/checkout@v2` runs on the **Node 12** runtime, which GitHub has removed, and `@v3` on the deprecated Node 16 runtime. Both emit deprecation annotations on every run today.

## Fix

Bump the 26 workflows still on v2 or v3 to `@v4`. Nothing else changes — no job names, triggers, inputs or steps are touched, and every edit is the version string alone.

## On the target version

I aligned on **v4** because it is the version most of this repo already uses (21 workflows). The repo also has 5 workflows on v5 and one SHA pin, so if you would rather standardise everything on v5 — or on a pinned SHA — say the word and I will retarget this branch; it is a mechanical find-and-replace either way.

I deliberately left the SHA-pinned workflow alone, since that pin looks intentional.

## Verification

All 53 workflow files re-parsed as YAML after the change. `grep` confirms no `checkout@v2` or `@v3` reference remains; the only versions left are v4, v5 and the intentional SHA pin.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->