### PR TITLE
feat(contract_manager): report SetFee and WithdrawFee in check_proposal

### DIFF
--- a/contract_manager/scripts/check_proposal.ts
+++ b/contract_manager/scripts/check_proposal.ts
@@ -13,9 +13,11 @@ import {
   EvmUpgradeContract,
   getProposalInstructions,
   MultisigParser,
+  SetFee,
   UpdateTrustedSigner256Bit,
   UpdateTrustedSigner264Bit,
   UpgradeSuiLazerContract,
+  WithdrawFee,
   WormholeMultisigInstruction,
 } from "@pythnetwork/xc-admin-common";
 import type { AccountMeta } from "@solana/web3.js";
@@ -48,6 +50,23 @@ function getSquadsMesh() {
   return (
     (SquadsMeshClass as { default?: typeof SquadsMeshClass }).default ??
     SquadsMeshClass
+  );
+}
+
+function evmChainsFor(targetChainId: string, cluster: PythCluster): EvmChain[] {
+  return Object.values(DefaultStore.chains).filter(
+    (chain): chain is EvmChain =>
+      chain instanceof EvmChain &&
+      chain.isMainnet() === (cluster === "mainnet-beta") &&
+      chain.wormholeChainName === targetChainId,
+  );
+}
+
+function pythContractsOn(chain: EvmChain): EvmPriceFeedContract[] {
+  return Object.values(DefaultStore.contracts).filter(
+    (contract): contract is EvmPriceFeedContract =>
+      contract instanceof EvmPriceFeedContract &&
+      contract.getChain().getId() === chain.getId(),
   );
 }
 
@@ -164,6 +183,69 @@ async function main() {
               `${chain.getId()} Code Id:${codeId} digest:${createHash("sha256")
                 .update(code)
                 .digest("hex")}`,
+            );
+          }
+        }
+      }
+      if (instruction.governanceAction instanceof SetFee) {
+        const { targetChainId, newFeeValue, newFeeExpo } =
+          instruction.governanceAction;
+        const newFee = instruction.governanceAction.getNewFeeAmount();
+
+        console.log(`\nVerifying SetFee on ${targetChainId}`);
+        console.log(
+          `  new fee: ${
+            newFee ?? `<expo ${newFeeExpo} exceeds ${SetFee.MAX_EXPO}>`
+          } (${newFeeValue} * 10^${newFeeExpo})`,
+        );
+        for (const chain of evmChainsFor(targetChainId, cluster)) {
+          for (const contract of pythContractsOn(chain)) {
+            const currentFee = await contract.getBaseUpdateFee();
+            console.log(
+              `${chain.getId()}  Address:${contract.address} current fee:${currentFee.amount}`,
+            );
+          }
+        }
+      }
+      if (instruction.governanceAction instanceof WithdrawFee) {
+        const { targetChainId, expo } = instruction.governanceAction;
+        const recipient = `0x${instruction.governanceAction.targetAddress.toString("hex")}`;
+        const requested = instruction.governanceAction.getTotalAmount();
+
+        console.log(`\nVerifying WithdrawFee on ${targetChainId}`);
+        console.log(`  recipient: ${recipient}`);
+        console.log(
+          `  amount:    ${
+            requested ?? `<expo ${expo} exceeds ${WithdrawFee.MAX_EXPO}>`
+          }`,
+        );
+        for (const chain of evmChainsFor(targetChainId, cluster)) {
+          const web3 = chain.getWeb3();
+          const hasCode = (await web3.eth.getCode(recipient)) !== "0x";
+          const recipientBalance = BigInt(await web3.eth.getBalance(recipient));
+          if (hasCode || recipientBalance > 0n) {
+            console.log(
+              `${chain.getId()}  recipient exists — code:${hasCode ? "yes" : "no"} balance:${recipientBalance}`,
+            );
+          } else {
+            console.log(
+              `${chain.getId()}  RECIPIENT DOES NOT EXIST — ${recipient} has no code and no balance on this chain`,
+            );
+          }
+          // A chain can host several Pyth deployments, only one of which
+          // executes this instruction, so the withdrawal only definitely
+          // reverts when none of them holds the requested amount.
+          let funded = false;
+          for (const contract of pythContractsOn(chain)) {
+            const balance = (await contract.getTotalFee()).amount;
+            funded ||= requested !== undefined && requested <= balance;
+            console.log(
+              `${chain.getId()}  Address:${contract.address} balance:${balance}`,
+            );
+          }
+          if (requested !== undefined && !funded) {
+            console.log(
+              `${chain.getId()}  INSUFFICIENT BALANCE — no Pyth contract on ${chain.getId()} holds ${requested}, withdrawFee reverts`,
             );
           }
         }

--- a/governance/xc_admin/packages/xc_admin_common/src/__tests__/SetFee.test.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/__tests__/SetFee.test.ts
@@ -1,0 +1,42 @@
+import { SetFee } from "../governance_payload/SetFee";
+
+describe("SetFee.getNewFeeAmount", () => {
+  test("computes newFeeValue * 10^newFeeExpo for ordinary exponents", () => {
+    expect(new SetFee("ethereum", 4000000000000n, 0n).getNewFeeAmount()).toBe(
+      4000000000000n,
+    );
+    expect(new SetFee("cronos", 2n, 17n).getNewFeeAmount()).toBe(
+      200000000000000000n,
+    );
+  });
+
+  test("computes at the MAX_EXPO boundary", () => {
+    expect(new SetFee("ethereum", 1n, SetFee.MAX_EXPO).getNewFeeAmount()).toBe(
+      10n ** SetFee.MAX_EXPO,
+    );
+  });
+
+  test("returns undefined above MAX_EXPO instead of evaluating 10^expo", () => {
+    expect(
+      new SetFee("ethereum", 1n, SetFee.MAX_EXPO + 1n).getNewFeeAmount(),
+    ).toBeUndefined();
+    // Full uint64 range must not hang or throw (RangeError) when displayed.
+    expect(
+      new SetFee("ethereum", 1n, 2n ** 64n - 1n).getNewFeeAmount(),
+    ).toBeUndefined();
+  });
+
+  test("round-trips a live payload and computes its amount", () => {
+    // SetFee instruction for abstract from proposal
+    // CQVZMPLeeswtAafjYiMPpsbN59wHsGd3vKh1FPfSRunA (OP-PIP-128).
+    const payload = Buffer.from(
+      "5054474d0103eaa700000000000000000000000000000000",
+      "hex",
+    );
+    const decoded = SetFee.decode(payload);
+    expect(decoded).toBeDefined();
+    expect(decoded?.targetChainId).toBe("abstract");
+    expect(decoded?.getNewFeeAmount()).toBe(0n);
+    expect(decoded?.encode().toString("hex")).toBe(payload.toString("hex"));
+  });
+});

--- a/governance/xc_admin/packages/xc_admin_common/src/governance_payload/SetFee.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/governance_payload/SetFee.ts
@@ -45,6 +45,21 @@ export class SetFee extends PythGovernanceActionImpl {
       newFeeValue: this.newFeeValue,
     });
   }
