### PR TITLE
Add XAGM to Sui push feed docs

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json
@@ -273,6 +273,14 @@
       "pro_compatible_status": "coming_soon"
     },
     {
+      "alias": "XAGM/USD.RR",
+      "id": "2e8a0af780e18d2cf68bebd172d720a69f21e528e63c642b97fcb40ebc3ba3db",
+      "time_difference": 10,
+      "price_deviation": 0.5,
+      "confidence_ratio": 100,
+      "pro_compatible_status": "available"
+    },
+    {
       "alias": "UP/USD",
       "id": "c591a547856b091560b120ee14b165a84ca58eca23b2ab635df641340bde1f10",
       "time_difference": 10,


### PR DESCRIPTION
Adds XAGM/USD.RR to the canonical Sui mainnet sponsored push-feed list with the Matrixdock feed ID and matching push parameters. The Pro-compatible status is marked available to match the upgraded Sui push config coverage added alongside this docs update.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->