### PR TITLE
feat(contract_manager): OP-PIP-128 core sunset proposal tooling

### DIFF
--- a/contract_manager/scripts/deploy_core_sunset_implementations.ts
+++ b/contract_manager/scripts/deploy_core_sunset_implementations.ts
@@ -1,0 +1,141 @@
+/* eslint-disable no-console */
+/**
+ * OP-PIP-128: deploy 1.4.6 PythUpgradable implementations (deploy ONLY, no
+ * proposal) on the chains listed in the sunset config's `upgrade` section,
+ * then write each deployed address back into the config's newImplementation
+ * field for generate_core_sunset_proposal.ts to consume.
+ *
+ * - Uses a cache file so re-runs never double-deploy (same pattern as
+ *   upgrade_evm_pricefeed_contracts.ts).
+ * - Reads the private key from the env var named by --private-key-env
+ *   (default: PK), or from a file via --private-key-path. Either way the key
+ *   never appears in argv, shell history, or logs.
+ * - Skips zksync-stack chains (zksync, abstract): their bytecode must come
+ *   from the zksolc pipeline, not the forge artifact.
+ *
+ * Usage:
+ *   export PK=<deployer_private_key>
+ *   pnpm tsx scripts/deploy_core_sunset_implementations.ts \
+ *     --config-path scripts/generate_core_sunset_config.json \
+ *     --std-output ../target_chains/ethereum/contracts/out/PythUpgradable.sol/PythUpgradable.json \
+ *     [--chain arbitrum --chain base]
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+import { toPrivateKey } from "../src/core/base";
+import { EvmChain } from "../src/core/chains";
+import { DefaultStore } from "../src/node/utils/store";
+import { makeCacheFunction } from "./common";
+
+const CACHE_FILE = ".cache-core-sunset-deploy";
+const ZK_STACK_CHAINS = new Set(["zksync", "abstract"]);
+
+const parser = yargs(hideBin(process.argv))
+  .usage(
+    "Usage: $0 --config-path <path> --std-output <path> --private-key-path <path> [--chain <id> ...]",
+  )
+  .options({
+    chain: {
+      desc: "Only deploy on these chain ids (default: all pending in config)",
+      type: "array",
+    },
+    "config-path": {
+      demandOption: true,
+      desc: "Path to the sunset config JSON",
+      type: "string",
+    },
+    "private-key-env": {
+      default: "PK",
+      desc: "Name of the env variable holding the deployer private key",
+      type: "string",
+    },
+    "private-key-path": {
+      desc: "Path to a file containing the deployer private key (overrides --private-key-env)",
+      type: "string",
+    },
+    "std-output": {
+      demandOption: true,
+      desc: "Path to the forge PythUpgradable artifact JSON",
+      type: "string",
+    },
+  });
+
+async function main() {
+  const argv = await parser.argv;
+  const runIfNotCached = makeCacheFunction(CACHE_FILE);
+
+  const configPath = path.resolve(argv["config-path"]);
+  const config = JSON.parse(fs.readFileSync(configPath, "utf8")) as {
+    upgrade: { chainName: string; newImplementation: string | null }[];
+    withdraw: unknown[];
+  };
+  const artifact = JSON.parse(fs.readFileSync(argv["std-output"], "utf8"));
+  const rawKey = argv["private-key-path"]
+    ? fs.readFileSync(path.resolve(argv["private-key-path"]), "utf8")
+    : // eslint-disable-next-line n/no-process-env, turbo/no-undeclared-env-vars
+      process.env[argv["private-key-env"]];
+  if (!rawKey)
+    throw new Error(
+      `No private key: set env var ${argv["private-key-env"]} or pass --private-key-path`,
+    );
+  const privateKey = toPrivateKey(rawKey.trim().replace(/^0x/, ""));
+
+  const only = argv.chain?.map(String);
+  const pending = config.upgrade.filter(
+    (u) =>
+      !u.newImplementation &&
+      (!only || only.includes(u.chainName)) &&
+      !ZK_STACK_CHAINS.has(u.chainName),
+  );
+  const skippedZk = config.upgrade.filter(
+    (u) => !u.newImplementation && ZK_STACK_CHAINS.has(u.chainName),
+  );
+  if (skippedZk.length > 0)
+    console.warn(
+      `Skipping zksync-stack chains (need zksolc pipeline): ${skippedZk.map((u) => u.chainName).join(", ")}`,
+    );
+  console.log(`Deploying on ${pending.length} chains, cache: ${CACHE_FILE}`);
+
+  for (const entry of pending) {
+    const chain = DefaultStore.getChainOrThrow(entry.chainName);
+    if (!(chain instanceof EvmChain))
+      throw new Error(`${entry.chainName} is not an EVM chain`);
+    try {
+      console.log(`deploying on ${entry.chainName}...`);
+      const address: string = await runIfNotCached(
+        `deploy-${entry.chainName}`,
+        // 1.1x gas and 1.5x gas price: cheap insurance against base-fee
+        // drift between estimation and send (bit us on arbitrum/ethereum).
+        () =>
+          chain.deploy(
+            privateKey,
+            artifact.abi,
+            artifact.bytecode.object,
+            [],
+            1.1,
+            1.5,
+          ),
+      );
+      entry.newImplementation = address;
+      console.log(`${entry.chainName}: ${address}`);
+      // Persist after every deploy so a mid-run failure loses nothing.
+      fs.writeFileSync(configPath, JSON.stringify(config, undefined, 2) + "\n");
+    } catch (error) {
+      console.error(`${entry.chainName}: FAILED - ${(error as Error).message}`);
+    }
+  }
+
+  const remaining = config.upgrade.filter((u) => !u.newImplementation);
+  console.log(
+    remaining.length === 0
+      ? "\nAll implementation addresses filled."
+      : `\nStill pending: ${remaining.map((u) => u.chainName).join(", ")}`,
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises, unicorn/prefer-top-level-await
+main();

--- a/contract_manager/scripts/generate_core_sunset_config.json
+++ b/contract_manager/scripts/generate_core_sunset_config.json
@@ -1,0 +1,297 @@
+{
+  "upgrade": [
+    {
+      "chainName": "abstract",
+      "newImplementation": "0x428706bFc85ba6f42Ce0FBB9DD9C4C9B3Fb00071"
+    },
+    {
+      "chainName": "apechain_mainnet",
+      "newImplementation": "0x91fD6D8f87661611cA722aec1347005045ae7F02"
+    },
+    {
+      "chainName": "arbitrum",
+      "newImplementation": "0x46f2b3a37F0F87c1a61dbbc959E999db6aed8FA5"
+    },
+    {
+      "chainName": "avalanche",
+      "newImplementation": "0x41c9e39574F40Ad34c79f1C99B66A45eFB830d4c"
+    },
+    {
+      "chainName": "base",
+      "newImplementation": "0x9A0E28e112b61164D4B28eCeD46758BDA71E62FD"
+    },
+    {
+      "chainName": "berachain_mainnet",
+      "newImplementation": "0x6842ce33288177bB0Dea21dEDDDcB12C7Bda817C"
+    },
+    {
+      "chainName": "blast",
+      "newImplementation": "0xe09059e9dc1361688aFc302840CddE1d9ce38d86"
+    },
+    {
+      "chainName": "bsc",
+      "newImplementation": "0x825c0390f379C631f3Cf11A82a37D20BddF93c07"
+    },
+    {
+      "chainName": "celo",
+      "newImplementation": "0x5f3c61944CEb01B3eAef861251Fb1E0f14b848fb"
+    },
+    {
+      "chainName": "coredao",
+      "newImplementation": "0x0708325268dF9F66270F1401206434524814508b"
+    },
+    {
+      "chainName": "cronos",
+      "newImplementation": "0x825c0390f379C631f3Cf11A82a37D20BddF93c07"
+    },
+    {
+      "chainName": "ethereum",
+      "newImplementation": "0x8e58897125Ce7817A0F5F7AD8ec0Be488D0Ca7d1"
+    },
+    {
+      "chainName": "flow_mainnet",
+      "newImplementation": "0x6E7D74FA7d5c90FEF9F0512987605a6d546181Bb"
+    },
+    {
+      "chainName": "gnosis",
+      "newImplementation": "0x825c0390f379C631f3Cf11A82a37D20BddF93c07"
+    },
+    {
+      "chainName": "hemi_mainnet",
+      "newImplementation": "0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320"
+    },
+    {
+      "chainName": "hyperevm",
+      "newImplementation": "0x411c586feCE3ABE2548d6cAED3C920AD9069ff00"
+    },
+    {
+      "chainName": "kraken_ink_mainnet",
+      "newImplementation": "0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320"
+    },
+    {
+      "chainName": "linea",
+      "newImplementation": "0x9fcDCAb0A147e799Fa866594B2c4c20F4eF29F37"
+    },
+    {
+      "chainName": "mantle",
+      "newImplementation": "0x24654078A8E043e8985D962a5100CDfA2026f92C"
+    },
+    {
+      "chainName": "optimism",
+      "newImplementation": "0xD35E56C06320B1ED549a8F85d316FEc854FF4b71"
+    },
+    {
+      "chainName": "opbnb",
+      "newImplementation": "0x8D254a21b3C86D32F7179855531CE99164721933"
+    },
+    {
+      "chainName": "polygon",
+      "newImplementation": "0x4374e5a8b9C22271E9EB878A2AA31DE97DF15DAF"
+    },
+    {
+      "chainName": "scroll",
+      "newImplementation": "0xD458261E832415CFd3BAE5E416FdF3230ce6F134"
+    },
+    {
+      "chainName": "sei_evm_mainnet",
+      "newImplementation": "0x986c00a290D1767651723c7cF9e5bD7bD745f6f9"
+    },
+    {
+      "chainName": "soneium",
+      "newImplementation": "0x1ba1bf00A525a8e492b88aF52Bfa8C1e151694dC"
+    },
+    {
+      "chainName": "fantom_sonic_mainnet",
+      "newImplementation": "0x91fD6D8f87661611cA722aec1347005045ae7F02"
+    },
+    {
+      "chainName": "unichain",
+      "newImplementation": "0x99fA5f405b795cA03F2AE47Cd48FEd22029892a2"
+    },
+    {
+      "chainName": "worldchain",
+      "newImplementation": "0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509"
+    },
+    {
+      "chainName": "zksync",
+      "newImplementation": "0x470d1c91b1b1d9295815A2357FB0D20E7350ab71"
+    }
+  ],
+  "withdraw": [
+    {
+      "chainName": "zero_gravity",
+      "pythContract": "0x2880aB155794e7179c9eE2e38200202908C17B43",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "abstract",
+      "pythContract": "0x8739d5024B5143278E2b15Bd9e7C26f6CEc658F1",
+      "targetAddress": "0x146a7a66c008E15E543b78aa3DeB39eaecD8fBcd"
+    },
+    {
+      "chainName": "apechain_mainnet",
+      "pythContract": "0x2880aB155794e7179c9eE2e38200202908C17B43",
+      "targetAddress": "0xaC400398aD744836a30Fb833Ea6A1b2Cb21505D9"
+    },
+    {
+      "chainName": "arbitrum",
+      "pythContract": "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "avalanche",
+      "pythContract": "0x4305FB66699C3B2702D4d05CF36551390A4c69C6",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "base",
+      "pythContract": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "berachain_mainnet",
+      "pythContract": "0x2880aB155794e7179c9eE2e38200202908C17B43",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "blast",
+      "pythContract": "0xA2aa501b19aff244D90cc15a4Cf739D2725B5729",
+      "targetAddress": "0x36e9f482712ADDcddE83b3326116D46bc578e918"
+    },
+    {
+      "chainName": "bsc",
+      "pythContract": "0x4D7E825f80bDf85e913E0DD2A2D54927e9dE1594",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "celo",
+      "pythContract": "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "coredao",
+      "pythContract": "0xA2aa501b19aff244D90cc15a4Cf739D2725B5729",
+      "targetAddress": "0x146a7a66c008E15E543b78aa3DeB39eaecD8fBcd"
+    },
+    {
+      "chainName": "cronos",
+      "pythContract": "0xE0d0e68297772Dd5a1f1D99897c581E2082dbA5B",
+      "targetAddress": "0xaC400398aD744836a30Fb833Ea6A1b2Cb21505D9"
+    },
+    {
+      "chainName": "ethereum",
+      "pythContract": "0x4305FB66699C3B2702D4d05CF36551390A4c69C6",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "gnosis",
+      "pythContract": "0x2880aB155794e7179c9eE2e38200202908C17B43",
+      "targetAddress": "0x36e9f482712ADDcddE83b3326116D46bc578e918"
+    },
+    {
+      "chainName": "hemi_mainnet",
+      "pythContract": "0x2880aB155794e7179c9eE2e38200202908C17B43",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "hyperevm",
+      "pythContract": "0xe9d69CdD6Fe41e7B621B4A688C5D1a68cB5c8ADc",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "injective_evm",
+      "pythContract": "0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320",
+      "targetAddress": "0x0694D676980856658e727341D7c9Ef87b490ae7D"
+    },
+    {
+      "chainName": "kraken_ink_mainnet",
+      "pythContract": "0x2880aB155794e7179c9eE2e38200202908C17B43",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "linea",
+      "pythContract": "0xA2aa501b19aff244D90cc15a4Cf739D2725B5729",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "mantle",
+      "pythContract": "0xA2aa501b19aff244D90cc15a4Cf739D2725B5729",
+      "targetAddress": "0x36e9f482712ADDcddE83b3326116D46bc578e918"
+    },
+    {
+      "chainName": "megaeth",
+      "pythContract": "0x2880aB155794e7179c9eE2e38200202908C17B43",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "mezo",
+      "pythContract": "0x2880aB155794e7179c9eE2e38200202908C17B43",
+      "targetAddress": "0x85Ab7030e8130775eA2C5F70CafBc8e8c55f2666"
+    },
+    {
+      "chainName": "monad",
+      "pythContract": "0x2880aB155794e7179c9eE2e38200202908C17B43",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "opbnb",
+      "pythContract": "0x2880aB155794e7179c9eE2e38200202908C17B43",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "optimism",
+      "pythContract": "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "plasma",
+      "pythContract": "0x2880aB155794e7179c9eE2e38200202908C17B43",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "polygon",
+      "pythContract": "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "robinhood",
+      "pythContract": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "scroll",
+      "pythContract": "0xA2aa501b19aff244D90cc15a4Cf739D2725B5729",
+      "targetAddress": "0x36e9f482712ADDcddE83b3326116D46bc578e918"
+    },
+    {
+      "chainName": "sei_evm_mainnet",
+      "pythContract": "0x2880aB155794e7179c9eE2e38200202908C17B43",
+      "targetAddress": "0x36e9f482712ADDcddE83b3326116D46bc578e918"
+    },
+    {
+      "chainName": "soneium",
+      "pythContract": "0x2880aB155794e7179c9eE2e38200202908C17B43",
+      "targetAddress": "0x36e9f482712ADDcddE83b3326116D46bc578e918"
+    },
+    {
+      "chainName": "fantom_sonic_mainnet",
+      "pythContract": "0x2880aB155794e7179c9eE2e38200202908C17B43",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "unichain",
+      "pythContract": "0x2880aB155794e7179c9eE2e38200202908C17B43",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "worldchain",
+      "pythContract": "0xe9d69CdD6Fe41e7B621B4A688C5D1a68cB5c8ADc",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    },
+    {
+      "chainName": "zksync",
+      "pythContract": "0xf087c864AEccFb6A2Bf1Af6A0382B0d0f6c5D834",
+      "targetAddress": "0xD879B2c9e70CA8e4bED04223D95f45F87F33B935"
+    }
+  ]
+}

--- a/contract_manager/scripts/generate_core_sunset_proposal.ts
+++ b/contract_manager/scripts/generate_core_sunset_proposal.ts
@@ -1,0 +1,195 @@
+/* eslint-disable no-console */
+/**
+ * OP-PIP-128: Core sunset proposal generator.
+ *
+ * Builds ONE Squads proposal containing, in this order:
+ *   1. SetFee(0) for every mainnet EVM chain with a Pyth price feed contract
+ *   2. UpgradeContract for chains running pre-WithdrawFee implementations
+ *   3. WithdrawFee(full balance -> PC multisig) for chains with PC Safe coverage
+ *
+ * Ordering matters: the Pyth contract enforces strictly increasing wormhole
+ * sequence numbers per contract, so placing upgrades before withdrawals
+ * guarantees each chain is upgrade-capable before its withdrawal executes.
+ *
+ * Withdrawal amounts are queried live at generation time. Balances can only
+ * grow until SetFee(0) executes, so the queried amount is a guaranteed lower
+ * bound at execution time and the withdrawal can never revert.
+ *
+ * Default is a dry run that prints all payloads. Pass --submit together with
+ * --ops-key-path to create the proposal on the mainnet-beta vault.
+ *
+ * Usage:
+ *   pnpm tsx scripts/generate_core_sunset_proposal.ts \
+ *     --config-path scripts/generate_core_sunset_config.json [--submit --ops-key-path <path>]
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+import { WithdrawFee } from "@pythnetwork/xc-admin-common";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+import { EvmChain } from "../src/core/chains";
+import { EvmPriceFeedContract } from "../src/core/contracts";
+import { loadHotWallet } from "../src/node/utils/governance";
+import { DefaultStore } from "../src/node/utils/store";
+
+const U64_MAX = 2n ** 64n;
+
+const parser = yargs(hideBin(process.argv))
+  .usage(
+    "Usage: $0 --config-path <path> [--submit --ops-key-path <path>] [--rpc-url <solana_rpc>]",
+  )
+  .options({
+    "config-path": {
+      demandOption: true,
+      desc: "Path to the sunset config JSON (upgrade + withdraw sections)",
+      type: "string",
+    },
+    "ops-key-path": {
+      desc: "Path to the ops key file (required with --submit)",
+      type: "string",
+    },
+    "rpc-url": {
+      // eslint-disable-next-line n/no-process-env, turbo/no-undeclared-env-vars
+      default: process.env.SOLANA_RPC_URL,
+      desc: "Solana RPC URL",
+      type: "string",
+    },
+    submit: {
+      default: false,
+      desc: "Actually create the Squads proposal (otherwise dry run)",
+      type: "boolean",
+    },
+    vault: {
+      default: "mainnet-beta_FVQyHcooAtThJ83XFrNnv74BcinbRH3bRmfFamAHBfuj",
+      desc: "Vault ID",
+      type: "string",
+    },
+  });
+
+interface UpgradeEntry {
+  chainName: string;
+  newImplementation: string | null;
+}
+interface WithdrawEntry {
+  chainName: string;
+  pythContract: string;
+  targetAddress: string;
+}
+
+/** Encode a wei amount as (value, expo) with value < 2^64 and value*10^expo <= wei. */
+function toValueExpo(wei: bigint): { value: bigint; expo: bigint } {
+  let expo = 0n;
+  let value = wei;
+  while (value >= U64_MAX) {
+    expo += 1n;
+    value = wei / 10n ** expo;
+  }
+  return { value, expo };
+}
+
+async function main() {
+  const argv = await parser.argv;
+  const config = JSON.parse(
+    fs.readFileSync(path.resolve(argv["config-path"]), "utf8"),
+  ) as { upgrade: UpgradeEntry[]; withdraw: WithdrawEntry[] };
+
+  const payloads: Buffer[] = [];
+  const summary: string[] = [];
+
+  // Part 2 payloads (SetFee) come first in the array so every chain's fee is
+  // frozen before (or at worst alongside) its upgrade and withdrawal.
+  const feeChains = [
+    ...new Set(
+      Object.values(DefaultStore.contracts)
+        .filter(
+          (c): c is EvmPriceFeedContract =>
+            c instanceof EvmPriceFeedContract && c.getChain().isMainnet(),
+        )
+        .map((c) => c.getChain().getId()),
+    ),
+  ].sort();
+  for (const chainName of feeChains) {
+    const chain = DefaultStore.getChainOrThrow(chainName);
+    payloads.push(chain.generateGovernanceSetFeePayload(0, 0));
+    summary.push(`SetFee(0)   ${chainName}`);
+  }
+
+  // Part 1 payloads (UpgradeContract).
+  const missing = config.upgrade.filter((u) => !u.newImplementation);
+  if (missing.length > 0) {
+    console.warn(
+      `WARNING: ${missing.length}/${config.upgrade.length} upgrade entries have no implementation address yet: ` +
+        missing.map((u) => u.chainName).join(", "),
+    );
+    if (argv.submit)
+      throw new Error(
+        "Cannot submit with missing implementation addresses. Deploy implementations first.",
+      );
+  }
+  for (const entry of config.upgrade) {
+    if (!entry.newImplementation) continue;
+    const chain = DefaultStore.getChainOrThrow(entry.chainName);
+    if (!(chain instanceof EvmChain))
+      throw new Error(`${entry.chainName} is not an EVM chain`);
+    payloads.push(
+      chain.generateGovernanceUpgradePayload(
+        entry.newImplementation.replace("0x", ""),
+      ),
+    );
+    summary.push(`Upgrade     ${entry.chainName} -> ${entry.newImplementation}`);
+  }
+
+  // Part 3 payloads (WithdrawFee), amounts queried live.
+  for (const entry of config.withdraw) {
+    const contract = Object.values(DefaultStore.contracts).find(
+      (c): c is EvmPriceFeedContract =>
+        c instanceof EvmPriceFeedContract &&
+        c.getChain().getId() === entry.chainName &&
+        c.address.toLowerCase() === entry.pythContract.toLowerCase(),
+    );
+    if (!contract)
+      throw new Error(
+        `No price feed contract ${entry.pythContract} on ${entry.chainName} in the store`,
+      );
+    const chain = contract.getChain() as EvmChain;
+    const fee = await contract.getTotalFee();
+    const { value, expo } = toValueExpo(fee.amount);
+    if (value === 0n) {
+      summary.push(`Withdraw    ${entry.chainName} SKIPPED (balance 0)`);
+      continue;
+    }
+    payloads.push(
+      new WithdrawFee(
+        chain.wormholeChainName,
+        Buffer.from(entry.targetAddress.replace("0x", ""), "hex"),
+        value,
+        expo,
+      ).encode(),
+    );
+    summary.push(
+      `Withdraw    ${entry.chainName} ${fee.amount} wei -> ${entry.targetAddress} (value=${value}, expo=${expo})`,
+    );
+  }
+
+  console.log(`\n=== ${payloads.length} payloads ===`);
+  for (const [i, line] of summary.entries()) console.log(`${i + 1}. ${line}`);
+  console.log("\n=== payload hex ===");
+  for (const p of payloads) console.log(p.toString("hex"));
+
+  if (!argv.submit) {
+    console.log("\nDry run complete. Re-run with --submit --ops-key-path to propose.");
+    return;
+  }
+  if (!argv["ops-key-path"]) throw new Error("--submit requires --ops-key-path");
+  const vault = DefaultStore.vaults[argv.vault];
+  if (!vault) throw new Error(`Vault '${argv.vault}' does not exist.`);
+  const keypair = await loadHotWallet(argv["ops-key-path"]);
+  vault.connect(keypair, argv["rpc-url"] ? () => argv["rpc-url"] as string : undefined);
+  const proposal = await vault.proposeWormholeMessage(payloads);
+  console.log("Proposal address:", proposal.address.toBase58());
+}
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises, unicorn/prefer-top-level-await
+main();

