### PR TITLE
docs(developer-hub): surface the OIS rewards pause on the OIS docs

### DIFF
--- a/apps/developer-hub/content/docs/oracle-integrity-staking/index.mdx
+++ b/apps/developer-hub/content/docs/oracle-integrity-staking/index.mdx
@@ -7,6 +7,18 @@ full: false
 index: true
 ---
 
+import { Callout } from "fumadocs-ui/components/callout";
+
+<Callout type="warning" title="OIS rewards are paused">
+  Following [OP-PIP-103](https://proposals.pyth.network/proposals/103), the OIS
+  reward rate was set to 0 on 22 April 2026, and no rewards are currently
+  distributed to any pool. Staking and slashing remain active — stake assigned to
+  a publisher is still subject to slashing. You can unstake and withdraw at any
+  time, and governance staking is unaffected. See the [governance
+  update](https://forum.pyth.network/t/ois-rewards-update-april-2026/2479) for
+  details.
+</Callout>
+
 This document outlines the design principles and implementation details of the [Oracle Integrity Staking (OIS)](https://staking.pyth.network/) protocol.
 
 ## Design Principles

--- a/apps/developer-hub/content/docs/oracle-integrity-staking/index.mdx
+++ b/apps/developer-hub/content/docs/oracle-integrity-staking/index.mdx
@@ -10,7 +10,7 @@ index: true
 import { Callout } from "fumadocs-ui/components/callout";
 
 <Callout type="warning" title="OIS rewards are paused">
-  Following [OP-PIP-103](https://proposals.pyth.network/proposals/103), the OIS
+  Following [OP-PIP-103](https://forum.pyth.network/t/passed-op-pip-103-pausing-ois-rewards/2471), the OIS
   reward rate was set to 0 on 22 April 2026, and no rewards are currently
   distributed to any pool. Staking and slashing remain active — stake assigned to
   a publisher is still subject to slashing. You can unstake and withdraw at any

--- a/apps/developer-hub/content/docs/oracle-integrity-staking/mathematical-representation.mdx
+++ b/apps/developer-hub/content/docs/oracle-integrity-staking/mathematical-representation.mdx
@@ -7,7 +7,7 @@ description: >-
 import { Callout } from "fumadocs-ui/components/callout";
 
 <Callout type="info" title="OP-PIP-103">
-  Per [OP-PIP-103](https://proposals.pyth.network/proposals/103), the reward rate $y$ is currently set to **0**. The staking and slashing mechanisms remain active.
+  Per [OP-PIP-103](https://forum.pyth.network/t/passed-op-pip-103-pausing-ois-rewards/2471), the reward rate $y$ is currently set to **0**. The staking and slashing mechanisms remain active.
 </Callout>
 
 As explained in the [implementation](../oracle-integrity-staking#implementation) section, every publisher is assigned a staking pool where they can self-stake and to which other stakers can delegate.

--- a/apps/developer-hub/content/docs/oracle-integrity-staking/slashing-rulebook.mdx
+++ b/apps/developer-hub/content/docs/oracle-integrity-staking/slashing-rulebook.mdx
@@ -45,7 +45,7 @@ The Pyth Network is designed to provide reliable and trustworthy financial data 
 
 Staking through OIS is a program to enhance the security of price feeds produced by publisher on the Pyth Network.
 
-Per the design of OIS, a pool aligned with a data publisher accepts stake from the publisher itself and from delegators. The additional stake allows such publisher to earn a delegation fee to contribute to the costs of providing data to the Pyth Network. Data publishers compete with one another to increase the number of price feeds they contribute to, and/or increase the quality of data that allows them to be selected to publish and/or enable higher staking cap for the pool each publisher is aligned to.
+Per the design of OIS, a pool aligned with a data publisher accepts stake from the publisher itself and from delegators. The additional stake allows such publisher to earn a delegation fee to contribute to the costs of providing data to the Pyth Network. The delegation fee is a share of the rewards accruing to delegators, so while the reward rate is set to 0 per [OP-PIP-103](https://proposals.pyth.network/proposals/103), no delegation fees accrue either. Slashing continues to apply throughout. Data publishers compete with one another to increase the number of price feeds they contribute to, and/or increase the quality of data that allows them to be selected to publish and/or enable higher staking cap for the pool each publisher is aligned to.
 
 ## Slashing
 

--- a/apps/developer-hub/content/docs/oracle-integrity-staking/slashing-rulebook.mdx
+++ b/apps/developer-hub/content/docs/oracle-integrity-staking/slashing-rulebook.mdx
@@ -45,7 +45,7 @@ The Pyth Network is designed to provide reliable and trustworthy financial data 
 
 Staking through OIS is a program to enhance the security of price feeds produced by publisher on the Pyth Network.
 
-Per the design of OIS, a pool aligned with a data publisher accepts stake from the publisher itself and from delegators. The additional stake allows such publisher to earn a delegation fee to contribute to the costs of providing data to the Pyth Network. The delegation fee is a share of the rewards accruing to delegators, so while the reward rate is set to 0 per [OP-PIP-103](https://proposals.pyth.network/proposals/103), no delegation fees accrue either. Slashing continues to apply throughout. Data publishers compete with one another to increase the number of price feeds they contribute to, and/or increase the quality of data that allows them to be selected to publish and/or enable higher staking cap for the pool each publisher is aligned to.
+Per the design of OIS, a pool aligned with a data publisher accepts stake from the publisher itself and from delegators. The additional stake allows such publisher to earn a delegation fee to contribute to the costs of providing data to the Pyth Network. The delegation fee is a share of the rewards accruing to delegators, so while the reward rate is set to 0 per [OP-PIP-103](https://forum.pyth.network/t/passed-op-pip-103-pausing-ois-rewards/2471), no delegation fees accrue either. Slashing continues to apply throughout. Data publishers compete with one another to increase the number of price feeds they contribute to, and/or increase the quality of data that allows them to be selected to publish and/or enable higher staking cap for the pool each publisher is aligned to.
 
 ## Slashing
 

--- a/apps/developer-hub/src/app/(docs)/[section]/layout.tsx
+++ b/apps/developer-hub/src/app/(docs)/[section]/layout.tsx
@@ -37,6 +37,26 @@ export default async function Layout({
           </span>
         </Banner>
       )}
+      {section === "oracle-integrity-staking" && (
+        <Banner
+          changeLayout={false}
+          className="min-h-12 bg-amber-950 py-2 text-amber-100"
+          height="auto"
+        >
+          <span>
+            <strong>OIS rewards are paused.</strong> Staking and slashing remain
+            active — stake is still at risk of slashing. &nbsp;|&nbsp;
+            <a
+              className="underline"
+              href="https://forum.pyth.network/t/ois-rewards-update-april-2026/2479"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Read the governance update.
+            </a>
+          </span>
+        </Banner>
+      )}
       {section === "price-feeds" && <MigrationBanner />}
       <ChangelogBar />
       <DocsLayout {...docsOptions}>{children}</DocsLayout>


### PR DESCRIPTION
Surfaces the OIS rewards pause on the developer-hub Oracle Integrity Staking docs, which still read as though rewards flow.

Today only `mathematical-representation.mdx` mentions OP-PIP-103 — a reader landing on any other OIS page gets the full design write-up with no indication that the reward rate has been 0 since 22 April 2026.

## Changes

- **Section banner** (`src/app/(docs)/[section]/layout.tsx`) — a `fumadocs-ui` `Banner` on the `oracle-integrity-staking` section, so the pause is visible on **every** OIS page rather than only the section index. Modelled on the sibling Entropy banner in the same file (same `Banner`, same `changeLayout={false}`, same `<span>` + separator + external-link shape); it carries no `id`, which is what makes it **non-dismissible** — `Banner` renders its close button and its `localStorage` dismissal script only when an `id` is present. Styled amber (`bg-amber-950 text-amber-100`) rather than Entropy's `rainbow` promo variant or the Core migration banner's violet, following the `MigrationBanner` precedent of overriding the palette via `className`.

  > **OIS rewards are paused.** Staking and slashing remain active — stake is still at risk of slashing. | [Read the governance update.](https://forum.pyth.network/t/ois-rewards-update-april-2026/2479)

  Two deliberate deviations from the Entropy banner, both measured in a real browser (numbers under Verification):

  - `height="auto"` + `min-h-12 py-2` instead of `Banner`'s default fixed `height: 3rem`. `Banner` applies `height` as an inline style on a `flex items-center` box with no clipping, so copy that wraps past one line at narrow widths spills out of the box and over whatever follows it. This copy wraps to four lines at 320–375px. On desktop the banner is still exactly 48px tall, identical to Entropy's.
  - `underline` on the link. `Banner` gives links no colour or decoration of their own, so an undecorated anchor is indistinguishable from the surrounding sentence.

- **`oracle-integrity-staking/index.mdx`** — a `warning` callout above the design principles stating that the reward rate was set to 0 on 22 April 2026 per OP-PIP-103, that staking and slashing remain active and stake assigned to a publisher is still subject to slashing, that stake can be unstaked and withdrawn at any time, and that governance staking is unaffected. Links to the [April 2026 governance update](https://forum.pyth.network/t/ois-rewards-update-april-2026/2479), which is the authoritative post-passage explainer. Kept alongside the banner deliberately: the banner is a single line and can only carry the headline plus the slashing warning, while the callout carries the date, the proposal, the unstake-anytime point, and the governance-unaffected point.

- **`oracle-integrity-staking/slashing-rulebook.mdx`** — the Staking section said additional stake "allows such publisher to earn a delegation fee" with no qualification. The delegation fee is a share of delegator rewards (`event.y * ... * computeDelegatorRewardPercentage(delegationFee)` in `governance/pyth_staking_sdk/src/utils/pool.ts`), so at `y = 0` no delegation fees accrue either. Added one sentence saying so, and noting slashing continues to apply.

- **`oracle-integrity-staking/mathematical-representation.mdx`** — one-line link fix, see below. Its existing OP-PIP-103 callout is otherwise accurate and left alone.

The "staking and slashing remain active" framing is deliberate throughout, banner included: "OIS is paused" is imprecise and could lead someone to leave stake at risk believing the program is inert.

## OP-PIP-103 links now point at the forum

Every `OP-PIP-103` link in this directory pointed at `https://proposals.pyth.network/proposals/103`, which **404s**. That host is the xc_admin multisig frontend (`governance/xc_admin/packages/xc_admin_frontend`) — a pages-router app exposing only `/` with query params, which is the form the CLI itself prints (`xc_admin_cli/src/index.ts:448`: `https://proposals.pyth.network/?tab=proposals&proposal=<pubkey>`). There is no `/proposals/<n>` route.

Measured, with a control to rule out bot-blocking:

| request | status |
| --- | --- |
| `https://proposals.pyth.network/` | 200 |
| `https://proposals.pyth.network/proposals/103` | **404** |
| `https://forum.pyth.network/t/passed-op-pip-103-pausing-ois-rewards/2471` | 200 — *"[PASSED] OP-PIP-103: Pausing OIS Rewards"* |

All three occurrences now point at the forum topic, which is the authoritative post-passage record. This includes the pre-existing one at `mathematical-representation.mdx:10`, folded in because it is the same dead link one directory over and leaving it would ship a page whose sole OP-PIP-103 citation 404s.

## Verification

`turbo build test:lint test:format test:types test:unit --filter @pythnetwork/developer-hub` — 47/47 tasks pass; `turbo fix` leaves the tree clean.

Rendered against a production build (`next build` + `next start`) rather than dev. Banner presence, scoped to the OIS section and to nothing else:

| path | status | OIS banner | close button |
| --- | --- | --- | --- |
| `/oracle-integrity-staking` | 200 | yes | none |
| `/oracle-integrity-staking/mathematical-representation` | 200 | yes | none |
| `/oracle-integrity-staking/slashing-rulebook` | 200 | yes | none |
| `/oracle-integrity-staking/publisher-quality-ranking` | 200 | yes | none |
| `/entropy` | 200 | no (its own banner, dismissible) | — |
| `/price-feeds`, `/price-feeds/core`, `/`, `/changelog` | 200 | no | — |

Those four are every page in the section (`content/docs/oracle-integrity-staking/meta.json`), and both the section index (`[section]/page.tsx`) and its sub-pages (`[section]/[...slug]/page.tsx`) sit under the edited layout. Emitted markup:

```html
<div class="sticky top-0 z-40 flex flex-row items-center justify-center px-4 text-center text-sm font-medium min-h-12 bg-amber-950 py-2 text-amber-100" style="height:auto">
  <span><strong>OIS rewards are paused.</strong> Staking and slashing remain active — stake is still at risk of slashing.  | <a class="underline" href="https://forum.pyth.network/t/ois-rewards-update-april-2026/2479" rel="noopener noreferrer" target="_blank">Read the governance update.</a></span>
</div>
```

Measured in headless Chromium at five viewport widths, comparing the banner box against its text and against the element that follows it (the changelog bar). Negative = clearance:

| viewport | box | text | spill above / below | overlap with next element |
| --- | --- | --- | --- | --- |
| 320px | 96px | 80px | −8px / −8px | −8px |
| 375px | 96px | 80px | −8px / −8px | −8px |
| 414px | 76px | 60px | −8px / −8px | −8px |
| 768px | 56px | 40px | −8px / −8px | −8px |
| 1280px | 48px | 20px | −14px / −14px | −14px |

With the default fixed `3rem` the same measurement gave +32px of spill and +16px of overlap at 320–375px, which is what `height="auto"` fixes. The link computes to `text-decoration-line: underline` in both light and dark colour schemes, with `target="_blank"` and `rel="noopener noreferrer"`.

Both forum links re-fetched: `…/ois-rewards-update-april-2026/2479` → 200 *"OIS Rewards Update (April 2026)"*; `…/passed-op-pip-103-pausing-ois-rewards/2471` → 200 *"[PASSED] OP-PIP-103: Pausing OIS Rewards"*. The index callout still resolves to the warning variant (`--color-fd-warning`).