### PR TITLE
feat(evm): allow SetWormholeAddress without dual-verify

### DIFF
--- a/target_chains/ethereum/contracts/contracts/pyth/PythGovernance.sol
+++ b/target_chains/ethereum/contracts/contracts/pyth/PythGovernance.sol
@@ -95,10 +95,7 @@ abstract contract PythGovernance is
         } else if (gi.action == GovernanceAction.SetWormholeAddress) {
             if (gi.targetChainId == 0)
                 revert PythErrors.InvalidGovernanceTarget();
-            setWormholeAddress(
-                parseSetWormholeAddressPayload(gi.payload),
-                encodedVM
-            );
+            setWormholeAddress(parseSetWormholeAddressPayload(gi.payload));
         } else if (gi.action == GovernanceAction.SetFeeInToken) {
             // No-op for EVM chains
         } else if (gi.action == GovernanceAction.SetTransactionFee) {
@@ -211,43 +208,16 @@ abstract contract PythGovernance is
     }
 
     function setWormholeAddress(
-        SetWormholeAddressPayload memory payload,
-        bytes memory encodedVM
+        SetWormholeAddressPayload memory payload
     ) internal {
+        if (payload.newWormholeAddress == address(0))
+            revert PythErrors.InvalidWormholeAddressToSet();
+
+        if (payload.newWormholeAddress.code.length == 0)
+            revert PythErrors.InvalidWormholeAddressToSet();
+
         address oldWormholeAddress = address(wormhole());
         setWormhole(payload.newWormholeAddress);
-
-        // We want to verify that the new wormhole address is valid, so we make sure that it can
-        // parse and verify the same governance VAA that is used to set it.
-        (IWormhole.VM memory vm, bool valid, ) = wormhole().parseAndVerifyVM(
-            encodedVM
-        );
-
-        if (!valid) revert PythErrors.InvalidGovernanceMessage();
-
-        if (!isValidGovernanceDataSource(vm.emitterChainId, vm.emitterAddress))
-            revert PythErrors.InvalidGovernanceMessage();
-
-        if (vm.sequence != lastExecutedGovernanceSequence())
-            revert PythErrors.InvalidWormholeAddressToSet();
-
-        GovernanceInstruction memory gi = parseGovernanceInstruction(
-            vm.payload
-        );
-
-        if (gi.action != GovernanceAction.SetWormholeAddress)
-            revert PythErrors.InvalidWormholeAddressToSet();
-
-        // Purposefully, we don't check whether the chainId is the same as the current chainId because
-        // we might want to change the chain id of the wormhole contract.
-
-        // The following check is not necessary for security, but is a sanity check that the new wormhole
-        // contract parses the payload correctly.
-        SetWormholeAddressPayload
-            memory newPayload = parseSetWormholeAddressPayload(gi.payload);
-
-        if (newPayload.newWormholeAddress != payload.newWormholeAddress)
-            revert PythErrors.InvalidWormholeAddressToSet();
 
         emit WormholeAddressSet(oldWormholeAddress, address(wormhole()));
     }

--- a/target_chains/ethereum/contracts/test/PythGovernance.t.sol
+++ b/target_chains/ethereum/contracts/test/PythGovernance.t.sol
@@ -47,6 +47,8 @@ contract PythGovernanceTest is
     uint16 constant TEST_PYTH2_WORMHOLE_CHAIN_ID = 1;
     bytes32 constant TEST_PYTH2_WORMHOLE_EMITTER =
         0x71f8dcb863d176e2c420ad6610cf687359612b6fb392e0642b0ca6b1f186aa3b;
+    bytes32 constant TEST_CUTOVER_PRICE_EMITTER =
+        0x0000000000000000000000000000000000000000000000000000000000001111;
     uint16 constant TARGET_CHAIN_ID = 2;
 
     function setUp() public {
@@ -304,9 +306,7 @@ contract PythGovernanceTest is
                 TARGET_CHAIN_ID,
                 uint8(1), // Number of data sources
                 uint16(1), // Chain ID
-                bytes32(
-                    0x0000000000000000000000000000000000000000000000000000000000001111
-                ) // Emitter
+                TEST_CUTOVER_PRICE_EMITTER
             );
     }
 
