### PR TITLE
deploy(pro-compatible) Etherlink Core contracts

### DIFF
--- a/contract_manager/src/store/contracts/EvmLazerContracts.json
+++ b/contract_manager/src/store/contracts/EvmLazerContracts.json
@@ -178,5 +178,10 @@
     "address": "0xACeA761c27A909d4D3895128EBe6370FDE2dF481",
     "chain": "flow_mainnet",
     "type": "EvmLazerContract"
+  },
+  {
+    "address": "0xACeA761c27A909d4D3895128EBe6370FDE2dF481",
+    "chain": "etherlink",
+    "type": "EvmLazerContract"
   }
 ]

--- a/contract_manager/src/store/contracts/EvmPriceFeedContracts.json
+++ b/contract_manager/src/store/contracts/EvmPriceFeedContracts.json
@@ -1152,5 +1152,11 @@
     "chain": "flow_mainnet",
     "type": "EvmPriceFeedContract",
     "deploymentType": "pro-compatible-production"
+  },
+  {
+    "address": "0x9DF02366A266D79DA5E978aDBEe8B8502117ee1a",
+    "chain": "etherlink",
+    "type": "EvmPriceFeedContract",
+    "deploymentType": "pro-compatible-production"
   }
 ]

--- a/contract_manager/src/store/contracts/EvmWormholeContracts.json
+++ b/contract_manager/src/store/contracts/EvmWormholeContracts.json
@@ -1174,5 +1174,11 @@
     "chain": "flow_mainnet",
     "type": "EvmWormholeContract",
     "deploymentType": "pro-compatible-production"
+  },
+  {
+    "address": "0x7698E925FfC29655576D0b361D75Af579e20AdAc",
+    "chain": "etherlink",
+    "type": "EvmWormholeContract",
+    "deploymentType": "pro-compatible-production"
   }
 ]


### PR DESCRIPTION
Adds the pro-compatible Core deployment on **Etherlink mainnet** (chain id 42793) to the contract store.

| Contract | Address |
| --- | --- |
| Core price feed (`pro-compatible-production`) | `0x9DF02366A266D79DA5E978aDBEe8B8502117ee1a` |
| Router Wormhole receiver | `0x7698E925FfC29655576D0b361D75Af579e20AdAc` |

The legacy Core contract (`0x2880aB155794e7179c9eE2e38200202908C17B43`) and its stable receiver are untouched; both deployments now coexist on Etherlink.

## Verification (all via `eth_call`, mainnet)

- `version()` → `1.4.6`
- `getValidTimePeriod()` → `60`
- `singleUpdateFeeInWei()` → `0`
- `wormhole()` → `0x7698E925FfC29655576D0b361D75Af579e20AdAc`
- `validDataSources()` → single entry, emitter chain `26` / `0x507974686e6574...` (`PythnetPythnetPythnetPythnetPyth`)
- Receiver `chainId()` → `60055`, matching `etherlink` in `xc_admin_common/src/chains.ts`
- Receiver guardian set index `0`, 5 routers (3-of-5 half quorum)
- **Replay:** a live `updatePriceFeedsIfNecessary` payload pulled from the Optimism pro contract `0xa78951b6bADC9F4740f6f456E9144705D5C5E4B2` executes without reverting against the new proxy
- **Negative:** a legacy `hermes.pyth.network` payload reverts `InvalidWormholeVaa()` (`0x2acbe915`), as expected

## Pyth Pro / Lazer

Also adds the `PythLazer` deployment on Etherlink mainnet, at the shared fleet address `0xACeA761c27A909d4D3895128EBe6370FDE2dF481`.

- `version()` -> `0.2.0`
- Implementation `0xd8f4a467abec64bc944eee1325b9007879b6555b`, bytecode **byte-identical** to the `0.2.0` deployments on Flow mainnet and Robinhood (same impl address, same code hash)
- `verification_fee()` -> `1` wei
- `owner()` -> `0x98046Bd286715D3B0BC227Dd7a956b83D8978603`, the Etherlink `EvmExecutorContract` already in the store, so the contract is under governance rather than a deployer EOA
- `getTrustedSigners()` -> one signer `0x26FB61A864c758AE9fBA027a96010480658385B9`, expiry `2077357410` (2035-10-30), matching the rest of the fleet
- **Live payload:** a freshly fetched signed update from `pyth-lazer-0.dourolabs.app` (feed 3) passes `verifyUpdate`, returning the payload and recovering the trusted signer. Byte-identical result to the same call on Flow mainnet.
- **Negative:** 0-wei call reverts `Insufficient fee provided`; malformed input reverts `input too short`

Both deployments are mainnet-only. Neither contract exists on shadownet (127823) or ghostnet (128123).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
