### PR TITLE
refactor(target_chains/ethereum): move governance handlers into a linked library

### DIFF
--- a/contract_manager/scripts/upgrade_evm_pricefeed_contracts.ts
+++ b/contract_manager/scripts/upgrade_evm_pricefeed_contracts.ts
@@ -1,8 +1,4 @@
-/* eslint-disable @typescript-eslint/await-thenable */
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable no-console */
+/** biome-ignore-all lint/suspicious/noConsole: CLI script */
 import { readFileSync } from "node:fs";
 
 import yargs from "yargs";
@@ -25,11 +21,107 @@ const parser = yargs(hideBin(process.argv))
       `Uses a cache file (${CACHE_FILE}) to avoid deploying contracts twice\n` +
       "Usage: $0 --chain <chain_1> --chain <chain_2> --private-key <private_key> --ops-key-path <ops_key_path> --std-output <std_output>",
   )
-  .options(COMMON_UPGRADE_OPTIONS);
+  .options({
+    ...COMMON_UPGRADE_OPTIONS,
+    "library-std-output": {
+      demandOption: false,
+      desc:
+        "Path to the standard JSON output of a library the pyth contract links against " +
+        "(e.g. PythGovernanceModule). Repeat once per library. Each library is deployed to " +
+        "every selected chain and its address is spliced into the pyth bytecode.",
+      string: true,
+      type: "array",
+    },
+  });
+
+type LinkPosition = { start: number; length: number };
+
+/** The subset of a forge build artifact that this script reads. */
+type ForgeArtifact = {
+  abi: unknown[];
+  bytecode: {
+    object: string;
+    linkReferences?: Record<string, Record<string, LinkPosition[]>>;
+  };
+  metadata?: { settings?: { compilationTarget?: Record<string, string> } };
+};
+
+/** One entry per library that a forge artifact links against. */
+type LinkReference = {
+  file: string;
+  name: string;
+  positions: LinkPosition[];
+};
+
+function readArtifact(path: string): ForgeArtifact {
+  return JSON.parse(readFileSync(path, "utf8")) as ForgeArtifact;
+}
+
+function getLinkReferences(artifact: ForgeArtifact): LinkReference[] {
+  return Object.entries(artifact.bytecode.linkReferences ?? {}).flatMap(
+    ([file, libraries]) =>
+      Object.entries(libraries).map(([name, positions]) => ({
+        file,
+        name,
+        positions,
+      })),
+  );
+}
+
+/** The `path/To/File.sol:LibraryName` that a forge artifact was compiled for. */
+function getCompilationTarget(artifact: ForgeArtifact): string {
+  const target = artifact.metadata?.settings?.compilationTarget ?? {};
+  const [file, name] = Object.entries(target)[0] ?? [];
+  if (file === undefined || name === undefined) {
+    throw new TypeError(
+      "Could not read metadata.settings.compilationTarget from the library artifact; " +
+        "make sure it is a forge build artifact",
+    );
+  }
+  return `${file}:${name}`;
+}
+
+/**
+ * Replaces the `__$<hash>$__` placeholders that forge leaves in unlinked bytecode
+ * with concrete library addresses. Positions are byte offsets into the bytecode,
+ * so each one maps to two hex characters.
+ */
+function linkBytecode(
+  bytecode: string,
+  linkReferences: LinkReference[],
+  addresses: Map<string, string>,
+): string {
+  const prefix = bytecode.startsWith("0x") ? "0x" : "";
+  let hex = bytecode.slice(prefix.length);
+
+  for (const { file, name, positions } of linkReferences) {
+    const address = addresses.get(`${file}:${name}`);
+    if (address === undefined) {
+      throw new Error(
+        `No address for library ${file}:${name}; pass its build artifact with --library-std-output`,
+      );
+    }
+    const addressHex = address.replace("0x", "").toLowerCase();
+    for (const { start, length } of positions) {
+      hex =
+        hex.slice(0, 2 * start) + addressHex + hex.slice(2 * (start + length));
+    }
+  }
+
+  if (/__\$[\da-f]{34}\$__/.test(hex)) {
+    throw new Error("Bytecode still contains unresolved library placeholders");
+  }
+  return prefix + hex;
+}
 
 async function main() {
   const argv = await parser.argv;
   const selectedChains = getSelectedChains(argv);
+
+  const stdOutput = argv["std-output"];
+  if (stdOutput === undefined) {
+    throw new Error("--std-output is required");
+  }
 
   const vault =
     DefaultStore.vaults[
@@ -42,15 +134,51 @@ async function main() {
     selectedChains.map((c) => c.getId()),
   );
 
+  const libraryArtifacts = (argv["library-std-output"] ?? []).map((path) =>
+    readArtifact(path),
+  );
+
   const payloads: Buffer[] = [];
   for (const chain of selectedChains) {
-    const artifact = JSON.parse(readFileSync(argv["std-output"], "utf8"));
+    const artifact = readArtifact(stdOutput);
+
+    // A linked library's address is baked into the implementation's code, so
+    // every library has to be deployed on the chain before the implementation.
+    const linkReferences = getLinkReferences(artifact);
+    const libraryAddresses = new Map<string, string>();
+    for (const libraryArtifact of libraryArtifacts) {
+      const target = getCompilationTarget(libraryArtifact);
+      console.log(`Deploying library ${target} to`, chain.getId());
+      const libraryAddress = await runIfNotCached(
+        `deploy-library-${target}-${chain.getId()}`,
+        () => {
+          return chain.deploy(
+            toPrivateKey(argv["private-key"]),
+            libraryArtifact.abi,
+            libraryArtifact.bytecode.object,
+            [],
+          );
+        },
+      );
+      console.log(
+        `Deployed library ${target} at ${libraryAddress} on ${chain.getId()}`,
+      );
+      libraryAddresses.set(target, libraryAddress);
+    }
+
+    // As per the artifacts generated by forge, bytecode is an object with an 'object' property
+    const bytecode = linkBytecode(
+      artifact.bytecode.object,
+      linkReferences,
+      libraryAddresses,
+    );
+
     console.log("Deploying contract to", chain.getId());
     const address = await runIfNotCached(`deploy-${chain.getId()}`, () => {
       return chain.deploy(
         toPrivateKey(argv["private-key"]),
         artifact.abi,
-        artifact.bytecode.object, // As per the artifacts generated by forge, bytecode is an object with an 'object' property
+        bytecode,
         [],
       );
     });

--- a/target_chains/ethereum/contracts/contracts/executor/Executor.sol
+++ b/target_chains/ethereum/contracts/contracts/executor/Executor.sol
@@ -1,25 +1,24 @@
 // SPDX-License-Identifier: Apache 2
 pragma solidity ^0.8.0;
 
-import "../pyth/PythGovernanceInstructions.sol";
+// Imported selectively so that the executor's own `MODULE` constant and
+// `GovernanceInstruction` struct — which differ from the Pyth target-chain ones —
+// do not collide with the file-level declarations of the same name.
+import {MAGIC, GovernanceModule} from "../pyth/PythGovernanceInstructions.sol";
+import "../libraries/external/BytesLib.sol";
 import "../wormhole/interfaces/IWormhole.sol";
 import "./ExecutorErrors.sol";
 
 contract Executor {
     using BytesLib for bytes;
 
-    // Magic is `PTGM` encoded as a 4 byte data: Pyth Governance Message
-    // TODO: it's annoying that we can't import this from PythGovernanceInstructions
-    uint32 constant MAGIC = 0x5054474d;
-
-    PythGovernanceInstructions.GovernanceModule constant MODULE =
-        PythGovernanceInstructions.GovernanceModule.EvmExecutor;
+    GovernanceModule constant MODULE = GovernanceModule.EvmExecutor;
 
     // Instruction indicating that the executor contract on
     // targetChainId at executorAddress should call the contract at callAddress
     // with the provided callData
     struct GovernanceInstruction {
-        PythGovernanceInstructions.GovernanceModule module;
+        GovernanceModule module;
         ExecutorAction action;
         uint16 targetChainId;
         // The address of the specific executor that should perform the call.
@@ -149,7 +148,7 @@ contract Executor {
         index += 4;
 
         uint8 modNumber = encodedInstruction.toUint8(index);
-        gi.module = PythGovernanceInstructions.GovernanceModule(modNumber);
+        gi.module = GovernanceModule(modNumber);
         index += 1;
 
         if (gi.module != MODULE)

--- a/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/Pyth.sol
@@ -700,7 +700,7 @@ abstract contract Pyth is
     }
 
     function version() public pure returns (string memory) {
-        return "1.4.6";
+        return "1.4.7";
     }
 
     /// @notice Calculates TWAP from two price points

--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernance.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernance.sol
@@ -3,7 +3,9 @@
 
 pragma solidity ^0.8.0;
 
+import "./PythGovernanceEvents.sol";
 import "./PythGovernanceInstructions.sol";
+import "./PythGovernanceModule.sol";
 import "./PythInternalStructs.sol";
 import "./PythGetters.sol";
 import "./PythSetters.sol";
@@ -13,34 +15,23 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 /**
  * @dev `Governance` defines a means to enacting changes to the Pyth contract.
+ *
+ * Only VAA verification, instruction parsing and the `UpgradeContract` action are
+ * handled here. Every other action is delegated to the `PythGovernanceModule`
+ * library, which is deployed separately and linked into this contract, so that the
+ * implementation stays below the EIP-170 code size limit.
+ *
+ * `UpgradeContract` stays inline on purpose. This function is the only working
+ * upgrade path — ownership is renounced in `PythUpgradable.initialize`, so
+ * `_authorizeUpgrade` always reverts — and routing it through a linked library
+ * would make an undeployed or mis-linked library permanently unrecoverable.
  */
 abstract contract PythGovernance is
     PythGetters,
     PythSetters,
-    PythGovernanceInstructions
+    PythGovernanceInstructions,
+    IPythGovernanceEvents
 {
-    event ContractUpgraded(
-        address oldImplementation,
-        address newImplementation
-    );
-    event GovernanceDataSourceSet(
-        PythInternalStructs.DataSource oldDataSource,
-        PythInternalStructs.DataSource newDataSource,
-        uint64 initialSequence
-    );
-    event DataSourcesSet(
-        PythInternalStructs.DataSource[] oldDataSources,
-        PythInternalStructs.DataSource[] newDataSources
-    );
-    event FeeSet(uint oldFee, uint newFee);
-    event ValidPeriodSet(uint oldValidPeriod, uint newValidPeriod);
-    event WormholeAddressSet(
-        address oldWormholeAddress,
-        address newWormholeAddress
-    );
-    event TransactionFeeSet(uint oldFee, uint newFee);
-    event FeeWithdrawn(address targetAddress, uint fee);
-
     function verifyGovernanceVM(
         bytes memory encodedVM
     ) internal returns (IWormhole.VM memory parsedVM) {
@@ -75,38 +66,14 @@ abstract contract PythGovernance is
             if (gi.targetChainId == 0)
                 revert PythErrors.InvalidGovernanceTarget();
             upgradeContract(parseUpgradeContractPayload(gi.payload));
-        } else if (
-            gi.action == GovernanceAction.AuthorizeGovernanceDataSourceTransfer
-        ) {
-            AuthorizeGovernanceDataSourceTransfer(
-                parseAuthorizeGovernanceDataSourceTransferPayload(gi.payload)
-            );
-        } else if (gi.action == GovernanceAction.SetDataSources) {
-            setDataSources(parseSetDataSourcesPayload(gi.payload));
-        } else if (gi.action == GovernanceAction.SetFee) {
-            setFee(parseSetFeePayload(gi.payload));
-        } else if (gi.action == GovernanceAction.SetValidPeriod) {
-            setValidPeriod(parseSetValidPeriodPayload(gi.payload));
-        } else if (
-            gi.action == GovernanceAction.RequestGovernanceDataSourceTransfer
-        ) {
-            // RequestGovernanceDataSourceTransfer can be only part of AuthorizeGovernanceDataSourceTransfer message
-            revert PythErrors.InvalidGovernanceMessage();
-        } else if (gi.action == GovernanceAction.SetWormholeAddress) {
-            if (gi.targetChainId == 0)
-                revert PythErrors.InvalidGovernanceTarget();
-            setWormholeAddress(
-                parseSetWormholeAddressPayload(gi.payload),
-                encodedVM
-            );
-        } else if (gi.action == GovernanceAction.SetFeeInToken) {
-            // No-op for EVM chains
-        } else if (gi.action == GovernanceAction.SetTransactionFee) {
-            setTransactionFee(parseSetTransactionFeePayload(gi.payload));
-        } else if (gi.action == GovernanceAction.WithdrawFee) {
-            withdrawFee(parseWithdrawFeePayload(gi.payload));
         } else {
-            revert PythErrors.InvalidGovernanceMessage();
+            // The already-parsed instruction is forwarded instead of the raw
+            // `msg.data`: `verifyGovernanceVM` above has already advanced
+            // `lastExecutedGovernanceSequence` to `vm.sequence`, so re-verifying
+            // the VAA inside the library would revert with `OldGovernanceMessage`.
+            // `encodedVM` is still passed along because `SetWormholeAddress` has
+            // to re-parse it with the newly set wormhole contract.
+            PythGovernanceModule.executeGovernanceAction(_state, gi, encodedVM);
         }
     }
 
@@ -119,155 +86,4 @@ abstract contract PythGovernance is
     function upgradeUpgradableContract(
         UpgradeContractPayload memory payload
     ) internal virtual;
-
-    // Transfer the governance data source to a new value with sanity checks
-    // to ensure the new governance data source can manage the contract.
-    function AuthorizeGovernanceDataSourceTransfer(
-        AuthorizeGovernanceDataSourceTransferPayload memory payload
-    ) internal {
-        PythInternalStructs.DataSource
-            memory oldGovernanceDatSource = governanceDataSource();
-
-        // Make sure the claimVaa is a valid VAA with RequestGovernanceDataSourceTransfer governance message
-        // If it's valid then its emitter can take over the governance from the current emitter.
-        // The VAA is checked here to ensure that the new governance data source is valid and can send message
-        // through wormhole.
-        (IWormhole.VM memory vm, bool valid, ) = wormhole().parseAndVerifyVM(
-            payload.claimVaa
-        );
-        if (!valid) revert PythErrors.InvalidWormholeVaa();
-
-        GovernanceInstruction memory gi = parseGovernanceInstruction(
-            vm.payload
-        );
-        if (gi.targetChainId != chainId() && gi.targetChainId != 0)
-            revert PythErrors.InvalidGovernanceTarget();
-
-        if (gi.action != GovernanceAction.RequestGovernanceDataSourceTransfer)
-            revert PythErrors.InvalidGovernanceMessage();
-
-        RequestGovernanceDataSourceTransferPayload
-            memory claimPayload = parseRequestGovernanceDataSourceTransferPayload(
-                gi.payload
-            );
-
-        // Governance data source index is used to prevent replay attacks, so a claimVaa cannot be used twice.
-        if (
-            governanceDataSourceIndex() >=
-            claimPayload.governanceDataSourceIndex
-        ) revert PythErrors.OldGovernanceMessage();
-
-        setGovernanceDataSourceIndex(claimPayload.governanceDataSourceIndex);
-
-        PythInternalStructs.DataSource
-            memory newGovernanceDS = PythInternalStructs.DataSource(
-                vm.emitterChainId,
-                vm.emitterAddress
-            );
-
-        setGovernanceDataSource(newGovernanceDS);
-
-        // Setting the last executed governance to the claimVaa sequence to avoid using older sequences.
-        setLastExecutedGovernanceSequence(vm.sequence);
-
-        emit GovernanceDataSourceSet(
-            oldGovernanceDatSource,
-            governanceDataSource(),
-            lastExecutedGovernanceSequence()
-        );
-    }
-
-    function setDataSources(SetDataSourcesPayload memory payload) internal {
-        PythInternalStructs.DataSource[]
-            memory oldDataSources = validDataSources();
-
-        for (uint i = 0; i < oldDataSources.length; i += 1) {
-            _state.isValidDataSource[hashDataSource(oldDataSources[i])] = false;
-        }
-
-        delete _state.validDataSources;
-        for (uint i = 0; i < payload.dataSources.length; i++) {
-            _state.validDataSources.push(payload.dataSources[i]);
-            _state.isValidDataSource[
-                hashDataSource(payload.dataSources[i])
-            ] = true;
-        }
-
-        emit DataSourcesSet(oldDataSources, validDataSources());
-    }
-
-    function setFee(SetFeePayload memory payload) internal {
-        uint oldFee = singleUpdateFeeInWei();
-        setSingleUpdateFeeInWei(payload.newFee);
-
-        emit FeeSet(oldFee, singleUpdateFeeInWei());
-    }
-
-    function setValidPeriod(SetValidPeriodPayload memory payload) internal {
-        uint oldValidPeriod = validTimePeriodSeconds();
-        setValidTimePeriodSeconds(payload.newValidPeriod);
-
-        emit ValidPeriodSet(oldValidPeriod, validTimePeriodSeconds());
-    }
-
-    function setWormholeAddress(
-        SetWormholeAddressPayload memory payload,
-        bytes memory encodedVM
-    ) internal {
-        address oldWormholeAddress = address(wormhole());
-        setWormhole(payload.newWormholeAddress);
-
-        // We want to verify that the new wormhole address is valid, so we make sure that it can
-        // parse and verify the same governance VAA that is used to set it.
-        (IWormhole.VM memory vm, bool valid, ) = wormhole().parseAndVerifyVM(
-            encodedVM
-        );
-
-        if (!valid) revert PythErrors.InvalidGovernanceMessage();
-
-        if (!isValidGovernanceDataSource(vm.emitterChainId, vm.emitterAddress))
-            revert PythErrors.InvalidGovernanceMessage();
-
-        if (vm.sequence != lastExecutedGovernanceSequence())
-            revert PythErrors.InvalidWormholeAddressToSet();
-
-        GovernanceInstruction memory gi = parseGovernanceInstruction(
-            vm.payload
-        );
-
-        if (gi.action != GovernanceAction.SetWormholeAddress)
-            revert PythErrors.InvalidWormholeAddressToSet();
-
-        // Purposefully, we don't check whether the chainId is the same as the current chainId because
-        // we might want to change the chain id of the wormhole contract.
-
-        // The following check is not necessary for security, but is a sanity check that the new wormhole
-        // contract parses the payload correctly.
-        SetWormholeAddressPayload
-            memory newPayload = parseSetWormholeAddressPayload(gi.payload);
-
-        if (newPayload.newWormholeAddress != payload.newWormholeAddress)
-            revert PythErrors.InvalidWormholeAddressToSet();
-
-        emit WormholeAddressSet(oldWormholeAddress, address(wormhole()));
-    }
-
-    function setTransactionFee(
-        SetTransactionFeePayload memory payload
-    ) internal {
-        uint oldFee = transactionFeeInWei();
-        setTransactionFeeInWei(payload.newFee);
-
-        emit TransactionFeeSet(oldFee, transactionFeeInWei());
-    }
-
-    function withdrawFee(WithdrawFeePayload memory payload) internal {
-        if (payload.fee > address(this).balance)
-            revert PythErrors.InsufficientFee();
-
-        (bool success, ) = payload.targetAddress.call{value: payload.fee}("");
-        require(success, "Failed to withdraw fees");
-
-        emit FeeWithdrawn(payload.targetAddress, payload.fee);
-    }
 }

--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceEvents.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceEvents.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "./PythInternalStructs.sol";
+
+/**
+ * @dev The events emitted while executing Pyth governance instructions.
+ *
+ * They live in a shared interface so that the implementation contract keeps them
+ * in its ABI while the `PythGovernanceModule` library — which runs via
+ * `delegatecall` and therefore emits from the proxy address — can emit them.
+ */
+interface IPythGovernanceEvents {
+    event ContractUpgraded(address oldImplementation, address newImplementation);
+    event GovernanceDataSourceSet(
+        PythInternalStructs.DataSource oldDataSource,
+        PythInternalStructs.DataSource newDataSource,
+        uint64 initialSequence
+    );
+    event DataSourcesSet(
+        PythInternalStructs.DataSource[] oldDataSources,
+        PythInternalStructs.DataSource[] newDataSources
+    );
+    event FeeSet(uint oldFee, uint newFee);
+    event ValidPeriodSet(uint oldValidPeriod, uint newValidPeriod);
+    event WormholeAddressSet(
+        address oldWormholeAddress,
+        address newWormholeAddress
+    );
+    event TransactionFeeSet(uint oldFee, uint newFee);
+    event FeeWithdrawn(address targetAddress, uint fee);
+}

--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceInstructions.sol
@@ -7,273 +7,161 @@ import "../libraries/external/BytesLib.sol";
 import "./PythInternalStructs.sol";
 import "@pythnetwork/pyth-sdk-solidity/PythErrors.sol";
 
+using BytesLib for bytes;
+
+// The governance instruction types below are declared at file level (rather than
+// inside `PythGovernanceInstructions`) so that both the Pyth implementation
+// contract and the `PythGovernanceModule` library can reference them. A library
+// cannot inherit from a contract, so contract-scoped declarations would not be
+// visible to it.
+
+// Magic is `PTGM` encoded as a 4 byte data: Pyth Governance Message
+uint32 constant MAGIC = 0x5054474d;
+
+enum GovernanceModule {
+    Executor, // 0
+    Target, // 1
+    EvmExecutor, // 2
+    // The stacks target chain contract has custom governance instructions and needs its own module.
+    StacksTarget, // 3
+    // The Stellar wormhole executor (in pyth-network/pyth-lazer) has its own
+    // module so its generic-dispatch actions do not collide with another
+    // module's fixed actions. Reserved here so the id is not reused.
+    StellarExecutor // 4
+}
+
+GovernanceModule constant MODULE = GovernanceModule.Target;
+
+enum GovernanceAction {
+    UpgradeContract, // 0
+    AuthorizeGovernanceDataSourceTransfer, // 1
+    SetDataSources, // 2
+    SetFee, // 3
+    SetValidPeriod, // 4
+    RequestGovernanceDataSourceTransfer, // 5
+    SetWormholeAddress, // 6
+    SetFeeInToken, // 7 - No-op for EVM chains
+    SetTransactionFee, // 8
+    WithdrawFee // 9
+}
+
+struct GovernanceInstruction {
+    GovernanceModule module;
+    GovernanceAction action;
+    uint16 targetChainId;
+    bytes payload;
+}
+
+struct UpgradeContractPayload {
+    address newImplementation;
+}
+
+struct AuthorizeGovernanceDataSourceTransferPayload {
+    // Transfer governance control over this contract to another data source.
+    // The claimVaa field is a VAA created by the new data source; using a VAA prevents mistakes
+    // in the handoff by ensuring that the new data source can send VAAs (i.e., is not an invalid address).
+    bytes claimVaa;
+}
+
+struct RequestGovernanceDataSourceTransferPayload {
+    // Governance data source index is used to prevent replay attacks
+    // So a claimVaa cannot be used twice.
+    uint32 governanceDataSourceIndex;
+}
+
+struct SetDataSourcesPayload {
+    PythInternalStructs.DataSource[] dataSources;
+}
+
+struct SetFeePayload {
+    uint newFee;
+}
+
+struct SetValidPeriodPayload {
+    uint newValidPeriod;
+}
+
+struct SetWormholeAddressPayload {
+    address newWormholeAddress;
+}
+
+struct SetTransactionFeePayload {
+    uint newFee;
+}
+
+struct WithdrawFeePayload {
+    address targetAddress;
+    // Fee in wei, matching the native uint256 type used for address.balance in EVM
+    uint256 fee;
+}
+
+/// @dev Parse a GovernanceInstruction
+/// Declared as a free function so that both `PythGovernanceInstructions` and the
+/// `PythGovernanceModule` library can use it without duplicating the logic.
+function decodeGovernanceInstruction(
+    bytes memory encodedInstruction
+) pure returns (GovernanceInstruction memory gi) {
+    uint index = 0;
+
+    uint32 magic = encodedInstruction.toUint32(index);
+
+    if (magic != MAGIC) revert PythErrors.InvalidGovernanceMessage();
+
+    index += 4;
+
+    uint8 modNumber = encodedInstruction.toUint8(index);
+    gi.module = GovernanceModule(modNumber);
+    index += 1;
+
+    if (gi.module != MODULE) revert PythErrors.InvalidGovernanceTarget();
+
+    uint8 actionNumber = encodedInstruction.toUint8(index);
+    gi.action = GovernanceAction(actionNumber);
+    index += 1;
+
+    gi.targetChainId = encodedInstruction.toUint16(index);
+    index += 2;
+
+    // As solidity performs math operations in a checked mode
+    // if the length of the encoded instruction be smaller than index
+    // it will revert. So we don't need any extra check.
+    gi.payload = encodedInstruction.slice(
+        index,
+        encodedInstruction.length - index
+    );
+}
+
+/// @dev Parse a UpgradeContractPayload (action 0) with minimal validation
+function decodeUpgradeContractPayload(
+    bytes memory encodedPayload
+) pure returns (UpgradeContractPayload memory uc) {
+    uint index = 0;
+
+    uc.newImplementation = address(encodedPayload.toAddress(index));
+    index += 20;
+
+    if (encodedPayload.length != index)
+        revert PythErrors.InvalidGovernanceMessage();
+}
+
 /**
- * @dev `PythGovernanceInstructions` defines a set of structs and parsing functions
- * for Pyth governance instructions.
+ * @dev `PythGovernanceInstructions` exposes the parsing functions that the Pyth
+ * implementation contract needs on its own hot/upgrade path. The parsers for the
+ * remaining governance actions live in the `PythGovernanceModule` library, which
+ * is deployed separately and linked into the implementation.
  */
 contract PythGovernanceInstructions {
-    using BytesLib for bytes;
-
-    // Magic is `PTGM` encoded as a 4 byte data: Pyth Governance Message
-    uint32 constant MAGIC = 0x5054474d;
-
-    enum GovernanceModule {
-        Executor, // 0
-        Target, // 1
-        EvmExecutor, // 2
-        // The stacks target chain contract has custom governance instructions and needs its own module.
-        StacksTarget, // 3
-        // The Stellar wormhole executor (in pyth-network/pyth-lazer) has its own
-        // module so its generic-dispatch actions do not collide with another
-        // module's fixed actions. Reserved here so the id is not reused.
-        StellarExecutor // 4
-    }
-
-    GovernanceModule constant MODULE = GovernanceModule.Target;
-
-    enum GovernanceAction {
-        UpgradeContract, // 0
-        AuthorizeGovernanceDataSourceTransfer, // 1
-        SetDataSources, // 2
-        SetFee, // 3
-        SetValidPeriod, // 4
-        RequestGovernanceDataSourceTransfer, // 5
-        SetWormholeAddress, // 6
-        SetFeeInToken, // 7 - No-op for EVM chains
-        SetTransactionFee, // 8
-        WithdrawFee // 9
-    }
-
-    struct GovernanceInstruction {
-        GovernanceModule module;
-        GovernanceAction action;
-        uint16 targetChainId;
-        bytes payload;
-    }
-
-    struct UpgradeContractPayload {
-        address newImplementation;
-    }
-
-    struct AuthorizeGovernanceDataSourceTransferPayload {
-        // Transfer governance control over this contract to another data source.
-        // The claimVaa field is a VAA created by the new data source; using a VAA prevents mistakes
-        // in the handoff by ensuring that the new data source can send VAAs (i.e., is not an invalid address).
-        bytes claimVaa;
-    }
-
-    struct RequestGovernanceDataSourceTransferPayload {
-        // Governance data source index is used to prevent replay attacks
-        // So a claimVaa cannot be used twice.
-        uint32 governanceDataSourceIndex;
-    }
-
-    struct SetDataSourcesPayload {
-        PythInternalStructs.DataSource[] dataSources;
-    }
-
-    struct SetFeePayload {
-        uint newFee;
-    }
-
-    struct SetValidPeriodPayload {
-        uint newValidPeriod;
-    }
-
-    struct SetWormholeAddressPayload {
-        address newWormholeAddress;
-    }
-
-    struct SetTransactionFeePayload {
-        uint newFee;
-    }
-
-    struct WithdrawFeePayload {
-        address targetAddress;
-        // Fee in wei, matching the native uint256 type used for address.balance in EVM
-        uint256 fee;
-    }
-
     /// @dev Parse a GovernanceInstruction
     function parseGovernanceInstruction(
         bytes memory encodedInstruction
     ) public pure returns (GovernanceInstruction memory gi) {
-        uint index = 0;
-
-        uint32 magic = encodedInstruction.toUint32(index);
-
-        if (magic != MAGIC) revert PythErrors.InvalidGovernanceMessage();
-
-        index += 4;
-
-        uint8 modNumber = encodedInstruction.toUint8(index);
-        gi.module = GovernanceModule(modNumber);
-        index += 1;
-
-        if (gi.module != MODULE) revert PythErrors.InvalidGovernanceTarget();
-
-        uint8 actionNumber = encodedInstruction.toUint8(index);
-        gi.action = GovernanceAction(actionNumber);
-        index += 1;
-
-        gi.targetChainId = encodedInstruction.toUint16(index);
-        index += 2;
-
-        // As solidity performs math operations in a checked mode
-        // if the length of the encoded instruction be smaller than index
-        // it will revert. So we don't need any extra check.
-        gi.payload = encodedInstruction.slice(
-            index,
-            encodedInstruction.length - index
-        );
+        return decodeGovernanceInstruction(encodedInstruction);
     }
 
-    /// @dev Parse a UpgradeContractPayload (action 1) with minimal validation
+    /// @dev Parse a UpgradeContractPayload (action 0) with minimal validation
     function parseUpgradeContractPayload(
         bytes memory encodedPayload
     ) public pure returns (UpgradeContractPayload memory uc) {
-        uint index = 0;
-
-        uc.newImplementation = address(encodedPayload.toAddress(index));
-        index += 20;
-
-        if (encodedPayload.length != index)
-            revert PythErrors.InvalidGovernanceMessage();
-    }
-
-    /// @dev Parse a AuthorizeGovernanceDataSourceTransferPayload (action 2) with minimal validation
-    function parseAuthorizeGovernanceDataSourceTransferPayload(
-        bytes memory encodedPayload
-    )
-        public
-        pure
-        returns (AuthorizeGovernanceDataSourceTransferPayload memory sgds)
-    {
-        sgds.claimVaa = encodedPayload;
-    }
-
-    /// @dev Parse a AuthorizeGovernanceDataSourceTransferPayload (action 2) with minimal validation
-    function parseRequestGovernanceDataSourceTransferPayload(
-        bytes memory encodedPayload
-    )
-        public
-        pure
-        returns (RequestGovernanceDataSourceTransferPayload memory sgdsClaim)
-    {
-        uint index = 0;
-
-        sgdsClaim.governanceDataSourceIndex = encodedPayload.toUint32(index);
-        index += 4;
-
-        if (encodedPayload.length != index)
-            revert PythErrors.InvalidGovernanceMessage();
-    }
-
-    /// @dev Parse a SetDataSourcesPayload (action 3) with minimal validation
-    function parseSetDataSourcesPayload(
-        bytes memory encodedPayload
-    ) public pure returns (SetDataSourcesPayload memory sds) {
-        uint index = 0;
-
-        uint8 dataSourcesLength = encodedPayload.toUint8(index);
-        index += 1;
-
-        sds.dataSources = new PythInternalStructs.DataSource[](
-            dataSourcesLength
-        );
-
-        for (uint i = 0; i < dataSourcesLength; i++) {
-            sds.dataSources[i].chainId = encodedPayload.toUint16(index);
-            index += 2;
-
-            sds.dataSources[i].emitterAddress = encodedPayload.toBytes32(index);
-            index += 32;
-        }
-
-        if (encodedPayload.length != index)
-            revert PythErrors.InvalidGovernanceMessage();
-    }
-
-    /// @dev Parse a SetFeePayload (action 4) with minimal validation
-    function parseSetFeePayload(
-        bytes memory encodedPayload
-    ) public pure returns (SetFeePayload memory sf) {
-        uint index = 0;
-
-        uint64 val = encodedPayload.toUint64(index);
-        index += 8;
-
-        uint64 expo = encodedPayload.toUint64(index);
-        index += 8;
-
-        sf.newFee = uint256(val) * uint256(10) ** uint256(expo);
-
-        if (encodedPayload.length != index)
-            revert PythErrors.InvalidGovernanceMessage();
-    }
-
-    /// @dev Parse a SetValidPeriodPayload (action 5) with minimal validation
-    function parseSetValidPeriodPayload(
-        bytes memory encodedPayload
-    ) public pure returns (SetValidPeriodPayload memory svp) {
-        uint index = 0;
-
-        svp.newValidPeriod = uint256(encodedPayload.toUint64(index));
-        index += 8;
-
-        if (encodedPayload.length != index)
-            revert PythErrors.InvalidGovernanceMessage();
-    }
-
-    /// @dev Parse a UpdateWormholeAddressPayload (action 6) with minimal validation
-    function parseSetWormholeAddressPayload(
-        bytes memory encodedPayload
-    ) public pure returns (SetWormholeAddressPayload memory sw) {
-        uint index = 0;
-
-        sw.newWormholeAddress = address(encodedPayload.toAddress(index));
-        index += 20;
-
-        if (encodedPayload.length != index)
-            revert PythErrors.InvalidGovernanceMessage();
-    }
-
-    /// @dev Parse a SetTransactionFeePayload (action 8) with minimal validation
-    function parseSetTransactionFeePayload(
-        bytes memory encodedPayload
-    ) public pure returns (SetTransactionFeePayload memory stf) {
-        uint index = 0;
-
-        uint64 val = encodedPayload.toUint64(index);
-        index += 8;
-
-        uint64 expo = encodedPayload.toUint64(index);
-        index += 8;
-
-        stf.newFee = uint256(val) * uint256(10) ** uint256(expo);
-
-        if (encodedPayload.length != index)
-            revert PythErrors.InvalidGovernanceMessage();
-    }
-
-    /// @dev Parse a WithdrawFeePayload (action 9) with minimal validation
-    function parseWithdrawFeePayload(
-        bytes memory encodedPayload
-    ) public pure returns (WithdrawFeePayload memory wf) {
-        uint index = 0;
-
-        wf.targetAddress = address(encodedPayload.toAddress(index));
-        index += 20;
-
-        uint64 val = encodedPayload.toUint64(index);
-        index += 8;
-
-        uint64 expo = encodedPayload.toUint64(index);
-        index += 8;
-
-        wf.fee = uint256(val) * uint256(10) ** uint256(expo);
-
-        if (encodedPayload.length != index)
-            revert PythErrors.InvalidGovernanceMessage();
+        return decodeUpgradeContractPayload(encodedPayload);
     }
 }

--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceModule.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernanceModule.sol
@@ -1,0 +1,402 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "../libraries/external/BytesLib.sol";
+import "../wormhole/interfaces/IWormhole.sol";
+import "./PythGovernanceEvents.sol";
+import "./PythGovernanceInstructions.sol";
+import "./PythInternalStructs.sol";
+import "./PythState.sol";
+import "@pythnetwork/pyth-sdk-solidity/PythErrors.sol";
+
+/**
+ * @dev `PythGovernanceModule` holds the cold-path governance handlers that used to
+ * live in the Pyth implementation contract. It is deployed once per chain and
+ * linked into the implementation, which keeps the implementation under the
+ * EIP-170 24,576 byte limit.
+ *
+ * The library is called with `delegatecall`, so `address(this)`, the emitted log
+ * origin and the balance are all those of the Pyth proxy. Storage is reached
+ * through the `PythStorage.State storage` pointer handed in by the caller rather
+ * than through an inherited state variable, so the library never needs to know
+ * where `_state` sits in the implementation's storage layout.
+ *
+ * `UpgradeContract` is deliberately NOT handled here: `executeGovernanceInstruction`
+ * is the only working upgrade path (the owner is renounced, so `_authorizeUpgrade`
+ * always reverts), and routing it through a linked library would make a
+ * mis-linked deployment unrecoverable.
+ */
+library PythGovernanceModule {
+    using BytesLib for bytes;
+
+    /// @dev Execute every governance action other than `UpgradeContract`.
+    ///
+    /// `gi` is the already-parsed instruction and `encodedVM` the raw VAA it came
+    /// from. The VAA is intentionally not re-verified here: the caller has
+    /// already advanced `lastExecutedGovernanceSequence` to `vm.sequence`, so a
+    /// second `verifyGovernanceVM` would revert with `OldGovernanceMessage`.
+    /// `encodedVM` is only needed by `SetWormholeAddress`, which re-parses it
+    /// with the newly set wormhole contract.
+    function executeGovernanceAction(
+        PythStorage.State storage state,
+        GovernanceInstruction memory gi,
+        bytes memory encodedVM
+    ) external {
+        if (
+            gi.action == GovernanceAction.AuthorizeGovernanceDataSourceTransfer
+        ) {
+            authorizeGovernanceDataSourceTransfer(
+                state,
+                parseAuthorizeGovernanceDataSourceTransferPayload(gi.payload)
+            );
+        } else if (gi.action == GovernanceAction.SetDataSources) {
+            setDataSources(state, parseSetDataSourcesPayload(gi.payload));
+        } else if (gi.action == GovernanceAction.SetFee) {
+            setFee(state, parseSetFeePayload(gi.payload));
+        } else if (gi.action == GovernanceAction.SetValidPeriod) {
+            setValidPeriod(state, parseSetValidPeriodPayload(gi.payload));
+        } else if (
+            gi.action == GovernanceAction.RequestGovernanceDataSourceTransfer
+        ) {
+            // RequestGovernanceDataSourceTransfer can be only part of AuthorizeGovernanceDataSourceTransfer message
+            revert PythErrors.InvalidGovernanceMessage();
+        } else if (gi.action == GovernanceAction.SetWormholeAddress) {
+            if (gi.targetChainId == 0)
+                revert PythErrors.InvalidGovernanceTarget();
+            setWormholeAddress(
+                state,
+                parseSetWormholeAddressPayload(gi.payload),
+                encodedVM
+            );
+        } else if (gi.action == GovernanceAction.SetFeeInToken) {
+            // No-op for EVM chains
+        } else if (gi.action == GovernanceAction.SetTransactionFee) {
+            setTransactionFee(state, parseSetTransactionFeePayload(gi.payload));
+        } else if (gi.action == GovernanceAction.WithdrawFee) {
+            withdrawFee(parseWithdrawFeePayload(gi.payload));
+        } else {
+            revert PythErrors.InvalidGovernanceMessage();
+        }
+    }
+
+    // Transfer the governance data source to a new value with sanity checks
+    // to ensure the new governance data source can manage the contract.
+    function authorizeGovernanceDataSourceTransfer(
+        PythStorage.State storage state,
+        AuthorizeGovernanceDataSourceTransferPayload memory payload
+    ) private {
+        PythInternalStructs.DataSource memory oldGovernanceDatSource = state
+            .governanceDataSource;
+
+        // Make sure the claimVaa is a valid VAA with RequestGovernanceDataSourceTransfer governance message
+        // If it's valid then its emitter can take over the governance from the current emitter.
+        // The VAA is checked here to ensure that the new governance data source is valid and can send message
+        // through wormhole.
+        (IWormhole.VM memory vm, bool valid, ) = IWormhole(state.wormhole)
+            .parseAndVerifyVM(payload.claimVaa);
+        if (!valid) revert PythErrors.InvalidWormholeVaa();
+
+        GovernanceInstruction memory gi = decodeGovernanceInstruction(
+            vm.payload
+        );
+        if (
+            gi.targetChainId != IWormhole(state.wormhole).chainId() &&
+            gi.targetChainId != 0
+        ) revert PythErrors.InvalidGovernanceTarget();
+
+        if (gi.action != GovernanceAction.RequestGovernanceDataSourceTransfer)
+            revert PythErrors.InvalidGovernanceMessage();
+
+        RequestGovernanceDataSourceTransferPayload
+            memory claimPayload = parseRequestGovernanceDataSourceTransferPayload(
+                gi.payload
+            );
+
+        // Governance data source index is used to prevent replay attacks, so a claimVaa cannot be used twice.
+        if (
+            state.governanceDataSourceIndex >=
+            claimPayload.governanceDataSourceIndex
+        ) revert PythErrors.OldGovernanceMessage();
+
+        state.governanceDataSourceIndex = claimPayload
+            .governanceDataSourceIndex;
+
+        state.governanceDataSource = PythInternalStructs.DataSource(
+            vm.emitterChainId,
+            vm.emitterAddress
+        );
+
+        // Setting the last executed governance to the claimVaa sequence to avoid using older sequences.
+        state.lastExecutedGovernanceSequence = vm.sequence;
+
+        emit IPythGovernanceEvents.GovernanceDataSourceSet(
+            oldGovernanceDatSource,
+            state.governanceDataSource,
+            state.lastExecutedGovernanceSequence
+        );
+    }
+
+    function setDataSources(
+        PythStorage.State storage state,
+        SetDataSourcesPayload memory payload
+    ) private {
+        PythInternalStructs.DataSource[] memory oldDataSources = state
+            .validDataSources;
+
+        for (uint i = 0; i < oldDataSources.length; i += 1) {
+            state.isValidDataSource[hashDataSource(oldDataSources[i])] = false;
+        }
+
+        delete state.validDataSources;
+        for (uint i = 0; i < payload.dataSources.length; i++) {
+            state.validDataSources.push(payload.dataSources[i]);
+            state.isValidDataSource[
+                hashDataSource(payload.dataSources[i])
+            ] = true;
+        }
+
+        emit IPythGovernanceEvents.DataSourcesSet(
+            oldDataSources,
+            state.validDataSources
+        );
+    }
+
+    function setFee(
+        PythStorage.State storage state,
+        SetFeePayload memory payload
+    ) private {
+        uint oldFee = state.singleUpdateFeeInWei;
+        state.singleUpdateFeeInWei = payload.newFee;
+
+        emit IPythGovernanceEvents.FeeSet(oldFee, state.singleUpdateFeeInWei);
+    }
+
+    function setValidPeriod(
+        PythStorage.State storage state,
+        SetValidPeriodPayload memory payload
+    ) private {
+        uint oldValidPeriod = state.validTimePeriodSeconds;
+        state.validTimePeriodSeconds = payload.newValidPeriod;
+
+        emit IPythGovernanceEvents.ValidPeriodSet(
+            oldValidPeriod,
+            state.validTimePeriodSeconds
+        );
+    }
+
+    function setWormholeAddress(
+        PythStorage.State storage state,
+        SetWormholeAddressPayload memory payload,
+        bytes memory encodedVM
+    ) private {
+        address oldWormholeAddress = state.wormhole;
+        state.wormhole = payable(payload.newWormholeAddress);
+
+        // We want to verify that the new wormhole address is valid, so we make sure that it can
+        // parse and verify the same governance VAA that is used to set it.
+        (IWormhole.VM memory vm, bool valid, ) = IWormhole(state.wormhole)
+            .parseAndVerifyVM(encodedVM);
+
+        if (!valid) revert PythErrors.InvalidGovernanceMessage();
+
+        if (
+            state.governanceDataSource.chainId != vm.emitterChainId ||
+            state.governanceDataSource.emitterAddress != vm.emitterAddress
+        ) revert PythErrors.InvalidGovernanceMessage();
+
+        if (vm.sequence != state.lastExecutedGovernanceSequence)
+            revert PythErrors.InvalidWormholeAddressToSet();
+
+        GovernanceInstruction memory gi = decodeGovernanceInstruction(
+            vm.payload
+        );
+
+        if (gi.action != GovernanceAction.SetWormholeAddress)
+            revert PythErrors.InvalidWormholeAddressToSet();
+
+        // Purposefully, we don't check whether the chainId is the same as the current chainId because
+        // we might want to change the chain id of the wormhole contract.
+
+        // The following check is not necessary for security, but is a sanity check that the new wormhole
+        // contract parses the payload correctly.
+        SetWormholeAddressPayload
+            memory newPayload = parseSetWormholeAddressPayload(gi.payload);
+
+        if (newPayload.newWormholeAddress != payload.newWormholeAddress)
+            revert PythErrors.InvalidWormholeAddressToSet();
+
+        emit IPythGovernanceEvents.WormholeAddressSet(
+            oldWormholeAddress,
+            state.wormhole
+        );
+    }
+
+    function setTransactionFee(
+        PythStorage.State storage state,
+        SetTransactionFeePayload memory payload
+    ) private {
+        uint oldFee = state.transactionFeeInWei;
+        state.transactionFeeInWei = payload.newFee;
+
+        emit IPythGovernanceEvents.TransactionFeeSet(
+            oldFee,
+            state.transactionFeeInWei
+        );
+    }
+
+    function withdrawFee(WithdrawFeePayload memory payload) private {
+        if (payload.fee > address(this).balance)
+            revert PythErrors.InsufficientFee();
+
+        (bool success, ) = payload.targetAddress.call{value: payload.fee}("");
+        require(success, "Failed to withdraw fees");
+
+        emit IPythGovernanceEvents.FeeWithdrawn(
+            payload.targetAddress,
+            payload.fee
+        );
+    }
+
+    function hashDataSource(
+        PythInternalStructs.DataSource memory ds
+    ) private pure returns (bytes32) {
+        return keccak256(abi.encodePacked(ds.chainId, ds.emitterAddress));
+    }
+
+    /// @dev Parse a AuthorizeGovernanceDataSourceTransferPayload (action 1) with minimal validation
+    function parseAuthorizeGovernanceDataSourceTransferPayload(
+        bytes memory encodedPayload
+    )
+        private
+        pure
+        returns (AuthorizeGovernanceDataSourceTransferPayload memory sgds)
+    {
+        sgds.claimVaa = encodedPayload;
+    }
+
+    /// @dev Parse a RequestGovernanceDataSourceTransferPayload (action 5) with minimal validation
+    function parseRequestGovernanceDataSourceTransferPayload(
+        bytes memory encodedPayload
+    )
+        private
+        pure
+        returns (RequestGovernanceDataSourceTransferPayload memory sgdsClaim)
+    {
+        uint index = 0;
+
+        sgdsClaim.governanceDataSourceIndex = encodedPayload.toUint32(index);
+        index += 4;
+
+        if (encodedPayload.length != index)
+            revert PythErrors.InvalidGovernanceMessage();
+    }
+
+    /// @dev Parse a SetDataSourcesPayload (action 2) with minimal validation
+    function parseSetDataSourcesPayload(
+        bytes memory encodedPayload
+    ) private pure returns (SetDataSourcesPayload memory sds) {
+        uint index = 0;
+
+        uint8 dataSourcesLength = encodedPayload.toUint8(index);
+        index += 1;
+
+        sds.dataSources = new PythInternalStructs.DataSource[](
+            dataSourcesLength
+        );
+
+        for (uint i = 0; i < dataSourcesLength; i++) {
+            sds.dataSources[i].chainId = encodedPayload.toUint16(index);
+            index += 2;
+
+            sds.dataSources[i].emitterAddress = encodedPayload.toBytes32(index);
+            index += 32;
+        }
+
+        if (encodedPayload.length != index)
+            revert PythErrors.InvalidGovernanceMessage();
+    }
+
+    /// @dev Parse a SetFeePayload (action 3) with minimal validation
+    function parseSetFeePayload(
+        bytes memory encodedPayload
+    ) private pure returns (SetFeePayload memory sf) {
+        uint index = 0;
+
+        uint64 val = encodedPayload.toUint64(index);
+        index += 8;
+
+        uint64 expo = encodedPayload.toUint64(index);
+        index += 8;
+
+        sf.newFee = uint256(val) * uint256(10) ** uint256(expo);
+
+        if (encodedPayload.length != index)
+            revert PythErrors.InvalidGovernanceMessage();
+    }
+
+    /// @dev Parse a SetValidPeriodPayload (action 4) with minimal validation
+    function parseSetValidPeriodPayload(
+        bytes memory encodedPayload
+    ) private pure returns (SetValidPeriodPayload memory svp) {
+        uint index = 0;
+
+        svp.newValidPeriod = uint256(encodedPayload.toUint64(index));
+        index += 8;
+
+        if (encodedPayload.length != index)
+            revert PythErrors.InvalidGovernanceMessage();
+    }
+
+    /// @dev Parse a SetWormholeAddressPayload (action 6) with minimal validation
+    function parseSetWormholeAddressPayload(
+        bytes memory encodedPayload
+    ) private pure returns (SetWormholeAddressPayload memory sw) {
+        uint index = 0;
+
+        sw.newWormholeAddress = address(encodedPayload.toAddress(index));
+        index += 20;
+
+        if (encodedPayload.length != index)
+            revert PythErrors.InvalidGovernanceMessage();
+    }
+
+    /// @dev Parse a SetTransactionFeePayload (action 8) with minimal validation
+    function parseSetTransactionFeePayload(
+        bytes memory encodedPayload
+    ) private pure returns (SetTransactionFeePayload memory stf) {
+        uint index = 0;
+
+        uint64 val = encodedPayload.toUint64(index);
+        index += 8;
+
+        uint64 expo = encodedPayload.toUint64(index);
+        index += 8;
+
+        stf.newFee = uint256(val) * uint256(10) ** uint256(expo);
+
+        if (encodedPayload.length != index)
+            revert PythErrors.InvalidGovernanceMessage();
+    }
+
+    /// @dev Parse a WithdrawFeePayload (action 9) with minimal validation
+    function parseWithdrawFeePayload(
+        bytes memory encodedPayload
+    ) private pure returns (WithdrawFeePayload memory wf) {
+        uint index = 0;
+
+        wf.targetAddress = address(encodedPayload.toAddress(index));
+        index += 20;
+
+        uint64 val = encodedPayload.toUint64(index);
+        index += 8;
+
+        uint64 expo = encodedPayload.toUint64(index);
+        index += 8;
+
+        wf.fee = uint256(val) * uint256(10) ** uint256(expo);
+
+        if (encodedPayload.length != index)
+            revert PythErrors.InvalidGovernanceMessage();
+    }
+}

--- a/target_chains/ethereum/contracts/contracts/pyth/PythUpgradable.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythUpgradable.sol
@@ -60,6 +60,14 @@ contract PythUpgradable is
         return 0x97a6f304;
     }
 
+    /// The address of the `PythGovernanceModule` library linked into this
+    /// implementation. Governance actions other than `UpgradeContract` are
+    /// executed by `delegatecall`ing into it, so deployment tooling and proposal
+    /// review can use this to confirm the link on-chain.
+    function governanceModule() public pure returns (address) {
+        return address(PythGovernanceModule);
+    }
+
     // Execute a UpgradeContract governance message
     function upgradeUpgradableContract(
         UpgradeContractPayload memory payload
@@ -71,6 +79,13 @@ contract PythUpgradable is
         // the new contract. This call will fail if the method does not exists or the magic
         // is different.
         if (this.pythUpgradableMagic() != 0x97a6f304)
+            revert PythErrors.InvalidGovernanceMessage();
+
+        // The new implementation only handles `UpgradeContract` on its own; every
+        // other governance action lives in its linked governance module. Reject
+        // the upgrade if that library is missing, so a mis-linked deployment
+        // reverts here instead of bricking governance on the proxy.
+        if (this.governanceModule().code.length == 0)
             revert PythErrors.InvalidGovernanceMessage();
 
         emit ContractUpgraded(oldImplementation, _getImplementation());

--- a/target_chains/ethereum/contracts/package.json
+++ b/target_chains/ethereum/contracts/package.json
@@ -54,5 +54,5 @@
     "setup-foundry": "./setup-foundry.sh",
     "test": "forge test"
   },
-  "version": "1.5.0"
+  "version": "1.5.1"
 }

--- a/target_chains/ethereum/contracts/test/Executor.t.sol
+++ b/target_chains/ethereum/contracts/test/Executor.t.sol
@@ -46,7 +46,7 @@ contract ExecutorTest is Test, WormholeTestUtils {
     ) internal returns (bytes memory vaa) {
         bytes memory payload = abi.encodePacked(
             uint32(0x5054474d),
-            PythGovernanceInstructions.GovernanceModule.EvmExecutor,
+            GovernanceModule.EvmExecutor,
             Executor.ExecutorAction.Execute,
             CHAIN_ID,
             address(executor),
@@ -73,7 +73,7 @@ contract ExecutorTest is Test, WormholeTestUtils {
     ) internal view returns (bytes memory vaa) {
         bytes memory payload = abi.encodePacked(
             uint32(0x5054474d),
-            PythGovernanceInstructions.GovernanceModule.EvmExecutor,
+            GovernanceModule.EvmExecutor,
             Executor.ExecutorAction.Execute,
             CHAIN_ID,
             address(executor),
@@ -161,7 +161,7 @@ contract ExecutorTest is Test, WormholeTestUtils {
 
         bytes memory payload = abi.encodePacked(
             uint32(0x5054474d),
-            PythGovernanceInstructions.GovernanceModule.EvmExecutor,
+            GovernanceModule.EvmExecutor,
             Executor.ExecutorAction.Execute,
             CHAIN_ID,
             address(executor),
@@ -235,7 +235,7 @@ contract ExecutorTest is Test, WormholeTestUtils {
 
         bytes memory payload = abi.encodePacked(
             uint32(0x5054474d),
-            PythGovernanceInstructions.GovernanceModule.EvmExecutor,
+            GovernanceModule.EvmExecutor,
             Executor.ExecutorAction.Execute,
             CHAIN_ID,
             address(executor),
@@ -320,7 +320,7 @@ contract ExecutorTest is Test, WormholeTestUtils {
         for (uint i = 0; i < forgeItems.length; i++) {
             bytes memory payload = abi.encodePacked(
                 uint32(0x5054474d),
-                PythGovernanceInstructions.GovernanceModule.EvmExecutor,
+                GovernanceModule.EvmExecutor,
                 Executor.ExecutorAction.Execute,
                 CHAIN_ID,
                 address(executor),
@@ -348,7 +348,7 @@ contract ExecutorTest is Test, WormholeTestUtils {
     function testIncorrectOwnerEmitterAddress() public {
         bytes memory payload = abi.encodePacked(
             uint32(0x5054474d),
-            PythGovernanceInstructions.GovernanceModule.EvmExecutor,
+            GovernanceModule.EvmExecutor,
             Executor.ExecutorAction.Execute,
             CHAIN_ID,
             address(executor),
@@ -373,7 +373,7 @@ contract ExecutorTest is Test, WormholeTestUtils {
     function testIncorrectOwnerEmitterChainId() public {
         bytes memory payload = abi.encodePacked(
             uint32(0x5054474d),
-            PythGovernanceInstructions.GovernanceModule.EvmExecutor,
+            GovernanceModule.EvmExecutor,
             Executor.ExecutorAction.Execute,
             CHAIN_ID,
             address(executor),
@@ -405,7 +405,7 @@ contract ExecutorTest is Test, WormholeTestUtils {
 
         bytes memory payload = abi.encodePacked(
             uint32(0x5054474d),
-            PythGovernanceInstructions.GovernanceModule.EvmExecutor,
+            GovernanceModule.EvmExecutor,
             Executor.ExecutorAction.Execute,
             CHAIN_ID,
             address(executor),
@@ -439,7 +439,7 @@ contract ExecutorTest is Test, WormholeTestUtils {
     function testInvalidPayload() public {
         bytes memory payload = abi.encodePacked(
             uint32(0x5054474d),
-            PythGovernanceInstructions.GovernanceModule.EvmExecutor,
+            GovernanceModule.EvmExecutor,
             Executor.ExecutorAction.Execute,
             CHAIN_ID,
             address(executor),
@@ -469,7 +469,7 @@ contract ExecutorTest is Test, WormholeTestUtils {
     function testIncorrectTargetChainId() public {
         bytes memory payload = abi.encodePacked(
             uint32(0x5054474d),
-            PythGovernanceInstructions.GovernanceModule.EvmExecutor,
+            GovernanceModule.EvmExecutor,
             Executor.ExecutorAction.Execute,
             uint16(3),
             address(executor),
@@ -494,7 +494,7 @@ contract ExecutorTest is Test, WormholeTestUtils {
     function testIncorrectTargetAddress() public {
         bytes memory payload = abi.encodePacked(
             uint32(0x5054474d),
-            PythGovernanceInstructions.GovernanceModule.EvmExecutor,
+            GovernanceModule.EvmExecutor,
             Executor.ExecutorAction.Execute,
             CHAIN_ID,
             address(0x1),
@@ -519,7 +519,7 @@ contract ExecutorTest is Test, WormholeTestUtils {
     function testIncorrectAction() public {
         bytes memory payload = abi.encodePacked(
             uint32(0x5054474d),
-            PythGovernanceInstructions.GovernanceModule.EvmExecutor,
+            GovernanceModule.EvmExecutor,
             uint8(17),
             CHAIN_ID,
             address(executor),
@@ -544,7 +544,7 @@ contract ExecutorTest is Test, WormholeTestUtils {
     function testCallReverts() public {
         bytes memory payload = abi.encodePacked(
             uint32(0x5054474d),
-            PythGovernanceInstructions.GovernanceModule.EvmExecutor,
+            GovernanceModule.EvmExecutor,
             Executor.ExecutorAction.Execute,
             CHAIN_ID,
             address(executor),
@@ -569,7 +569,7 @@ contract ExecutorTest is Test, WormholeTestUtils {
     function testCallToEoaReverts() public {
         bytes memory payload = abi.encodePacked(
             uint32(0x5054474d),
-            PythGovernanceInstructions.GovernanceModule.EvmExecutor,
+            GovernanceModule.EvmExecutor,
             Executor.ExecutorAction.Execute,
             CHAIN_ID,
             address(executor),

--- a/target_chains/ethereum/contracts/test/PythGovernance.t.sol
+++ b/target_chains/ethereum/contracts/test/PythGovernance.t.sol
@@ -58,6 +58,15 @@ contract PythGovernanceTest is
         assertEq(OwnableUpgradeable(address(pyth)).owner(), address(0));
     }
 
+    function testGovernanceModuleIsLinked() public {
+        // Governance actions other than UpgradeContract are executed by the
+        // separately deployed PythGovernanceModule library, so the address it was
+        // linked at must be readable on-chain and must hold code.
+        address module = PythUpgradable(address(pyth)).governanceModule();
+        assertTrue(module != address(0));
+        assertTrue(module.code.length > 0);
+    }
+
     function testValidDataSources() public {
         assertTrue(
             PythGetters(address(pyth)).isValidDataSource(


### PR DESCRIPTION
## The problem

`PythUpgradable` was **24,490 bytes** of runtime code against the EIP-170 limit of
24,576 — **86 bytes of headroom**. Any new governance action failed to deploy.

Governance execution accounted for 3,646 of those bytes and is a cold path
(executed a few times a year), so it is the right thing to move out of the
implementation.

This PR is deliberately scoped to the refactor **only**. No new governance action,
no migration logic.

## Sizes

| Contract | Before | After |
| --- | --- | --- |
| `PythUpgradable` (runtime) | 24,490 B (86 B headroom) | **20,599 B (3,977 B headroom)** |
| `PythGovernanceModule` (new library, runtime) | — | 7,073 B |

`optimizer_runs` is unchanged at 200 and `via_ir` stays **off** — it was evaluated
and rejected because it costs 3–5% gas on `parsePriceFeedUpdates`/`getPrice`.

## The hybrid split, and why

`executeGovernanceInstruction` keeps inline, in the implementation:

- `verifyGovernanceVM` (VAA verification + sequence bookkeeping)
- `parseGovernanceInstruction` (the instruction header parse)
- the `GovernanceAction.UpgradeContract` branch, including
  `parseUpgradeContractPayload` and `upgradeContract` / `upgradeUpgradableContract`

Everything else — `AuthorizeGovernanceDataSourceTransfer`, `SetDataSources`,
`SetFee`, `SetValidPeriod`, the `RequestGovernanceDataSourceTransfer` reject
branch, `SetWormholeAddress`, the `SetFeeInToken` no-op, `SetTransactionFee`,
`WithdrawFee`, and their payload parsers — moved into
`contracts/pyth/PythGovernanceModule.sol`.

**`UpgradeContract` must stay inline.** `executeGovernanceInstruction` →
`upgradeContract` is the *only* upgrade path that exists: the owner is renounced in
`PythUpgradable.initialize`, and `_authorizeUpgrade` is `onlyOwner`, so it always
reverts. If the library were ever mis-linked or undeployed and *all* governance
went through it, the contract would be permanently unupgradeable — an
unrecoverable brick. Keeping `UpgradeContract` in the implementation makes that
failure mode recoverable: a bad link costs you every other governance action until
you upgrade out of it, but you can still upgrade.

## Why a library with a storage pointer, not a module contract

The mechanism is a Solidity `library` whose external functions take
`PythStorage.State storage` as their first parameter.

A module *contract* that re-inherits `PythGetters`/`PythSetters` was rejected:
`_state` sits at **slot 201** in `PythUpgradable` (OZ's `Initializable`,
`OwnableUpgradeable` and `UUPSUpgradeable` gaps occupy slots 0–200), and a module
contract would place its own `_state` at slot 0 unless hand-padded. That kind of
drift corrupts state silently instead of reverting, and the padding has to be kept
in sync by hand forever.

With a library the caller passes the storage pointer, so there is nothing to keep
in sync. Concretely:

- The library address is embedded in **code** at link time (`linkReferences` in the
  artifact), never in storage.
- The storage pointer resolves correctly across the `delegatecall`.
- Events emitted inside the library are emitted from the **caller's** address (the
  proxy), so log origin and topics are unchanged. Verified against the proxy
  address with `vm.recordLogs`.

## The `msg.data` sequence double-write trap

`verifyGovernanceVM` calls `setLastExecutedGovernanceSequence(vm.sequence)`
**before** dispatch. A library that re-verified the VAA from raw `msg.data` would
hit `vm.sequence <= lastExecutedGovernanceSequence()` on an *equal* comparison and
revert with `OldGovernanceMessage` — every governance action would fail.

So the implementation forwards the **already-parsed `GovernanceInstruction`** plus
the raw `encodedVM`. The VAA is not re-verified in the library. `encodedVM` is
still passed because `SetWormholeAddress` needs it: it re-parses that same VAA with
the newly set wormhole contract as a liveness check.

## Module address exposure and upgrade guard

- `PythUpgradable.governanceModule()` returns `address(PythGovernanceModule)`, so
  deployment tooling and proposal review can verify the link on-chain.
- `upgradeUpgradableContract` already probed the new implementation with
  `this.pythUpgradableMagic()`. It now *also* requires that the new
  implementation's `governanceModule()` has non-empty code. A mis-linked deployment
  is now a reverted upgrade instead of a bricked contract.

## Behavior, ABI and storage

- **Storage layout is byte-identical.** `forge inspect PythUpgradable storage-layout`
  before and after diff to nothing:

  | Name | Type | Slot | Offset | Bytes |
  | --- | --- | --- | --- | --- |
  | `_initialized` | `uint8` | 0 | 0 | 1 |
  | `_initializing` | `bool` | 0 | 1 | 1 |
  | `__gap` | `uint256[50]` | 1 | 0 | 1600 |
  | `_owner` | `address` | 51 | 0 | 20 |
  | `__gap` | `uint256[49]` | 52 | 0 | 1568 |
  | `__gap` | `uint256[50]` | 101 | 0 | 1600 |
  | `__gap` | `uint256[50]` | 151 | 0 | 1600 |
  | `_state` | `struct PythStorage.State` | **201** | 0 | 448 |

- **Same events**, same signatures, same emitting address (the proxy). They are now
  declared once in `IPythGovernanceEvents` so both the implementation (which keeps
  them in its ABI) and the library (which emits them) can reference them.
- **Same custom errors and revert conditions** on every path, including the
  `InvalidGovernanceTarget` guard on `SetWormholeAddress` with `targetChainId == 0`
  and the `require(success, "Failed to withdraw fees")` string.
- **The governance test suite passes essentially unedited.** `test/PythGovernance.t.sol`
  (706 lines, covering every action) needed **zero** changes to imports, types or
  assertions; the only edit is one *added* test asserting `governanceModule()`
  points at deployed code. `test/Executor.t.sol` changed only in the qualified name
  of the `GovernanceModule` enum.

### ABI delta (intentional)

Moving the payload parsers into the library removes them from the *implementation's*
ABI. Nothing in this repo or in `contract_manager` calls them, and they were pure
decoding helpers with no state access:

- Removed: `parseSetFeePayload`, `parseSetValidPeriodPayload`,
  `parseSetDataSourcesPayload`, `parseSetWormholeAddressPayload`,
  `parseSetTransactionFeePayload`, `parseWithdrawFeePayload`,
  `parseAuthorizeGovernanceDataSourceTransferPayload`,
  `parseRequestGovernanceDataSourceTransferPayload`, and the
  `InvalidWormholeAddressToSet()` error entry (only thrown from
  `SetWormholeAddress`, which now lives in the library — the selector still
  bubbles up unchanged at runtime, and it is still declared in `PythErrors`).
- Added: `governanceModule()`.
- Unchanged: `executeGovernanceInstruction`, `parseGovernanceInstruction`,
  `parseUpgradeContractPayload`, every `IPyth` method, and every event.

## File-level type hoist

`GovernanceInstruction`, the payload structs, and the `GovernanceAction` /
`GovernanceModule` enums used to live *inside* the `PythGovernanceInstructions`
contract. A library cannot inherit a contract, so they moved to file level.

This also let `contracts/executor/Executor.sol` drop its `MAGIC` redeclaration and
the `// TODO: it's annoying that we can't import this from PythGovernanceInstructions`
workaround; it now imports `MAGIC` and `GovernanceModule` directly. The import is
selective (`import {MAGIC, GovernanceModule} from ...`) so that the executor's own
`MODULE` constant and its differently-shaped `GovernanceInstruction` struct do not
collide with the file-level declarations of the same name.

## Deployment tooling

`contract_manager/scripts/upgrade_evm_pricefeed_contracts.ts` passed
`artifact.bytecode.object` straight into `chain.deploy`. With a linked library that
string still contains unresolved `__$…$__` placeholders, so the deployment would
fail or produce broken bytecode.

The script now takes a repeatable `--library-std-output <path>`, deploys each
library to every selected chain (cached like the implementation), and splices the
addresses into the implementation bytecode before deploying it. It throws if any
placeholder is left unresolved.

## Verification

- `forge test --deny-warnings`: **367 passed, 0 failed, 0 skipped** (366 on `main`;
  the extra one is the added `governanceModule()` test).
- `forge build --sizes`: numbers in the table above.
- `forge inspect PythUpgradable storage-layout`: identical before/after.
- `pre-commit run --from-ref origin/main --to-ref HEAD`: all hooks pass.
- Contract version cut to `1.4.7` in `contracts/pyth/Pyth.sol`, package version to
  `1.5.1`.

## Follow-ups (deliberately not in this PR)

1. **`contract_manager/scripts/check_proposal.ts`** (lines ~144 and ~232) prints
   `getCodeDigestWithoutAddress` per chain so reviewers can confirm identical code
   across chains. A per-chain library address embedded in the implementation breaks
   that equality. Options: CREATE2-deploy the library to an identical address on
   every chain, or extend the strip to zero the library address and print a second
   digest for the library itself.
2. **zkSync/zksolc `libraries` linking config** in `deploy/zkSyncDeployNewPythImpl.ts`.
3. **Etherscan verification** now needs library addresses — `VERIFY.md`.
4. **Fresh deploys**: `contract_manager/scripts/deploy_evm_pricefeed_contracts.ts`
   goes through `deployIfNotCached` in `scripts/common.ts`, which has the same
   unresolved-placeholder problem as the upgrade script did. The link helper added
   here should be hoisted into `common.ts` and wired in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
