### PR TITLE
docs(developer-hub): list the Stellar mainnet Pyth Pro verifier

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/contract-addresses.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/contract-addresses.mdx
@@ -54,6 +54,7 @@ For IOTA, both the package ID and the shared state object ID are relevant. Integ
 
 | Network         | Contract Address                                                                                                                                                                                            |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Stellar Mainnet | <CopyAddress address="CACZ3GBAKUPIAFRILUFO27J5RUH5GJ2VSJ46LP6GJYSKGDRTQ5MS3HCH" url="https://stellar.expert/explorer/public/contract/CACZ3GBAKUPIAFRILUFO27J5RUH5GJ2VSJ46LP6GJYSKGDRTQ5MS3HCH" />  |
 | Stellar Testnet | <CopyAddress address="CAYFT5JE3UQTKT4Q6ZOZK4FXVYVT6RE3MFC7STA4UB6WAEGBT65MRU52" url="https://stellar.expert/explorer/testnet/contract/CAYFT5JE3UQTKT4Q6ZOZK4FXVYVT6RE3MFC7STA4UB6WAEGBT65MRU52" /> |
 
 ## EVM Mainnets


### PR DESCRIPTION
The Pyth Pro contract-addresses page listed only `Stellar Testnet`, so the `#stellar` deep link from the [Stellar consumer guide](/price-feeds/pro/integrate-as-consumer/stellar) — which tells integrators to "pass the deployed `pyth-lazer-stellar` contract id" — was effectively telling readers Pyth Pro only runs on Stellar testnet.

Adds the `Stellar Mainnet` row for the deployed verifier `CACZ3GBAKUPIAFRILUFO27J5RUH5GJ2VSJ46LP6GJYSKGDRTQ5MS3HCH`, matching the mainnet-first row ordering used by every other chain section on the page.

The address is the one already registered in `contract_manager/src/store/contracts/StellarLazerContracts.json` under `stellar_mainnet` (#3963), and confirmed live on the Stellar public network via the stellar.expert contract API (created ledger-time 1786399057, wasm `7a625f14…141477`, 2 storage entries).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->