### PR TITLE
docs: add August product changelog entries

### DIFF
--- a/apps/developer-hub/content/changelog/2026-08-03-pyth-pro-euronext-fx-top-of-book.mdx
+++ b/apps/developer-hub/content/changelog/2026-08-03-pyth-pro-euronext-fx-top-of-book.mdx
@@ -1,0 +1,21 @@
+---
+title: Pyth Pro adds Euronext FX top-of-book coverage
+date: 2026-08-03
+product: pyth-pro
+type: feature
+area: market-data
+---
+
+Pyth Pro now publishes Euronext FX (FastMatch) top-of-book prices through a
+FIX 4.2 publisher connected to the venue's BBO stream. Mid prices are derived
+from the venue bid and ask.
+
+Production configuration covers the full planned 93-pair list, including
+EUR/HKD, EUR/RUB, EUR/THB, USD/CNY, and USD/RUB. The venue can reject
+subscriptions for pairs it does not currently offer; those rejections are
+logged as warnings, and the pairs can begin streaming if the venue enables
+them later. In live UAT, 86 of 88 venue-available pairs initially published.
+
+The feed follows the venue-aware schedule: Sunday 17:30 through Friday 17:00
+America/New_York, with a daily 17:00-17:30 maintenance break. Treat those
+scheduled windows as expected downtime rather than feed failures.

--- a/apps/developer-hub/content/changelog/2026-08-05-stellar-governance-replay-guidance.mdx
+++ b/apps/developer-hub/content/changelog/2026-08-05-stellar-governance-replay-guidance.mdx
@@ -1,0 +1,24 @@
+---
+title: Stellar integration guidance for governance authorization and replay protection
+date: 2026-08-05
+product: pyth-core
+type: docs
+area: contracts
+---
+
+Stellar and Soroban integration guidance now makes two requirements explicit
+for governance and price-update consumers.
+
+Governance `Call` targets that require authorization must receive those
+authorizations as their own top-level authorization. Integrators should not
+assume they are bound to the outer Wormhole-governed action.
+
+`verify_update` is stateless: it proves signer trust, but it does not prevent
+replay by itself. Consumers must deduplicate updates and enforce freshness
+using the payload timestamp and, where relevant, each feed's
+`feed_update_timestamp`, not envelope bytes, signatures, or signature hashes.
+
+The Stellar SDK was bumped to 0.3.1 so the guidance reaches published SDK and
+documentation consumers. This is documentation and remediation guidance only;
+there is no behavior change to the current deployment, and the Soroban host
+already rejects high-s signatures.


### PR DESCRIPTION
## Summary
- Add the August 3 Pyth Pro Euronext FX top-of-book changelog entry.
- Add the August 5 Pyth Core Stellar governance/replay guidance changelog entry.

## Validation
- npx -y -p node@24.12.0 -p pnpm@10.28.0 pnpm install
- npx -y -p node@24.12.0 -p pnpm@10.28.0 pnpm turbo run test:types --filter=@pythnetwork/developer-hub
- npx -y -p node@24.12.0 -p pnpm@10.28.0 pnpm turbo run test:lint --filter=@pythnetwork/developer-hub
- git fetch origin main && git merge-tree origin/main HEAD
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->