### PR TITLE
docs(price-pusher): log-level paragraph names two modules but only one flag

### DIFF
--- a/apps/price_pusher/README.md
+++ b/apps/price_pusher/README.md
@@ -227,7 +227,7 @@ human-readable logs, you can pipe the output of the program to `pino-pretty`. Se
 
 You can configure the log level of some of the modules of the price pusher as well. The available modules are PriceServiceConnection, which
 is responsible for connecting to the Hermes price service, and Controller, which is responsible for checking the prices from the Hermes
-and the on-chain Pyth contract and deciding whether to push a new price. You can configure the log level of these modules by passing the `--controller-log-level` arguments, respectively.
+and the on-chain Pyth contract and deciding whether to push a new price. You can configure the log level of these modules by passing the `--log-level` and `--controller-log-level` arguments, respectively.
 
 ### Example
 


### PR DESCRIPTION
## Problem

`apps/price_pusher/README.md:228-230` reads:

> The available modules are PriceServiceConnection, which is responsible for connecting to the Hermes price service, and **Controller**, which is responsible for … You can configure the log level of these modules by passing the `--controller-log-level` arguments, **respectively**.

The sentence names two modules, says "arguments" in the plural and ends with "respectively", but only one flag is listed — the other was dropped at some point.

Both flags do exist (`src/options.ts:69-88`):

- `--log-level` — sets the root logger: `pino({ level: logLevel })`
- `--controller-log-level` — sets the Controller child logger: `logger.child({ module: "Controller" }, { level: controllerLogLevel })`

Both are registered by every chain command (`src/evm/command.ts:137-138`, `src/aptos/command.ts:50-51`, and the same pair in the fuel, injective, near, solana, sui and ton commands).

## Fix

Name the missing flag, so the sentence matches the code:

```diff
-by passing the `--controller-log-level` arguments, respectively.
+by passing the `--log-level` and `--controller-log-level` arguments, respectively.
```

One line. I chose to restore the missing flag rather than drop the mention of `PriceServiceConnection`, because the flag genuinely exists and controls the root logger the Hermes client writes through — removing the sentence's second half would have deleted true information.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->