### PR TITLE
docs: sync Sui pro push-feed status

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json
@@ -206,7 +206,7 @@
       "time_difference": 10,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "TRX/USD",

--- a/apps/developer-hub/package.json
+++ b/apps/developer-hub/package.json
@@ -74,6 +74,7 @@
     "snapshot:changelog": "tsx ./scripts/snapshot-and-diff.ts",
     "start:dev": "next dev --port 3627",
     "start:prod": "next start --port 3627",
+    "sync:sui-push-feed-status": "tsx ./scripts/sync-sui-push-feed-status.ts",
     "test:lint:stylelint": "stylelint 'src/**/*.scss' --max-warnings 0",
     "test:types": "tsc",
     "test:unit": "test-unit"

--- a/apps/developer-hub/scripts/sync-sui-push-feed-status.ts
+++ b/apps/developer-hub/scripts/sync-sui-push-feed-status.ts
@@ -1,0 +1,243 @@
+import * as fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+type ProCompatibleStatus = "available" | "coming_soon";
+
+type SponsoredFeed = {
+  alias: string;
+  id: string;
+  time_difference: number;
+  price_deviation: number;
+  confidence_ratio: number;
+  pro_compatible_status?: ProCompatibleStatus;
+};
+
+type SuiPushFeedsData = {
+  feeds: SponsoredFeed[];
+};
+
+type DeploymentConfig = {
+  name: string;
+  legacyPath: string;
+  upgradedPath: string;
+};
+
+type AuditRow = {
+  alias: string;
+  id: string;
+  docsStatus: ProCompatibleStatus;
+  legacyDeployments: string[];
+  upgradedDeployments: string[];
+  upgradedHermes: boolean;
+  expectedStatus: ProCompatibleStatus;
+};
+
+const HERMES_URL = "https://pyth.dourolabs.app/hermes/v2/price_feeds";
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DEVELOPER_HUB_DIR = path.resolve(SCRIPT_DIR, "..");
+const REPO_DIR = path.resolve(DEVELOPER_HUB_DIR, "../..");
+const DEFAULT_DEPLOYMENTS_DIR = path.resolve(REPO_DIR, "../deployments");
+const SUI_MAINNET_DATA_PATH = path.join(
+  DEVELOPER_HUB_DIR,
+  "content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json",
+);
+
+const deployments: DeploymentConfig[] = [
+  {
+    legacyPath:
+      "environments/platform-yellow/sui-price-pusher-mainnet/price-config-0.yaml",
+    name: "platform-yellow",
+    upgradedPath:
+      "environments/platform-yellow/sui-price-pusher-mainnet/price-config-pro-compatible.yaml",
+  },
+  {
+    legacyPath:
+      "environments/platform-green/sui-price-pusher-mainnet/price-config-0.yaml",
+    name: "platform-green",
+    upgradedPath:
+      "environments/platform-green/sui-price-pusher-mainnet/price-config-pro-compatible.yaml",
+  },
+];
+
+const parseArgs = (args: string[]) => {
+  const result = {
+    deploymentsDir: DEFAULT_DEPLOYMENTS_DIR,
+    write: false,
+  };
+
+  for (const arg of args) {
+    if (arg === "--write") {
+      result.write = true;
+    } else if (arg.startsWith("--deployments-dir=")) {
+      result.deploymentsDir = path.resolve(
+        arg.slice("--deployments-dir=".length),
+      );
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return result;
+};
+
+const readJson = async <T>(filePath: string): Promise<T> =>
+  JSON.parse(await fs.readFile(filePath, "utf8")) as T;
+
+const activePriceConfigIds = async (filePath: string): Promise<Set<string>> => {
+  const ids = new Set<string>();
+  let insideFeed = false;
+
+  for (const rawLine of (await fs.readFile(filePath, "utf8")).split(/\r?\n/u)) {
+    const line = rawLine.trim();
+
+    if (line === "" || line.startsWith("#")) {
+      continue;
+    }
+
+    if (line.startsWith("- alias:")) {
+      insideFeed = true;
+      continue;
+    }
+
+    if (insideFeed) {
+      const match = /^id:\s*([0-9a-fA-F]{64})$/u.exec(line);
+      const feedId = match?.[1];
+      if (feedId !== undefined) {
+        ids.add(feedId.toLowerCase());
+        insideFeed = false;
+      }
+    }
+  }
+
+  return ids;
+};
+
+const hermesIds = async (): Promise<Set<string>> => {
+  const response = await fetch(HERMES_URL);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch upgraded Hermes listing: ${response.status.toString()} ${response.statusText}`,
+    );
+  }
+
+  const feeds = (await response.json()) as { id: string }[];
+  return new Set(feeds.map((feed) => feed.id.toLowerCase()));
+};
+
+const deploymentIdSets = async (deploymentsDir: string) => {
+  const legacy = new Map<string, string[]>();
+  const upgraded = new Map<string, string[]>();
+
+  for (const deployment of deployments) {
+    const [legacyIds, upgradedIds] = await Promise.all([
+      activePriceConfigIds(path.join(deploymentsDir, deployment.legacyPath)),
+      activePriceConfigIds(path.join(deploymentsDir, deployment.upgradedPath)),
+    ]);
+
+    for (const id of legacyIds) {
+      legacy.set(id, [...(legacy.get(id) ?? []), deployment.name]);
+    }
+
+    for (const id of upgradedIds) {
+      upgraded.set(id, [...(upgraded.get(id) ?? []), deployment.name]);
+    }
+  }
+
+  return { legacy, upgraded };
+};
+
+const auditRows = async (deploymentsDir: string): Promise<AuditRow[]> => {
+  const [{ feeds }, { legacy, upgraded }, hermes] = await Promise.all([
+    readJson<SuiPushFeedsData>(SUI_MAINNET_DATA_PATH),
+    deploymentIdSets(deploymentsDir),
+    hermesIds(),
+  ]);
+
+  return feeds.map((feed) => {
+    const id = feed.id.toLowerCase();
+    const upgradedDeployments = upgraded.get(id) ?? [];
+    const upgradedHermes = hermes.has(id);
+    const expectedStatus =
+      upgradedDeployments.length > 0 && upgradedHermes
+        ? "available"
+        : "coming_soon";
+
+    return {
+      alias: feed.alias,
+      docsStatus: feed.pro_compatible_status ?? "coming_soon",
+      expectedStatus,
+      id,
+      legacyDeployments: legacy.get(id) ?? [],
+      upgradedDeployments,
+      upgradedHermes,
+    };
+  });
+};
+
+const writeStatuses = async (rows: AuditRow[]) => {
+  const data = await readJson<SuiPushFeedsData>(SUI_MAINNET_DATA_PATH);
+  const statusesById = new Map(
+    rows.map((row) => [row.id, row.expectedStatus] as const),
+  );
+
+  const updatedData: SuiPushFeedsData = {
+    feeds: data.feeds.map((feed) => ({
+      ...feed,
+      pro_compatible_status:
+        statusesById.get(feed.id.toLowerCase()) ?? "coming_soon",
+    })),
+  };
+
+  await fs.writeFile(
+    SUI_MAINNET_DATA_PATH,
+    `${JSON.stringify(updatedData, null, 2)}\n`,
+  );
+};
+
+const formatDeployments = (names: string[]) =>
+  names.length === 0 ? "-" : names.join("+");
+
+const main = async () => {
+  const { deploymentsDir, write } = parseArgs(process.argv.slice(2));
+  const rows = await auditRows(deploymentsDir);
+
+  if (write) {
+    await writeStatuses(rows);
+  }
+
+  console.log(
+    [
+      "alias",
+      "docs_status",
+      "legacy_deployments",
+      "upgraded_deployments",
+      "upgraded_hermes",
+      "expected_status",
+    ].join(","),
+  );
+
+  for (const row of rows) {
+    console.log(
+      [
+        row.alias,
+        row.docsStatus,
+        formatDeployments(row.legacyDeployments),
+        formatDeployments(row.upgradedDeployments),
+        row.upgradedHermes.toString(),
+        row.expectedStatus,
+      ].join(","),
+    );
+  }
+
+  const drift = rows.filter((row) => row.docsStatus !== row.expectedStatus);
+  if (drift.length > 0 && !write) {
+    throw new Error(
+      `Sui pro-compatible status drift detected for ${drift
+        .map((row) => row.alias)
+        .join(", ")}`,
+    );
+  }
+};
+
+await main();

--- a/apps/developer-hub/scripts/sync-sui-push-feed-status.ts
+++ b/apps/developer-hub/scripts/sync-sui-push-feed-status.ts
@@ -110,6 +110,10 @@ const activePriceConfigIds = async (filePath: string): Promise<Set<string>> => {
     }
   }
 
+  if (ids.size === 0) {
+    throw new Error(`No feed ids parsed from price config: ${filePath}`);
+  }
+
   return ids;
 };
 

--- a/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
+++ b/apps/developer-hub/src/components/SponsoredFeedsTable/index.tsx
@@ -22,10 +22,12 @@ const PRO_COMPATIBLE_DOCS_URL = "/price-feeds/core/upgrade/preparing";
  *
  *   1. Fetch the Pro-compatible Hermes listing:
  *      GET https://pyth.dourolabs.app/hermes/v2/price_feeds
- *   2. For each feed, set "available" if its `id` is present in that listing,
- *      otherwise "coming_soon".
+ *   2. For Sui, require the full Core feed ID to be present in both the
+ *      chain-local upgraded pusher config and the Hermes listing.
+ *   3. For each feed, set "available" only when the chain-specific criteria
+ *      above are met, otherwise "coming_soon".
  *
- * Last refreshed 2026-07-03. To refresh, re-run the steps above.
+ * Last refreshed 2026-08-12.
  */
 type ProCompatibleStatus = "available" | "coming_soon";
 


### PR DESCRIPTION
## Summary
- mark SUIUSDE/USD available in the Sui mainnet sponsored feed docs after confirming the full Core feed ID is active in both upgraded Sui pusher configs and live upgraded Hermes
- add a Developer Hub sync/audit script for Sui push-feed pro-compatible status so docs can be checked against chain-local deployment configs plus Hermes availability
- update the SponsoredFeedsTable maintenance note to document the Sui-specific chain-local config requirement

## Validation
- pnpm --dir apps/developer-hub sync:sui-push-feed-status --deployments-dir=/tmp/.tmpH6oJoM/deployments
  - SUIUSDE/USD: docs_status=available, legacy_deployments=platform-yellow+platform-green, upgraded_deployments=platform-yellow+platform-green, upgraded_hermes=true, expected_status=available
  - all Sui docs rows matched expected status
- pnpm --dir apps/developer-hub test:types
- pnpm --dir apps/developer-hub test:unit
- pnpm --dir apps/developer-hub test:lint:stylelint
- pnpm exec biome check apps/developer-hub/scripts/sync-sui-push-feed-status.ts apps/developer-hub/package.json
- git fetch origin main && git merge-tree origin/main HEAD
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->