@@ -336,7 +336,7 @@ contract PythGovernanceTest is
         assertTrue(
             PythGetters(address(pyth)).isValidDataSource(
                 1,
-                0x0000000000000000000000000000000000000000000000000000000000001111
+                TEST_CUTOVER_PRICE_EMITTER
             )
         );
 
@@ -345,12 +345,7 @@ contract PythGovernanceTest is
         ).validDataSources();
         assertEq(dataSources.length, 1);
         assertEq(dataSources[0].chainId, 1);
-        assertEq(
-            dataSources[0].emitterAddress,
-            bytes32(
-                0x0000000000000000000000000000000000000000000000000000000000001111
-            )
-        );
+        assertEq(dataSources[0].emitterAddress, TEST_CUTOVER_PRICE_EMITTER);
 
         assertEq(
             address(PythGetters(address(pyth)).wormhole()),
@@ -366,6 +361,50 @@ contract PythGovernanceTest is
             PythGetters(address(pyth)).lastExecutedGovernanceSequence(),
             expectedSequence
         );
+    }
+
+    /// @dev After cutover, Pyth must verify VAAs on the new receiver. A payload
+    /// still signed by the legacy guardians is rejected; the same payload signed
+    /// by the new receiver's keys executes.
+    function executeGovernanceWithNewWormhole(
+        address newWormhole,
+        uint8 numGuardians,
+        uint256 keyOffset,
+        uint64 sequence
+    ) internal {
+        bytes memory setFeeMessage = abi.encodePacked(
+            MAGIC,
+            uint8(GovernanceModule.Target),
+            uint8(GovernanceAction.SetFee),
+            TARGET_CHAIN_ID,
+            uint64(5),
+            uint64(3)
+        );
+
+        bytes memory staleVaa = encodeAndSignMessage(
+            setFeeMessage,
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            sequence
+        );
+        vm.expectRevert(PythErrors.InvalidWormholeVaa.selector);
+        PythGovernance(address(pyth)).executeGovernanceInstruction(staleVaa);
+
+        uint256[] memory newSigners = new uint256[](numGuardians);
+        for (uint256 i = 0; i < numGuardians; ++i) {
+            newSigners[i] = i + 1 + keyOffset;
+        }
+        currentSigners = newSigners;
+        wormholeReceiverAddr = newWormhole;
+
+        bytes memory setFeeVaa = encodeAndSignMessage(
+            setFeeMessage,
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            sequence
+        );
+        PythGovernance(address(pyth)).executeGovernanceInstruction(setFeeVaa);
+        assertEq(PythGetters(address(pyth)).singleUpdateFeeInWei(), 5000);
     }
 
     function testSetWormholeAddressToUnrelatedReceiver() public {
@@ -430,6 +469,7 @@ contract PythGovernanceTest is
         );
 
         assertCutoverState(newWormhole, 2);
+        executeGovernanceWithNewWormhole(newWormhole, 1, 100, 3);
     }
 
     function testCutoverUpgradeThenSetDataSourcesThenSetWormhole() public {
@@ -484,6 +524,7 @@ contract PythGovernanceTest is
         );
 
         assertCutoverState(newWormhole, 3);
+        executeGovernanceWithNewWormhole(newWormhole, 1, 100, 4);
     }
 
     function testTransferGovernanceDataSource() public {

--- a/target_chains/ethereum/contracts/test/PythGovernance.t.sol
+++ b/target_chains/ethereum/contracts/test/PythGovernance.t.sol
@@ -264,6 +264,228 @@ contract PythGovernanceTest is
         assertEq(address(PythGetters(address(pyth)).wormhole()), newWormhole);
     }
 
