### PR TITLE
feat(contract_manager): register stellar_mainnet and add a Stellar Lazer deployment audit

### DIFF
--- a/contract_manager/scripts/manage_stellar_lazer_contract.ts
+++ b/contract_manager/scripts/manage_stellar_lazer_contract.ts
@@ -12,7 +12,7 @@ import type { Options } from "yargs";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
-import { toPrivateKey } from "../src/core/base";
+import { getDefaultDeploymentConfig, toPrivateKey } from "../src/core/base";
 import {
   StellarExecutorContract,
   StellarLazerContract,
@@ -45,6 +45,32 @@ function connectMainnetVault(wallet: Wallet): Vault {
   const vault = getMainnetVault();
   vault.connect(wallet, (rpc) => RPCS[rpc]);
   return vault;
+}
+
+/** Fetch the guardian set the Wormhole mainnet guardians are currently signing with. */
+async function fetchLiveMainnetGuardianSet(): Promise<{
+  index: number;
+  addresses: string[];
+}> {
+  const endpoint = WORMHOLE_API_ENDPOINT["mainnet-beta"];
+  const response = await fetch(`${endpoint}/v1/guardianset/current`);
+  const { guardianSet } = (await response.json()) as {
+    guardianSet: { index: number; addresses: string[] };
+  };
+  return guardianSet;
+}
+
+/**
+ * Report whether an on-chain value matches the canonical one, echoing both so the
+ * output stands on its own as an audit record. Returns the verdict so the caller
+ * can fail the command after running every check rather than at the first one.
+ */
+function check(label: string, actual: string, expected: string): boolean {
+  const passed = actual.toLowerCase() === expected.toLowerCase();
+  console.log(`${passed ? "PASS" : "FAIL"}  ${label}`);
+  console.log(`      on-chain: ${actual}`);
+  console.log(`      expected: ${expected}`);
+  return passed;
 }
 
 /** Build a proposal carrying a single Wormhole governance payload. */
@@ -275,11 +301,7 @@ parser.command(
       console.log(`    ${guardian}`);
     }
 
-    const endpoint = WORMHOLE_API_ENDPOINT["mainnet-beta"];
-    const response = await fetch(`${endpoint}/v1/guardianset/current`);
-    const { guardianSet } = (await response.json()) as {
-      guardianSet: { index: number; addresses: string[] };
-    };
+    const guardianSet = await fetchLiveMainnetGuardianSet();
     console.log(
       `Live mainnet guardian set index: ${guardianSet.index.toString()}`,
     );
@@ -290,6 +312,113 @@ parser.command(
         `Executor is ${(guardianSet.index - index).toString()} set(s) behind; run upgrade-guardian-set.`,
       );
     }
