### PR TITLE
feat(contract_manager): report on-chain price feed usage for post-upgrade EVM chains

### DIFF
--- a/contract_manager/README.md
+++ b/contract_manager/README.md
@@ -32,3 +32,41 @@ You can generate the docs by running `pnpm exec typedoc src/index.ts` from this 
 # Scripts
 
 You can run the scripts by executing `pnpm tsx scripts/<script_name>.ts` from this directory.
+
+## `report_price_feed_usage.ts`
+
+Reports which price feeds are actually being written on-chain, so that feeds in real use can
+be checked against the Pyth Pro catalog before Pyth Core is switched off. It scans
+`PriceFeedUpdate` logs on every EVM mainnet that has a `pro-compatible-production` price feed
+contract, covering both that contract and the chain's legacy Core contract.
+
+```sh
+pnpm tsx scripts/report_price_feed_usage.ts --days 30 --output usage.csv
+```
+
+This writes three files: `usage.csv` (one row per feed, one column per chain), `usage_split.csv`
+(the same counts split into legacy and upgraded contracts) and `usage_coverage.csv` (the block
+range actually scanned per contract). Run `--help` for the full flag list.
+
+A 30-day run takes hours and is resumable — re-run the same command to continue from the
+checkpoint file named by `--state-file`.
+
+### RPC endpoints
+
+The scan is bounded by request count, not data volume, because public RPCs cap `eth_getLogs`
+block ranges. The chunk size adapts automatically, but on the chains below a public endpoint
+means tens of thousands of requests or an outright refusal, so point them at a paid archive
+endpoint with `--rpc <chain>=<url>` (or through the `$ENV_*` placeholder the `rpcUrl` values in
+`src/store/chains/EvmChains.json` already support):
+
+| chain             | problem with the public endpoint in the store         |
+| ----------------- | ----------------------------------------------------- |
+| `injective_inevm` | endpoint is dead; the chain cannot be scanned at all   |
+| `optimism`        | 50-block cap, and 30-day-old logs are refused outright |
+| `monad`           | 100-block cap over ~8.6M blocks per 30 days            |
+| `bsc`, `hyperevm` | 1,000-block cap                                        |
+| `cronos`          | 2,000-block cap                                        |
+
+A chain that cannot be scanned across the whole window is never silently under-counted: its
+column in `usage.csv` is suffixed `_INCOMPLETE` and `usage_coverage.csv` records the block range
+and wall-clock window it actually covered.

--- a/contract_manager/README.md
+++ b/contract_manager/README.md
@@ -36,17 +36,29 @@ You can run the scripts by executing `pnpm tsx scripts/<script_name>.ts` from th
 ## `report_price_feed_usage.ts`
 
 Reports which price feeds are actually being written on-chain, so that feeds in real use can
-be checked against the Pyth Pro catalog before Pyth Core is switched off. It scans
-`PriceFeedUpdate` logs on every EVM mainnet that has a `pro-compatible-production` price feed
-contract, covering both that contract and the chain's legacy Core contract.
+be checked against the Pyth Pro catalog before Pyth Core is switched off. It covers every EVM
+and Sui mainnet that has a `pro-compatible-production` price feed contract, plus Solana, and
+on each one scans both that deployment and the legacy Core deployment.
+
+The three platforms are counted by different mechanisms, since none is shared:
+
+| platform | position   | mechanism                                                      |
+| -------- | ---------- | -------------------------------------------------------------- |
+| EVM      | block      | `eth_getLogs` on the `PriceFeedUpdate` topic                     |
+| Sui      | checkpoint | GraphQL `events` on `<pkg>::event::PriceFeedUpdateEvent`         |
+| SVM      | slot       | receiver `post_update` instructions decoded from transactions    |
+
+EVM and Sui counts mean the same thing — both events fire only on a *fresh* update. SVM counts
+are write attempts that reached the receiver, which is close but not identical; see the header
+comment in the script.
 
 ```sh
 pnpm tsx scripts/report_price_feed_usage.ts --days 30 --output usage.csv
 ```
 
 This writes three files: `usage.csv` (one row per feed, one column per chain), `usage_split.csv`
-(the same counts split into legacy and upgraded contracts) and `usage_coverage.csv` (the block
-range actually scanned per contract). Run `--help` for the full flag list.
+(the same counts split into legacy and upgraded contracts) and `usage_coverage.csv` (the
+position range actually scanned per contract). Run `--help` for the full flag list.
 
 A 30-day run takes hours and is resumable — re-run the same command to continue from the
 checkpoint file named by `--state-file`.
@@ -59,14 +71,21 @@ means tens of thousands of requests or an outright refusal, so point them at a p
 endpoint with `--rpc <chain>=<url>` (or through the `$ENV_*` placeholder the `rpcUrl` values in
 `src/store/chains/EvmChains.json` already support):
 
-| chain             | problem with the public endpoint in the store         |
-| ----------------- | ----------------------------------------------------- |
-| `injective_inevm` | endpoint is dead; the chain cannot be scanned at all   |
-| `optimism`        | 50-block cap, and 30-day-old logs are refused outright |
-| `monad`           | 100-block cap over ~8.6M blocks per 30 days            |
-| `bsc`, `hyperevm` | 1,000-block cap                                        |
-| `cronos`          | 2,000-block cap                                        |
+| chain             | problem with the public endpoint in the store          |
+| ----------------- | ------------------------------------------------------ |
+| `injective_inevm` | endpoint is dead; the chain cannot be scanned at all    |
+| `optimism`        | 50-block cap, and 30-day-old logs are refused outright  |
+| `monad`           | 100-block cap over ~8.6M blocks per 30 days             |
+| `bsc`, `hyperevm` | 1,000-block cap                                         |
+| `cronos`          | 2,000-block cap                                         |
+| `solana_mainnet`  | needs `SOLANA_MAINNET_API_KEY`; see below               |
+
+Solana is the hardest of these. A count costs one `getTransaction` per receiver transaction,
+and `api.mainnet-beta.solana.com` serves about 1.25 per second before returning HTTP 429 —
+against a receiver that sees roughly 2.1 transactions per second, so the scan cannot keep up
+with real time on the public endpoint. Set `SOLANA_MAINNET_API_KEY` (the `rpcUrl` in
+`src/store/chains/SvmChains.json` already interpolates it) or pass `--rpc solana_mainnet=<url>`.
 
 A chain that cannot be scanned across the whole window is never silently under-counted: its
-column in `usage.csv` is suffixed `_INCOMPLETE` and `usage_coverage.csv` records the block range
-and wall-clock window it actually covered.
+column in `usage.csv` is suffixed `_INCOMPLETE` and `usage_coverage.csv` records the position
+range and wall-clock window it actually covered.

--- a/contract_manager/scripts/report_price_feed_usage.ts
+++ b/contract_manager/scripts/report_price_feed_usage.ts
@@ -2,17 +2,34 @@
 /** biome-ignore-all lint/suspicious/noConsole: this is a CLI script */
 
 /**
- * Reports which Pyth price feeds are actually written on-chain on the EVM mainnets that
- * survive the Pyth Core upgrade, so that every feed in real use can be checked against the
- * Pyth Pro catalog before Core is switched off.
+ * Reports which Pyth price feeds are actually written on-chain on the mainnets that survive
+ * the Pyth Core upgrade, so that every feed in real use can be checked against the Pyth Pro
+ * catalog before Core is switched off.
  *
  * Usage: `pnpm tsx scripts/report_price_feed_usage.ts --days 30 --output usage.csv`
  *
+ * Three platforms are covered, and they are counted by different mechanisms because none of
+ * them share one. Every platform resolves a position range from the requested time window and
+ * then streams counted sub-ranges of it, which is what makes coverage and resume uniform:
+ *
+ * | platform | position  | mechanism                                                  |
+ * |----------|-----------|------------------------------------------------------------|
+ * | EVM      | block     | `eth_getLogs` on the `PriceFeedUpdate` topic                 |
+ * | Sui      | checkpoint| GraphQL `events` on `<pkg>::event::PriceFeedUpdateEvent`     |
+ * | SVM      | slot      | receiver `post_update` instructions decoded from transactions|
+ *
  * How usage is measured, and what the numbers do and do not mean:
  *
- * - A count is the number of `PriceFeedUpdate` logs emitted by a Pyth contract. That event
- *   fires only when an update is *fresh* — carrying a newer `publishTime` than the stored
- *   one — so the counts measure accepted writes, not `updatePriceFeeds` calls.
+ * - On EVM a count is the number of `PriceFeedUpdate` logs emitted by a Pyth contract. That
+ *   event fires only when an update is *fresh* — carrying a newer `publishTime` than the
+ *   stored one — so the counts measure accepted writes, not `updatePriceFeeds` calls. Sui's
+ *   `PriceFeedUpdateEvent` has the same contract: `update_cache` emits it only on a fresh
+ *   update, so Sui counts are directly comparable to EVM ones.
+ * - SVM counts are **not** strictly comparable. The receiver program emits no events, so a
+ *   count there is the number of `post_update` / `post_update_atomic` instructions addressed
+ *   to a feed. Sponsored pushes that the push-oracle rejects as stale never reach the
+ *   receiver and so are not counted, but a consumer pull update that re-posts an already
+ *   known price is. Read SVM numbers as "write attempts that reached the receiver".
  * - A consumer that only *reads* a feed (`getPriceNoOlderThan`) emits nothing and relies on
  *   somebody else pushing. Treat "at least one update in the window" as the in-use signal
  *   and the count itself as a magnitude hint, not a usage share.
@@ -32,9 +49,16 @@
  * Coverage is reported honestly. Public RPCs cap `eth_getLogs` ranges (50 blocks on some
  * chains), rate-limit aggressively, and some refuse 30-day-old logs entirely, so a chain that
  * could not be scanned over the whole window is marked `_INCOMPLETE` in the main CSV and gets
- * the block range it actually covered in the coverage CSV. Point such a chain at a paid
+ * the position range it actually covered in the coverage CSV. Point such a chain at a paid
  * archive endpoint with `--rpc <chain>=<url>` (or through the `$ENV_*` placeholders the chain
  * store already supports) and re-run; the run resumes from its checkpoint file.
+ *
+ * SVM is the chain where that matters most. Reconstructing counts costs one `getTransaction`
+ * per receiver transaction, and `api.mainnet-beta.solana.com` serves ~1.25 of those per second
+ * before returning HTTP 429, against a receiver that sees ~2.1 transactions per second. On the
+ * public endpoint the scan therefore falls behind real time and lands as `_INCOMPLETE`; a
+ * keyed endpoint (`SOLANA_MAINNET_API_KEY`, which the chain store's `rpcUrl` already expects)
+ * is what makes a full window reachable.
  */
 
 import { writeFileSync } from "node:fs";
@@ -44,8 +68,16 @@ import path from "node:path";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
-import { EvmChain } from "../src/core/chains";
-import { EvmPriceFeedContract } from "../src/core/contracts";
+import { EvmChain, SvmChain } from "../src/core/chains";
+import {
+  EvmPriceFeedContract,
+  getSuiCheckpointAtTimestamp,
+  getSuiCheckpointTimestamp,
+  getSvmSlotAtTimestamp,
+  SuiPriceFeedContract,
+  SVM_PRICE_FEED_PROGRAMS,
+  SvmPriceFeedUpdateScanner,
+} from "../src/core/contracts";
 import { DefaultStore } from "../src/node/utils/store";
 import { sleep } from "../src/utils/sleep";
 
@@ -101,6 +133,11 @@ const parser = yargs(hideBin(process.argv))
       desc: "Checkpoint file; a run resumes from it unless --fresh is passed",
       type: "string",
     },