+    /// @dev Deploy a receiver with distinct guardian keys, then restore
+    /// `currentSigners` / `wormholeReceiverAddr` so later VAAs are still signed
+    /// by the original guardians.
+    function deployUnrelatedWormholeReceiver(
+        uint8 numGuardians,
+        uint256 keyOffset
+    ) internal returns (address newWormhole) {
+        uint256[] memory originalSigners = currentSigners;
+        address originalReceiver = wormholeReceiverAddr;
+        newWormhole = setUpWormholeReceiverWithKeyOffset(
+            numGuardians,
+            keyOffset
+        );
+        currentSigners = originalSigners;
+        wormholeReceiverAddr = originalReceiver;
+    }
+
+    function deployUnrelatedHalfWormholeReceiver(
+        uint8 numGuardians,
+        uint256 keyOffset
+    ) internal returns (address newWormhole) {
+        uint256[] memory originalSigners = currentSigners;
+        address originalReceiver = wormholeReceiverAddr;
+        newWormhole = setUpWormholeReceiverHalfWithKeyOffset(
+            numGuardians,
+            keyOffset
+        );
+        currentSigners = originalSigners;
+        wormholeReceiverAddr = originalReceiver;
+    }
+
+    function encodeSetDataSourcesMessage() internal pure returns (bytes memory) {
+        return
+            abi.encodePacked(
+                MAGIC,
+                uint8(GovernanceModule.Target),
+                uint8(GovernanceAction.SetDataSources),
+                TARGET_CHAIN_ID,
+                uint8(1), // Number of data sources
+                uint16(1), // Chain ID
+                bytes32(
+                    0x0000000000000000000000000000000000000000000000000000000000001111
+                ) // Emitter
+            );
+    }
+
+    function encodeSetWormholeAddressMessage(
+        address newWormhole
+    ) internal pure returns (bytes memory) {
+        return
+            abi.encodePacked(
+                MAGIC,
+                uint8(GovernanceModule.Target),
+                uint8(GovernanceAction.SetWormholeAddress),
+                TARGET_CHAIN_ID,
+                newWormhole
+            );
+    }
+
+    function assertCutoverState(
+        address expectedWormhole,
+        uint64 expectedSequence
+    ) internal {
+        assertFalse(
+            PythGetters(address(pyth)).isValidDataSource(
+                TEST_PYTH2_WORMHOLE_CHAIN_ID,
+                TEST_PYTH2_WORMHOLE_EMITTER
+            )
+        );
+        assertTrue(
+            PythGetters(address(pyth)).isValidDataSource(
+                1,
+                0x0000000000000000000000000000000000000000000000000000000000001111
+            )
+        );
+
+        PythInternalStructs.DataSource[] memory dataSources = PythGetters(
+            address(pyth)
+        ).validDataSources();
+        assertEq(dataSources.length, 1);
+        assertEq(dataSources[0].chainId, 1);
+        assertEq(
+            dataSources[0].emitterAddress,
+            bytes32(
+                0x0000000000000000000000000000000000000000000000000000000000001111
+            )
+        );
+
+        assertEq(
+            address(PythGetters(address(pyth)).wormhole()),
+            expectedWormhole
+        );
+
+        PythInternalStructs.DataSource memory govDs = PythGetters(address(pyth))
+            .governanceDataSource();
+        assertEq(govDs.chainId, TEST_GOVERNANCE_CHAIN_ID);
+        assertEq(govDs.emitterAddress, TEST_GOVERNANCE_EMITTER);
+
+        assertEq(
+            PythGetters(address(pyth)).lastExecutedGovernanceSequence(),
+            expectedSequence
+        );
+    }
+
+    function testSetWormholeAddressToUnrelatedReceiver() public {
+        address newWormhole = deployUnrelatedWormholeReceiver(1, 100);
+
+        bytes memory vaa = encodeAndSignMessage(
+            encodeSetWormholeAddressMessage(newWormhole),
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            1
+        );
+
+        PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
+        assertEq(address(PythGetters(address(pyth)).wormhole()), newWormhole);
+    }
+
+    function testSetWormholeAddressRejectsZero() public {
+        bytes memory vaa = encodeAndSignMessage(
+            encodeSetWormholeAddressMessage(address(0)),
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            1
+        );
+
+        vm.expectRevert(PythErrors.InvalidWormholeAddressToSet.selector);
+        PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
+    }
+
+    function testSetWormholeAddressRejectsNoCode() public {
+        bytes memory vaa = encodeAndSignMessage(
+            encodeSetWormholeAddressMessage(address(0xdead)),
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            1
+        );
+
+        vm.expectRevert(PythErrors.InvalidWormholeAddressToSet.selector);
+        PythGovernance(address(pyth)).executeGovernanceInstruction(vaa);
+    }
+
+    function testCutoverSetDataSourcesThenSetWormhole() public {
+        address newWormhole = deployUnrelatedHalfWormholeReceiver(1, 100);
+
+        bytes memory setDataSourcesVaa = encodeAndSignMessage(
+            encodeSetDataSourcesMessage(),
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            1
+        );
+        PythGovernance(address(pyth)).executeGovernanceInstruction(
+            setDataSourcesVaa
+        );
+
+        bytes memory setWormholeVaa = encodeAndSignMessage(
+            encodeSetWormholeAddressMessage(newWormhole),
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            2
+        );
+        PythGovernance(address(pyth)).executeGovernanceInstruction(
+            setWormholeVaa
+        );
+
+        assertCutoverState(newWormhole, 2);
+    }
+
+    function testCutoverUpgradeThenSetDataSourcesThenSetWormhole() public {
+        PythUpgradable newImplementation = new PythUpgradable();
+        address newWormhole = deployUnrelatedHalfWormholeReceiver(1, 100);
+
+        bytes memory upgradeData = abi.encodePacked(
+            MAGIC,
+            uint8(GovernanceModule.Target),
+            uint8(GovernanceAction.UpgradeContract),
+            TARGET_CHAIN_ID,
+            address(newImplementation)
+        );
+        bytes memory upgradeVaa = encodeAndSignMessage(
+            upgradeData,
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            1
+        );
+        PythGovernance(address(pyth)).executeGovernanceInstruction(upgradeVaa);
+
+        address implAddr = address(
+            uint160(
+                uint256(
+                    vm.load(
+                        address(pyth),
+                        0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc
+                    )
+                )
+            )
+        );
+        assertEq(implAddr, address(newImplementation));
+
+        bytes memory setDataSourcesVaa = encodeAndSignMessage(
+            encodeSetDataSourcesMessage(),
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            2
+        );
+        PythGovernance(address(pyth)).executeGovernanceInstruction(
+            setDataSourcesVaa
+        );
+
+        bytes memory setWormholeVaa = encodeAndSignMessage(
+            encodeSetWormholeAddressMessage(newWormhole),
+            TEST_GOVERNANCE_CHAIN_ID,
+            TEST_GOVERNANCE_EMITTER,
+            3
+        );
+        PythGovernance(address(pyth)).executeGovernanceInstruction(
+            setWormholeVaa
+        );
+
+        assertCutoverState(newWormhole, 3);
+    }
+
     function testTransferGovernanceDataSource() public {
         uint16 newEmitterChain = 2;
         bytes32 newEmitterAddress = 0x0000000000000000000000000000000000000000000000000000000000001111;

--- a/target_chains/ethereum/contracts/test/utils/WormholeTestUtils.t.sol
+++ b/target_chains/ethereum/contracts/test/utils/WormholeTestUtils.t.sol
@@ -81,6 +81,41 @@ abstract contract WormholeTestUtils is Test {
         return wormholeReceiverAddr;
     }
 
+    /// @dev Like `setUpWormholeReceiverHalf`, but guardian private keys start at
+    /// `1 + keyOffset`. A second `setUpWormholeReceiverHalf(n)` call reuses keys
+    /// `1..n` and would share guardians with the first receiver.
+    function setUpWormholeReceiverHalfWithKeyOffset(
+        uint8 numGuardians,
+        uint256 keyOffset
+    ) public returns (address) {
+        ReceiverImplementationHalf wormholeReceiverImpl = new ReceiverImplementationHalf();
+        ReceiverSetup wormholeReceiverSetup = new ReceiverSetup();
+
+        WormholeReceiver wormholeReceiver = new WormholeReceiver(
+            address(wormholeReceiverSetup),
+            new bytes(0)
+        );
+
+        address[] memory initSigners = new address[](numGuardians);
+        currentSigners = new uint256[](numGuardians);
+
+        for (uint256 i = 0; i < numGuardians; ++i) {
+            currentSigners[i] = i + 1 + keyOffset;
+            initSigners[i] = vm.addr(currentSigners[i]);
+        }
+
+        ReceiverSetup(address(wormholeReceiver)).setup(
+            address(wormholeReceiverImpl),
+            initSigners,
+            CHAIN_ID,
+            GOVERNANCE_CHAIN_ID,
+            GOVERNANCE_CONTRACT
+        );
+        wormholeReceiverAddr = address(wormholeReceiver);
+
+        return wormholeReceiverAddr;
+    }
+
     function setUpWormholeReceiver(
         uint8 numGuardians
     ) public returns (address) {
@@ -108,6 +143,41 @@ abstract contract WormholeTestUtils is Test {
             CHAIN_ID, // Ethereum chain ID
             GOVERNANCE_CHAIN_ID, // Governance source chain ID (1 = solana)
             GOVERNANCE_CONTRACT // Governance source address
+        );
+        wormholeReceiverAddr = address(wormholeReceiver);
+
+        return wormholeReceiverAddr;
+    }
+
+    /// @dev Like `setUpWormholeReceiver`, but guardian private keys start at
+    /// `1 + keyOffset`. A second `setUpWormholeReceiver(n)` call reuses keys
+    /// `1..n` and would share guardians with the first receiver.
+    function setUpWormholeReceiverWithKeyOffset(
+        uint8 numGuardians,
+        uint256 keyOffset
+    ) public returns (address) {
+        ReceiverImplementation wormholeReceiverImpl = new ReceiverImplementation();
+        ReceiverSetup wormholeReceiverSetup = new ReceiverSetup();
+
+        WormholeReceiver wormholeReceiver = new WormholeReceiver(
+            address(wormholeReceiverSetup),
+            new bytes(0)
+        );
+
+        address[] memory initSigners = new address[](numGuardians);
+        currentSigners = new uint256[](numGuardians);
+
+        for (uint256 i = 0; i < numGuardians; ++i) {
+            currentSigners[i] = i + 1 + keyOffset;
+            initSigners[i] = vm.addr(currentSigners[i]);
+        }
+
+        ReceiverSetup(address(wormholeReceiver)).setup(
+            address(wormholeReceiverImpl),
+            initSigners,
+            CHAIN_ID,
+            GOVERNANCE_CHAIN_ID,
+            GOVERNANCE_CONTRACT
         );
         wormholeReceiverAddr = address(wormholeReceiver);
 


### PR DESCRIPTION
## Summary
- Remove the post-write dual-VAA re-verify from `SetWormholeAddress` so a governance VAA verified on the legacy Wormhole can point `_state.wormhole` at a Pro receiver whose guardians cannot verify that same VAA.
- Reject zero-address and empty-code targets (`extcodesize`) instead; emit `WormholeAddressSet` as before.
- Add forge tests for an unrelated receiver, reject zero/no-code, and the `SetDataSources` → `SetWormholeAddress` (and upgrade-first) cutover sequence. Governance emitter and sequence watermark stay unchanged.

This is PR A of the EVM pro-compatible in-place cutover. `PythUpgradable` runtime is **24,067 bytes** (EIP-170 limit 24,576).

## Test plan
- [ ] `cd target_chains/ethereum/contracts && forge test --match-contract PythGovernanceTest`
- [ ] `forge build --sizes` — confirm `PythUpgradable` runtime stays under 24,576
- [ ] Confirm `testSetWormholeAddress` (same-guardian) still passes
- [ ] Confirm `testSetWormholeAddressToUnrelatedReceiver` succeeds (different guardian keys; VAA signed by the original set)
- [ ] Confirm zero address and `address(0xdead)` revert with `InvalidWormholeAddressToSet`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->