--- a/contract_manager/scripts/generate_core_sunset_proposal.ts
+++ b/contract_manager/scripts/generate_core_sunset_proposal.ts
@@ -157,7 +157,7 @@ async function main() {
     const fee = await contract.getTotalFee();
     const { value, expo } = toValueExpo(fee.amount);
     if (value === 0n) {
-      summary.push(`Withdraw    ${entry.chainName} SKIPPED (balance 0)`);
+      console.log(`Withdraw    ${entry.chainName} SKIPPED (balance 0)`);
       continue;
     }
     payloads.push(

--- a/contract_manager/src/store/chains/EvmChains.json
+++ b/contract_manager/src/store/chains/EvmChains.json
@@ -1123,7 +1123,7 @@
     "id": "soneium",
     "mainnet": true,
     "networkId": 1868,
-    "rpcUrl": "https://soneium.drpc.org",
+    "rpcUrl": "https://rpc.soneium.org",
     "type": "EvmChain"
   },
   {
@@ -1144,7 +1144,7 @@
     "id": "kraken_ink_mainnet",
     "mainnet": true,
     "networkId": 57073,
-    "rpcUrl": "https://ink-public.nodies.app",
+    "rpcUrl": "https://rpc-gel.inkonchain.com",
     "type": "EvmChain"
   },
   {

--- a/target_chains/ethereum/contracts/deploy/zkSyncDeployNewPythImpl.ts
+++ b/target_chains/ethereum/contracts/deploy/zkSyncDeployNewPythImpl.ts
@@ -17,8 +17,9 @@ function envOrErr(name: string): string {
 
 export default async function (hre: HardhatRuntimeEnvironment) {
   // Initialize the wallet from PK (raw private key) or MNEMONIC.
-  const wallet = process.env.PK
-    ? new Wallet(process.env.PK)
+  const rawPk = process.env.PK?.trim();
+  const wallet = rawPk
+    ? new Wallet(rawPk.startsWith("0x") ? rawPk : `0x${rawPk}`)
     : Wallet.fromMnemonic(envOrErr("MNEMONIC"));
 
   // Create deployer object and load the artifact of the contract we want to deploy.

--- a/target_chains/ethereum/contracts/deploy/zkSyncDeployNewPythImpl.ts
+++ b/target_chains/ethereum/contracts/deploy/zkSyncDeployNewPythImpl.ts
@@ -16,8 +16,10 @@ function envOrErr(name: string): string {
 }
 
 export default async function (hre: HardhatRuntimeEnvironment) {
-  // Initialize the wallet.
-  const wallet = Wallet.fromMnemonic(envOrErr("MNEMONIC"));
+  // Initialize the wallet from PK (raw private key) or MNEMONIC.
+  const wallet = process.env.PK
+    ? new Wallet(process.env.PK)
+    : Wallet.fromMnemonic(envOrErr("MNEMONIC"));
 
   // Create deployer object and load the artifact of the contract we want to deploy.
   const deployer = new Deployer(hre, wallet);


### PR DESCRIPTION
## Summary

Tooling for the **OP-PIP-128** governance proposal (Pyth Core sunset: set fees to zero on all EVM chains, upgrade legacy contracts, repatriate accumulated fees to Pythian Council multisigs per OP-PIP-125).

- **`generate_core_sunset_proposal.ts`** — builds ONE Squads proposal containing, in order: `SetFee(0)` for every mainnet EVM chain (86), `UpgradeContract` → v1.4.6 for the 29 chains running pre-WithdrawFee implementations, and `WithdrawFee` (full balance → PC Safe) for the 35 chains with council multisig coverage. Ordering guarantees upgrades execute before the withdrawals that depend on them (per-contract wormhole sequence enforcement). Withdrawal amounts are queried live at generation time — balances only grow until `SetFee` lands, so amounts can never exceed the execution-time balance. Dry-run by default; `--submit --ops-key-path` creates the proposal.
- **`deploy_core_sunset_implementations.ts`** — deploy-only helper (no proposal side effects) that deploys the `PythUpgradable` forge artifact per chain and records addresses into the config. Cache-protected against double-deploys; ZK-stack chains excluded (deployed via `hardhat deploy-zksync` instead).
- **`generate_core_sunset_config.json`** — the 29 deployed v1.4.6 implementation addresses and the 35 PC multisig targets. Every implementation is on-chain-verified (`version() == 1.4.6`; deployed bytecode digest `0xaf4ad08da4597ac42664541c32a989fe02efb87bbb5de0ee6430ae61bc9529bc` after masking the UUPS self-address, matching a `forge build` of `d657d97ed`) and source-verified (Sourcify `exact_match` on the 27 standard-EVM chains; zkSync Era + Abstract natively verified on their explorers). Every multisig is a deployed Safe with the council's 5-of-8 signer set, checked on-chain.
- **`EvmChains.json`** — replace broken public RPCs: `kraken_ink_mainnet` (dead endpoint) and `soneium` (drpc endpoint lacks `eth_sendRawTransaction`).
- **`zkSyncDeployNewPythImpl.ts`** — accept a raw `PK` env var alongside `MNEMONIC`.

## Verification

```bash
pnpm install && pnpm turbo build --filter @pythnetwork/contract-manager
cd contract_manager
pnpm tsx scripts/generate_core_sunset_proposal.ts --config-path scripts/generate_core_sunset_config.json  # dry run, prints all payloads
```

Implementation digest reproduction: `forge build` in `target_chains/ethereum/contracts`, then keccak of `deployedBytecode` per the OP-PIP-83 recipe.

The on-chain proposal has **not** been submitted yet; it follows the OP-PIP-128 forum post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->