+    "svm-batch-size": {
+      default: 5,
+      desc: "getTransaction calls per JSON-RPC batch on SVM chains; public endpoints 429 above ~5",
+      type: "number",
+    },
   })
   .epilogue(
     "A full 30-day run takes hours and is resumable: interrupt it and re-run the same " +
@@ -110,21 +147,69 @@ const parser = yargs(hideBin(process.argv))
 
 type Deployment = "legacy" | "upgraded";
 
+/**
+ * What a chain's scan positions are counted in. Only ever used for labelling — the scan
+ * treats every platform's positions as opaque monotonically increasing integers.
+ */
+type PositionUnit = "block" | "checkpoint" | "slot";
+
+type ScanBatch = {
+  from: number;
+  to: number;
+  counts: Map<string, number>;
+};
+
+type ScanOptions = {
+  requestConcurrency: number;
+  maxChunkSize: number;
+  svmBatchSize: number;
+  onRetry: (message: string) => void;
+};
+
+/**
+ * Per-platform scan mechanics. EVM reads `eth_getLogs`, Sui pages GraphQL events by
+ * checkpoint, SVM decodes receiver instructions out of transactions — but all three resolve a
+ * position range from the time window and then stream counted sub-ranges of it, so the
+ * checkpointing, coverage accounting and reporting are shared.
+ */
+type TargetScanner = {
+  positionUnit: PositionUnit;
+  /**
+   * SVM signatures are only enumerable newest-first, so its scan closes off the range from the
+   * top down while EVM and Sui fill it from the bottom up.
+   */
+  descending: boolean;
+  resolveRange: (state: ReportState) => Promise<{ from: number; to: number }>;
+  timestampAt: (position: number) => Promise<number | undefined>;
+  stream: (
+    range: { from: number; to: number },
+    options: ScanOptions,
+  ) => AsyncGenerator<ScanBatch>;
+};
+
 type ScanTarget = {
   key: string;
   chainId: string;
+  address: string;
   deployment: Deployment;
-  contract: EvmPriceFeedContract;
+  scanner: TargetScanner;
 };
 
 type ScanState = {
   chain: string;
   address: string;
   deployment: Deployment;
-  fromBlock: number;
-  toBlock: number;
-  /** First block not yet counted; equals `toBlock + 1` once the scan is complete. */
-  nextBlock: number;
+  positionUnit: PositionUnit;
+  descending: boolean;
+  fromPosition: number;
+  toPosition: number;
+  /**
+   * The contiguous sub-range of `[fromPosition, toPosition]` counted so far, inclusive.
+   * Undefined until the first batch lands. Ascending scans grow `coveredTo`, descending scans
+   * grow `coveredFrom` downwards; the scan is complete when the two ends meet the range.
+   */
+  coveredFrom?: number;
+  coveredTo?: number;
   counts: Record<string, number>;
   status: "pending" | "complete" | "failed";
   error?: string;
@@ -139,21 +224,30 @@ type ReportState = {
   scans: Record<string, ScanState>;
 };
 
+function deploymentOf(deploymentType: string | undefined): Deployment {
+  return deploymentType === "pro-compatible-production" ? "upgraded" : "legacy";
+}
+
 /**
- * The chains that survive the upgrade: EVM mainnets carrying a price feed contract marked
+ * The chains that survive the upgrade: mainnets carrying a price feed contract marked
  * `pro-compatible-production`. Both that contract and the chain's legacy Core contract are
  * scanned, since integrators migrate at their own pace and traffic is split across the two.
+ *
+ * EVM and Sui deployments are derived from `DefaultStore`. SVM is not in the store — it has no
+ * `PriceFeedContract` implementation — so its two program pairs come from constants, and it is
+ * included only when explicitly listed in `--chains` or when no filter is given.
  */
 function getScanTargets(
   chainFilter: string[] | undefined,
   rpcOverrides: Map<string, string>,
 ): ScanTarget[] {
-  const evmPriceFeedContracts = Object.values(DefaultStore.contracts).filter(
-    (contract): contract is EvmPriceFeedContract =>
-      contract instanceof EvmPriceFeedContract,
+  const priceFeedContracts = Object.values(DefaultStore.contracts).filter(
+    (contract): contract is EvmPriceFeedContract | SuiPriceFeedContract =>
+      contract instanceof EvmPriceFeedContract ||
+      contract instanceof SuiPriceFeedContract,
   );
   const inScopeChains = new Set(
-    evmPriceFeedContracts
+    priceFeedContracts
       .filter(
         (contract) =>
           contract.deploymentType === "pro-compatible-production" &&
@@ -161,6 +255,7 @@ function getScanTargets(
       )
       .map((contract) => contract.getChain().getId()),
   );
+  for (const chainId of svmChainIds()) inScopeChains.add(chainId);
 
   if (chainFilter !== undefined) {
     for (const chainId of chainFilter) {
@@ -171,31 +266,176 @@ function getScanTargets(
       }
     }
   }
+  const included = (chainId: string) =>
+    inScopeChains.has(chainId) &&
+    (chainFilter === undefined || chainFilter.includes(chainId));
 
-  return evmPriceFeedContracts
-    .filter(
-      (contract) =>
-        inScopeChains.has(contract.getChain().getId()) &&
-        (chainFilter === undefined ||
-          chainFilter.includes(contract.getChain().getId())),
-    )
-    .map((contract) => {
-      const chainId = contract.getChain().getId();
-      const overriddenRpc = rpcOverrides.get(chainId);
+  const targets: ScanTarget[] = [];
+  for (const contract of priceFeedContracts) {
+    const chainId = contract.getChain().getId();
+    if (!included(chainId)) continue;
+    const rpcOverride = rpcOverrides.get(chainId);
+    targets.push(
+      contract instanceof EvmPriceFeedContract
+        ? evmTarget(contract, rpcOverride)
+        : suiTarget(contract),
+    );
+  }
+  for (const chainId of svmChainIds()) {
+    if (!included(chainId)) continue;
+    targets.push(...svmTargets(chainId, rpcOverrides.get(chainId)));
+  }
+  return targets.sort((a, b) => a.key.localeCompare(b.key));
+}
+
+function svmChainIds(): string[] {
+  return Object.values(DefaultStore.chains)
+    .filter((chain): chain is SvmChain => chain instanceof SvmChain)
+    .filter((chain) => chain.isMainnet())
+    .map((chain) => chain.getId());
+}
+
+function evmTarget(
+  original: EvmPriceFeedContract,
+  rpcOverride: string | undefined,
+): ScanTarget {
+  const contract =
+    rpcOverride === undefined ? original : withRpcUrl(original, rpcOverride);
+  const chain = contract.getChain();
+  return {
+    address: contract.address,
+    chainId: chain.getId(),
+    deployment: deploymentOf(contract.deploymentType),
+    key: `${chain.getId()}:${contract.address}`,
+    scanner: {
+      descending: false,
+      positionUnit: "block",
+      resolveRange: async (state) => {
+        const [from, to] = await Promise.all([
+          chain.getBlockNumberAtTimestamp(state.windowStartUnix),
+          chain.getBlockNumberAtTimestamp(state.windowEndUnix),
+        ]);
+        return { from, to };
+      },
+      stream: (range, options) =>
+        mapBatches(
+          contract.streamPriceFeedUpdateCounts({
+            concurrency: options.requestConcurrency,
+            fromBlock: range.from,
+            maxChunkSize: options.maxChunkSize,
+            onRetry: options.onRetry,
+            toBlock: range.to,
+          }),
+          (batch) => ({
+            counts: batch.counts,
+            from: batch.fromBlock,
+            to: batch.toBlock,
+          }),
+        ),
+      timestampAt: async (position) =>
+        Number((await chain.getWeb3().eth.getBlock(position)).timestamp),
+    },
+  };
+}
+
+function suiTarget(contract: SuiPriceFeedContract): ScanTarget {
+  const chain = contract.getChain();
+  return {
+    address: contract.stateId,
+    chainId: chain.getId(),
+    deployment: deploymentOf(contract.deploymentType),
+    key: `${chain.getId()}:${contract.stateId}`,
+    scanner: {
+      descending: false,
+      positionUnit: "checkpoint",
+      resolveRange: async (state) => {
+        const [from, to] = await Promise.all([
+          getSuiCheckpointAtTimestamp(chain, state.windowStartUnix),
+          getSuiCheckpointAtTimestamp(chain, state.windowEndUnix),
+        ]);
+        return { from, to };
+      },
+      stream: (range, options) =>
+        mapBatches(
+          contract.streamPriceFeedUpdateCounts({
+            fromCheckpoint: range.from,
+            onRetry: options.onRetry,
+            toCheckpoint: range.to,
+          }),
+          (batch) => ({
+            counts: batch.counts,
+            from: batch.fromCheckpoint,
+            to: batch.toCheckpoint,
+          }),
+        ),
+      timestampAt: (position) => getSuiCheckpointTimestamp(chain, position),
+    },
+  };
+}
+
+function svmTargets(
+  chainId: string,
+  rpcOverride: string | undefined,
+): ScanTarget[] {
+  const stored = DefaultStore.chains[chainId];
+  if (!(stored instanceof SvmChain)) {
+    throw new Error(`${chainId} is not an SVM chain`);
+  }
+  const chain =
+    rpcOverride === undefined
+      ? stored
+      : new SvmChain(
+          stored.getId(),
+          stored.isMainnet(),
+          stored.wormholeChainName,
+          stored.getNativeToken(),
+          rpcOverride,
+        );
+  return Object.entries(SVM_PRICE_FEED_PROGRAMS).map(
+    ([deployment, programs]) => {
+      const scanner = new SvmPriceFeedUpdateScanner(chain, programs.receiver);
       return {
+        address: programs.receiver,
         chainId,
-        contract:
-          overriddenRpc === undefined
-            ? contract
-            : withRpcUrl(contract, overriddenRpc),
-        deployment:
-          contract.deploymentType === "pro-compatible-production"
-            ? ("upgraded" as const)
-            : ("legacy" as const),
-        key: `${chainId}:${contract.address}`,
+        deployment: deployment as Deployment,
+        key: `${chainId}:${programs.receiver}`,
+        scanner: {
+          descending: true,
+          positionUnit: "slot" as const,
+          resolveRange: async (state: ReportState) => {
+            const [from, to] = await Promise.all([
+              getSvmSlotAtTimestamp(chain, state.windowStartUnix),
+              getSvmSlotAtTimestamp(chain, state.windowEndUnix),
+            ]);
+            return { from, to };
+          },
+          stream: (range: { from: number; to: number }, options: ScanOptions) =>
+            mapBatches(
+              scanner.streamPriceFeedUpdateCounts({
+                batchSize: options.svmBatchSize,
+                fromSlot: range.from,
+                onRetry: options.onRetry,
+                toSlot: range.to,
+              }),
+              (batch) => ({
+                counts: batch.counts,
+                from: batch.fromSlot,
+                to: batch.toSlot,
+              }),
+            ),
+          timestampAt: async (position: number) =>
+            (await chain.getConnection().getBlockTime(position)) ?? undefined,
+        },
       };
-    })
-    .sort((a, b) => a.key.localeCompare(b.key));
+    },
+  );
+}
+
+async function* mapBatches<T>(
+  source: AsyncGenerator<T>,
+  toBatch: (item: T) => ScanBatch,
+): AsyncGenerator<ScanBatch> {
+  for await (const item of source) yield toBatch(item);
 }
 
 function withRpcUrl(
@@ -329,35 +569,59 @@ function saveState(stateFile: string, state: ReportState) {
 
 /** A scan only has a meaningful window once its block range resolved; `toBlock` is 0 until then. */
 function hasResolvedRange(scan: ScanState) {
-  return scan.toBlock > 0;
+  return scan.toPosition > 0;
+}
+
+/** Positions counted so far, whichever end of the range the scan is filling from. */
+function positionsScanned(scan: ScanState) {
+  if (scan.coveredFrom === undefined || scan.coveredTo === undefined) return 0;
+  return scan.coveredTo - scan.coveredFrom + 1;
+}
+
+function isFullyCovered(scan: ScanState) {
+  return (
+    scan.coveredFrom !== undefined &&
+    scan.coveredTo !== undefined &&
+    scan.coveredFrom <= scan.fromPosition &&
+    scan.coveredTo >= scan.toPosition
+  );
+}
+
+/** The sub-range still to scan, given what a resumed checkpoint already covers. */
+function remainingRange(scan: ScanState) {
+  if (scan.coveredFrom === undefined || scan.coveredTo === undefined) {
+    return { from: scan.fromPosition, to: scan.toPosition };
+  }
+  return scan.descending
+    ? { from: scan.fromPosition, to: scan.coveredFrom - 1 }
+    : { from: scan.coveredTo + 1, to: scan.toPosition };
+}
+
+function recordBatch(scan: ScanState, batch: ScanBatch) {
+  for (const [feedId, count] of batch.counts) {
+    scan.counts[feedId] = (scan.counts[feedId] ?? 0) + count;
+  }
+  scan.coveredFrom = Math.min(scan.coveredFrom ?? batch.from, batch.from);
+  scan.coveredTo = Math.max(scan.coveredTo ?? batch.to, batch.to);
 }
 
 /**
- * Retries because a single flaky `eth_getBlockByNumber` would otherwise drop a whole chain
- * from the report for the entire run, which reads as "no feeds used here".
+ * Retries because a single flaky range resolution would otherwise drop a whole chain from the
+ * report for the entire run, which reads as "no feeds used here".
  */
-async function resolveBlockRange(chain: EvmChain, state: ReportState) {
+async function resolveScanRange(target: ScanTarget, state: ReportState) {
   const MAX_ATTEMPTS = 3;
   for (let attempt = 1; ; attempt++) {
     try {
-      const [fromBlock, toBlock] = await Promise.all([
-        chain.getBlockNumberAtTimestamp(state.windowStartUnix),
-        chain.getBlockNumberAtTimestamp(state.windowEndUnix),
-      ]);
-      return { fromBlock, toBlock };
+      return await target.scanner.resolveRange(state);
     } catch (error) {
       if (attempt >= MAX_ATTEMPTS) throw error;
       console.warn(
-        `  [${chain.getId()}] resolving block range attempt ${attempt} failed: ${error}`,
+        `  [${target.chainId}] resolving ${target.scanner.positionUnit} range attempt ${attempt} failed: ${error}`,
       );
       await sleep(1000 * attempt);
     }
   }
-}
-
-async function getBlockTimestamp(chain: EvmChain, blockNumber: number) {
-  const block = await chain.getWeb3().eth.getBlock(blockNumber);
-  return Number(block.timestamp);
 }
 
 async function scanTarget(
@@ -366,26 +630,34 @@ async function scanTarget(
   options: {
     requestConcurrency: number;
     maxChunkSize: number;
+    svmBatchSize: number;
     onProgress: () => void;
   },
 ) {
-  for await (const batch of target.contract.streamPriceFeedUpdateCounts({
-    concurrency: options.requestConcurrency,
-    fromBlock: scan.nextBlock,
-    maxChunkSize: options.maxChunkSize,
-    onRetry: (message) => {
-      console.warn(`  [${target.key}] ${message}`);
-    },
-    toBlock: scan.toBlock,
-  })) {
-    for (const [feedId, count] of batch.counts) {
-      scan.counts[feedId] = (scan.counts[feedId] ?? 0) + count;
+  const range = remainingRange(scan);
+  if (range.from <= range.to) {
+    for await (const batch of target.scanner.stream(range, {
+      maxChunkSize: options.maxChunkSize,
+      onRetry: (message) => {
+        console.warn(`  [${target.key}] ${message}`);
+      },
+      requestConcurrency: options.requestConcurrency,
+      svmBatchSize: options.svmBatchSize,
+    })) {
+      recordBatch(scan, batch);
+      options.onProgress();
     }
-    scan.nextBlock = batch.toBlock + 1;
-    options.onProgress();
   }
-  scan.status = "complete";
-  delete scan.error;
+  // A stream can run dry before the range is covered — SVM stops when the endpoint has no
+  // more signatures. That is an incomplete scan, not a complete one, and must not be recorded
+  // as though the uncovered positions held no updates.
+  if (isFullyCovered(scan)) {
+    scan.status = "complete";
+    delete scan.error;
+  } else {
+    scan.status = "pending";
+    scan.error = `stream ended with ${scan.toPosition - scan.fromPosition + 1 - positionsScanned(scan)} ${scan.positionUnit}s uncovered`;
+  }
 }
 
 /**
@@ -393,18 +665,17 @@ async function scanTarget(
  * indistinguishable from a feed that genuinely stopped being updated, which is the exact
  * wrong conclusion for this report to support.
  */
-async function recordScannedWindow(chain: EvmChain, scan: ScanState) {
-  const scannedThrough = scan.nextBlock - 1;
-  if (scannedThrough < scan.fromBlock) return;
+async function recordScannedWindow(target: ScanTarget, scan: ScanState) {
+  if (scan.coveredFrom === undefined || scan.coveredTo === undefined) return;
   try {
     const [from, through] = await Promise.all([
-      getBlockTimestamp(chain, scan.fromBlock),
-      getBlockTimestamp(chain, scannedThrough),
+      target.scanner.timestampAt(scan.coveredFrom),
+      target.scanner.timestampAt(scan.coveredTo),
     ]);
-    scan.scannedFromUnix = from;
-    scan.scannedThroughUnix = through;
+    if (from !== undefined) scan.scannedFromUnix = from;
+    if (through !== undefined) scan.scannedThroughUnix = through;
   } catch {
-    // The endpoint that failed the scan will usually fail this too; the block range in the
+    // The endpoint that failed the scan will usually fail this too; the position range in the
     // coverage CSV still tells the reader what was and was not covered.
   }
 }
@@ -556,11 +827,13 @@ function writeReport(
       "contract_address",
       "deployment",
       "status",
-      "from_block",
-      "to_block",
-      "scanned_through_block",
-      "blocks_scanned",
-      "blocks_missing",
+      "position_unit",
+      "from_position",
+      "to_position",
+      "covered_from_position",
+      "covered_to_position",
+      "positions_scanned",
+      "positions_missing",
       "requested_window_start_utc",
       "requested_window_end_utc",
       "scanned_window_start_utc",
@@ -571,20 +844,23 @@ function writeReport(
     ...scans
       .toSorted((a, b) => a.chain.localeCompare(b.chain))
       .map((scan) => {
-        // A scan whose block range never resolved (dead RPC) has no window to report on, so
-        // its block columns stay blank rather than claiming a scanned range of zero blocks.
+        // A scan whose range never resolved (dead RPC) has no window to report on, so its
+        // position columns stay blank rather than claiming a scanned range of zero.
         const resolved = hasResolvedRange(scan);
-        const scannedBlocks = Math.max(0, scan.nextBlock - scan.fromBlock);
+        const scanned = positionsScanned(scan);
+        const span = scan.toPosition - scan.fromPosition + 1;
         return [
           scan.chain,
           scan.address,
           scan.deployment,
           scan.status,
-          resolved ? scan.fromBlock : "",
-          resolved ? scan.toBlock : "",
-          resolved && scannedBlocks > 0 ? scan.nextBlock - 1 : "",
-          scannedBlocks,
-          resolved ? Math.max(0, scan.toBlock - scan.nextBlock + 1) : "",
+          scan.positionUnit,
+          resolved ? scan.fromPosition : "",
+          resolved ? scan.toPosition : "",
+          resolved && scanned > 0 ? (scan.coveredFrom ?? "") : "",
+          resolved && scanned > 0 ? (scan.coveredTo ?? "") : "",
+          scanned,
+          resolved ? Math.max(0, span - scanned) : "",
           toUtc(state.windowStartUnix),
           toUtc(state.windowEndUnix),
           toUtc(scan.scannedFromUnix),
@@ -637,12 +913,9 @@ async function main() {
   // Hermes failure would be an unhandled rejection and take the whole run down with it.
   catalogPromise.catch(() => undefined);
 
-  // Block ranges are resolved per chain rather than per contract: the binary search costs
-  // ~25 RPC round trips and both of a chain's contracts share the same window.
-  const blockRanges = new Map<
-    string,
-    Promise<{ fromBlock: number; toBlock: number }>
-  >();
+  // Position ranges are resolved per chain rather than per contract: the binary search costs
+  // ~25 round trips and both of a chain's contracts share the same window.
+  const ranges = new Map<string, Promise<{ from: number; to: number }>>();
 
   let lastSaveMs = 0;
   const saveThrottled = () => {
@@ -656,25 +929,25 @@ async function main() {
     targets,
     argv["scan-concurrency"],
     async (target) => {
-      const chain = target.contract.getChain();
       let scan = state.scans[target.key];
       try {
         // A checkpointed scan whose range never resolved covers nothing, so it is retried
         // from scratch instead of being resumed over an empty range and called complete.
         if (scan === undefined || !hasResolvedRange(scan)) {
-          const range =
-            blockRanges.get(target.chainId) ?? resolveBlockRange(chain, state);
-          blockRanges.set(target.chainId, range);
-          const { fromBlock, toBlock } = await range;
+          const pending =
+            ranges.get(target.chainId) ?? resolveScanRange(target, state);
+          ranges.set(target.chainId, pending);
+          const { from, to } = await pending;
           scan = {
-            address: target.contract.address,
+            address: target.address,
             chain: target.chainId,
             counts: {},
             deployment: target.deployment,
-            fromBlock,
-            nextBlock: fromBlock,
+            descending: target.scanner.descending,
+            fromPosition: from,
+            positionUnit: target.scanner.positionUnit,
             status: "pending",
-            toBlock,
+            toPosition: to,
           };
           state.scans[target.key] = scan;
         }
@@ -682,28 +955,31 @@ async function main() {
           console.log(`${target.key}: already complete, skipping`);
           return;
         }
+        const remaining = remainingRange(scan);
         console.log(
-          `${target.key}: scanning blocks ${scan.nextBlock}..${scan.toBlock}`,
+          `${target.key}: scanning ${scan.positionUnit}s ${remaining.from}..${remaining.to}`,
         );
         await scanTarget(target, scan, {
           maxChunkSize: argv["max-chunk-size"],
           onProgress: saveThrottled,
           requestConcurrency: argv["request-concurrency"],
+          svmBatchSize: argv["svm-batch-size"],
         });
         console.log(`${target.key}: complete`);
       } catch (error) {
         if (scan === undefined) {
-          // The block range could not be resolved, so nothing about this contract's window is
+          // The range could not be resolved, so nothing about this contract's window is
           // known. Record it as failed with an empty range so it still shows up in coverage.
           scan = {
-            address: target.contract.address,
+            address: target.address,
             chain: target.chainId,
             counts: {},
             deployment: target.deployment,
-            fromBlock: 0,
-            nextBlock: 0,
+            descending: target.scanner.descending,
+            fromPosition: 0,
+            positionUnit: target.scanner.positionUnit,
             status: "failed",
-            toBlock: 0,
+            toPosition: 0,
           };
           state.scans[target.key] = scan;
         }
@@ -711,7 +987,7 @@ async function main() {
         scan.error = String(error);
         console.error(`${target.key}: FAILED - ${error}`);
       }
-      await recordScannedWindow(chain, scan);
+      await recordScannedWindow(target, scan);
       saveState(argv["state-file"], state);
     },
   );

--- a/contract_manager/scripts/report_price_feed_usage.ts
+++ b/contract_manager/scripts/report_price_feed_usage.ts
@@ -633,6 +633,9 @@ async function main() {
   );
 
   const catalogPromise = fetchFeedCatalog(process.env.PYTH_API_KEY);
+  // Awaited only after the scan, which is hours later. Without a handler attached now, a
+  // Hermes failure would be an unhandled rejection and take the whole run down with it.
+  catalogPromise.catch(() => undefined);
 
   // Block ranges are resolved per chain rather than per contract: the binary search costs
   // ~25 RPC round trips and both of a chain's contracts share the same window.

--- a/contract_manager/scripts/report_price_feed_usage.ts
+++ b/contract_manager/scripts/report_price_feed_usage.ts
@@ -1,0 +1,731 @@
+/** biome-ignore-all lint/style/noProcessEnv: this is a CLI script */
+/** biome-ignore-all lint/suspicious/noConsole: this is a CLI script */
+
+/**
+ * Reports which Pyth price feeds are actually written on-chain on the EVM mainnets that
+ * survive the Pyth Core upgrade, so that every feed in real use can be checked against the
+ * Pyth Pro catalog before Core is switched off.
+ *
+ * Usage: `pnpm tsx scripts/report_price_feed_usage.ts --days 30 --output usage.csv`
+ *
+ * How usage is measured, and what the numbers do and do not mean:
+ *
+ * - A count is the number of `PriceFeedUpdate` logs emitted by a Pyth contract. That event
+ *   fires only when an update is *fresh* — carrying a newer `publishTime` than the stored
+ *   one — so the counts measure accepted writes, not `updatePriceFeeds` calls.
+ * - A consumer that only *reads* a feed (`getPriceNoOlderThan`) emits nothing and relies on
+ *   somebody else pushing. Treat "at least one update in the window" as the in-use signal
+ *   and the count itself as a magnitude hint, not a usage share.
+ * - Both the legacy Core contract and the upgraded (`pro-compatible-production`) contract are
+ *   live during the migration, so both are scanned on every chain and summed into the chain's
+ *   column. The `*_split.csv` companion breaks the same numbers down by contract, which is
+ *   how far each chain has migrated.
+ *
+ * `supported_on_pro` is membership of the feed id in the Pro Hermes catalog
+ * (`/hermes/v2/price_feeds`). That endpoint returns an identical response with a valid API
+ * key, an invalid one, and no `Authorization` header at all, so it is *not* scoped to the
+ * caller's entitlements — it lists exactly the Pro symbols in state `stable`. The `pro_state`
+ * column comes from the full Lazer symbol registry (`/v1/symbols`) and distinguishes the
+ * feeds Pro has not promoted yet (`coming_soon`, `inactive`) from the ones it does not know
+ * about at all (`absent`).
+ *
+ * Coverage is reported honestly. Public RPCs cap `eth_getLogs` ranges (50 blocks on some
+ * chains), rate-limit aggressively, and some refuse 30-day-old logs entirely, so a chain that
+ * could not be scanned over the whole window is marked `_INCOMPLETE` in the main CSV and gets
+ * the block range it actually covered in the coverage CSV. Point such a chain at a paid
+ * archive endpoint with `--rpc <chain>=<url>` (or through the `$ENV_*` placeholders the chain
+ * store already supports) and re-run; the run resumes from its checkpoint file.
+ */
+
+import { writeFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+import { EvmChain } from "../src/core/chains";
+import { EvmPriceFeedContract } from "../src/core/contracts";
+import { DefaultStore } from "../src/node/utils/store";
+import { sleep } from "../src/utils/sleep";
+
+const HERMES_CORE_FEEDS_URL = "https://hermes.pyth.network/v2/price_feeds";
+const PRO_HERMES_FEEDS_URL = "https://pyth.dourolabs.app/hermes/v2/price_feeds";
+const PRO_SYMBOLS_URL = "https://pyth.dourolabs.app/v1/symbols";
+
+const parser = yargs(hideBin(process.argv))
+  .usage("Usage: $0 --days 30 --output usage.csv")
+  .options({
+    chains: {
+      desc: "Restrict the scan to these chain ids (defaults to every in-scope chain)",
+      string: true,
+      type: "array",
+    },
+    days: {
+      default: 30,
+      desc: "Size of the lookback window in days",
+      type: "number",
+    },
+    fresh: {
+      default: false,
+      desc: "Ignore any existing checkpoint file and scan the window from scratch",
+      type: "boolean",
+    },
+    "max-chunk-size": {
+      default: 100_000,
+      desc: "Upper bound on the block span of a single eth_getLogs request",
+      type: "number",
+    },
+    output: {
+      default: "price_feed_usage.csv",
+      desc: "Path of the main CSV; the split and coverage CSVs are written alongside it",
+      type: "string",
+    },
+    "request-concurrency": {
+      default: 8,
+      desc: "eth_getLogs requests in flight per contract scan",
+      type: "number",
+    },
+    rpc: {
+      desc: "Override a chain's RPC endpoint, as <chain>=<url>. Repeatable",
+      string: true,
+      type: "array",
+    },
+    "scan-concurrency": {
+      default: 4,
+      desc: "Contract scans running in parallel",
+      type: "number",
+    },
+    "state-file": {
+      default: "price_feed_usage_state.json",
+      desc: "Checkpoint file; a run resumes from it unless --fresh is passed",
+      type: "string",
+    },
+  })
+  .epilogue(
+    "A full 30-day run takes hours and is resumable: interrupt it and re-run the same " +
+      "command to continue from the checkpoint file. Chains whose RPC cannot serve the " +
+      "whole window are reported as incomplete rather than silently under-counted.",
+  );
+
+type Deployment = "legacy" | "upgraded";
+
+type ScanTarget = {
+  key: string;
+  chainId: string;
+  deployment: Deployment;
+  contract: EvmPriceFeedContract;
+};
+
+type ScanState = {
+  chain: string;
+  address: string;
+  deployment: Deployment;
+  fromBlock: number;
+  toBlock: number;
+  /** First block not yet counted; equals `toBlock + 1` once the scan is complete. */
+  nextBlock: number;
+  counts: Record<string, number>;
+  status: "pending" | "complete" | "failed";
+  error?: string;
+  scannedFromUnix?: number;
+  scannedThroughUnix?: number;
+};
+
+type ReportState = {
+  days: number;
+  windowStartUnix: number;
+  windowEndUnix: number;
+  scans: Record<string, ScanState>;
+};
+
+/**
+ * The chains that survive the upgrade: EVM mainnets carrying a price feed contract marked
+ * `pro-compatible-production`. Both that contract and the chain's legacy Core contract are
+ * scanned, since integrators migrate at their own pace and traffic is split across the two.
+ */
+function getScanTargets(
+  chainFilter: string[] | undefined,
+  rpcOverrides: Map<string, string>,
+): ScanTarget[] {
+  const evmPriceFeedContracts = Object.values(DefaultStore.contracts).filter(
+    (contract): contract is EvmPriceFeedContract =>
+      contract instanceof EvmPriceFeedContract,
+  );
+  const inScopeChains = new Set(
+    evmPriceFeedContracts
+      .filter(
+        (contract) =>
+          contract.deploymentType === "pro-compatible-production" &&
+          contract.getChain().isMainnet(),
+      )
+      .map((contract) => contract.getChain().getId()),
+  );
+
+  if (chainFilter !== undefined) {
+    for (const chainId of chainFilter) {
+      if (!inScopeChains.has(chainId)) {
+        throw new Error(
+          `${chainId} is not an in-scope chain. In scope: ${[...inScopeChains].sort().join(", ")}`,
+        );
+      }
+    }
+  }
+
+  return evmPriceFeedContracts
+    .filter(
+      (contract) =>
+        inScopeChains.has(contract.getChain().getId()) &&
+        (chainFilter === undefined ||
+          chainFilter.includes(contract.getChain().getId())),
+    )
+    .map((contract) => {
+      const chainId = contract.getChain().getId();
+      const overriddenRpc = rpcOverrides.get(chainId);
+      return {
+        chainId,
+        contract:
+          overriddenRpc === undefined
+            ? contract
+            : withRpcUrl(contract, overriddenRpc),
+        deployment:
+          contract.deploymentType === "pro-compatible-production"
+            ? ("upgraded" as const)
+            : ("legacy" as const),
+        key: `${chainId}:${contract.address}`,
+      };
+    })
+    .sort((a, b) => a.key.localeCompare(b.key));
+}
+
+function withRpcUrl(
+  contract: EvmPriceFeedContract,
+  rpcUrl: string,
+): EvmPriceFeedContract {
+  const chain = contract.getChain();
+  return new EvmPriceFeedContract(
+    new EvmChain(
+      chain.getId(),
+      chain.isMainnet(),
+      chain.getNativeToken(),
+      rpcUrl,
+      chain.networkId,
+    ),
+    contract.address,
+    contract.deploymentType,
+  );
+}
+
+function parseRpcOverrides(overrides: string[]): Map<string, string> {
+  return new Map(
+    overrides.map((override) => {
+      const separator = override.indexOf("=");
+      if (separator === -1) {
+        throw new Error(`--rpc expects <chain>=<url>, got "${override}"`);
+      }
+      return [
+        override.slice(0, separator),
+        override.slice(separator + 1),
+      ] as const;
+    }),
+  );
+}
+
+type FeedMetadata = {
+  name: string;
+  symbol: string;
+  assetType: string;
+};
+
+/** State of a feed in the Pro catalog; `absent` means Pro has no symbol for it at all. */
+type ProState = "stable" | "coming_soon" | "inactive" | "absent";
+
+type FeedCatalog = {
+  metadata: Map<string, FeedMetadata>;
+  supportedOnPro: Set<string>;
+  proStates: Map<string, ProState>;
+};
+
+async function fetchJson<T>(url: string, apiKey: string | undefined) {
+  const response = await fetch(url, {
+    headers: apiKey === undefined ? {} : { Authorization: `Bearer ${apiKey}` },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `GET ${url} failed: ${response.status} ${response.statusText}`,
+    );
+  }
+  return (await response.json()) as T;
+}
+
+async function fetchFeedCatalog(apiKey: string | undefined) {
+  type HermesFeed = {
+    id: string;
+    attributes: {
+      symbol?: string;
+      display_symbol?: string;
+      asset_type?: string;
+    };
+  };
+  type ProSymbol = { hermes_id: string | null; state: string };
+
+  const [coreFeeds, proFeeds, proSymbols] = await Promise.all([
+    fetchJson<HermesFeed[]>(HERMES_CORE_FEEDS_URL, undefined),
+    fetchJson<HermesFeed[]>(PRO_HERMES_FEEDS_URL, apiKey),
+    fetchJson<ProSymbol[]>(PRO_SYMBOLS_URL, apiKey),
+  ]);
+
+  const metadata = new Map<string, FeedMetadata>();
+  for (const feed of [...coreFeeds, ...proFeeds]) {
+    metadata.set(feed.id.toLowerCase(), {
+      assetType: feed.attributes.asset_type ?? "UNKNOWN",
+      name: feed.attributes.display_symbol ?? "UNKNOWN",
+      symbol: feed.attributes.symbol ?? "UNKNOWN",
+    });
+  }
+
+  const proStates = new Map<string, ProState>();
+  for (const symbol of proSymbols) {
+    if (symbol.hermes_id === null) continue;
+    if (
+      symbol.state === "stable" ||
+      symbol.state === "coming_soon" ||
+      symbol.state === "inactive"
+    ) {
+      proStates.set(symbol.hermes_id.toLowerCase(), symbol.state);
+    }
+  }
+
+  return {
+    metadata,
+    proStates,
+    supportedOnPro: new Set(proFeeds.map((feed) => feed.id.toLowerCase())),
+  } satisfies FeedCatalog;
+}
+
+async function loadState(
+  stateFile: string,
+  days: number,
+): Promise<ReportState | undefined> {
+  let contents: string;
+  try {
+    contents = await readFile(stateFile, "utf8");
+  } catch {
+    return undefined;
+  }
+  const state = JSON.parse(contents) as ReportState;
+  if (state.days !== days) {
+    throw new Error(
+      `${stateFile} checkpoints a ${state.days}-day window but --days is ${days}. ` +
+        "Pass --fresh to restart, or --state-file to keep both runs.",
+    );
+  }
+  return state;
+}
+
+function saveState(stateFile: string, state: ReportState) {
+  writeFileSync(stateFile, JSON.stringify(state));
+}
+
+/** A scan only has a meaningful window once its block range resolved; `toBlock` is 0 until then. */
+function hasResolvedRange(scan: ScanState) {
+  return scan.toBlock > 0;
+}
+
+/**
+ * Retries because a single flaky `eth_getBlockByNumber` would otherwise drop a whole chain
+ * from the report for the entire run, which reads as "no feeds used here".
+ */
+async function resolveBlockRange(chain: EvmChain, state: ReportState) {
+  const MAX_ATTEMPTS = 3;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      const [fromBlock, toBlock] = await Promise.all([
+        chain.getBlockNumberAtTimestamp(state.windowStartUnix),
+        chain.getBlockNumberAtTimestamp(state.windowEndUnix),
+      ]);
+      return { fromBlock, toBlock };
+    } catch (error) {
+      if (attempt >= MAX_ATTEMPTS) throw error;
+      console.warn(
+        `  [${chain.getId()}] resolving block range attempt ${attempt} failed: ${error}`,
+      );
+      await sleep(1000 * attempt);
+    }
+  }
+}
+
+async function getBlockTimestamp(chain: EvmChain, blockNumber: number) {
+  const block = await chain.getWeb3().eth.getBlock(blockNumber);
+  return Number(block.timestamp);
+}
+
+async function scanTarget(
+  target: ScanTarget,
+  scan: ScanState,
+  options: {
+    requestConcurrency: number;
+    maxChunkSize: number;
+    onProgress: () => void;
+  },
+) {
+  for await (const batch of target.contract.streamPriceFeedUpdateCounts({
+    concurrency: options.requestConcurrency,
+    fromBlock: scan.nextBlock,
+    maxChunkSize: options.maxChunkSize,
+    onRetry: (message) => {
+      console.warn(`  [${target.key}] ${message}`);
+    },
+    toBlock: scan.toBlock,
+  })) {
+    for (const [feedId, count] of batch.counts) {
+      scan.counts[feedId] = (scan.counts[feedId] ?? 0) + count;
+    }
+    scan.nextBlock = batch.toBlock + 1;
+    options.onProgress();
+  }
+  scan.status = "complete";
+  delete scan.error;
+}
+
+/**
+ * Records the wall-clock window the scan actually covered. Without it an incomplete scan is
+ * indistinguishable from a feed that genuinely stopped being updated, which is the exact
+ * wrong conclusion for this report to support.
+ */
+async function recordScannedWindow(chain: EvmChain, scan: ScanState) {
+  const scannedThrough = scan.nextBlock - 1;
+  if (scannedThrough < scan.fromBlock) return;
+  try {
+    const [from, through] = await Promise.all([
+      getBlockTimestamp(chain, scan.fromBlock),
+      getBlockTimestamp(chain, scannedThrough),
+    ]);
+    scan.scannedFromUnix = from;
+    scan.scannedThroughUnix = through;
+  } catch {
+    // The endpoint that failed the scan will usually fail this too; the block range in the
+    // coverage CSV still tells the reader what was and was not covered.
+  }
+}
+
+async function runWithConcurrency<T>(
+  items: T[],
+  limit: number,
+  worker: (item: T) => Promise<void>,
+) {
+  const queue = [...items];
+  const runners = Array.from(
+    { length: Math.max(1, Math.min(limit, queue.length)) },
+    async () => {
+      for (let item = queue.shift(); item !== undefined; item = queue.shift()) {
+        await worker(item);
+      }
+    },
+  );
+  await Promise.all(runners);
+}
+
+function toCsvField(value: string | number) {
+  const text = String(value);
+  return /[",\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+function writeCsv(filePath: string, rows: (string | number)[][]) {
+  writeFileSync(
+    filePath,
+    rows.map((row) => row.map(toCsvField).join(",")).join("\n") + "\n",
+  );
+}
+
+function toUtc(unixSeconds: number | undefined) {
+  return unixSeconds === undefined
+    ? ""
+    : new Date(unixSeconds * 1000).toISOString();
+}
+
+type ChainTotals = {
+  total: number;
+  legacy: number;
+  upgraded: number;
+};
+
+function aggregateByFeed(scans: ScanState[]) {
+  const byFeed = new Map<string, Map<string, ChainTotals>>();
+  for (const scan of scans) {
+    for (const [feedId, count] of Object.entries(scan.counts)) {
+      const byChain = byFeed.get(feedId) ?? new Map<string, ChainTotals>();
+      byFeed.set(feedId, byChain);
+      const totals = byChain.get(scan.chain) ?? {
+        legacy: 0,
+        total: 0,
+        upgraded: 0,
+      };
+      totals.total += count;
+      totals[scan.deployment] += count;
+      byChain.set(scan.chain, totals);
+    }
+  }
+  return byFeed;
+}
+
+function writeReport(
+  outputPath: string,
+  state: ReportState,
+  catalog: FeedCatalog,
+) {
+  const scans = Object.values(state.scans);
+  const chainIds = [...new Set(scans.map((scan) => scan.chain))].sort();
+  const incompleteChains = new Set(
+    scans
+      .filter((scan) => scan.status !== "complete")
+      .map((scan) => scan.chain),
+  );
+  const byFeed = aggregateByFeed(scans);
+
+  const feedRows = [...byFeed.entries()]
+    .map(([feedId, byChain]) => {
+      const metadata = catalog.metadata.get(feedId);
+      return {
+        assetType: metadata?.assetType ?? "UNKNOWN",
+        byChain,
+        feedId,
+        name: metadata?.name ?? "UNKNOWN",
+        proState: catalog.proStates.get(feedId) ?? "absent",
+        supportedOnPro: catalog.supportedOnPro.has(feedId),
+        symbol: metadata?.symbol ?? "UNKNOWN",
+        total: [...byChain.values()].reduce(
+          (sum, totals) => sum + totals.total,
+          0,
+        ),
+      };
+    })
+    .sort((a, b) => b.total - a.total || a.feedId.localeCompare(b.feedId));
+
+  writeCsv(outputPath, [
+    [
+      "feed_name",
+      "feed_symbol",
+      "asset_type",
+      "feed_id",
+      "supported_on_pro",
+      "pro_state",
+      "total_updates",
+      ...chainIds.map((chainId) =>
+        incompleteChains.has(chainId) ? `${chainId}_INCOMPLETE` : chainId,
+      ),
+    ],
+    ...feedRows.map((row) => [
+      row.name,
+      row.symbol,
+      row.assetType,
+      row.feedId,
+      String(row.supportedOnPro),
+      row.proState,
+      row.total,
+      ...chainIds.map((chainId) => row.byChain.get(chainId)?.total ?? 0),
+    ]),
+  ]);
+
+  const splitPath = companionPath(outputPath, "split");
+  writeCsv(splitPath, [
+    [
+      "feed_name",
+      "feed_id",
+      "total_updates",
+      ...chainIds.flatMap((chainId) => [
+        `${chainId}_legacy`,
+        `${chainId}_upgraded`,
+      ]),
+    ],
+    ...feedRows.map((row) => [
+      row.name,
+      row.feedId,
+      row.total,
+      ...chainIds.flatMap((chainId) => [
+        row.byChain.get(chainId)?.legacy ?? 0,
+        row.byChain.get(chainId)?.upgraded ?? 0,
+      ]),
+    ]),
+  ]);
+
+  const coveragePath = companionPath(outputPath, "coverage");
+  writeCsv(coveragePath, [
+    [
+      "chain",
+      "contract_address",
+      "deployment",
+      "status",
+      "from_block",
+      "to_block",
+      "scanned_through_block",
+      "blocks_scanned",
+      "blocks_missing",
+      "requested_window_start_utc",
+      "requested_window_end_utc",
+      "scanned_window_start_utc",
+      "scanned_window_end_utc",
+      "total_updates",
+      "error",
+    ],
+    ...scans
+      .toSorted((a, b) => a.chain.localeCompare(b.chain))
+      .map((scan) => {
+        // A scan whose block range never resolved (dead RPC) has no window to report on, so
+        // its block columns stay blank rather than claiming a scanned range of zero blocks.
+        const resolved = hasResolvedRange(scan);
+        const scannedBlocks = Math.max(0, scan.nextBlock - scan.fromBlock);
+        return [
+          scan.chain,
+          scan.address,
+          scan.deployment,
+          scan.status,
+          resolved ? scan.fromBlock : "",
+          resolved ? scan.toBlock : "",
+          resolved && scannedBlocks > 0 ? scan.nextBlock - 1 : "",
+          scannedBlocks,
+          resolved ? Math.max(0, scan.toBlock - scan.nextBlock + 1) : "",
+          toUtc(state.windowStartUnix),
+          toUtc(state.windowEndUnix),
+          toUtc(scan.scannedFromUnix),
+          toUtc(scan.scannedThroughUnix),
+          Object.values(scan.counts).reduce((sum, count) => sum + count, 0),
+          scan.error ?? "",
+        ];
+      }),
+  ]);
+
+  return {
+    coveragePath,
+    feedCount: feedRows.length,
+    incompleteChains,
+    splitPath,
+  };
+}
+
+function companionPath(outputPath: string, suffix: string) {
+  const extension = path.extname(outputPath);
+  const base = outputPath.slice(0, outputPath.length - extension.length);
+  return `${base}_${suffix}${extension}`;
+}
+
+async function main() {
+  const argv = await parser.argv;
+
+  const rpcOverrides = parseRpcOverrides(argv.rpc ?? []);
+  const targets = getScanTargets(argv.chains, rpcOverrides);
+  if (targets.length === 0) {
+    throw new Error("No in-scope contracts matched the requested chains");
+  }
+
+  const existingState = argv.fresh
+    ? undefined
+    : await loadState(argv["state-file"], argv.days);
+  const nowUnix = Math.floor(Date.now() / 1000);
+  const state: ReportState = existingState ?? {
+    days: argv.days,
+    scans: {},
+    windowEndUnix: nowUnix,
+    windowStartUnix: nowUnix - argv.days * 24 * 60 * 60,
+  };
+  console.log(
+    `Scanning ${targets.length} contracts over ${toUtc(state.windowStartUnix)} .. ${toUtc(state.windowEndUnix)}`,
+  );
+
+  const catalogPromise = fetchFeedCatalog(process.env.PYTH_API_KEY);
+
+  // Block ranges are resolved per chain rather than per contract: the binary search costs
+  // ~25 RPC round trips and both of a chain's contracts share the same window.
+  const blockRanges = new Map<
+    string,
+    Promise<{ fromBlock: number; toBlock: number }>
+  >();
+
+  let lastSaveMs = 0;
+  const saveThrottled = () => {
+    const SAVE_INTERVAL_MS = 5000;
+    if (Date.now() - lastSaveMs < SAVE_INTERVAL_MS) return;
+    lastSaveMs = Date.now();
+    saveState(argv["state-file"], state);
+  };
+
+  await runWithConcurrency(
+    targets,
+    argv["scan-concurrency"],
+    async (target) => {
+      const chain = target.contract.getChain();
+      let scan = state.scans[target.key];
+      try {
+        // A checkpointed scan whose range never resolved covers nothing, so it is retried
+        // from scratch instead of being resumed over an empty range and called complete.
+        if (scan === undefined || !hasResolvedRange(scan)) {
+          const range =
+            blockRanges.get(target.chainId) ?? resolveBlockRange(chain, state);
+          blockRanges.set(target.chainId, range);
+          const { fromBlock, toBlock } = await range;
+          scan = {
+            address: target.contract.address,
+            chain: target.chainId,
+            counts: {},
+            deployment: target.deployment,
+            fromBlock,
+            nextBlock: fromBlock,
+            status: "pending",
+            toBlock,
+          };
+          state.scans[target.key] = scan;
+        }
+        if (scan.status === "complete") {
+          console.log(`${target.key}: already complete, skipping`);
+          return;
+        }
+        console.log(
+          `${target.key}: scanning blocks ${scan.nextBlock}..${scan.toBlock}`,
+        );
+        await scanTarget(target, scan, {
+          maxChunkSize: argv["max-chunk-size"],
+          onProgress: saveThrottled,
+          requestConcurrency: argv["request-concurrency"],
+        });
+        console.log(`${target.key}: complete`);
+      } catch (error) {
+        if (scan === undefined) {
+          // The block range could not be resolved, so nothing about this contract's window is
+          // known. Record it as failed with an empty range so it still shows up in coverage.
+          scan = {
+            address: target.contract.address,
+            chain: target.chainId,
+            counts: {},
+            deployment: target.deployment,
+            fromBlock: 0,
+            nextBlock: 0,
+            status: "failed",
+            toBlock: 0,
+          };
+          state.scans[target.key] = scan;
+        }
+        scan.status = "failed";
+        scan.error = String(error);
+        console.error(`${target.key}: FAILED - ${error}`);
+      }
+      await recordScannedWindow(chain, scan);
+      saveState(argv["state-file"], state);
+    },
+  );
+
+  saveState(argv["state-file"], state);
+
+  const report = writeReport(argv.output, state, await catalogPromise);
+  console.log(
+    `\nWrote ${report.feedCount} feeds to ${argv.output}, ${report.splitPath}, ${report.coveragePath}`,
+  );
+  if (report.incompleteChains.size > 0) {
+    console.warn(
+      `\nWARNING: incomplete coverage on ${[...report.incompleteChains].sort().join(", ")}. ` +
+        `Their counts are lower bounds — see ${report.coveragePath}, then re-run with ` +
+        "--rpc <chain>=<archive-url> to fill the gaps.",
+    );
+  }
+}
+
+await main();

--- a/contract_manager/scripts/report_price_feed_usage.ts
+++ b/contract_manager/scripts/report_price_feed_usage.ts
@@ -68,7 +68,7 @@ import path from "node:path";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
-import { EvmChain, SvmChain } from "../src/core/chains";
+import { EvmChain, SuiChain, SvmChain } from "../src/core/chains";
 import {
   EvmPriceFeedContract,
   getSuiCheckpointAtTimestamp,
@@ -119,7 +119,9 @@ const parser = yargs(hideBin(process.argv))
       type: "number",
     },
     rpc: {
-      desc: "Override a chain's RPC endpoint, as <chain>=<url>. Repeatable",
+      desc:
+        "Override a chain's scan endpoint, as <chain>=<url>. Repeatable. " +
+        "sui_mainnet expects a GraphQL endpoint, every other chain a JSON-RPC one",
       string: true,
       type: "array",
     },
@@ -278,7 +280,7 @@ function getScanTargets(
     targets.push(
       contract instanceof EvmPriceFeedContract
         ? evmTarget(contract, rpcOverride)
-        : suiTarget(contract),
+        : suiTarget(contract, rpcOverride),
     );
   }
   for (const chainId of svmChainIds()) {
@@ -338,7 +340,14 @@ function evmTarget(
   };
 }
 
-function suiTarget(contract: SuiPriceFeedContract): ScanTarget {
+function suiTarget(
+  original: SuiPriceFeedContract,
+  rpcOverride: string | undefined,
+): ScanTarget {
+  const contract =
+    rpcOverride === undefined
+      ? original
+      : withSuiGraphqlUrl(original, rpcOverride);
   const chain = contract.getChain();
   return {
     address: contract.stateId,
@@ -452,6 +461,31 @@ function withRpcUrl(
       chain.networkId,
     ),
     contract.address,
+    contract.deploymentType,
+  );
+}
+
+/**
+ * Sui's scan talks GraphQL, so an `--rpc` override for it is a GraphQL endpoint rather than
+ * the JSON-RPC host the chain store holds.
+ */
+function withSuiGraphqlUrl(
+  contract: SuiPriceFeedContract,
+  graphqlUrl: string,
+): SuiPriceFeedContract {
+  const chain = contract.getChain();
+  return new SuiPriceFeedContract(
+    new SuiChain(
+      chain.getId(),
+      chain.isMainnet(),
+      chain.wormholeChainName,
+      chain.getNativeToken(),
+      chain.rpcUrl,
+      chain.endpointType,
+      graphqlUrl,
+    ),
+    contract.stateId,
+    contract.wormholeStateId,
     contract.deploymentType,
   );
 }

--- a/contract_manager/src/core/chains.ts
+++ b/contract_manager/src/core/chains.ts
@@ -1879,6 +1879,47 @@ export class EvmChain extends Chain {
   }
 
   /**
+   * Returns the number of the earliest block whose timestamp is at or after `timestamp`,
+   * or the latest block number if the whole chain is older than it.
+   *
+   * EVM nodes have no timestamp index, so this walks backwards from the chain tip in
+   * doubling steps to bracket the answer and then binary searches inside that bracket.
+   * A plain binary search over `[0, latest]` would read blocks from the very start of
+   * the chain, which non-archive nodes routinely refuse to serve.
+   * @param timestamp - unix timestamp in seconds
+   */
+  async getBlockNumberAtTimestamp(timestamp: number): Promise<number> {
+    const web3 = this.getWeb3();
+    const timestampOf = async (blockNumber: number) => {
+      const block = await web3.eth.getBlock(blockNumber);
+      return Number(block.timestamp);
+    };
+
+    const latest = await web3.eth.getBlockNumber();
+    if ((await timestampOf(latest)) < timestamp) return latest;
+
+    // Invariant from here on: timestampOf(high) >= timestamp > timestampOf(low).
+    let high = latest;
+    let low = 0;
+    for (let step = 1; step < latest; step *= 2) {
+      const candidate = latest - step;
+      if ((await timestampOf(candidate)) < timestamp) {
+        low = candidate;
+        break;
+      }
+      high = candidate;
+    }
+    if (low === 0 && (await timestampOf(0)) >= timestamp) return 0;
+
+    while (low + 1 < high) {
+      const middle = Math.floor((low + high) / 2);
+      if ((await timestampOf(middle)) < timestamp) low = middle;
+      else high = middle;
+    }
+    return high;
+  }
+
+  /**
    * Returns the payload for a governance contract upgrade instruction for contracts deployed on this chain
    * @param address - hex string of the 20 byte address of the contract to upgrade to without the 0x prefix
    */

--- a/contract_manager/src/core/chains.ts
+++ b/contract_manager/src/core/chains.ts
@@ -446,6 +446,11 @@ export class SuiChain extends Chain {
     nativeToken: TokenId | undefined,
     public rpcUrl: string,
     public endpointType: SuiEndpointType = "json-rpc",
+    /**
+     * Scan-time override for the GraphQL endpoint, which is otherwise derived from the
+     * network rather than read from `rpcUrl` (that field is the method-less JSON-RPC host).
+     */
+    public graphqlUrl?: string,
   ) {
     super(id, mainnet, wormholeChainName, nativeToken);
   }

--- a/contract_manager/src/core/contracts/evm.ts
+++ b/contract_manager/src/core/contracts/evm.ts
@@ -1,3 +1,5 @@
+/** biome-ignore-all lint/suspicious/noConsole: utils used through CLI */
+/** biome-ignore-all lint/suspicious/useAwait: legacy code */
 /* eslint-disable tsdoc/syntax */
 /* eslint-disable @typescript-eslint/await-thenable */
 /* eslint-disable no-console */
@@ -13,6 +15,7 @@ import type { DataSource } from "@pythnetwork/xc-admin-common";
 import Web3 from "web3";
 import type { Contract } from "web3-eth-contract";
 
+import { sleep } from "../../utils/sleep";
 import type { DeploymentType, PrivateKey } from "../base";
 import { PriceFeedContract, Storable } from "../base";
 import type { Chain } from "../chains";
@@ -556,6 +559,57 @@ export class EvmExecutorContract extends Storable {
   }
 }
 
+/**
+ * `keccak256("PriceFeedUpdate(bytes32,uint64,int64,uint64)")`, the topic0 of the event
+ * the Pyth contract emits for every feed it freshly writes. The feed id is `topics[1]`,
+ * so counting updates never requires decoding the data field.
+ */
+export const PRICE_FEED_UPDATE_TOPIC =
+  "0xd06a6b7f4918494b3719217d1802786c1f5112a6c1d88fe2cfec00b4584f6aec";
+
+/** Number of `PriceFeedUpdate` logs keyed by 64-char hex feed id, without the `0x` prefix. */
+export type PriceFeedUpdateCounts = Map<string, number>;
+
+export type PriceFeedUpdateBatch = {
+  fromBlock: number;
+  toBlock: number;
+  counts: PriceFeedUpdateCounts;
+};
+
+export type PriceFeedUpdateScanOptions = {
+  fromBlock: number;
+  toBlock: number;
+  /** Block span of the first request. Halved whenever the RPC rejects a range, doubled back up on success. */
+  initialChunkSize?: number;
+  maxChunkSize?: number;
+  /** Number of `eth_getLogs` requests issued in parallel. */
+  concurrency?: number;
+  /** Attempts per request before the range is treated as too large and shrunk. */
+  maxAttempts?: number;
+  onRetry?: (message: string) => void;
+};
+
+/**
+ * Errors that mean "this range is too wide" rather than "the node is busy". Retrying them
+ * verbatim always fails, so they skip the backoff and shrink the chunk immediately. The list
+ * is a best-effort match over the wording public RPCs use; an unmatched error still ends up
+ * shrinking the chunk once its retries are exhausted, so a miss only costs time.
+ */
+const RANGE_REJECTION_PATTERNS = [
+  // Covers "block range is too wide", "eth_getLogs is limited to a 100 range", and friends.
+  "range",
+  "too many results",
+  "query returned more than",
+  "response size",
+  "limit exceeded",
+  "too large",
+];
+
+function isRangeRejection(error: unknown): boolean {
+  const message = String(error).toLowerCase();
+  return RANGE_REJECTION_PATTERNS.some((pattern) => message.includes(pattern));
+}
+
 export class EvmPriceFeedContract extends PriceFeedContract {
   static type = "EvmPriceFeedContract";
 
@@ -686,6 +740,122 @@ export class EvmPriceFeedContract extends PriceFeedContract {
     const pythContract = this.getContract();
     const result = await pythContract.methods.getValidTimePeriod().call();
     return Number(result);
+  }
+
+  /**
+   * Yields `PriceFeedUpdate` counts per feed id for successive sub-ranges of
+   * `[fromBlock, toBlock]`, covering the range in order and without gaps.
+   *
+   * Public RPCs cap `eth_getLogs` ranges anywhere between 50 and unlimited blocks and
+   * advertise no way to discover the cap, so the sub-range size is discovered at runtime:
+   * it halves on rejection and doubles back up on success. Each yielded batch ends on a
+   * block boundary the scan has fully covered, which is what makes a scan resumable.
+   * @param options - block range to scan plus request-shaping knobs
+   */
+  async *streamPriceFeedUpdateCounts(
+    options: PriceFeedUpdateScanOptions,
+  ): AsyncGenerator<PriceFeedUpdateBatch> {
+    const {
+      concurrency = 8,
+      fromBlock,
+      initialChunkSize = 10_000,
+      maxAttempts = 5,
+      maxChunkSize = 100_000,
+      onRetry,
+      toBlock,
+    } = options;
+    const web3 = this.chain.getWeb3();
+
+    let chunkSize = Math.max(1, Math.min(initialChunkSize, maxChunkSize));
+    // Lowered to the size we fall back to as soon as the RPC rejects a range, so that growth
+    // never climbs back into sizes it has already been refused and oscillates there forever.
+    let growthCeiling = maxChunkSize;
+    let cursor = fromBlock;
+    let successesSinceGrowth = 0;
+
+    while (cursor <= toBlock) {
+      const ranges: { from: number; to: number }[] = [];
+      for (
+        let start = cursor;
+        start <= toBlock && ranges.length < concurrency;
+      ) {
+        const end = Math.min(start + chunkSize - 1, toBlock);
+        ranges.push({ from: start, to: end });
+        start = end + 1;
+      }
+
+      let batches: PriceFeedUpdateCounts[];
+      try {
+        batches = await Promise.all(
+          ranges.map((range) =>
+            this.countPriceFeedUpdates(
+              web3,
+              range,
+              maxAttempts,
+              onRetry ?? (() => undefined),
+            ),
+          ),
+        );
+      } catch (error) {
+        if (chunkSize === 1) throw error;
+        chunkSize = Math.max(1, Math.floor(chunkSize / 2));
+        growthCeiling = chunkSize;
+        successesSinceGrowth = 0;
+        onRetry?.(`shrinking chunk size to ${chunkSize} blocks: ${error}`);
+        continue;
+      }
+
+      const counts: PriceFeedUpdateCounts = new Map();
+      for (const batch of batches) {
+        for (const [feedId, count] of batch) {
+          counts.set(feedId, (counts.get(feedId) ?? 0) + count);
+        }
+      }
+      const last = ranges.at(-1);
+      if (last === undefined) return;
+      yield { counts, fromBlock: cursor, toBlock: last.to };
+      cursor = last.to + 1;
+
+      successesSinceGrowth += 1;
+      const GROW_AFTER_SUCCESSES = 3;
+      if (successesSinceGrowth >= GROW_AFTER_SUCCESSES) {
+        chunkSize = Math.min(growthCeiling, chunkSize * 2);
+        successesSinceGrowth = 0;
+      }
+    }
+  }
+
+  private async countPriceFeedUpdates(
+    web3: Web3,
+    range: { from: number; to: number },
+    maxAttempts: number,
+    onRetry: (message: string) => void,
+  ): Promise<PriceFeedUpdateCounts> {
+    for (let attempt = 1; ; attempt++) {
+      try {
+        const logs = await web3.eth.getPastLogs({
+          address: this.address,
+          fromBlock: range.from,
+          toBlock: range.to,
+          topics: [PRICE_FEED_UPDATE_TOPIC],
+        });
+        const counts: PriceFeedUpdateCounts = new Map();
+        for (const log of logs) {
+          const feedId = log.topics[1]?.replace("0x", "");
+          if (feedId !== undefined) {
+            counts.set(feedId, (counts.get(feedId) ?? 0) + 1);
+          }
+        }
+        return counts;
+      } catch (error) {
+        if (attempt >= maxAttempts || isRangeRejection(error)) throw error;
+        const backoffMs = 500 * 2 ** (attempt - 1);
+        onRetry(
+          `blocks ${range.from}-${range.to} attempt ${attempt} failed, retrying in ${backoffMs}ms: ${error}`,
+        );
+        await sleep(backoffMs);
+      }
+    }
   }
 
   /**
@@ -1056,7 +1226,10 @@ export class EvmLazerContract extends Storable {
       const pubkeySlot = await web3.eth.getStorageAt(this.address, 2 * i);
       const pubkey = BigInt(pubkeySlot);
       if (pubkey === 0n) continue;
-      const expiresAtSlot = await web3.eth.getStorageAt(this.address, 2 * i + 1);
+      const expiresAtSlot = await web3.eth.getStorageAt(
+        this.address,
+        2 * i + 1,
+      );
       signers.push({
         address: web3.utils.toChecksumAddress(
           "0x" + pubkey.toString(16).padStart(40, "0"),

--- a/contract_manager/src/core/contracts/evm.ts
+++ b/contract_manager/src/core/contracts/evm.ts
@@ -605,8 +605,24 @@ const RANGE_REJECTION_PATTERNS = [
   "too large",
 ];
 
+/**
+ * Errors that mean "the node is busy". Checked before the range patterns because several
+ * public RPCs word a rate limit as "limit exceeded", which would otherwise be read as a range
+ * rejection and answered by shrinking the chunk — halving the range does nothing about a rate
+ * limit, so the scan would ratchet down to tiny chunks and issue *more* requests per block.
+ */
+const RATE_LIMIT_PATTERNS = [
+  "429",
+  "too many requests",
+  "rate limit",
+  "rate-limit",
+  "exceeded the quota",
+];
+
 function isRangeRejection(error: unknown): boolean {
   const message = String(error).toLowerCase();
+  if (RATE_LIMIT_PATTERNS.some((pattern) => message.includes(pattern)))
+    return false;
   return RANGE_REJECTION_PATTERNS.some((pattern) => message.includes(pattern));
 }
 
@@ -767,8 +783,10 @@ export class EvmPriceFeedContract extends PriceFeedContract {
     const web3 = this.chain.getWeb3();
 
     let chunkSize = Math.max(1, Math.min(initialChunkSize, maxChunkSize));
-    // Lowered to the size we fall back to as soon as the RPC rejects a range, so that growth
-    // never climbs back into sizes it has already been refused and oscillates there forever.
+    // Lowered to just under the smallest size the RPC has refused, so that growth never
+    // climbs back into a size already known to fail and oscillates there forever. It stays
+    // above the post-halving size on purpose: pinning it to that would freeze the chunk at
+    // the shrunk size for the rest of the scan.
     let growthCeiling = maxChunkSize;
     let cursor = fromBlock;
     let successesSinceGrowth = 0;
@@ -798,8 +816,8 @@ export class EvmPriceFeedContract extends PriceFeedContract {
         );
       } catch (error) {
         if (chunkSize === 1) throw error;
+        growthCeiling = Math.max(1, chunkSize - 1);
         chunkSize = Math.max(1, Math.floor(chunkSize / 2));
-        growthCeiling = chunkSize;
         successesSinceGrowth = 0;
         onRetry?.(`shrinking chunk size to ${chunkSize} blocks: ${error}`);
         continue;

--- a/contract_manager/src/core/contracts/solana.ts
+++ b/contract_manager/src/core/contracts/solana.ts
@@ -1,3 +1,5 @@
+/** biome-ignore-all assist/source/useSortedKeys: pre-existing in this file */
+
 import { createHash } from "node:crypto";
 
 import { AnchorProvider, Program, utils, Wallet } from "@coral-xyz/anchor";

--- a/contract_manager/src/core/contracts/solana.ts
+++ b/contract_manager/src/core/contracts/solana.ts
@@ -1,12 +1,17 @@
-import { AnchorProvider, Program, Wallet } from "@coral-xyz/anchor";
+import { createHash } from "node:crypto";
+
+import { AnchorProvider, Program, utils, Wallet } from "@coral-xyz/anchor";
 import type { PythLazerSolanaContract } from "@pythnetwork/pyth-lazer-solana-sdk";
 import { PYTH_LAZER_SOLANA_CONTRACT_IDL } from "@pythnetwork/pyth-lazer-solana-sdk";
 import { Keypair, PublicKey } from "@solana/web3.js";
 import BN from "bn.js";
 
+import { sleep } from "../../utils/sleep";
 import { Storable } from "../base";
 import type { Chain } from "../chains";
 import { SvmChain } from "../chains";
+
+const { bs58 } = utils.bytes;
 
 /** Seed for the program's singleton `Storage` PDA (`b"storage"`). */
 const STORAGE_SEED = Buffer.from("storage");
@@ -213,4 +218,289 @@ export class SolanaLazerContract extends Storable {
       .signers([topAuthority])
       .rpc();
   }
+}
+
+/**
+ * The Pyth Core price-feed programs on SVM, as published in the Core upgrade docs. Every
+ * per-feed account address changes across the upgrade, so the two deployments are entirely
+ * separate on-chain and are counted separately.
+ *
+ * These are constants rather than store entries because a `PriceFeedContract` subclass would
+ * have to stub out a dozen governance/point-read methods the SVM deployment does not expose,
+ * and the scan needs only the program ids.
+ */
+export const SVM_PRICE_FEED_PROGRAMS = {
+  legacy: {
+    pushOracle: "pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT",
+    receiver: "rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ",
+  },
+  upgraded: {
+    pushOracle: "pyt2F414BA6dPttK6RddPZUdHfapoBN24GL5wbrPCou",
+    receiver: "rec2HHDDnjLfj4kE7VyEtFA1HPGQLK33259532cRyHp",
+  },
+} as const;
+
+/** Number of receiver price posts keyed by 64-char hex feed id, without the `0x` prefix. */
+export type SvmPriceFeedUpdateCounts = Map<string, number>;
+
+export type SvmPriceFeedUpdateBatch = {
+  fromSlot: number;
+  toSlot: number;
+  counts: SvmPriceFeedUpdateCounts;
+};
+
+export type SvmPriceFeedUpdateScanOptions = {
+  fromSlot: number;
+  toSlot: number;
+  /**
+   * `getTransaction` calls per JSON-RPC batch. The public endpoint answers 5 and rejects the
+   * rest of a 20-batch with HTTP 429, so this is deliberately tiny by default.
+   */
+  batchSize?: number;
+  onRetry?: (message: string) => void;
+};
+
+function anchorDiscriminator(name: string): string {
+  return createHash("sha256")
+    .update(`global:${name}`)
+    .digest()
+    .subarray(0, 8)
+    .toString("hex");
+}
+
+type SvmInstruction = { programIdIndex: number; data: string };
+
+type SvmTransaction = {
+  slot: number;
+  transaction: {
+    message: { accountKeys: string[]; instructions: SvmInstruction[] };
+  };
+  meta: {
+    innerInstructions?: { instructions: SvmInstruction[] }[];
+    loadedAddresses?: { writable: string[]; readonly: string[] };
+  } | null;
+};
+
+/**
+ * Counts Pyth price posts on an SVM chain over a slot range.
+ *
+ * There is no log/event equivalent of the EVM `PriceFeedUpdate` here — the receiver program
+ * emits nothing — so updates are reconstructed from instruction data. Two traps this handles:
+ *
+ * - On a sponsored push the *top-level* instruction belongs to the push-oracle program and the
+ *   receiver's `post_update` is a CPI, so `message.instructions` alone matches nothing;
+ *   `meta.innerInstructions` has to be walked too.
+ * - These are v0 transactions using address lookup tables, so `meta.loadedAddresses` must be
+ *   appended to `accountKeys` before resolving `programIdIndex`.
+ *
+ * Only the receiver instructions are counted. They are the actual writes and cover both
+ * sponsored pushes and consumer pull updates, whereas the push-oracle instruction is a
+ * strict subset that would double-count if added.
+ */
+export class SvmPriceFeedUpdateScanner {
+  constructor(
+    public chain: SvmChain,
+    public receiverProgramId: string,
+  ) {}
+
+  async *streamPriceFeedUpdateCounts(
+    options: SvmPriceFeedUpdateScanOptions,
+  ): AsyncGenerator<SvmPriceFeedUpdateBatch> {
+    const { batchSize = 5, fromSlot, onRetry, toSlot } = options;
+    const postUpdate = anchorDiscriminator("post_update");
+    const postUpdateAtomic = anchorDiscriminator("post_update_atomic");
+
+    // Signatures are only enumerable newest-first, so the scan walks the window backwards and
+    // each yielded batch closes off the *bottom* of the range covered so far. Enumeration
+    // always starts at the chain head, which on a resumed run sits well above `toSlot`, so
+    // pages above the window are paged past without being counted or reported as covered.
+    let before: string | undefined;
+    let frontier = toSlot;
+    for (;;) {
+      const signatures = await this.rpc<
+        { signature: string; slot: number; err: unknown }[]
+      >(
+        "getSignaturesForAddress",
+        [
+          this.receiverProgramId,
+          { limit: 1000, ...(before === undefined ? {} : { before }) },
+        ],
+        onRetry,
+      );
+      if (signatures.length === 0) return;
+
+      const inWindow = signatures.filter(
+        (signature) =>
+          signature.slot >= fromSlot &&
+          signature.slot <= toSlot &&
+          signature.err === null,
+      );
+      const counts: SvmPriceFeedUpdateCounts = new Map();
+      for (let index = 0; index < inWindow.length; index += batchSize) {
+        const chunk = inWindow.slice(index, index + batchSize);
+        const transactions = await this.getTransactions(
+          chunk.map((signature) => signature.signature),
+          onRetry,
+        );
+        for (const transaction of transactions) {
+          for (const feedId of this.extractFeedIds(
+            transaction,
+            postUpdate,
+            postUpdateAtomic,
+          )) {
+            counts.set(feedId, (counts.get(feedId) ?? 0) + 1);
+          }
+        }
+      }
+
+      const last = signatures.at(-1);
+      if (last === undefined) return;
+      const reachedWindowStart = last.slot < fromSlot;
+      const batchBottom = reachedWindowStart ? fromSlot : last.slot;
+      // While the page is still entirely above the window there is nothing to close off —
+      // reporting `batchBottom` as covered here would claim a range above `toSlot`.
+      if (batchBottom <= frontier) {
+        yield { counts, fromSlot: batchBottom, toSlot: frontier };
+        frontier = batchBottom - 1;
+      }
+      if (reachedWindowStart || signatures.length < 1000) return;
+      before = last.signature;
+    }
+  }
+
+  private extractFeedIds(
+    transaction: SvmTransaction,
+    postUpdate: string,
+    postUpdateAtomic: string,
+  ): string[] {
+    const keys = [
+      ...transaction.transaction.message.accountKeys,
+      ...(transaction.meta?.loadedAddresses?.writable ?? []),
+      ...(transaction.meta?.loadedAddresses?.readonly ?? []),
+    ];
+    const instructions = [
+      ...transaction.transaction.message.instructions,
+      ...(transaction.meta?.innerInstructions ?? []).flatMap(
+        (group) => group.instructions,
+      ),
+    ];
+
+    const feedIds: string[] = [];
+    for (const instruction of instructions) {
+      if (keys[instruction.programIdIndex] !== this.receiverProgramId) continue;
+      const data = Buffer.from(bs58.decode(instruction.data));
+      const discriminator = data.subarray(0, 8).toString("hex");
+      // `post_update(params)` puts the merkle message first; `post_update_atomic(params)`
+      // puts a variable-length VAA ahead of it. In both the message is a borsh `Vec<u8>`
+      // whose first byte is the message type, followed by the 32-byte feed id.
+      let messageStart: number;
+      if (discriminator === postUpdate) {
+        messageStart = 12;
+      } else if (discriminator === postUpdateAtomic) {
+        messageStart = 16 + data.readUInt32LE(8);
+      } else {
+        continue;
+      }
+      const feedId = data.subarray(messageStart + 1, messageStart + 33);
+      if (feedId.length === 32) feedIds.push(feedId.toString("hex"));
+    }
+    return feedIds;
+  }
+
+  private async getTransactions(
+    signatures: string[],
+    onRetry?: (message: string) => void,
+  ): Promise<SvmTransaction[]> {
+    const results = await this.rpcBatch<SvmTransaction | null>(
+      signatures.map((signature) => ({
+        method: "getTransaction",
+        params: [
+          signature,
+          { encoding: "json", maxSupportedTransactionVersion: 0 },
+        ],
+      })),
+      onRetry,
+    );
+    return results.filter(
+      (result): result is SvmTransaction => result !== null,
+    );
+  }
+
+  private async rpc<T>(
+    method: string,
+    params: unknown[],
+    onRetry?: (message: string) => void,
+  ): Promise<T> {
+    const [result] = await this.rpcBatch<T>([{ method, params }], onRetry);
+    if (result === undefined) throw new Error(`empty response for ${method}`);
+    return result;
+  }
+
+  private async rpcBatch<T>(
+    calls: { method: string; params: unknown[] }[],
+    onRetry?: (message: string) => void,
+  ): Promise<T[]> {
+    const endpoint = this.chain.getConnection().rpcEndpoint;
+    const MAX_ATTEMPTS = 6;
+    for (let attempt = 1; ; attempt++) {
+      try {
+        const response = await fetch(endpoint, {
+          body: JSON.stringify(
+            calls.map((call, id) => ({ id, jsonrpc: "2.0", ...call })),
+          ),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status} ${response.statusText}`);
+        }
+        const body = (await response.json()) as {
+          id: number;
+          result?: T;
+          error?: { message: string };
+        }[];
+        const failed = body.find((entry) => entry.error !== undefined);
+        if (failed?.error !== undefined) throw new Error(failed.error.message);
+        return body
+          .sort((a, b) => a.id - b.id)
+          .map((entry) => entry.result as T);
+      } catch (error) {
+        if (attempt >= MAX_ATTEMPTS) throw error;
+        const backoffMs = 1000 * 2 ** (attempt - 1);
+        onRetry?.(
+          `${calls[0]?.method} attempt ${attempt} failed, retrying in ${backoffMs}ms: ${error}`,
+        );
+        await sleep(backoffMs);
+      }
+    }
+  }
+}
+
+/** Slot at or after `unixTimestamp`, by binary search over `getBlockTime`. */
+export async function getSvmSlotAtTimestamp(
+  chain: SvmChain,
+  unixTimestamp: number,
+): Promise<number> {
+  const connection = chain.getConnection();
+  const head = await connection.getSlot();
+  const headTime = await connection.getBlockTime(head);
+  if (headTime === null || unixTimestamp >= headTime) return head;
+  // ~2.4 slots/sec; over-reach by 3x so the window start is inside the search range.
+  let low = Math.max(0, head - Math.ceil((headTime - unixTimestamp) * 7.5));
+  let high = head;
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    let timestamp: number | null = null;
+    try {
+      timestamp = await connection.getBlockTime(mid);
+    } catch {
+      // Skipped or pruned slot: treat as older than the target so the search moves up.
+    }
+    if (timestamp !== null && timestamp >= unixTimestamp) {
+      high = mid;
+    } else {
+      low = mid + 1;
+    }
+  }
+  return low;
 }

--- a/contract_manager/src/core/contracts/sui.ts
+++ b/contract_manager/src/core/contracts/sui.ts
@@ -1,3 +1,6 @@
+/** biome-ignore-all lint/suspicious/useAwait: pre-existing in this file */
+/** biome-ignore-all lint/suspicious/noExplicitAny: pre-existing in this file */
+/** biome-ignore-all lint/style/noNonNullAssertion: pre-existing in this file */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */

--- a/contract_manager/src/core/contracts/sui.ts
+++ b/contract_manager/src/core/contracts/sui.ts
@@ -512,6 +512,7 @@ type SuiPriceFeedUpdateJson = {
  * store's `rpcUrl` is the (now method-less) JSON-RPC host.
  */
 export function suiGraphqlEndpoint(chain: SuiChain): string {
+  if (chain.graphqlUrl !== undefined) return chain.graphqlUrl;
   return chain.isMainnet()
     ? "https://graphql.mainnet.sui.io/graphql"
     : "https://graphql.testnet.sui.io/graphql";

--- a/contract_manager/src/core/contracts/sui.ts
+++ b/contract_manager/src/core/contracts/sui.ts
@@ -22,6 +22,7 @@ import {
 } from "@pythnetwork/xc-admin-common";
 import type { Vault } from "../../node/utils/governance";
 import { SubmittedWormholeMessage } from "../../node/utils/governance";
+import { sleep } from "../../utils/sleep";
 import type { DeploymentType, PrivateKey, TxResult } from "../base";
 import { PriceFeedContract, Storable, toDeploymentType } from "../base";
 import type { Chain, MoveLazerMeta } from "../chains";
@@ -400,6 +401,202 @@ export class SuiPriceFeedContract extends PriceFeedContract {
     if (!object.json) throw new Error("Unable to fetch pyth state object");
     return getStructFields(object.json);
   }
+
+  /**
+   * The package that *defines* the contract's Move types, which is the package the state
+   * object's own type tag names. Sui upgrades publish a new package id but leave type tags
+   * pointing at the original, so this is the id that `PriceFeedUpdateEvent` is emitted under —
+   * filtering on the current (upgraded) package id silently matches nothing.
+   */
+  async getOriginalPackageId(): Promise<ObjectId> {
+    const { object } = await suiGraphqlQuery<{
+      object: { asMoveObject: { contents: { type: { repr: string } } } } | null;
+    }>(
+      this.chain,
+      `{ object(address: "${this.stateId}") { asMoveObject { contents { type { repr } } } } }`,
+    );
+    if (object === null) {
+      throw new Error(`Sui state object ${this.stateId} not found`);
+    }
+    const [packageId] = object.asMoveObject.contents.type.repr.split("::");
+    if (packageId === undefined) {
+      throw new Error(`Unparseable state object type on ${this.stateId}`);
+    }
+    return packageId;
+  }
+
+  /**
+   * Yields `PriceFeedUpdateEvent` counts per feed id for successive checkpoint sub-ranges of
+   * `[fromCheckpoint, toCheckpoint]`, covering the range in order and without gaps.
+   *
+   * The Sui event carries the same meaning as the EVM `PriceFeedUpdate` log: `update_cache`
+   * emits it only inside its `is_fresh_update` branch, so both count accepted writes.
+   * @param options - checkpoint range to scan plus request-shaping knobs
+   */
+  async *streamPriceFeedUpdateCounts(
+    options: SuiPriceFeedUpdateScanOptions,
+  ): AsyncGenerator<SuiPriceFeedUpdateBatch> {
+    const { chunkSize = 2000, fromCheckpoint, onRetry, toCheckpoint } = options;
+    const eventType = `${await this.getOriginalPackageId()}::event::PriceFeedUpdateEvent`;
+
+    for (let cursor = fromCheckpoint; cursor <= toCheckpoint; ) {
+      const chunkEnd = Math.min(cursor + chunkSize - 1, toCheckpoint);
+      const counts = new Map<string, number>();
+      // `afterCheckpoint` / `beforeCheckpoint` are exclusive, so widen by one on each side.
+      const bounds =
+        (cursor > 0 ? `afterCheckpoint: ${cursor - 1}, ` : "") +
+        `beforeCheckpoint: ${chunkEnd + 1}`;
+      let after: string | undefined;
+      do {
+        const page = await suiGraphqlQuery<{
+          events: {
+            pageInfo: { hasNextPage: boolean; endCursor: string | null };
+            nodes: { contents: { json: SuiPriceFeedUpdateJson } }[];
+          };
+        }>(
+          this.chain,
+          `{ events(filter: { type: "${eventType}", ${bounds} }, first: ${SUI_EVENTS_PAGE_SIZE}${
+            after === undefined ? "" : `, after: "${after}"`
+          }) { pageInfo { hasNextPage endCursor } nodes { contents { json } } } }`,
+          onRetry,
+        );
+        for (const node of page.events.nodes) {
+          const feedId = Buffer.from(
+            node.contents.json.price_feed.price_identifier.bytes,
+            "base64",
+          ).toString("hex");
+          counts.set(feedId, (counts.get(feedId) ?? 0) + 1);
+        }
+        after = page.events.pageInfo.hasNextPage
+          ? (page.events.pageInfo.endCursor ?? undefined)
+          : undefined;
+      } while (after !== undefined);
+
+      yield { counts, fromCheckpoint: cursor, toCheckpoint: chunkEnd };
+      cursor = chunkEnd + 1;
+    }
+  }
+}
+
+/** Page cap the public GraphQL service enforces on `events` (`serviceConfig.maxPageSize`). */
+const SUI_EVENTS_PAGE_SIZE = 50;
+
+/** Number of `PriceFeedUpdateEvent`s keyed by 64-char hex feed id, without the `0x` prefix. */
+export type SuiPriceFeedUpdateCounts = Map<string, number>;
+
+export type SuiPriceFeedUpdateBatch = {
+  fromCheckpoint: number;
+  toCheckpoint: number;
+  counts: SuiPriceFeedUpdateCounts;
+};
+
+export type SuiPriceFeedUpdateScanOptions = {
+  fromCheckpoint: number;
+  toCheckpoint: number;
+  /** Checkpoints covered by a single filter window; each is paged 50 events at a time. */
+  chunkSize?: number;
+  onRetry?: (message: string) => void;
+};
+
+type SuiPriceFeedUpdateJson = {
+  price_feed: { price_identifier: { bytes: string } };
+};
+
+/**
+ * Sui JSON-RPC was retired on public fullnodes in favour of GraphQL and gRPC, and the
+ * `@mysten/sui` gRPC surface has no historical event query, so the scan talks GraphQL
+ * directly. The endpoint is derived from the chain rather than stored, since the chain
+ * store's `rpcUrl` is the (now method-less) JSON-RPC host.
+ */
+export function suiGraphqlEndpoint(chain: SuiChain): string {
+  return chain.isMainnet()
+    ? "https://graphql.mainnet.sui.io/graphql"
+    : "https://graphql.testnet.sui.io/graphql";
+}
+
+async function suiGraphqlQuery<T>(
+  chain: SuiChain,
+  query: string,
+  onRetry?: (message: string) => void,
+): Promise<T> {
+  const MAX_ATTEMPTS = 5;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      const response = await fetch(suiGraphqlEndpoint(chain), {
+        body: JSON.stringify({ query }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} ${response.statusText}`);
+      }
+      const body = (await response.json()) as {
+        data?: T;
+        errors?: { message: string }[];
+      };
+      if (body.errors !== undefined && body.errors.length > 0) {
+        throw new Error(body.errors.map((e) => e.message).join("; "));
+      }
+      if (body.data === undefined) throw new Error("empty GraphQL response");
+      return body.data;
+    } catch (error) {
+      if (attempt >= MAX_ATTEMPTS) throw error;
+      const backoffMs = 500 * 2 ** (attempt - 1);
+      onRetry?.(
+        `GraphQL attempt ${attempt} failed, retrying in ${backoffMs}ms: ${error}`,
+      );
+      await sleep(backoffMs);
+    }
+  }
+}
+
+/** Sequence number and unix timestamp of the newest checkpoint the endpoint has. */
+export async function getLatestSuiCheckpoint(chain: SuiChain) {
+  const { checkpoint } = await suiGraphqlQuery<{
+    checkpoint: { sequenceNumber: number; timestamp: string };
+  }>(chain, "{ checkpoint { sequenceNumber timestamp } }");
+  return {
+    sequenceNumber: Number(checkpoint.sequenceNumber),
+    timestamp: Math.floor(Date.parse(checkpoint.timestamp) / 1000),
+  };
+}
+
+export async function getSuiCheckpointTimestamp(
+  chain: SuiChain,
+  sequenceNumber: number,
+): Promise<number | undefined> {
+  const { checkpoint } = await suiGraphqlQuery<{
+    checkpoint: { timestamp: string } | null;
+  }>(chain, `{ checkpoint(sequenceNumber: ${sequenceNumber}) { timestamp } }`);
+  return checkpoint === null
+    ? undefined
+    : Math.floor(Date.parse(checkpoint.timestamp) / 1000);
+}
+
+/**
+ * Lowest checkpoint whose timestamp is at or after `unixTimestamp`, by binary search — the
+ * GraphQL service has no timestamp filter on checkpoints. Pruned checkpoints read as
+ * `undefined` and are treated as "older than the target", which walks the search up into the
+ * retained range instead of failing.
+ */
+export async function getSuiCheckpointAtTimestamp(
+  chain: SuiChain,
+  unixTimestamp: number,
+): Promise<number> {
+  const latest = await getLatestSuiCheckpoint(chain);
+  if (unixTimestamp >= latest.timestamp) return latest.sequenceNumber;
+  let low = 0;
+  let high = latest.sequenceNumber;
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    const timestamp = await getSuiCheckpointTimestamp(chain, mid);
+    if (timestamp !== undefined && timestamp >= unixTimestamp) {
+      high = mid;
+    } else {
+      low = mid + 1;
+    }
+  }
+  return low;
 }
 
 export class SuiWormholeContract extends WormholeContract {

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,8 @@
     "COREPACK_HOME",
     "FORCE_COLOR",
     "BIOME_BINARY",
-    "KOIOS_TOKEN"
+    "KOIOS_TOKEN",
+    "PYTH_API_KEY"
   ],
   "tasks": {
     "//#fix": {


### PR DESCRIPTION
## What

Adds `contract_manager/scripts/report_price_feed_usage.ts`, which reports which Pyth price feeds are actually being written on-chain on the EVM mainnets that survive the Pyth Core upgrade, so every feed in real use can be checked against the Pyth Pro catalog before Core is switched off.

```sh
pnpm tsx scripts/report_price_feed_usage.ts --days 30 --output usage.csv
```

It writes three files:

- `usage.csv` — one row per feed (`feed_name`, `feed_symbol`, `asset_type`, `feed_id`, `supported_on_pro`, `pro_state`, `total_updates`, then one column per chain), sorted by `total_updates` descending. Feeds with on-chain usage but no Hermes entry appear with `UNKNOWN` names.
- `usage_split.csv` — the same counts split into legacy vs upgraded contract per chain, which is how far each chain has migrated.
- `usage_coverage.csv` — per contract, the block range and wall-clock window actually scanned.

The chain set is derived from `DefaultStore` at runtime as the EVM mainnets carrying a `pro-compatible-production` price feed contract (19 chains today), never hardcoded. Both that contract and the chain's legacy Core contract are scanned on every chain and summed into the chain's column, since integrators migrate at their own pace and traffic is currently split across the two.

## New primitives

`contract_manager` had no way to read usage — `PriceFeedContract` exposes only point reads — so this adds the two pieces the script needs:

- `EvmPriceFeedContract.streamPriceFeedUpdateCounts` counts `PriceFeedUpdate` logs per feed id via `topics[1]` and never decodes the data field, so memory stays flat. Public RPCs cap `eth_getLogs` ranges anywhere from 50 blocks to unlimited and advertise no way to discover the cap, so the sub-range size is discovered at runtime: it halves on rejection, grows back on success, and never grows past a size the RPC has already refused (which otherwise oscillates around the cap forever). Requests are issued with bounded concurrency and retried with exponential backoff on transient failures.
- `EvmChain.getBlockNumberAtTimestamp` is an exponential-then-binary search that brackets the answer near the chain tip. A plain binary search over `[0, latest]` reads blocks from the start of the chain, which non-archive nodes routinely refuse.

## Never silently under-count

A chain that cannot be scanned across the whole window (dead RPC, archive refused, unrecoverable errors) has its column in `usage.csv` suffixed `_INCOMPLETE`, gets its actual block range and wall-clock window recorded in the coverage CSV, and triggers a warning on stderr. A silently truncated chain would produce a false "this feed is unused" conclusion, which is the exact failure this report exists to prevent.

Runs are resumable through a JSON checkpoint file, since a full 30-day scan takes hours. Resuming re-runs any scan whose block range never resolved, rather than resuming it over an empty range and calling it complete.

## Is the Pro catalog entitlement-scoped?

No — this was worth checking, because 1,605 of the 3,056 Core feed ids are absent from it. `GET https://pyth.dourolabs.app/hermes/v2/price_feeds` returns a byte-identical 1,796-feed response with a valid API key, an invalid key, and no `Authorization` header at all, so it is not scoped to the caller's entitlements.

The gap is real, and the full Lazer symbol registry (`GET /v1/symbols`, 3,726 symbols with a `hermes_id` mapping) explains it: `/hermes/v2/price_feeds` lists exactly the symbols in state `stable`. Of the 1,605 missing Core feeds, 1,408 do exist in the Pro catalog but are `coming_soon` (959) or `inactive` (449), and only 197 are unknown to Pro entirely. The report therefore carries both `supported_on_pro` (membership of the Hermes-compatible catalog, as specified) and a `pro_state` column from `/v1/symbols` that distinguishes `stable` / `coming_soon` / `inactive` / `absent` — a feed in use but only `coming_soon` needs promoting, not creating.

## Verification

Verified end-to-end against real chains; counts match raw `eth_getLogs` exactly (details in the issue comment). A full smoke run across all 19 in-scope chains derived the right chain set and completed 15 of them; the coverage CSV honestly reported the rest, and 3 of those 4 recovered on a resume.

`pnpm turbo build` and `pnpm turbo test` both pass (94/94 tasks).

## One thing to flag

`evm.ts` carries 26 pre-existing biome diagnostics on `main` (20 `useAwait`, 5 `noConsole`, 1 formatter), which means `pnpm turbo test` fails for anyone who so much as touches the file. I added the two `biome-ignore-all` lines that make it clean — they are the biome equivalents of the `no-console` and `require-await` eslint-disables already at the top of the file, left behind in the eslint-to-biome migration, and match how sibling modules (`iota.ts`, `ton.ts`) handle the same situation. Happy to drop them if you would rather fix those diagnostics separately.