+  },
+);
+
+parser.command(
+  "verify-deployment",
+  "audit a deployed executor + verifier pair against the canonical Pyth-DAO governance configuration",
+  (b) =>
+    b.options({
+      executor: commonOptions.executor,
+      verifier: commonOptions.verifier,
+    }),
+  async (argv) => {
+    const { executor, verifier } = argv;
+    if (executor.chain.getId() !== verifier.chain.getId()) {
+      throw new Error(
+        `Executor is on ${executor.chain.getId()} but verifier is on ${verifier.chain.getId()}.`,
+      );
+    }
+
+    console.log(`Chain:    ${executor.chain.getId()}`);
+    console.log(`Executor: ${executor.address}`);
+    console.log(`Verifier: ${verifier.address}\n`);
+
+    const { governanceDataSource, wormholeConfig } =
+      getDefaultDeploymentConfig("stable");
+    const config = await executor.getConfig();
+    const guardianSet = await fetchLiveMainnetGuardianSet();
+    const vault = getMainnetVault();
+    const daoEmitter = await vault.getEmitter();
+
+    const results = [
+      check(
+        "verifier authorizes the registered executor",
+        await verifier.getExecutor(),
+        executor.address,
+      ),
+      check(
+        "Pyth receiver chain id (governance targets this exact id)",
+        config.chainId.toString(),
+        executor.chain.getWormholeChainId().toString(),
+      ),
+      check(
+        "governance (owner) emitter chain",
+        config.ownerEmitterChain.toString(),
+        governanceDataSource.emitterChain.toString(),
+      ),
+      check(
+        "governance (owner) emitter address",
+        config.ownerEmitterAddress,
+        governanceDataSource.emitterAddress,
+      ),
+      // The same address again, but derived live from the DAO Squads multisig
+      // rather than read from this repo's constants — this is what proves only
+      // the DAO can produce a governance VAA the executor accepts.
+      check(
+        `governance emitter is the Wormhole emitter of DAO vault ${vault.getId()}`,
+        config.ownerEmitterAddress,
+        daoEmitter.toBuffer().toString("hex"),
+      ),
+      check(
+        "guardian-set-upgrade emitter chain",
+        config.gsUpgradeEmitterChain.toString(),
+        wormholeConfig.governanceChainId.toString(),
+      ),
+      check(
+        "guardian-set-upgrade emitter address (Wormhole core bridge)",
+        config.gsUpgradeEmitterAddress,
+        wormholeConfig.governanceContract,
+      ),
+      check(
+        "guardian set index matches the live Wormhole mainnet set",
+        (await executor.getCurrentGuardianSetIndex()).toString(),
+        guardianSet.index.toString(),
+      ),
+      check(
+        "guardian set members match the live Wormhole mainnet set",
+        (await executor.getGuardianSet()).join(","),
+        guardianSet.addresses.join(","),
+      ),
+    ];
+
+    // The trusted signer set has no canonical off-chain constant to diff
+    // against, so it is reported rather than compared. `verify_update` against a
+    // live Lazer message is what proves the set is the right one — the contract
+    // only returns a payload if it was signed by a trusted, unexpired signer.
+    const now = BigInt(Math.floor(Date.now() / 1000));
+    const signers = await verifier.getTrustedSigners();
+    console.log(`Trusted Lazer signers (${signers.length.toString()}):`);
+    for (const { expiresAt, publicKey } of signers) {
+      const expiry = new Date(Number(expiresAt) * 1000).toISOString();
+      console.log(
+        `      ${publicKey} expires ${expiry} ${expiresAt > now ? "(active)" : "(EXPIRED)"}`,
+      );
+    }
+    results.push(
+      check(
+        "verifier has at least one unexpired trusted Lazer signer",
+        signers.some(({ expiresAt }) => expiresAt > now).toString(),
+        "true",
+      ),
+    );
+
+    const failed = results.filter((passed) => !passed).length;
+    if (failed > 0) {
+      throw new Error(`${failed.toString()} check(s) FAILED.`);
+    }
+    console.log(`\nAll ${results.length.toString()} checks passed.`);
   },
 );
 

--- a/contract_manager/scripts/test_stellar_lazer_contract.ts
+++ b/contract_manager/scripts/test_stellar_lazer_contract.ts
@@ -48,7 +48,7 @@ import { DefaultStore } from "../src/node/utils/store";
 //    pass them as `--executor-contract` / `--lazer-contract`.
 //
 // Why mainnet-beta? deploy.sh defaults to the Wormhole *mainnet* guardian set
-// (index 4) on both networks, because the canonical owner emitter lives on Solana
+// (index 7) on both networks, because the canonical owner emitter lives on Solana
 // mainnet. The executor checks guardian signatures against the set it holds, so
 // with that default the VAA must be signed by the mainnet guardians — post the
 // message on `mainnet-beta` (the `--guardian-cluster` default) with the `--emitter`