+
+  /**
+   * Maximum exponent for which getNewFeeAmount computes a value. Anything
+   * larger would overflow uint256 on-chain (the contract's checked math
+   * reverts), and evaluating 10n ** expo for huge decoded exponents can hang
+   * or throw in the caller.
+   */
+  static MAX_EXPO = 60n;
+
+  /** New fee in wei (newFeeValue * 10^newFeeExpo), or undefined if newFeeExpo exceeds MAX_EXPO. */
+  getNewFeeAmount(): bigint | undefined {
+    return this.newFeeExpo <= SetFee.MAX_EXPO
+      ? this.newFeeValue * 10n ** this.newFeeExpo
+      : undefined;
+  }
 }
 
 /** Set the fee in the specified token on the target chain to newFeeValue * 10^newFeeExpo.


### PR DESCRIPTION
## Problem

`contract_manager/scripts/check_proposal.ts` is the tool governance reviewers are pointed at (it is the documented "Check proposal" step in OP-PIP-128 and prior PIPs). It dispatches on the decoded governance action, but had no branch for `SetFee` or `WithdrawFee` — so it printed nothing for those instructions and exited successfully.

On proposal `CQVZMPLeeswtAafjYiMPpsbN59wHsGd3vKh1FPfSRunA` (OP-PIP-128) it reported on 29 of 149 instructions. The 120 it silently skipped are 86 `SetFee` and 34 `WithdrawFee`, including every instruction that moves native token balances to an external address — the highest-risk part of that proposal. Decoders for both actions already existed in `xc_admin_common`, so this was a reporting gap, not a parsing gap.

## Changes

Both branches resolve the target `EvmChain` the same way the existing `EvmUpgradeContract` branch does (`wormholeChainName` plus a mainnet/cluster match), now factored into `evmChainsFor`; `pythContractsOn` finds the Pyth deployments on that chain.

**`SetFee`** prints the proposed fee (`newFeeValue`, `newFeeExpo`, and the computed `value * 10^expo`) next to the current `singleUpdateFeeInWei()` of each Pyth contract on the target chain, so the reviewer sees before and after.

**`WithdrawFee`** prints:

- the `targetAddress`, and whether it exists on the target chain — an address with neither code nor a balance there is flagged `RECIPIENT DOES NOT EXIST`, since a recipient that is not deployed on the target chain would otherwise silently receive funds nobody controls there;
- the requested amount from `getTotalAmount()`;
- the current native balance of each Pyth contract on the chain, with an `INSUFFICIENT BALANCE` flag when none of them holds the requested amount, since `PythGovernance.withdrawFee` reverts on `payload.fee > address(this).balance`.

Recipients are treated uniformly — the report says whether the address exists and how much it holds, and makes no attempt to interpret what kind of contract it is.

A chain can host more than one Pyth deployment (e.g. a `pro-compatible-production` one alongside the original), only one of which executes the instruction, so the balance flag fires only when no deployment on the chain can cover the withdrawal. Flagging per-contract instead produced a false `INSUFFICIENT BALANCE` on 16 of the 34 withdrawals in OP-PIP-128, all against zero-balance secondary deployments that are not the withdrawal target.

`SetFee` gains `getNewFeeAmount()`, mirroring the existing `WithdrawFee.getTotalAmount()`: an exponent beyond what the contract can represent returns `undefined` and renders explicitly, rather than evaluating `10n ** expo` for an arbitrary decoded `uint64` and throwing `RangeError` mid-run.

## Out of scope

The script still aborts when a single public RPC endpoint fails, losing output for the remaining instructions. That is tracked separately and was explicitly deferred from this change.

## Verification

Run against `CQVZMPLeeswtAafjYiMPpsbN59wHsGd3vKh1FPfSRunA` on `mainnet-beta`: all 149 instructions now report and no instruction is silently skipped. Full output and commands are on the issue.