### PR TITLE
fix(developer-hub): menu-surface Subscribe popover + per-type changelog feeds

### DIFF
--- a/apps/developer-hub/src/app/(docs)/[section]/page.tsx
+++ b/apps/developer-hub/src/app/(docs)/[section]/page.tsx
@@ -5,8 +5,10 @@ import { notFound } from "next/navigation";
 
 import {
   CHANGELOG_PRODUCTS,
+  CHANGELOG_TYPES,
   feedUrl,
   PRODUCT_LABELS,
+  TYPE_LABELS,
 } from "../../../lib/changelog";
 import { source } from "../../../lib/source";
 
@@ -41,7 +43,11 @@ export async function generateMetadata(props: {
           { title: "Pyth Changelog", url: feedUrl() },
           ...CHANGELOG_PRODUCTS.map((product) => ({
             title: `Pyth Changelog — ${PRODUCT_LABELS[product]}`,
-            url: feedUrl(product),
+            url: feedUrl({ product }),
+          })),
+          ...CHANGELOG_TYPES.map((type) => ({
+            title: `Pyth Changelog — ${TYPE_LABELS[type]}`,
+            url: feedUrl({ type }),
           })),
         ],
       },

--- a/apps/developer-hub/src/app/changelog/feed.xml/feed.test.ts
+++ b/apps/developer-hub/src/app/changelog/feed.xml/feed.test.ts
@@ -54,6 +54,19 @@ describe("buildFeedXml", () => {
     );
   });
 