--- a/contract_manager/src/core/contracts/stellar.ts
+++ b/contract_manager/src/core/contracts/stellar.ts
@@ -146,9 +146,7 @@ export class StellarLazerContract extends Storable {
    * registered executor means the registry is stale.
    */
   async getExecutor(): Promise<string> {
-    const value = await readInstanceStorage(
-      this.chain,
-      this.address,
+    const value = (await readInstanceStorage(this.chain, this.address)).get(
       "Executor",
     );
     if (!value) {
@@ -206,6 +204,25 @@ export class StellarLazerContract extends Storable {
 }
 
 /**
+ * The deploy-time configuration a {@link StellarExecutorContract} authenticates
+ * governance against. All of it is immutable — the executor's constructor is the
+ * only writer — so a mismatch against the canonical Pyth-DAO values can only be
+ * fixed by redeploying.
+ */
+export type StellarExecutorConfig = {
+  /** Pyth receiver chain id this deployment answers governance for. */
+  chainId: number;
+  /** Guardian-set-upgrade emitter address, 32-byte hex without `0x`. */
+  gsUpgradeEmitterAddress: string;
+  /** Wormhole chain id of the guardian-set-upgrade emitter. */
+  gsUpgradeEmitterChain: number;
+  /** Governance (owner) emitter address, 32-byte hex without `0x`. */
+  ownerEmitterAddress: string;
+  /** Wormhole chain id of the governance (owner) emitter. */
+  ownerEmitterChain: number;
+};
+
+/**
  * The Wormhole governance **executor** (`wormhole-executor-stellar`). It verifies
  * Pyth governance VAAs and dispatches the decoded PTGM action to the verifier, or
  * upgrades itself. Mirrors {@link EvmExecutorContract}.
@@ -242,8 +259,8 @@ export class StellarExecutorContract extends WormholeContract {
     return this.chain;
   }
 
-  getChainId(): Promise<number> {
-    return Promise.resolve(this.chain.getWormholeChainId());
+  async getChainId(): Promise<number> {
+    return (await this.getConfig()).chainId;
   }
 
   toJson() {
@@ -363,6 +380,33 @@ export class StellarExecutorContract extends WormholeContract {
   }
 
   /**
+   * Read the deploy-time governance configuration the executor authenticates
+   * every VAA against. There is no entry point that exposes it, so it is read
+   * straight out of instance storage — one fetch covers all five fields.
+   */
+  async getConfig(): Promise<StellarExecutorConfig> {
+    const values = await readInstanceStorage(this.chain, this.address);
+    const read = (key: string): xdr.ScVal => {
+      const value = values.get(key);
+      if (!value) {
+        throw new Error(`Executor has no ${key} (not initialized)`);
+      }
+      return value;
+    };
+    const toHex = (value: xdr.ScVal): string =>
+      (scValToNative(value) as Buffer).toString("hex");
+    return {
+      chainId: scValToNative(read("ChainId")) as number,
+      gsUpgradeEmitterAddress: toHex(read("GsUpgradeEmitterAddress")),
+      gsUpgradeEmitterChain: scValToNative(
+        read("GsUpgradeEmitterChain"),
+      ) as number,
+      ownerEmitterAddress: toHex(read("OwnerEmitterAddress")),
+      ownerEmitterChain: scValToNative(read("OwnerEmitterChain")) as number,
+    };
+  }
+
+  /**
    * Read the executor's current Wormhole guardian set index.
    *
    * The index lives in *persistent* storage (see the executor's `guardian.rs`),
@@ -475,16 +519,16 @@ async function readPersistentStorage(
 }
 
 /**
- * Read a single entry from a contract's instance storage. Instance storage is
- * bundled inside the contract instance ledger entry (not stored as separate
- * ledger entries), so the whole instance is fetched and its storage map is
- * scanned for `keySymbol`.
+ * Read a contract's whole instance storage, keyed by the leading symbol of each
+ * `DataKey`. Instance storage is bundled inside the contract instance ledger
+ * entry (not stored as separate ledger entries), so every entry arrives in the
+ * one fetch — callers that need several fields should fetch once and index the
+ * result rather than fetching per field.
  */
 async function readInstanceStorage(
   chain: StellarChain,
   contractId: string,
-  keySymbol: string,
-): Promise<xdr.ScVal | undefined> {
+): Promise<Map<string, xdr.ScVal>> {
   const server = chain.getProvider();
   const entry = await server.getContractData(
     contractId,
@@ -492,11 +536,12 @@ async function readInstanceStorage(
     stellarRpc.Durability.Persistent,
   );
   const storage = entry.val.contractData().val().instance().storage() ?? [];
+  const values = new Map<string, xdr.ScVal>();
   for (const item of storage) {
     const key = scValToNative(item.key()) as unknown;
-    if (Array.isArray(key) && key[0] === keySymbol) {
-      return item.val();
+    if (Array.isArray(key) && typeof key[0] === "string") {
+      values.set(key[0], item.val());
     }
   }
-  return undefined;
+  return values;
 }

--- a/contract_manager/src/store/chains/StellarChains.json
+++ b/contract_manager/src/store/chains/StellarChains.json
@@ -7,5 +7,14 @@
     "rpcUrl": "https://soroban-testnet.stellar.org",
     "type": "StellarChain",
     "wormholeChainName": "stellar_testnet"
+  },
+  {
+    "horizonUrl": "https://horizon.stellar.org",
+    "id": "stellar_mainnet",
+    "mainnet": true,
+    "networkPassphrase": "Public Global Stellar Network ; September 2015",
+    "rpcUrl": "https://mainnet.sorobanrpc.com",
+    "type": "StellarChain",
+    "wormholeChainName": "stellar_mainnet"
   }
 ]

--- a/contract_manager/src/store/contracts/StellarExecutorContracts.json
+++ b/contract_manager/src/store/contracts/StellarExecutorContracts.json
@@ -3,5 +3,10 @@
     "address": "CA542YLVDLBQXTTS2FOERQAED2WE5DQRKLRZUUEG75DQ2TEX2525QNBG",
     "chain": "stellar_testnet",
     "type": "StellarExecutorContract"
+  },
+  {
+    "address": "CDBUGCAVCZIS7RQXYKQTACS32JZ7EOVDBXXNR3BW7AVAHGGMMGGYZY35",
+    "chain": "stellar_mainnet",
+    "type": "StellarExecutorContract"
   }
 ]

--- a/contract_manager/src/store/contracts/StellarLazerContracts.json
+++ b/contract_manager/src/store/contracts/StellarLazerContracts.json
@@ -3,5 +3,10 @@
     "address": "CAYFT5JE3UQTKT4Q6ZOZK4FXVYVT6RE3MFC7STA4UB6WAEGBT65MRU52",
     "chain": "stellar_testnet",
     "type": "StellarLazerContract"
+  },
+  {
+    "address": "CACZ3GBAKUPIAFRILUFO27J5RUH5GJ2VSJ46LP6GJYSKGDRTQ5MS3HCH",
+    "chain": "stellar_mainnet",
+    "type": "StellarLazerContract"
   }
 ]


