### PR TITLE
feat(developer-hub): redesign /changelog as editorial timeline with filter rail

### DIFF
--- a/apps/developer-hub/src/components/ChangeLogHub/EntryCard.tsx
+++ b/apps/developer-hub/src/components/ChangeLogHub/EntryCard.tsx
@@ -30,16 +30,19 @@ export const EntryCard = ({
     className={clsx(styles.rel, isHighlighted && styles.entryCardHighlighted)}
     id={entry.slug}
   >
-    <div className={styles.aside}>
+    <span aria-hidden className={styles.dot} />
+    <div className={styles.meta}>
       <EntryCopyLink
         date={fmtEntryDate(entry.date)}
         relative={entry.relative}
         slug={entry.slug}
       />
+    </div>
+    <div className={styles.tags}>
       <span className={clsx(styles.kind, KIND_CLASS[entry.type])}>
         {TYPE_LABELS[entry.type]}
       </span>
-      <div className={styles.who}>
+      <span className={styles.who}>
         {PRODUCT_LABELS[entry.product]}
         {entry.area !== undefined && (
           <>
@@ -47,13 +50,11 @@ export const EntryCard = ({
             {AREA_LABELS[entry.area]}
           </>
         )}
-      </div>
+      </span>
     </div>
-    <div className={styles.content}>
-      <h3 className={styles.entryTitle}>
-        <a href={`#${entry.slug}`}>{entry.title}</a>
-      </h3>
-      <div className={styles.entryBody}>{entry.body}</div>
-    </div>
+    <h3 className={styles.entryTitle}>
+      <a href={`#${entry.slug}`}>{entry.title}</a>
+    </h3>
+    <div className={styles.entryBody}>{entry.body}</div>
   </article>
 );

--- a/apps/developer-hub/src/components/ChangeLogHub/EntryCopyLink.tsx
+++ b/apps/developer-hub/src/components/ChangeLogHub/EntryCopyLink.tsx
@@ -8,8 +8,8 @@ import { CHANGELOG_PATH, SITE } from "../../lib/changelog";
 import styles from "./index.module.scss";
 
 // The entry date doubles as its permalink: clicking copies a canonical
-// docs.pyth.network deep link and anchors the URL to the entry. The
-// relative-time line flips to a "Link copied" confirmation while active.
+// docs.pyth.network deep link and anchors the URL to the entry. The adjacent
+// relative-time label flips to a "Link copied" confirmation while active.
 export const EntryCopyLink = ({
   slug,
   date,
@@ -36,14 +36,17 @@ export const EntryCopyLink = ({
         }}
         type="button"
       >
-        <span className={styles.dt}>{date}</span>
+        <time className={styles.dt}>{date}</time>
         <LinkIcon aria-hidden className={styles.chain} />
       </button>
-      <div className={clsx(styles.rock, isCopied && styles.rockCopied)}>
+      <span aria-hidden className={styles.sep}>
+        ·
+      </span>
+      <span className={clsx(styles.relTime, isCopied && styles.relCopied)}>
         {isCopied ? "Link copied" : relative}
-      </div>
-      {/* The visible confirmation above is a plain div; mirror it into a live
-          region so screen readers announce the copy. */}
+      </span>
+      {/* The visible confirmation is a plain span; mirror it into a live region
+          so screen readers announce the copy. */}
       <span className={styles.srStatus} role="status">
         {isCopied ? "Link copied" : ""}
       </span>

--- a/apps/developer-hub/src/components/ChangeLogHub/FilterBar.tsx
+++ b/apps/developer-hub/src/components/ChangeLogHub/FilterBar.tsx
@@ -12,17 +12,22 @@ import styles from "./index.module.scss";
 type FilterBarProps = {
   filters: ChangelogFilters;
   hasFilters: boolean;
+  filteredCount: number;
   countFor: (facet: Facet, value: string) => number;
   onToggle: (facet: Facet, value: string) => void;
   onClear: () => void;
 };
 
-// Faceted checklist (Product / Type / Area) modelled on the Lazer
-// ItemListFilter: labelled sections of checkbox rows with live, right-aligned
-// counts and a "Clear all". Collapses behind a disclosure on mobile.
+// Sticky filter rail (Product / Type / Area) modelled on the Lazer
+// ItemListFilter: a live result count, stacked labelled sections of checkbox
+// rows with right-aligned counts, and a "Clear all". Options that match no
+// entries are hidden (unless selected) so the rail never advertises dead
+// filters; a facet with no visible options drops out entirely. Collapses
+// behind a disclosure on mobile.
 export const FilterBar = ({
   filters,
   hasFilters,
+  filteredCount,
   countFor,
   onToggle,
   onClear,
@@ -30,9 +35,16 @@ export const FilterBar = ({
   const [open, setOpen] = useState(false);
 
   return (
-    <div className={styles.filters}>
-      <div className={styles.filtersHead}>
-        <span className={styles.filtersLabel}>Filter</span>
+    <aside className={styles.rail}>
+      <div className={styles.railHead}>
+        <span className={styles.railCount}>
+          {filteredCount} {filteredCount === 1 ? "update" : "updates"}
+        </span>
+        {hasFilters && (
+          <button className={styles.clear} onClick={onClear} type="button">
+            Clear all
+          </button>
+        )}
         <button
           aria-controls="changelog-facets"
           aria-expanded={open}
@@ -48,55 +60,63 @@ export const FilterBar = ({
           {open ? "Hide" : "Filters"}
           <CaretDown aria-hidden className={styles.filtersToggleCaret} />
         </button>
-        {hasFilters && (
-          <button className={styles.clear} onClick={onClear} type="button">
-            Clear all
-          </button>
-        )}
       </div>
 
       <div
         className={clsx(styles.facets, !open && styles.facetsCollapsed)}
         id="changelog-facets"
       >
-        {FACETS.map(({ key, label, filterKey, values, labelFor }) => (
-          <div key={key}>
-            <h4 className={styles.facetHead}>{label}</h4>
-            <div aria-label={label} role="group">
-              {values.map((value) => {
-                const active = (filters[filterKey] as string[]).includes(value);
-                const count = countFor(key, value);
-                return (
-                  <button
-                    aria-checked={active}
-                    className={clsx(
-                      styles.frow,
-                      active && styles.frowChecked,
-                      !active && count === 0 && styles.frowEmpty,
-                    )}
-                    key={value}
-                    onClick={() => {
-                      onToggle(key, value);
-                    }}
-                    role="checkbox"
-                    type="button"
-                  >
-                    <span className={styles.box}>
-                      <Check
-                        aria-hidden
-                        className={styles.boxIcon}
-                        weight="bold"
-                      />
-                    </span>
-                    <span className={styles.frowLabel}>{labelFor(value)}</span>
-                    <span className={styles.frowCount}>{count}</span>
-                  </button>
-                );
-              })}
+        {FACETS.map(({ key, label, filterKey, values, labelFor }) => {
+          // TS can't correlate `filterKey` with the matching array element type
+          // across the union, so the string[] cast is required (TS#30581).
+          const selected = filters[filterKey] as string[];
+          const visible = values.filter(
+            (value) => selected.includes(value) || countFor(key, value) > 0,
+          );
+          if (visible.length === 0) {
+            return null;
+          }
+          return (
+            <div className={styles.facetGroup} key={key}>
+              <h4 className={styles.facetHead}>{label}</h4>
+              <div aria-label={label} role="group">
+                {visible.map((value) => {
+                  const active = selected.includes(value);
+                  return (
+                    <button
+                      aria-checked={active}
+                      className={clsx(
+                        styles.frow,
+                        active && styles.frowChecked,
+                      )}
+                      key={value}
+                      onClick={() => {
+                        onToggle(key, value);
+                      }}
+                      role="checkbox"
+                      type="button"
+                    >
+                      <span className={styles.box}>
+                        <Check
+                          aria-hidden
+                          className={styles.boxIcon}
+                          weight="bold"
+                        />
+                      </span>
+                      <span className={styles.frowLabel}>
+                        {labelFor(value)}
+                      </span>
+                      <span className={styles.frowCount}>
+                        {countFor(key, value)}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
-    </div>
+    </aside>
   );
 };

--- a/apps/developer-hub/src/components/ChangeLogHub/ProductUpdates.tsx
+++ b/apps/developer-hub/src/components/ChangeLogHub/ProductUpdates.tsx
@@ -166,54 +166,62 @@ export const ProductUpdates = ({
       ?.scrollIntoView({ behavior: "smooth", block: "start" });
   }, [highlighted, visible]);
 
+  // Nothing authored yet: a single message in place of the rail + timeline.
+  if (entries.length === 0) {
+    return (
+      <div className={styles.empty}>
+        <p className={styles.emptyText}>
+          No product updates yet. Check back soon.
+        </p>
+      </div>
+    );
+  }
+
   return (
-    <div>
+    <div className={styles.layout}>
       <FilterBar
         countFor={countFor}
+        filteredCount={filtered.length}
         filters={filters}
         hasFilters={hasFilters}
         onClear={clearFilters}
         onToggle={toggle}
       />
 
-      {filtered.length === 0 ? (
-        <div className={styles.empty}>
-          <p className={styles.emptyText}>
-            {entries.length === 0
-              ? "No product updates yet — check back soon."
-              : "No updates match these filters."}
-          </p>
-          {entries.length > 0 && (
+      <div className={styles.main}>
+        {filtered.length === 0 ? (
+          <div className={styles.empty}>
+            <p className={styles.emptyText}>No updates match these filters.</p>
             <Button onPress={clearFilters} size="sm" variant="ghost">
               Clear all filters
             </Button>
-          )}
-        </div>
-      ) : (
-        <div className={styles.feed}>
-          {visible.map((entry) => (
-            <EntryCard
-              entry={entry}
-              isHighlighted={entry.slug === highlighted}
-              key={entry.slug}
-            />
-          ))}
-        </div>
-      )}
+          </div>
+        ) : (
+          <div className={styles.timeline}>
+            {visible.map((entry) => (
+              <EntryCard
+                entry={entry}
+                isHighlighted={entry.slug === highlighted}
+                key={entry.slug}
+              />
+            ))}
+          </div>
+        )}
 
-      {filtered.length > limit && (
-        <div className={styles.loadMore}>
-          <Button
-            onPress={() => {
-              setLimit((l) => l + PAGE_SIZE);
-            }}
-            size="sm"
-            variant="outline"
-          >
-            Load more ({filtered.length - limit} remaining)
-          </Button>
-        </div>
-      )}
+        {filtered.length > limit && (
+          <div className={styles.loadMore}>
+            <Button
+              onPress={() => {
+                setLimit((l) => l + PAGE_SIZE);
+              }}
+              size="sm"
+              variant="outline"
+            >
+              Load more ({filtered.length - limit} remaining)
+            </Button>
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/apps/developer-hub/src/components/ChangeLogHub/index.module.scss
+++ b/apps/developer-hub/src/components/ChangeLogHub/index.module.scss
@@ -1,30 +1,52 @@
 @use "@pythnetwork/component-library/theme";
 
-// Cross-product changelog UI. Editorial layout matched to the Pyth Lazer
-// (@pythnetwork/components) design language: Inter (the docs shell font),
-// violet accent, tinted semantic type tags, a faceted checkbox filter, and a
-// solid primary Subscribe. Rendered inside fumadocs' DocsBody, below the
-// shell-provided <h1>Changelog</h1> + description.
+// Cross-product changelog UI (Direction A: editorial timeline + sticky filter
+// rail). Rendered inside fumadocs' DocsBody on the `full: true` /changelog page,
+// which renders its own composed header (title + Subscribe) in place of the
+// shell's DocsTitle/DocsDescription. Inter (the docs shell font), violet accent,
+// tinted semantic type tags. The automated market-data changelog is a separate,
+// public page (`/price-feeds/changelog`) and is intentionally not shown here.
 
 .root {
   display: flex;
   flex-direction: column;
-  max-width: 54rem;
+  max-width: 64rem;
 }
 
-// ─── Controls row: subscribe ─────────────────────────────────────────────
+// ─── Composed header: title + description + Subscribe on one row ──────────
 
-.heroBar {
+.pageHead {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
+  justify-content: space-between;
   flex-wrap: wrap;
-  gap: theme.spacing(4);
-  padding-bottom: theme.spacing(4);
+  gap: theme.spacing(4) theme.spacing(6);
+  padding-bottom: theme.spacing(5);
   border-bottom: 1px solid theme.color("border");
-  margin-bottom: theme.spacing(7);
+  margin-bottom: theme.spacing(8);
 }
 
-// ─── Subscribe ───────────────────────────────────────────────────────────
+.pageTitle {
+  margin: 0;
+  font-size: theme.font-size("3xl");
+  font-weight: theme.font-weight("bold");
+  letter-spacing: theme.letter-spacing("tighter");
+  line-height: 1.1;
+  color: theme.color("heading");
+
+  @include theme.breakpoint("sm") {
+    font-size: theme.font-size("4xl");
+  }
+}
+
+.pageDesc {
+  margin: theme.spacing(2.5) 0 0;
+  font-size: theme.font-size("lg");
+  line-height: 1.5;
+  color: theme.color("muted");
+}
+
+// ─── Subscribe (solid violet primary, per-product RSS popover) ────────────
 
 .subscribe {
   margin-left: auto;
@@ -38,7 +60,7 @@
 
 .subscribeHeading {
   padding: theme.spacing(1) theme.spacing(2);
-  font-size: 0.68rem;
+  font-size: theme.font-size("xxs");
   font-weight: theme.font-weight("semibold");
   letter-spacing: theme.letter-spacing("widest");
   text-transform: uppercase;
@@ -52,7 +74,7 @@
   gap: theme.spacing(3);
   padding: theme.spacing(2) theme.spacing(2.5);
   border-radius: theme.border-radius("md");
-  font-size: 0.875rem;
+  font-size: theme.font-size("sm");
   color: theme.color("foreground");
   text-decoration: none;
 
@@ -67,30 +89,40 @@
 }
 
 .subscribeItem .feedTag {
-  font-size: 0.7rem;
+  font-size: theme.font-size("xs");
   letter-spacing: theme.letter-spacing("wide");
   color: theme.color("muted");
 }
 
-// ─── Faceted checklist filter ────────────────────────────────────────────
+// ─── Two-column layout: sticky filter rail | timeline ────────────────────
 
-.filters {
-  margin-bottom: theme.spacing(6);
+.layout {
+  display: grid;
+  grid-template-columns: 200px minmax(0, 1fr);
+  gap: theme.spacing(10);
+  align-items: start;
 }
 
-.filtersHead {
+.rail {
+  position: sticky;
+  top: calc(var(--header-height, 3.5rem) + #{theme.spacing(4)});
+  align-self: start;
+}
+
+.railHead {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
   gap: theme.spacing(3);
-  margin-bottom: theme.spacing(3.5);
+  padding-bottom: theme.spacing(3.5);
+  margin-bottom: theme.spacing(4);
+  border-bottom: 1px solid theme.color("border");
 }
 
-.filtersLabel {
-  font-size: 0.7rem;
-  font-weight: theme.font-weight("semibold");
-  letter-spacing: theme.letter-spacing("widest");
-  text-transform: uppercase;
+.railCount {
+  font-size: theme.font-size("sm");
+  font-weight: theme.font-weight("medium");
+  font-variant-numeric: tabular-nums;
   color: theme.color("muted");
 }
 
@@ -99,7 +131,7 @@
   padding: 0;
   border: 0;
   background: none;
-  font-size: 0.8rem;
+  font-size: theme.font-size("xs");
   color: theme.color("link", "primary");
   cursor: pointer;
 
@@ -120,16 +152,14 @@
 }
 
 .facets {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: theme.spacing(1) theme.spacing(8);
-  padding-bottom: theme.spacing(6);
-  border-bottom: 1px solid theme.color("border");
+  display: flex;
+  flex-direction: column;
+  gap: theme.spacing(6);
 }
 
 .facetHead {
   margin: 0 0 theme.spacing(2);
-  font-size: 0.7rem;
+  font-size: theme.font-size("xxs");
   font-weight: theme.font-weight("semibold");
   letter-spacing: theme.letter-spacing("widest");
   text-transform: uppercase;
@@ -140,12 +170,13 @@
   display: flex;
   align-items: center;
   gap: theme.spacing(2.5);
+  width: 100%;
   margin: 0 theme.spacing(-1.5);
-  padding: theme.spacing(1.5) theme.spacing(1.5);
+  padding: theme.spacing(1.5);
   border: 0;
   border-radius: theme.border-radius("md");
   background: none;
-  font-size: 0.9rem;
+  font-size: theme.font-size("sm");
   color: theme.color("foreground");
   text-align: left;
   cursor: pointer;
@@ -158,10 +189,6 @@
     outline: 2px solid theme.color("highlight");
     outline-offset: -2px;
   }
-}
-
-.frowEmpty {
-  color: theme.color("muted");
 }
 
 .box {
@@ -198,29 +225,51 @@
 
 .frowCount {
   margin-left: auto;
-  font-size: 0.78rem;
+  font-family: theme.font-family("monospace");
+  font-size: theme.font-size("xs");
   font-variant-numeric: tabular-nums;
   color: theme.color("muted");
 }
 
-// ─── Feed ────────────────────────────────────────────────────────────────
+// ─── Timeline ────────────────────────────────────────────────────────────
 
-.feed {
-  display: flex;
-  flex-direction: column;
+.main {
+  min-width: 0;
+}
+
+.timeline {
+  position: relative;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  left: 5px;
+  top: theme.spacing(2);
+  bottom: theme.spacing(2);
+  width: 2px;
+  background: theme.color("border");
 }
 
 .rel {
-  display: grid;
-  grid-template-columns: 9rem 1fr;
-  gap: theme.spacing(8);
-  padding: theme.spacing(9) 0;
-  border-top: 1px solid theme.color("border");
-  scroll-margin-top: theme.spacing(8);
+  position: relative;
+  padding-left: theme.spacing(8);
+  padding-bottom: theme.spacing(11);
+  scroll-margin-top: theme.spacing(20);
 
-  &:first-child {
-    border-top: 0;
+  &:last-child {
+    padding-bottom: 0;
   }
+}
+
+.dot {
+  position: absolute;
+  left: 0;
+  top: theme.spacing(1.5);
+  width: 12px;
+  height: 12px;
+  border-radius: theme.border-radius("full");
+  background: theme.color("highlight");
 }
 
 .entryCardHighlighted {
@@ -247,53 +296,52 @@
   }
 }
 
-.aside {
-  padding-top: theme.spacing(0.5);
+// Date-as-permalink meta row.
+.meta {
+  display: flex;
+  align-items: center;
+  gap: theme.spacing(2);
+  font-family: theme.font-family("monospace");
+  font-size: theme.font-size("xs");
+  font-variant-numeric: tabular-nums;
+  color: theme.color("muted");
 }
 
-// Date-as-permalink.
 .datelink {
   display: inline-flex;
   align-items: center;
-  gap: theme.spacing(1.5);
+  gap: theme.spacing(1);
   padding: 0;
   border: 0;
   background: none;
   font: inherit;
-  color: theme.color("foreground");
+  color: theme.color("muted");
   cursor: pointer;
+
+  &:hover {
+    color: theme.color("link", "primary");
+  }
 
   &:focus-visible {
     outline: 2px solid theme.color("highlight");
     outline-offset: 3px;
     border-radius: theme.border-radius("sm");
   }
-
-  &:hover {
-    color: theme.color("link", "primary");
-  }
 }
 
-.dt {
-  font-size: 0.9rem;
-  font-weight: theme.font-weight("medium");
-  font-variant-numeric: tabular-nums;
+.sep {
+  opacity: 0.55;
 }
 
 .chain {
-  width: 12px;
-  height: 12px;
-  color: theme.color("muted");
+  width: 11px;
+  height: 11px;
   opacity: 0;
-  transition:
-    opacity 120ms ease,
-    color 120ms ease;
+  transition: opacity 120ms ease;
 }
 
-.datelinkCopied {
-  color: theme.color("states", "success", "base");
-}
-
+// Copied-state chain (kept before the :hover rules below so specificity is
+// non-descending per stylelint).
 .datelinkCopied .chain {
   opacity: 1;
   color: theme.color("states", "success", "base");
@@ -304,14 +352,15 @@
   opacity: 1;
 }
 
-.rock {
-  margin-top: theme.spacing(0.5);
-  font-size: 0.8rem;
-  color: theme.color("muted");
+.relTime {
   transition: color 120ms ease;
 }
 
-.rockCopied {
+.relCopied {
+  color: theme.color("states", "success", "base");
+}
+
+.datelinkCopied {
   color: theme.color("states", "success", "base");
 }
 
@@ -319,14 +368,21 @@
   @include theme.sr-only;
 }
 
-// Tinted type tag.
+// Type tag + product/area line.
+.tags {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: theme.spacing(2.5);
+  margin: theme.spacing(3) 0 theme.spacing(2.5);
+}
+
 .kind {
   display: inline-flex;
   align-items: center;
-  margin-top: theme.spacing(3);
   padding: theme.spacing(0.75) theme.spacing(1.75);
   border-radius: theme.border-radius("sm");
-  font-size: 0.66rem;
+  font-size: theme.font-size("xxs");
   font-weight: theme.font-weight("semibold");
   letter-spacing: theme.letter-spacing("wider");
   text-transform: uppercase;
@@ -359,8 +415,7 @@
 }
 
 .who {
-  margin-top: theme.spacing(2.5);
-  font-size: 0.82rem;
+  font-size: theme.font-size("sm");
   color: theme.color("paragraph");
 }
 
@@ -376,11 +431,11 @@
 
 .entryTitle {
   margin: 0;
-  font-size: 1.24rem;
+  font-size: theme.font-size("xl");
   font-weight: theme.font-weight("semibold");
   letter-spacing: theme.letter-spacing("tight");
   line-height: 1.32;
-  color: theme.color("foreground");
+  color: theme.color("heading");
   text-wrap: balance;
 }
 
@@ -403,7 +458,7 @@
 
 .entryBody {
   margin-top: theme.spacing(2.5);
-  font-size: 0.9375rem;
+  font-size: theme.font-size("sm");
   line-height: 1.62;
   color: theme.color("paragraph");
 
@@ -419,24 +474,41 @@
 // ─── Empty state / load more ─────────────────────────────────────────────
 
 .empty {
-  padding: theme.spacing(12) 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: theme.spacing(4);
+  padding: theme.spacing(14) 0;
 }
 
 .emptyText {
-  margin: 0 0 theme.spacing(3.5);
-  font-size: 1rem;
+  margin: 0;
+  font-size: theme.font-size("base");
   color: theme.color("muted");
 }
 
 .loadMore {
   display: flex;
   justify-content: center;
-  margin-top: theme.spacing(8);
+  margin-top: theme.spacing(10);
 }
 
 // ─── Responsive ──────────────────────────────────────────────────────────
 
 @media (width <= 48rem) {
+  .layout {
+    grid-template-columns: 1fr;
+    gap: theme.spacing(6);
+  }
+
+  .rail {
+    position: static;
+  }
+
+  .railHead {
+    margin-bottom: theme.spacing(3);
+  }
+
   .filtersToggle {
     display: inline-flex;
     align-items: center;
@@ -444,7 +516,7 @@
     padding: 0;
     border: 0;
     background: none;
-    font-size: 0.7rem;
+    font-size: theme.font-size("xxs");
     font-weight: theme.font-weight("semibold");
     letter-spacing: theme.letter-spacing("widest");
     text-transform: uppercase;
@@ -463,8 +535,12 @@
   }
 
   .facets {
-    grid-template-columns: 1fr 1fr;
-    gap: theme.spacing(0.5) theme.spacing(6);
+    flex-flow: row wrap;
+    gap: theme.spacing(5) theme.spacing(8);
+  }
+
+  .facetGroup {
+    flex: 1 1 8rem;
   }
 
   .facetsCollapsed {
@@ -472,31 +548,6 @@
   }
 
   .rel {
-    grid-template-columns: 1fr;
-    gap: theme.spacing(2.5);
-    padding: theme.spacing(7) 0;
-  }
-
-  .aside {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: theme.spacing(2) theme.spacing(3.5);
-    padding-top: 0;
-  }
-
-  .rock:not(.rockCopied) {
-    display: none;
-  }
-
-  .kind,
-  .who {
-    margin-top: 0;
-  }
-}
-
-@media (width <= 26rem) {
-  .facets {
-    grid-template-columns: 1fr;
+    padding-bottom: theme.spacing(9);
   }
 }

--- a/apps/developer-hub/src/components/ChangeLogHub/index.tsx
+++ b/apps/developer-hub/src/components/ChangeLogHub/index.tsx
@@ -8,8 +8,10 @@ import { SubscribeMenu } from "./SubscribeMenu";
 
 // Server component: loads the hand-authored changelog entry collection at build
 // time, renders each entry's MDX body, and hands the result to the client
-// product-updates feed. The automated market-data changelog is a separate,
-// public page (`/price-feeds/changelog`) and is intentionally not shown here.
+// product-updates feed. The composed header (title + description + Subscribe)
+// replaces the shell's DocsTitle/DocsDescription, which BasePage omits for this
+// page. The automated market-data changelog is a separate, public page
+// (`/price-feeds/changelog`) and is intentionally not shown here.
 export const ChangeLogHub = () => {
   const entries: ProductUpdatesEntry[] = getChangelogEntries().map((entry) => {
     const Body = entry.body;
@@ -27,9 +29,15 @@ export const ChangeLogHub = () => {
 
   return (
     <div className={styles.root}>
-      <div className={styles.heroBar}>
+      <header className={styles.pageHead}>
+        <div>
+          <h1 className={styles.pageTitle}>Changelog</h1>
+          <p className={styles.pageDesc}>
+            Product updates across Pyth Pro, Pyth Core, and Entropy.
+          </p>
+        </div>
         <SubscribeMenu />
-      </div>
+      </header>
       <ProductUpdates entries={entries} />
     </div>
   );

--- a/apps/developer-hub/src/components/Pages/BasePage/index.tsx
+++ b/apps/developer-hub/src/components/Pages/BasePage/index.tsx
@@ -24,6 +24,10 @@ export async function BasePage(props: { params: { slug: string[] } }) {
   // market-data changelog and the unlisted product-updates changelog).
   const isApiReference = url.startsWith("/api-reference");
   const isChangelog = url === "/price-feeds/changelog" || url === "/changelog";
+  // The product-updates changelog renders its own composed header (title +
+  // Subscribe) inside ChangeLogHub, so suppress the shell's title/description
+  // there to avoid a duplicate heading. The market-data changelog keeps them.
+  const isProductChangelog = url === "/changelog";
 
   return (
     <DocsPage
@@ -31,8 +35,10 @@ export async function BasePage(props: { params: { slug: string[] } }) {
       tableOfContent={{ style: "clerk" }}
       toc={page.data.toc}
     >
-      <DocsTitle>{page.data.title}</DocsTitle>
-      <DocsDescription>{page.data.description}</DocsDescription>
+      {!isProductChangelog && <DocsTitle>{page.data.title}</DocsTitle>}
+      {!isProductChangelog && (
+        <DocsDescription>{page.data.description}</DocsDescription>
+      )}
       {!isApiReference && !isChangelog && (
         <PageActions content={content} title={title} url={url} />
       )}


### PR DESCRIPTION
## What

Redesigns the cross-product **product-updates changelog** (`/changelog`) into an editorial timeline with a sticky filter rail ("Direction A"), replacing the previous layout where entries were buried under an empty hero and a full-viewport 3-column filter wall with an orphaned Subscribe button and zero-count facets.

This is the unlisted `/changelog` page (noindex, not in nav). The public **market-data** changelog at `/price-feeds/changelog` is untouched.

## Changes

- **Composed header** — title + description with a right-aligned **Subscribe** on one row. `BasePage` suppresses the shell `DocsTitle`/`DocsDescription` for `/changelog` only, so there is no duplicate heading; the market-data changelog keeps them.
- **Sticky filter rail** — Product / Type / Area as a stacked checklist with a live result count. Options that match no entries are hidden (unless selected), and a facet with no visible options drops out. Counts are right-aligned and tabular.
- **Editorial timeline** — a vertical spine with a violet dot per entry, monospace `date · relative` meta (the date is still the copy-permalink), tinted semantic type tags, `product · area`, title, and MDX body (with Shiki-highlighted code).
- Empty state, filtering, deep-link copy/scroll, RSS subscribe, and pagination are all preserved.

## Preserved / unchanged

- Market-data changelog (`/price-feeds/changelog`) is byte-identical.
- `/changelog` stays unlisted (noindex, nofollow, excluded from sitemap, not in nav).
- The sample entries and the month-rounding relative dates are unchanged.

## Verification

- biome, stylelint, `tsc`, and 57 unit tests all pass.
- Production build completes; `/changelog` prerenders **statically** (`● /[section]`) with no `useSearchParams` bailout; `/changelog/feed.xml` remains a dynamic route handler.
- Rendered and screenshotted in the real fumadocs shell in light and dark, plus the empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->