+  it("escapes the & joining a multi-facet self URL", () => {
+    const xml = buildFeedXml(
+      {
+        ...channel,
+        self: "https://docs.pyth.network/changelog/feed.xml?product=pyth-pro&type=feature",
+      },
+      [item],
+    );
+    expect(xml).toContain(
+      '<atom:link href="https://docs.pyth.network/changelog/feed.xml?product=pyth-pro&amp;type=feature" rel="self" type="application/rss+xml"/>',
+    );
+  });
+
   it("renders a valid channel with no items", () => {
     const xml = buildFeedXml(channel, []);
     expect(xml).toContain("<channel>");

--- a/apps/developer-hub/src/app/changelog/feed.xml/feed.ts
+++ b/apps/developer-hub/src/app/changelog/feed.xml/feed.ts
@@ -30,7 +30,7 @@ export type RssChannel = {
   description: string;
   /** Human-facing page URL. */
   link: string;
-  /** Canonical self URL of this feed. */
+  /** Canonical self URL of this feed — escaped here, it carries a query. */
   self: string;
   /** RFC-822 date string. */
   lastBuildDate: string;
@@ -57,7 +57,7 @@ export const buildFeedXml = (channel: RssChannel, items: RssItem[]): string =>
     "<channel>",
     `<title>${escapeXml(channel.title)}</title>`,
     `<link>${channel.link}</link>`,
-    `<atom:link href="${channel.self}" rel="self" type="application/rss+xml"/>`,
+    `<atom:link href="${escapeXml(channel.self)}" rel="self" type="application/rss+xml"/>`,
     `<description>${escapeXml(channel.description)}</description>`,
     `<lastBuildDate>${channel.lastBuildDate}</lastBuildDate>`,
     items.map(renderItem).join("\n"),

--- a/apps/developer-hub/src/app/changelog/feed.xml/route.tsx
+++ b/apps/developer-hub/src/app/changelog/feed.xml/route.tsx
@@ -5,9 +5,11 @@ import {
   AREA_LABELS,
   CHANGELOG_PATH,
   CHANGELOG_PRODUCTS,
+  CHANGELOG_TYPES,
   feedUrl,
   PRODUCT_LABELS,
   parseProductParam,
+  parseTypeParam,
   SITE,
   TYPE_LABELS,
 } from "../../../lib/changelog";
@@ -15,7 +17,7 @@ import { getChangelogEntries } from "../../../lib/changelog-data";
 import type { RssItem } from "./feed";
 import { buildFeedXml } from "./feed";
 
-const DESCRIPTION = "Product updates across Pyth Pro, Pyth Core, and Entropy.";
+const ALL_PRODUCTS = "across Pyth Pro, Pyth Core, and Entropy";
 
 // Minimal, fully server-renderable component map for RSS content. Fumadocs'
 // getMDXComponents() pulls in *client* components (CodeBlock, Tabs, Link, …)
@@ -46,9 +48,10 @@ const rssComponents: MDXComponents = {
 };
 
 // RSS 2.0 feed for the cross-product changelog. `/changelog/feed.xml` covers
-// all products; `?product=pyth-pro|pyth-core|entropy` narrows it — this is
-// what the Subscribe menu links to. Serialization lives in ./feed; this
-// handler only validates the param, renders bodies, and assembles the items.
+// everything; `?product=pyth-pro|pyth-core|entropy` and
+// `?type=feature|fix|breaking-change|deprecation|docs` narrow it, and combine
+// — this is what the Subscribe menu links to. Serialization lives in ./feed;
+// this handler only validates the params, renders bodies, and assembles items.
 export const GET = async (request: Request): Promise<Response> => {
   // Loaded dynamically: Next.js rejects a static `react-dom/server` import
   // anywhere in the app module graph, but a route handler is a plain Node
@@ -56,36 +59,49 @@ export const GET = async (request: Request): Promise<Response> => {
   // renderToStaticMarkup is for.
   const { renderToStaticMarkup } = await import("react-dom/server");
 
-  const parsed = parseProductParam(
-    new URL(request.url).searchParams.get("product"),
-  );
-  if (!parsed.ok) {
+  const params = new URL(request.url).searchParams;
+  const parsedProduct = parseProductParam(params.get("product"));
+  if (!parsedProduct.ok) {
     return new Response(
-      `Unknown product "${parsed.value}". Expected one of: ${CHANGELOG_PRODUCTS.join(", ")}.`,
+      `Unknown product "${parsedProduct.value}". Expected one of: ${CHANGELOG_PRODUCTS.join(", ")}.`,
       { headers: { "Content-Type": "text/plain" }, status: 400 },
     );
   }
-  const { product } = parsed;
+  const parsedType = parseTypeParam(params.get("type"));
+  if (!parsedType.ok) {
+    return new Response(
+      `Unknown type "${parsedType.value}". Expected one of: ${CHANGELOG_TYPES.join(", ")}.`,
+      { headers: { "Content-Type": "text/plain" }, status: 400 },
+    );
+  }
+  const product = parsedProduct.value;
+  const type = parsedType.value;
 
   const entries = getChangelogEntries().filter(
-    (entry) => product === null || entry.product === product,
+    (entry) =>
+      (product === null || entry.product === product) &&
+      (type === null || entry.type === type),
   );
 
   const latest = entries[0]?.date;
+  const kind = type === null ? "Product updates" : `${TYPE_LABELS[type]} updates`;
+  const scope =
+    product === null ? ALL_PRODUCTS : `for ${PRODUCT_LABELS[product]}`;
+  const narrowing = [
+    product === null ? undefined : PRODUCT_LABELS[product],
+    type === null ? undefined : TYPE_LABELS[type],
+  ].filter((label) => label !== undefined);
   const channel = {
-    description:
-      product === null
-        ? DESCRIPTION
-        : `Product updates for ${PRODUCT_LABELS[product]}.`,
+    description: `${kind} ${scope}.`,
     lastBuildDate: latest
       ? new Date(`${latest}T00:00:00Z`).toUTCString()
       : new Date().toUTCString(),
     link: `${SITE}${CHANGELOG_PATH}`,
-    self: `${SITE}${feedUrl(product ?? undefined)}`,
+    self: `${SITE}${feedUrl({ product: product ?? undefined, type: type ?? undefined })}`,
     title:
-      product === null
+      narrowing.length === 0
         ? "Pyth Changelog"
-        : `Pyth Changelog — ${PRODUCT_LABELS[product]}`,
+        : `Pyth Changelog — ${narrowing.join(", ")}`,
   };
 
   const items: RssItem[] = entries.map((entry) => {

--- a/apps/developer-hub/src/components/ChangeLogHub/SubscribeMenu.tsx
+++ b/apps/developer-hub/src/components/ChangeLogHub/SubscribeMenu.tsx
@@ -4,35 +4,52 @@ import { RssSimple } from "@phosphor-icons/react/dist/ssr";
 import { Button } from "@pythnetwork/component-library/Button";
 import { Popover } from "@pythnetwork/component-library/Popover";
 
-import { feedUrl } from "../../lib/changelog";
+import {
+  CHANGELOG_PRODUCTS,
+  CHANGELOG_TYPES,
+  feedUrl,
+  PRODUCT_LABELS,
+  TYPE_LABELS,
+} from "../../lib/changelog";
 import styles from "./index.module.scss";
 
-const FEEDS: { label: string; href: string }[] = [
-  { href: feedUrl(), label: "All products" },
-  { href: feedUrl("pyth-pro"), label: "Pyth Pro" },
-  { href: feedUrl("pyth-core"), label: "Pyth Core" },
-  { href: feedUrl("entropy"), label: "Entropy" },
+type Feed = { label: string; href: string };
+
+const PRODUCT_FEEDS: Feed[] = [
+  { href: feedUrl(), label: "All updates" },
+  ...CHANGELOG_PRODUCTS.map((product) => ({
+    href: feedUrl({ product }),
+    label: PRODUCT_LABELS[product],
+  })),
 ];
 
-// Solid violet primary (Lazer `cta`-style) Subscribe, opening a Popover of
-// per-product RSS feeds.
+const TYPE_FEEDS: Feed[] = CHANGELOG_TYPES.map((type) => ({
+  href: feedUrl({ type }),
+  label: TYPE_LABELS[type],
+}));
+
+const FeedGroup = ({ feeds, heading }: { feeds: Feed[]; heading: string }) => (
+  <div aria-label={heading} className={styles.subscribeGroup} role="group">
+    <span className={styles.subscribeHeading}>{heading}</span>
+    {feeds.map(({ label, href }) => (
+      <a className={styles.subscribeItem} href={href} key={href}>
+        {label}
+        <span className={styles.feedTag}>RSS</span>
+      </a>
+    ))}
+  </div>
+);
+
+// Solid violet primary (Lazer `cta`-style) Subscribe, opening a Popover of RSS
+// feeds narrowed by product or by change type.
 export const SubscribeMenu = () => (
   <div className={styles.subscribe}>
     <Popover
       dialogProps={{ "aria-label": "RSS feeds" }}
       popoverContents={
-        <div
-          aria-label="RSS feeds"
-          className={styles.subscribeMenu}
-          role="group"
-        >
-          <span className={styles.subscribeHeading}>RSS feeds</span>
-          {FEEDS.map(({ label, href }) => (
-            <a className={styles.subscribeItem} href={href} key={href}>
-              {label}
-              <span className={styles.feedTag}>RSS</span>
-            </a>
-          ))}
+        <div className={styles.subscribeMenu}>
+          <FeedGroup feeds={PRODUCT_FEEDS} heading="By product" />
+          <FeedGroup feeds={TYPE_FEEDS} heading="By type" />
         </div>
       }
       variant="menu"

--- a/apps/developer-hub/src/components/ChangeLogHub/SubscribeMenu.tsx
+++ b/apps/developer-hub/src/components/ChangeLogHub/SubscribeMenu.tsx
@@ -35,6 +35,7 @@ export const SubscribeMenu = () => (
           ))}
         </div>
       }
+      variant="menu"
     >
       <Button
         beforeIcon={<RssSimple weight="bold" />}

--- a/apps/developer-hub/src/components/ChangeLogHub/index.module.scss
+++ b/apps/developer-hub/src/components/ChangeLogHub/index.module.scss
@@ -58,6 +58,17 @@
   min-width: 12rem;
 }
 
+.subscribeGroup {
+  display: flex;
+  flex-direction: column;
+
+  & + & {
+    padding-top: theme.spacing(1);
+    margin-top: theme.spacing(1);
+    border-top: 1px solid theme.color("border");
+  }
+}
+
 .subscribeHeading {
   padding: theme.spacing(1) theme.spacing(2);
   font-size: theme.font-size("xxs");

--- a/apps/developer-hub/src/lib/changelog.test.ts
+++ b/apps/developer-hub/src/lib/changelog.test.ts
@@ -6,8 +6,10 @@ import {
   filterEntries,
   fmtEntryDate,
   isChangelogProduct,
+  isChangelogType,
   matchesFilters,
   parseProductParam,
+  parseTypeParam,
   relativeDate,
   resolveDeepLink,
   slugFromPath,
@@ -80,9 +82,24 @@ describe("filterEntries", () => {
 });
 
 describe("feedUrl", () => {
-  it("builds the all-products and per-product feed URLs", () => {
+  it("builds the unfiltered feed URL when given no facets", () => {
     expect(feedUrl()).toBe("/changelog/feed.xml");
-    expect(feedUrl("pyth-pro")).toBe("/changelog/feed.xml?product=pyth-pro");
+    expect(feedUrl({})).toBe("/changelog/feed.xml");
+  });
+
+  it("narrows on a single facet", () => {
+    expect(feedUrl({ product: "pyth-pro" })).toBe(
+      "/changelog/feed.xml?product=pyth-pro",
+    );
+    expect(feedUrl({ type: "breaking-change" })).toBe(
+      "/changelog/feed.xml?type=breaking-change",
+    );
+  });
+
+  it("combines both facets, product first", () => {
+    expect(feedUrl({ product: "entropy", type: "feature" })).toBe(
+      "/changelog/feed.xml?product=entropy&type=feature",
+    );
   });
 });
 
@@ -126,21 +143,59 @@ describe("isChangelogProduct", () => {
   });
 });
 
+describe("isChangelogType", () => {
+  it("narrows only recognised type ids", () => {
+    expect(isChangelogType("feature")).toBe(true);
+    expect(isChangelogType("breaking-change")).toBe(true);
+    expect(isChangelogType("pyth-pro")).toBe(false);
+    expect(isChangelogType("")).toBe(false);
+  });
+});
+
 describe("parseProductParam", () => {
   it("treats absent or empty as the all-products feed", () => {
-    expect(parseProductParam(null)).toEqual({ ok: true, product: null });
-    expect(parseProductParam("")).toEqual({ ok: true, product: null });
+    expect(parseProductParam(null)).toEqual({ ok: true, value: null });
+    expect(parseProductParam("")).toEqual({ ok: true, value: null });
   });
 
   it("narrows a recognised value to that product", () => {
     expect(parseProductParam("pyth-core")).toEqual({
       ok: true,
-      product: "pyth-core",
+      value: "pyth-core",
     });
   });
 
   it("reports an unrecognised value as unknown", () => {
     expect(parseProductParam("bogus")).toEqual({ ok: false, value: "bogus" });
+  });
+
+  it("does not accept a type id", () => {
+    expect(parseProductParam("feature")).toEqual({
+      ok: false,
+      value: "feature",
+    });
+  });
+});
+
+describe("parseTypeParam", () => {
+  it("treats absent or empty as the all-types feed", () => {
+    expect(parseTypeParam(null)).toEqual({ ok: true, value: null });
+    expect(parseTypeParam("")).toEqual({ ok: true, value: null });
+  });
+
+  it("narrows a recognised value to that type", () => {
+    expect(parseTypeParam("breaking-change")).toEqual({
+      ok: true,
+      value: "breaking-change",
+    });
+  });
+
+  it("reports an unrecognised value as unknown", () => {
+    expect(parseTypeParam("bogus")).toEqual({ ok: false, value: "bogus" });
+  });
+
+  it("does not accept a product id", () => {
+    expect(parseTypeParam("entropy")).toEqual({ ok: false, value: "entropy" });
   });
 });
 

--- a/apps/developer-hub/src/lib/changelog.ts
+++ b/apps/developer-hub/src/lib/changelog.ts
@@ -132,34 +132,59 @@ export const CHANGELOG_PATH = "/changelog";
 // docs site regardless of where the copy happens.
 export const SITE = "https://docs.pyth.network";
 
-// RSS feed URLs. No `product` → the all-products feed.
-export const feedUrl = (product?: ChangelogProduct): string =>
-  product === undefined
-    ? `${CHANGELOG_PATH}/feed.xml`
-    : `${CHANGELOG_PATH}/feed.xml?product=${product}`;
+// A feed's narrowing facets. An omitted facet widens the feed: no `product`
+// covers every product, no `type` every change type.
+export type FeedFacets = {
+  product?: ChangelogProduct | undefined;
+  type?: ChangelogType | undefined;
+};
 
-// ─── Product parsing ─────────────────────────────────────────────────────
+// RSS feed URLs. No facets → the firehose feed.
+export const feedUrl = ({ product, type }: FeedFacets = {}): string => {
+  const query = new URLSearchParams([
+    ...(product === undefined ? [] : [["product", product]]),
+    ...(type === undefined ? [] : [["type", type]]),
+  ]).toString();
+  return `${CHANGELOG_PATH}/feed.xml${query === "" ? "" : `?${query}`}`;
+};
+
+// ─── Facet parsing ───────────────────────────────────────────────────────
 
 export const isChangelogProduct = (value: string): value is ChangelogProduct =>
   (CHANGELOG_PRODUCTS as readonly string[]).includes(value);
 
-// Parse the RSS `?product=` query param: an absent or empty value means the
-// all-products feed, a recognised value narrows to that product, and anything
-// else is reported as unknown so the caller can reject it.
-export const parseProductParam = (
+export const isChangelogType = (value: string): value is ChangelogType =>
+  (CHANGELOG_TYPES as readonly string[]).includes(value);
+
+export type ParsedFacetParam<T> =
+  | { ok: true; value: T | null }
+  | { ok: false; value: string };
+
+// Parse one RSS narrowing query param: an absent or empty value means "don't
+// narrow on this facet", a recognised value narrows to it, and anything else
+// is reported as unknown so the caller can reject it.
+const parseFacetParam = <T extends string>(
   raw: string | null,
-):
-  | { ok: true; product: ChangelogProduct | null }
-  | { ok: false; value: string } => {
+  isValid: (value: string) => value is T,
+): ParsedFacetParam<T> => {
   const value = raw ?? "";
   if (value === "") {
-    return { ok: true, product: null };
+    return { ok: true, value: null };
   }
-  if (isChangelogProduct(value)) {
-    return { ok: true, product: value };
+  if (isValid(value)) {
+    return { ok: true, value };
   }
   return { ok: false, value };
 };
+
+export const parseProductParam = (
+  raw: string | null,
+): ParsedFacetParam<ChangelogProduct> =>
+  parseFacetParam(raw, isChangelogProduct);
+
+export const parseTypeParam = (
+  raw: string | null,
+): ParsedFacetParam<ChangelogType> => parseFacetParam(raw, isChangelogType);
 
 // ─── Display helpers ─────────────────────────────────────────────────────
 

--- a/packages/component-library/css-module-mock.cjs
+++ b/packages/component-library/css-module-mock.cjs
@@ -1,0 +1,8 @@
+// Jest doesn't compile CSS modules, so hand back each requested key as its own
+// class name. That lets component tests assert on which classes get applied.
+module.exports = new Proxy(
+  {},
+  {
+    get: (_target, key) => (key === "__esModule" ? false : key),
+  },
+);

--- a/packages/component-library/jest.config.js
+++ b/packages/component-library/jest.config.js
@@ -1,3 +1,7 @@
 import { defineJestConfigForNextJs } from "@pythnetwork/jest-config/define-next-config";
 
-export default defineJestConfigForNextJs();
+export default defineJestConfigForNextJs({
+  moduleNameMapper: {
+    "\\.module\\.scss$": "<rootDir>/css-module-mock.cjs",
+  },
+});

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -216,6 +216,10 @@
       "default": "./dist/Popover/index.mjs",
       "types": "./dist/Popover/index.d.ts"
     },
+    "./Popover/popover.test": {
+      "default": "./dist/Popover/popover.test.mjs",
+      "types": "./dist/Popover/popover.test.d.ts"
+    },
     "./package.json": "./package.json",
     "./SearchButton": {
       "default": "./dist/SearchButton/index.mjs",

--- a/packages/component-library/src/Popover/index.module.scss
+++ b/packages/component-library/src/Popover/index.module.scss
@@ -14,6 +14,10 @@
     background-color: theme.color("background", "modal");
     border: 1px solid theme.color("border");
     color: theme.color("paragraph");
+
+    // Matches the gutter `Select` puts around its listbox, so menu rows sit
+    // close to the panel edge instead of floating in a tooltip-sized inset.
+    padding: theme.spacing(1);
   }
 
   &[data-placement="bottom"] {

--- a/packages/component-library/src/Popover/index.module.scss
+++ b/packages/component-library/src/Popover/index.module.scss
@@ -10,6 +10,12 @@
   overflow-y: auto;
   padding: theme.spacing(4);
 
+  &.menu {
+    background-color: theme.color("background", "modal");
+    border: 1px solid theme.color("border");
+    color: theme.color("paragraph");
+  }
+
   &[data-placement="bottom"] {
     margin-top: theme.spacing(2);
   }

--- a/packages/component-library/src/Popover/index.tsx
+++ b/packages/component-library/src/Popover/index.tsx
@@ -28,6 +28,13 @@ export type PopoverProps = PropsWithChildren &
      * Additional options to apply directly to the popover
      */
     popoverProps?: AriaPopoverProps;
+
+    /**
+     * The surface to render the popover on; `tooltip` is an inverted chip for
+     * short bits of transient content, `menu` is a regular elevated surface for
+     * menus and lists.
+     */
+    variant?: "tooltip" | "menu";
   };
 
 export function Popover({
@@ -35,6 +42,7 @@ export function Popover({
   dialogProps,
   popoverContents,
   popoverProps,
+  variant = "tooltip",
   ...rest
 }: PopoverProps) {
   const { className, placement, ...popoverRest } = popoverProps ?? {};
@@ -44,7 +52,11 @@ export function Popover({
       {children}
       <AriaPopover
         {...popoverRest}
-        className={cx(classes.popoverRoot, className)}
+        className={cx(
+          classes.popoverRoot,
+          variant === "menu" && classes.menu,
+          className,
+        )}
         placement={placement ?? "bottom"}
       >
         <Dialog {...dialogProps}>{popoverContents}</Dialog>

--- a/packages/component-library/src/Popover/popover.test.tsx
+++ b/packages/component-library/src/Popover/popover.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { Button } from "react-aria-components";
+
+import { Popover } from ".";
+import styles from "./index.module.scss";
+
+const classes = styles as { menu: string; popoverRoot: string };
+
+const renderPopover = (popover: ReactElement) => {
+  render(popover);
+
+  const root = screen.getByRole("dialog").closest(`.${classes.popoverRoot}`);
+
+  if (root === null) {
+    throw new Error("popover root not found");
+  }
+
+  return root;
+};
+
+describe("<Popover /> tests", () => {
+  it("should render on the tooltip surface by default", () => {
+    const root = renderPopover(
+      <Popover defaultOpen popoverContents="contents">
+        <Button>open</Button>
+      </Popover>,
+    );
+
+    expect(root.classList.contains(classes.menu)).toBe(false);
+  });
+
+  it("should render on the menu surface when the menu variant is selected", () => {
+    const root = renderPopover(
+      <Popover defaultOpen popoverContents="contents" variant="menu">
+        <Button>open</Button>
+      </Popover>,
+    );
+
+    expect(root.classList.contains(classes.menu)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Subscribe dropdown colors

`SubscribeMenu` rendered its contents inside the shared `Popover`, which paints an **inverted tooltip chip** — `background/tooltip` (steel-700 light / steel-200 dark) with `tooltip` foreground. The menu contents were styled for a *normal* surface, so the two fought each other: item text came out at ~1.2:1 against the panel in light mode, and the same inverted in dark.

`Popover` now takes `variant?: "tooltip" | "menu"`, defaulting to `tooltip` (unchanged). The `menu` variant uses `background/modal` + `border` + `paragraph` and a `spacing(1)` gutter — the same tokens and inset `Select`'s dropdown already uses. `SubscribeMenu` passes `variant="menu"`; the only other `Popover` caller (the insights mobile tools menu) passes nothing and is untouched.

## Subscribing to specific change types

The Subscribe menu only offered per-product feeds, so a reader who cares about breaking changes across every product had no feed to subscribe to.

- `/changelog/feed.xml` now accepts `?type=feature|fix|breaking-change|deprecation|docs` alongside the existing `?product=`, and the two **combine** (`?product=pyth-pro&type=feature`). An unknown value on either param is a 400 naming the allowed set, as before.
- `feedUrl` takes a facets object (`feedUrl({ product, type })`) instead of a positional product; the two param parsers now share one validator, so `parseProductParam`/`parseTypeParam` return `{ ok, value }` rather than a facet-specific field name.
- The Subscribe popover splits into a **By product** group (All updates, Pyth Pro, Pyth Core, Entropy) and a **By type** group (Feature, Fix, Breaking Change, Deprecation, Docs), separated by a hairline in the `border` token. Both lists are derived from `CHANGELOG_PRODUCTS` / `CHANGELOG_TYPES`, so a new facet shows up automatically.
- The changelog page advertises the type feeds via `rel="alternate"` the same way it already advertised the product feeds.

### Incidental fix

`buildFeedXml` interpolated the channel's `self` URL into the `atom:link` href unescaped. That was harmless while feed URLs had at most one query param, but a two-facet URL puts a raw `&` in an XML attribute and made the feed unparseable. It is escaped now, with a regression test.

## Verification

`pnpm turbo run test:types test:lint test:lint:stylelint test:format test:unit --filter=@pythnetwork/developer-hub --filter=@pythnetwork/component-library` → 50/50 tasks successful.

Every feed variant was fetched from a running dev server and parsed with a real XML parser (all well-formed), with the item set, channel title, description, and self URL checked against the four seeded entries.