### PR TITLE
chore(xc-admin, contract-manager): drop retired rpcpool solana mainnet endpoint

### DIFF
--- a/.github/workflows/docker-xc-admin-frontend.yml
+++ b/.github/workflows/docker-xc-admin-frontend.yml
@@ -33,6 +33,7 @@ jobs:
           DOCKER_BUILDKIT=1 docker build -t builder-base --target builder-base -f Dockerfile.node .
           DOCKER_BUILDKIT=1 docker build -t runner-base --target runner-base -f Dockerfile.node .
           DOCKER_BUILDKIT=1 docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
+            --build-arg NEXT_PUBLIC_ALCHEMY_API_KEY=${{ secrets.NEXT_PUBLIC_ALCHEMY_API_KEY }} \
             -f governance/xc_admin/packages/xc_admin_frontend/Dockerfile .
       - name: Push docker image
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/docker-xc-admin-frontend.yml
+++ b/.github/workflows/docker-xc-admin-frontend.yml
@@ -33,7 +33,6 @@ jobs:
           DOCKER_BUILDKIT=1 docker build -t builder-base --target builder-base -f Dockerfile.node .
           DOCKER_BUILDKIT=1 docker build -t runner-base --target runner-base -f Dockerfile.node .
           DOCKER_BUILDKIT=1 docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
-            --build-arg NEXT_PUBLIC_RPC_POOL_TOKEN=${{ secrets.NEXT_PUBLIC_RPC_POOL_TOKEN }} \
             -f governance/xc_admin/packages/xc_admin_frontend/Dockerfile .
       - name: Push docker image
         if: github.ref == 'refs/heads/main'

--- a/contract_manager/src/store/chains/SvmChains.json
+++ b/contract_manager/src/store/chains/SvmChains.json
@@ -3,7 +3,7 @@
     "id": "solana_mainnet",
     "mainnet": true,
     "nativeToken": "SOL",
-    "rpcUrl": "https://pyth-network.rpcpool.com/$ENV_SOLANA_MAINNET_API_KEY",
+    "rpcUrl": "https://solana-mainnet.g.alchemy.com/v2/$ENV_SOLANA_MAINNET_API_KEY",
     "type": "SvmChain",
     "wormholeChainName": "solana"
   },

--- a/governance/xc_admin/packages/xc_admin_frontend/Dockerfile
+++ b/governance/xc_admin/packages/xc_admin_frontend/Dockerfile
@@ -1,9 +1,7 @@
 # Defined in Dockerfile.node
 FROM builder-base AS xc-admin-frontend-builder
-ARG NEXT_PUBLIC_RPC_POOL_TOKEN
 ENV NEXT_TELEMETRY_DISABLED 1
 ENV BUILD_STANDALONE true
-ENV NEXT_PUBLIC_RPC_POOL_TOKEN $NEXT_PUBLIC_RPC_POOL_TOKEN
 ENV CI true
 RUN pnpm turbo build --filter @pythnetwork/xc-admin-frontend
 

--- a/governance/xc_admin/packages/xc_admin_frontend/Dockerfile
+++ b/governance/xc_admin/packages/xc_admin_frontend/Dockerfile
@@ -1,7 +1,9 @@
 # Defined in Dockerfile.node
 FROM builder-base AS xc-admin-frontend-builder
+ARG NEXT_PUBLIC_ALCHEMY_API_KEY
 ENV NEXT_TELEMETRY_DISABLED 1
 ENV BUILD_STANDALONE true
+ENV NEXT_PUBLIC_ALCHEMY_API_KEY $NEXT_PUBLIC_ALCHEMY_API_KEY
 ENV CI true
 RUN pnpm turbo build --filter @pythnetwork/xc-admin-frontend
 

--- a/governance/xc_admin/packages/xc_admin_frontend/utils/pythClusterApiUrl.ts
+++ b/governance/xc_admin/packages/xc_admin_frontend/utils/pythClusterApiUrl.ts
@@ -9,6 +9,8 @@ const CLUSTER_URLS: Record<PythCluster, string[]> = {
   localnet: ["http://localhost:8899/"],
   "mainnet-beta": [
     process.env.NEXT_PUBLIC_MAINNET_RPC || getPythClusterApiUrl("mainnet-beta"),
+    "https://solana-mainnet.g.alchemy.com/v2/" +
+      (process.env.NEXT_PUBLIC_ALCHEMY_API_KEY || ""),
     "http://pyth-rpc1.certus.one:8899/",
     "http://pyth-rpc2.certus.one:8899/",
     "https://api.mainnet-beta.solana.com/",

--- a/governance/xc_admin/packages/xc_admin_frontend/utils/pythClusterApiUrl.ts
+++ b/governance/xc_admin/packages/xc_admin_frontend/utils/pythClusterApiUrl.ts
@@ -9,8 +9,6 @@ const CLUSTER_URLS: Record<PythCluster, string[]> = {
   localnet: ["http://localhost:8899/"],
   "mainnet-beta": [
     process.env.NEXT_PUBLIC_MAINNET_RPC || getPythClusterApiUrl("mainnet-beta"),
-    "https://pyth-network.rpcpool.com/" +
-      (process.env.NEXT_PUBLIC_RPC_POOL_TOKEN || ""),
     "http://pyth-rpc1.certus.one:8899/",
     "http://pyth-rpc2.certus.one:8899/",
     "https://api.mainnet-beta.solana.com/",


### PR DESCRIPTION
## What

Removes the last references to the `pyth-network.rpcpool.com` Solana **mainnet** endpoint, which is being retired:

- **xc-admin frontend** (`pythClusterApiUrl.ts`): replace it in the `mainnet-beta` fallback list with a private Alchemy endpoint. The Alchemy API key is injected at image build time via a `NEXT_PUBLIC_ALCHEMY_API_KEY` build arg (Dockerfile ARG/ENV + docker workflow `--build-arg`) — the same pattern the old `NEXT_PUBLIC_RPC_POOL_TOKEN` used, so the key never lands in the repo. The env-configured `NEXT_PUBLIC_MAINNET_RPC` primary and the public `api.mainnet-beta.solana.com` last resort remain.
- **contract manager** (`SvmChains.json`): `solana_mainnet.rpcUrl` now points at Alchemy with the same `$ENV_SOLANA_MAINNET_API_KEY` templating — operators set that env var to an Alchemy API key instead of the old rpcpool token.

## Notes for reviewers

- The pythnet entries (`pythnet.rpcpool.com`) are intentionally untouched — only the Solana mainnet endpoint is being retired.
- The `pyth-rpc{1,2}.certus.one` fallbacks look long-dead too, but are left as-is to keep this change minimal — happy to drop them here if preferred.
- **Merge prerequisite**: add a `NEXT_PUBLIC_ALCHEMY_API_KEY` repo secret (Alchemy Solana-mainnet API key) so the docker workflow can bake it into the frontend bundle; the old `NEXT_PUBLIC_RPC_POOL_TOKEN` secret can be deleted once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