### PR DESCRIPTION
Registers the Pyth Lazer Stellar **mainnet** deployment in contract_manager and adds the tooling that proves a deployed pair is configured correctly.

## Deployed contracts (mainnet)

| Contract | Address |
|---|---|
| `pyth-lazer-stellar` (verifier) | [`CACZ3GBAKUPIAFRILUFO27J5RUH5GJ2VSJ46LP6GJYSKGDRTQ5MS3HCH`](https://stellar.expert/explorer/public/contract/CACZ3GBAKUPIAFRILUFO27J5RUH5GJ2VSJ46LP6GJYSKGDRTQ5MS3HCH) |
| `wormhole-executor-stellar` (executor) | [`CDBUGCAVCZIS7RQXYKQTACS32JZ7EOVDBXXNR3BW7AVAHGGMMGGYZY35`](https://stellar.expert/explorer/public/contract/CDBUGCAVCZIS7RQXYKQTACS32JZ7EOVDBXXNR3BW7AVAHGGMMGGYZY35) |

Deployed with `pyth-lazer` `contracts/stellar/scripts/deploy.sh --network mainnet`, no governance overrides — the script's canonical Pyth-DAO defaults.

## Changes

- **`stellar_mainnet` chain** added to `StellarChains.json` (public network passphrase, `https://horizon.stellar.org`, `https://mainnet.sorobanrpc.com`). `stellar_mainnet: 60100` already exists in `xc_admin_common` `RECEIVER_CHAINS`, so registering the chain is all that is needed for contract_manager to address it.
- **Both deployed contracts registered** in `StellarExecutorContracts.json` / `StellarLazerContracts.json`.
- **`StellarExecutorContract.getConfig()`** reads the executor's five deploy-time governance constants (Pyth receiver chain id, owner emitter chain/address, guardian-set-upgrade emitter chain/address) out of instance storage. The executor exposes no view entry point for them, so they are read as ledger state.
- **`getChainId()` now returns the on-chain chain id** instead of echoing the registry value. `WormholeContract.getChainId()` is documented as "the chain id set in this contract", and every other implementation (EVM, Sui, Cosmwasm, Ton, ...) reads it from the contract; the Stellar one returned `chain.getWormholeChainId()`, so it could never disagree with the registry and was useless as a check.
- **`readInstanceStorage` now returns the whole instance storage map** instead of one entry. Instance storage arrives in a single ledger entry, so fetching per field would have made `getConfig()` issue five identical RPC round-trips.
- **New `verify-deployment` command** in `manage_stellar_lazer_contract.ts` diffs a deployed executor + verifier pair against the canonical Pyth-DAO configuration and exits non-zero on any mismatch. It compares against derived sources rather than restating constants: the governance emitter against `getMainnetVault().getEmitter()` (the DAO Squads authority PDA) as well as `getDefaultDeploymentConfig("stable")`, and the guardian set index and members against the live Wormhole mainnet set from the Wormhole API. The trusted signer set is reported rather than diffed — there is no off-chain constant for it, and `verify_update` against a live Lazer message is the real proof, since the contract only returns a payload when the update was signed by a trusted, unexpired signer.
- Stale doc fix: a comment in `test_stellar_lazer_contract.ts` said the deploy defaults to guardian set index 4; the current Wormhole mainnet set — and `deploy.sh`'s default — is index 7.

## Verification

`verify-deployment` against the live mainnet pair, reading real ledger state over Soroban RPC:

```
$ pnpm tsx scripts/manage_stellar_lazer_contract.ts verify-deployment \
    --executor stellar_mainnet_CDBUGCAVCZIS7RQXYKQTACS32JZ7EOVDBXXNR3BW7AVAHGGMMGGYZY35 \
    --verifier stellar_mainnet_CACZ3GBAKUPIAFRILUFO27J5RUH5GJ2VSJ46LP6GJYSKGDRTQ5MS3HCH

PASS  verifier authorizes the registered executor                      CDBUGCAV...GYZY35
PASS  Pyth receiver chain id (governance targets this exact id)        60100
PASS  governance (owner) emitter chain                                 1
PASS  governance (owner) emitter address                               5635979a...75b12e9e
PASS  governance emitter is the Wormhole emitter of DAO vault mainnet-beta_FVQyHcooAtThJ83XFrNnv74BcinbRH3bRmfFamAHBfuj
PASS  guardian-set-upgrade emitter chain                               1
PASS  guardian-set-upgrade emitter address (Wormhole core bridge)      00...04
PASS  guardian set index matches the live Wormhole mainnet set         7
PASS  guardian set members match the live Wormhole mainnet set         (19 addresses)
Trusted Lazer signers (1):
      03a4380f01136eb2640f90c17e1e319e02bbafbeef2e6e67dc48af53f9827e155b expires 2286-11-20T17:46:39.000Z (active)
PASS  verifier has at least one unexpired trusted Lazer signer

All 10 checks passed.
```

The same command against the canonical testnet pair also passes 10/10 (chain id reads 50140).

Trusted-signer authority was proven separately by verifying a real Lazer update on the deployed mainnet verifier — tx [`a9046d74...13cd7`](https://stellar.expert/explorer/public/tx/a9046d74141ae437bc42da46bf198ae3e9bf9a45809f6ae576307a1d1cb13cd7) (ledger 63893570), which returned a 28-byte payload with magic `0x93c7d375`, channel 3, feed id 1, price 6389849338399.

`biome check` clean on the changed files; `tsc --noEmit` clean for `tsconfig.build.json` (the two errors under `tsconfig.json` are pre-existing, in `scripts/deploy_solana_programs.ts` and `scripts/upgrade_evm_pricefeed_contracts.ts`, both untouched here).