### PR TITLE
fix(contract_manager): bid a competitive Stellar inclusion fee on mainnet

### DIFF
--- a/contract_manager/src/core/chains.ts
+++ b/contract_manager/src/core/chains.ts
@@ -2491,6 +2491,9 @@ export class NearChain extends Chain {
   }
 }
 
+/** Inclusion bid on Stellar mainnet, in stroops (0.1 XLM). */
+const STELLAR_MAINNET_INCLUSION_FEE = "1000000";
+
 export class StellarChain extends Chain {
   static override type = "StellarChain";
 
@@ -2545,6 +2548,19 @@ export class StellarChain extends Chain {
     return new stellarRpc.Server(this.rpcUrl, {
       allowHttp: this.rpcUrl.startsWith("http://"),
     });
+  }
+
+  /**
+   * The inclusion bid to build transactions on this chain with, in stroops.
+   *
+   * `prepareTransaction` adds the Soroban resource fee on top of this but never
+   * raises the bid itself, and mainnet ledgers routinely run near capacity, so a
+   * `BASE_FEE` bid gets outbid and the transaction expires without ever reaching
+   * a ledger. Surge pricing charges the market-clearing rate rather than the
+   * bid, so bidding high costs nothing extra on an uncongested ledger.
+   */
+  getInclusionFee(): string {
+    return this.isMainnet() ? STELLAR_MAINNET_INCLUSION_FEE : BASE_FEE;
   }
 
   /**
@@ -2603,7 +2619,7 @@ export class StellarChain extends Chain {
     const account = await server.getAccount(keypair.publicKey());
 
     const tx = new StellarTransactionBuilder(account, {
-      fee: BASE_FEE,
+      fee: this.getInclusionFee(),
       networkPassphrase: this.networkPassphrase,
     })
       .addOperation(StellarOperation.uploadContractWasm({ wasm }))

--- a/contract_manager/src/core/chains.ts
+++ b/contract_manager/src/core/chains.ts
@@ -2494,6 +2494,16 @@ export class NearChain extends Chain {
 /** Inclusion bid on Stellar mainnet, in stroops (0.1 XLM). */
 const STELLAR_MAINNET_INCLUSION_FEE = "1000000";
 
+/** How long a submitted Stellar transaction stays eligible for inclusion, in seconds. */
+export const STELLAR_TX_VALIDITY_SECONDS = 30;
+
+/**
+ * One-second poll attempts to wait for a submitted Stellar transaction. Set past
+ * {@link STELLAR_TX_VALIDITY_SECONDS} so that a still-unknown transaction is
+ * known to have expired rather than merely being slow to index.
+ */
+const STELLAR_TX_POLL_ATTEMPTS = 40;
+
 export class StellarChain extends Chain {
   static override type = "StellarChain";
 
@@ -2564,6 +2574,41 @@ export class StellarChain extends Chain {
   }
 
   /**
+   * Wait for a submitted transaction to land, distinguishing the two ways it can
+   * fail to: one still unknown to the RPC past its validity window was dropped
+   * before reaching a ledger, so nothing executed and it is safe to resubmit,
+   * whereas any other non-success status did execute and failed.
+   *
+   * @param hash - hash returned by `sendTransaction`
+   * @param description - what the transaction does, for error messages
+   */
+  async waitForTransaction(
+    hash: string,
+    description: string,
+  ): Promise<stellarRpc.Api.GetSuccessfulTransactionResponse> {
+    const result = await this.getProvider().pollTransaction(hash, {
+      attempts: STELLAR_TX_POLL_ATTEMPTS,
+    });
+
+    if (result.status === stellarRpc.Api.GetTransactionStatus.NOT_FOUND) {
+      throw new Error(
+        `${description} transaction ${hash} was still unknown to the RPC ` +
+          `${STELLAR_TX_POLL_ATTEMPTS}s after submission, past its ` +
+          `${STELLAR_TX_VALIDITY_SECONDS}s validity window: it was dropped before ` +
+          `reaching a ledger, so nothing executed and no fee was charged. This ` +
+          `usually means the ledger was full and the inclusion bid of ` +
+          `${this.getInclusionFee()} stroops was outbid; it is safe to resubmit.`,
+      );
+    }
+
+    if (result.status !== stellarRpc.Api.GetTransactionStatus.SUCCESS) {
+      throw new Error(`${description} transaction ${hash} failed`);
+    }
+
+    return result;
+  }
+
+  /**
    * Stellar contract upgrades are governance actions dispatched through the
    * wormhole executor, which needs the executor and target contract ids. Build
    * them with the per-contract methods instead.
@@ -2623,7 +2668,7 @@ export class StellarChain extends Chain {
       networkPassphrase: this.networkPassphrase,
     })
       .addOperation(StellarOperation.uploadContractWasm({ wasm }))
-      .setTimeout(30)
+      .setTimeout(STELLAR_TX_VALIDITY_SECONDS)
       .build();
 
     const prepared = await server.prepareTransaction(tx);
@@ -2635,10 +2680,7 @@ export class StellarChain extends Chain {
         `Failed to upload WASM: ${JSON.stringify(sent.errorResult)}`,
       );
     }
-    const result = await server.pollTransaction(sent.hash);
-    if (result.status !== stellarRpc.Api.GetTransactionStatus.SUCCESS) {
-      throw new Error(`WASM upload transaction ${sent.hash} failed`);
-    }
+    await this.waitForTransaction(sent.hash, "WASM upload");
 
     return createHash("sha256").update(wasm).digest("hex");
   }

--- a/contract_manager/src/core/contracts/stellar.ts
+++ b/contract_manager/src/core/contracts/stellar.ts
@@ -3,7 +3,6 @@ import {
   UpgradeStellarExecutor,
 } from "@pythnetwork/xc-admin-common";
 import {
-  BASE_FEE,
   Contract,
   nativeToScVal,
   Keypair as StellarKeypair,
@@ -13,7 +12,6 @@ import {
   xdr,
 } from "@stellar/stellar-sdk";
 
-import { sleep } from "../../utils/sleep";
 import type { PrivateKey, TxResult } from "../base";
 import { Storable } from "../base";
 import type { Chain } from "../chains";
@@ -36,6 +34,16 @@ import { WormholeContract } from "./wormhole";
  * PTGM `Call` is submitted to `execute_governance_action`, which invokes the
  * named function on the verifier.
  */
+
+/** How long a submitted transaction stays eligible for inclusion, in seconds. */
+const TX_VALIDITY_SECONDS = 30;
+
+/**
+ * One-second poll attempts to wait for a submitted transaction. Set past
+ * {@link TX_VALIDITY_SECONDS} so that a still-unknown transaction is known to
+ * have expired rather than merely being slow to index.
+ */
+const TX_POLL_ATTEMPTS = 40;
 
 /**
  * The Lazer **verifier** (`pyth-lazer-stellar`).
@@ -348,12 +356,13 @@ export class StellarExecutorContract extends WormholeContract {
     const account = await server.getAccount(keypair.publicKey());
     const executor = new Contract(this.address);
 
+    const fee = this.chain.getInclusionFee();
     const tx = new TransactionBuilder(account, {
-      fee: BASE_FEE,
+      fee,
       networkPassphrase: this.chain.networkPassphrase,
     })
       .addOperation(executor.call(method, xdr.ScVal.scvBytes(vaa)))
-      .setTimeout(30)
+      .setTimeout(TX_VALIDITY_SECONDS)
       .build();
 
     const prepared = await server.prepareTransaction(tx);
@@ -366,10 +375,18 @@ export class StellarExecutorContract extends WormholeContract {
       );
     }
 
-    let result = await server.getTransaction(sent.hash);
-    while (result.status === stellarRpc.Api.GetTransactionStatus.NOT_FOUND) {
-      await sleep(1000);
-      result = await server.getTransaction(sent.hash);
+    const result = await server.pollTransaction(sent.hash, {
+      attempts: TX_POLL_ATTEMPTS,
+    });
+
+    if (result.status === stellarRpc.Api.GetTransactionStatus.NOT_FOUND) {
+      throw new Error(
+        `${method} transaction ${sent.hash} was still unknown to the RPC ` +
+          `${TX_POLL_ATTEMPTS}s after submission, past its ${TX_VALIDITY_SECONDS}s ` +
+          `validity window: it was dropped before reaching a ledger, so nothing ` +
+          `executed and no fee was charged. This usually means the ledger was full ` +
+          `and the inclusion bid of ${fee} stroops was outbid; it is safe to resubmit.`,
+      );
     }
 
     if (result.status !== stellarRpc.Api.GetTransactionStatus.SUCCESS) {

--- a/contract_manager/src/core/contracts/stellar.ts
+++ b/contract_manager/src/core/contracts/stellar.ts
@@ -15,7 +15,7 @@ import {
 import type { PrivateKey, TxResult } from "../base";
 import { Storable } from "../base";
 import type { Chain } from "../chains";
-import { StellarChain } from "../chains";
+import { STELLAR_TX_VALIDITY_SECONDS, StellarChain } from "../chains";
 import { WormholeContract } from "./wormhole";
 
 /**
@@ -34,16 +34,6 @@ import { WormholeContract } from "./wormhole";
  * PTGM `Call` is submitted to `execute_governance_action`, which invokes the
  * named function on the verifier.
  */
-
-/** How long a submitted transaction stays eligible for inclusion, in seconds. */
-const TX_VALIDITY_SECONDS = 30;
-
-/**
- * One-second poll attempts to wait for a submitted transaction. Set past
- * {@link TX_VALIDITY_SECONDS} so that a still-unknown transaction is known to
- * have expired rather than merely being slow to index.
- */
-const TX_POLL_ATTEMPTS = 40;
 
 /**
  * The Lazer **verifier** (`pyth-lazer-stellar`).
@@ -356,13 +346,12 @@ export class StellarExecutorContract extends WormholeContract {
     const account = await server.getAccount(keypair.publicKey());
     const executor = new Contract(this.address);
 
-    const fee = this.chain.getInclusionFee();
     const tx = new TransactionBuilder(account, {
-      fee,
+      fee: this.chain.getInclusionFee(),
       networkPassphrase: this.chain.networkPassphrase,
     })
       .addOperation(executor.call(method, xdr.ScVal.scvBytes(vaa)))
-      .setTimeout(TX_VALIDITY_SECONDS)
+      .setTimeout(STELLAR_TX_VALIDITY_SECONDS)
       .build();
 
     const prepared = await server.prepareTransaction(tx);
@@ -375,23 +364,7 @@ export class StellarExecutorContract extends WormholeContract {
       );
     }
 
-    const result = await server.pollTransaction(sent.hash, {
-      attempts: TX_POLL_ATTEMPTS,
-    });
-
-    if (result.status === stellarRpc.Api.GetTransactionStatus.NOT_FOUND) {
-      throw new Error(
-        `${method} transaction ${sent.hash} was still unknown to the RPC ` +
-          `${TX_POLL_ATTEMPTS}s after submission, past its ${TX_VALIDITY_SECONDS}s ` +
-          `validity window: it was dropped before reaching a ledger, so nothing ` +
-          `executed and no fee was charged. This usually means the ledger was full ` +
-          `and the inclusion bid of ${fee} stroops was outbid; it is safe to resubmit.`,
-      );
-    }
-
-    if (result.status !== stellarRpc.Api.GetTransactionStatus.SUCCESS) {
-      throw new Error(`${method} transaction ${sent.hash} failed`);
-    }
+    const result = await this.chain.waitForTransaction(sent.hash, method);
 
     return { id: sent.hash, info: result };
   }


### PR DESCRIPTION
`StellarExecutorContract.submitVaa` — the path that submits Pyth DAO governance VAAs to the Stellar executor — built its transaction with `fee: BASE_FEE` (100 stroops). That is the *inclusion* bid, and `prepareTransaction` only adds the Soroban resource fee on top; it never raises the bid. Mainnet ledgers routinely run near capacity, so the transaction is outbid and evicted: `sendTransaction` returns `PENDING`, the transaction expires, nothing executes and no fee is charged. This was observed for real during the Stellar mainnet Lazer deployment, where two `verify_update` submissions and one WASM upload were dropped this way before one landed.

## Competitive inclusion bid

`StellarChain.getInclusionFee()` returns 1,000,000 stroops (0.1 XLM) on mainnet and `BASE_FEE` on testnet. Stellar's surge pricing charges the market-clearing rate rather than the bid, so bidding high costs nothing extra on an uncongested ledger — a mainnet upload prepared during verification bid 1,000,000 and would have been *charged* far less.

Both Stellar transaction builders in `contract_manager` use it: `submitVaa` and `StellarChain.uploadContractWasm`. The upload path is the one that dropped the deploy during the mainnet rollout, so leaving it on `BASE_FEE` would have left the same bug in place.

This mirrors the fix already made to the Lazer Stellar e2e verifier in `pyth-network/pyth-lazer` (PR #3148).

## Dropped transactions are now reported as dropped

`submitVaa` polled `getTransaction` in an unbounded `while NOT_FOUND` loop, so an evicted transaction hung the caller forever, and `uploadContractWasm` used the SDK-default `pollTransaction` window and reported the same situation as `WASM upload transaction <hash> failed` — which reads as "it executed and failed" when in fact nothing ran.

Both now go through `StellarChain.waitForTransaction(hash, description)`, which polls for 40 seconds — past the transaction's own 30-second validity window, so a still-unknown transaction has provably expired rather than merely being slow to index — and throws:

> `execute_governance_action transaction <hash> was still unknown to the RPC 40s after submission, past its 30s validity window: it was dropped before reaching a ledger, so nothing executed and no fee was charged. This usually means the ledger was full and the inclusion bid of 1000000 stroops was outbid; it is safe to resubmit.`

Any other non-success status keeps the old `<description> transaction <hash> failed`. The 30-second timeout was already there as a bare `setTimeout(30)`; it is now the named `STELLAR_TX_VALIDITY_SECONDS` that the poll window is derived from, shared by both builders.

## Verification

Exercised against the live Stellar testnet and mainnet deployments — full command output, transaction hashes and fee arithmetic are in the issue thread. Highlights:

- **Testnet, real submitted transaction** through the changed `uploadContractWasm`, waited on by the shared `waitForTransaction`: tx [`c02fe4cc…9691b8`](https://stellar.expert/explorer/testnet/tx/c02fe4ccef133414f789c2a2ff5324fed151d8a58ae7a41ad6c9078ea19691b8), successful in ledger 4093231, `attempts=40` poll returned `SUCCESS` after 5.1s. An earlier revision landed [`d45b7818…d544a0`](https://stellar.expert/explorer/testnet/tx/d45b7818daad30d6d6fba2b879889f1f472128b1491f18882ca7e9af28d544a0) the same way.
- **Mainnet, simulated**: `prepareTransaction` against `https://mainnet.sorobanrpc.com` took the new 1,000,000-stroop bid to 1,073,610 — it added only the 73,610-stroop resource fee and left the inclusion bid alone, which is the mechanism behind the dropped transactions.
- **`submitVaa` against both live executors** (`CA542YLV…25QNBG` testnet, `CDBUGCAV…MMGGYZY35` mainnet): built with 100 and 1,000,000 stroops respectively, with simulation reaching the deployed contract in both cases. Not submitted for real — that needs a governance VAA the executor will accept, and this session has no mainnet signer.
- **Dropped-transaction path** run end to end against both live RPCs with the upload path's description: polled 40s, got `NOT_FOUND`, threw the new message quoting the per-chain bid (100 on testnet, 1,000,000 on mainnet).

`pnpm turbo build test --filter=@pythnetwork/contract-manager` and `pnpm test:lint` pass.