### PR TITLE
feat(contract_manager): migrate legacy EVM price feeds to pro-compatible

### DIFF
--- a/contract_manager/scripts/check_proposal.ts
+++ b/contract_manager/scripts/check_proposal.ts
@@ -7,12 +7,15 @@ import { Wallet } from "@coral-xyz/anchor";
 import type { PythCluster } from "@pythnetwork/client/lib/cluster";
 import { getPythClusterApiUrl } from "@pythnetwork/client/lib/cluster";
 import {
+  AuthorizeGovernanceDataSourceTransfer,
   CosmosUpgradeContract,
   EvmExecute,
   EvmSetWormholeAddress,
   EvmUpgradeContract,
   getProposalInstructions,
   MultisigParser,
+  RequestGovernanceDataSourceTransfer,
+  SetDataSources,
   UpdateTrustedSigner256Bit,
   UpdateTrustedSigner264Bit,
   UpgradeSuiLazerContract,
@@ -24,7 +27,8 @@ import SquadsMeshClass from "@sqds/mesh";
 import Web3 from "web3";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-
+import type { DeploymentType } from "../src/core/base";
+import { getDefaultDeploymentConfig, toDeploymentType } from "../src/core/base";
 import {
   CosmWasmChain,
   EvmChain,
@@ -40,6 +44,11 @@ import {
   getCodeDigestWithoutAddress,
 } from "../src/core/contracts/evm";
 import { DefaultStore } from "../src/node/utils/store";
+import {
+  dataSourcesEqual,
+  findStoredWormhole,
+  normalizeHex,
+} from "./evm_pro_cutover";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -48,6 +57,32 @@ function getSquadsMesh() {
   return (
     (SquadsMeshClass as { default?: typeof SquadsMeshClass }).default ??
     SquadsMeshClass
+  );
+}
+
+type CutoverGroup = {
+  upgrade?: EvmUpgradeContract;
+  setDataSources?: SetDataSources;
+  setWormhole?: EvmSetWormholeAddress;
+  governanceTransfer?: string;
+};
+
+function matchingEvmChains(
+  targetChainId: string,
+  cluster: PythCluster,
+): EvmChain[] {
+  return Object.values(DefaultStore.chains).filter(
+    (chain): chain is EvmChain =>
+      chain instanceof EvmChain &&
+      chain.isMainnet() === (cluster === "mainnet-beta") &&
+      chain.wormholeChainName === targetChainId,
+  );
+}
+
+function guardianSetsEqual(onChain: string[], expected: string[]): boolean {
+  if (onChain.length !== expected.length) return false;
+  return onChain.every(
+    (guardian, i) => normalizeHex(guardian) === normalizeHex(expected[i] ?? ""),
   );
 }
 
@@ -65,6 +100,11 @@ const parser = yargs(hideBin(process.argv))
       desc: "Type of EVM contract to verify (entropy or lazer). Required when checking EvmExecute instructions.",
       type: "string",
     },
+    "deployment-type": {
+      demandOption: false,
+      desc: "Pro deployment config to check against. Defaults from --cluster: mainnet-beta → pro-compatible-production, otherwise pro-compatible-staging",
+      type: "string",
+    },
     proposal: {
       demandOption: true,
       desc: "The proposal address to check",
@@ -72,9 +112,117 @@ const parser = yargs(hideBin(process.argv))
     },
   });
 
+async function verifyCutoverGroup(
+  targetChainId: string,
+  group: CutoverGroup,
+  cluster: PythCluster,
+  deploymentType: DeploymentType,
+): Promise<boolean> {
+  const expected = getDefaultDeploymentConfig(deploymentType);
+  let ok = true;
+  console.log(
+    `\nVerifying Pro cutover triple on ${targetChainId} against ${deploymentType}`,
+  );
+
+  if (group.governanceTransfer) {
+    console.error(
+      `FAIL: cutover for ${targetChainId} also contains ${group.governanceTransfer}; governance emitter must not change`,
+    );
+    ok = false;
+  }
+
+  for (const chain of matchingEvmChains(targetChainId, cluster)) {
+    if (group.upgrade) {
+      const contract = new EvmPriceFeedContract(chain, group.upgrade.address);
+      const digest = await contract.getCodeDigestWithoutAddress();
+      console.log(
+        `${chain.getId()}  UpgradeContract address:${group.upgrade.address} digest:${digest}`,
+      );
+    }
+
+    if (group.setDataSources) {
+      const match = dataSourcesEqual(
+        group.setDataSources.dataSources,
+        expected.dataSources,
+      );
+      console.log(
+        `${chain.getId()}  SetDataSources ${match ? "MATCH" : "MISMATCH"} expected ${JSON.stringify(expected.dataSources)} got ${JSON.stringify(group.setDataSources.dataSources)}`,
+      );
+      if (!match) ok = false;
+    }
+
+    if (group.setWormhole) {
+      const address = group.setWormhole.address;
+      const stored = findStoredWormhole(chain, address);
+      if (!stored) {
+        console.error(
+          `FAIL: ${chain.getId()} SetWormholeAddress ${address} is not an EvmWormholeContract in the store`,
+        );
+        ok = false;
+      } else if (stored.deploymentType !== deploymentType) {
+        console.error(
+          `FAIL: ${chain.getId()} wormhole ${address} deploymentType=${stored.deploymentType ?? "unlabeled"}, expected ${deploymentType}`,
+        );
+        ok = false;
+      } else {
+        console.log(
+          `${chain.getId()}  SetWormholeAddress ${address} store deploymentType=${stored.deploymentType} MATCH`,
+        );
+      }
+
+      const prefixed = address.startsWith("0x") ? address : `0x${address}`;
+      const contract = new EvmWormholeContract(chain, prefixed);
+      const currentIndex = await contract.getCurrentGuardianSetIndex();
+      const guardianSet = await contract.getGuardianSet();
+      const proxyContract = new EvmPriceFeedContract(chain, prefixed);
+      const proxyCode = await proxyContract.getCode();
+      const receiverImplementation =
+        await proxyContract.getImplementationAddress();
+      const implementationCode = await new EvmPriceFeedContract(
+        chain,
+        receiverImplementation,
+      ).getCode();
+      const proxyDigest = Web3.utils.keccak256(proxyCode);
+      const implementationDigest = Web3.utils.keccak256(implementationCode);
+      const guardianMatch = guardianSetsEqual(
+        guardianSet,
+        expected.wormholeConfig.initialGuardianSet,
+      );
+      const halfQuorum = Math.floor(guardianSet.length / 2) + 1;
+      console.log(
+        `${chain.getId()}  wormhole proxy digest:\t${proxyDigest}\nimplementation digest:\t${implementationDigest} (should be ReceiverImplementationHalf)\nguardian set index:\t${currentIndex}\nguardian set vs ${deploymentType} initialGuardianSet:\t${guardianMatch ? "MATCH" : "MISMATCH"}\nconfig quorum:\t${expected.wormholeConfig.quorum} (half quorum of ${guardianSet.length} is ${halfQuorum})`,
+      );
+      if (!guardianMatch) ok = false;
+      if (expected.wormholeConfig.quorum !== "half") {
+        console.error(
+          `FAIL: ${deploymentType} wormholeConfig.quorum is ${expected.wormholeConfig.quorum}, expected half`,
+        );
+        ok = false;
+      }
+    }
+  }
+
+  return ok;
+}
+
 async function main() {
   const argv = await parser.argv;
   const cluster = argv.cluster as PythCluster;
+  let deploymentType: DeploymentType;
+  if (argv["deployment-type"]) {
+    deploymentType = toDeploymentType(argv["deployment-type"]);
+  } else if (cluster === "mainnet-beta") {
+    deploymentType = "pro-compatible-production";
+  } else {
+    deploymentType = "pro-compatible-staging";
+  }
+  const cutoverByTarget = new Map<string, CutoverGroup>();
+  const record = (targetChainId: string) => {
+    const current = cutoverByTarget.get(targetChainId) ?? {};
+    cutoverByTarget.set(targetChainId, current);
+    return current;
+  };
+  let failed = false;
   const mesh = getSquadsMesh();
   const squad = mesh.endpoint(
     getPythClusterApiUrl(cluster),
@@ -93,7 +241,26 @@ async function main() {
 
   for (const instruction of parsedInstructions) {
     if (instruction instanceof WormholeMultisigInstruction) {
+      if (
+        instruction.governanceAction instanceof
+          AuthorizeGovernanceDataSourceTransfer ||
+        instruction.governanceAction instanceof
+          RequestGovernanceDataSourceTransfer
+      ) {
+        const targetChainId = instruction.governanceAction.targetChainId;
+        const name =
+          instruction.governanceAction instanceof
+          AuthorizeGovernanceDataSourceTransfer
+            ? "AuthorizeGovernanceDataSourceTransfer"
+            : "RequestGovernanceDataSourceTransfer";
+        console.error(
+          `WARNING: proposal contains ${name} for ${targetChainId}. Cutover must not change the governance emitter.`,
+        );
+        record(targetChainId).governanceTransfer = name;
+      }
       if (instruction.governanceAction instanceof EvmSetWormholeAddress) {
+        record(instruction.governanceAction.targetChainId).setWormhole =
+          instruction.governanceAction;
         console.log(
           `Verifying EVM set wormhole address on ${instruction.governanceAction.targetChainId}`,
         );
@@ -129,6 +296,8 @@ async function main() {
         }
       }
       if (instruction.governanceAction instanceof EvmUpgradeContract) {
+        record(instruction.governanceAction.targetChainId).upgrade =
+          instruction.governanceAction;
         console.log(
           `Verifying EVM Upgrade Contract on ${instruction.governanceAction.targetChainId}`,
         );
@@ -145,6 +314,32 @@ async function main() {
             // this should be the same keccak256 of the deployedCode property generated by truffle
             console.log(`${chain.getId()}  Address:${address} digest:${code}`);
           }
+        }
+      }
+      if (instruction.governanceAction instanceof SetDataSources) {
+        record(instruction.governanceAction.targetChainId).setDataSources =
+          instruction.governanceAction;
+        const expected = getDefaultDeploymentConfig(deploymentType);
+        console.log(
+          `Verifying SetDataSources on ${instruction.governanceAction.targetChainId} against ${deploymentType}`,
+        );
+        const match = dataSourcesEqual(
+          instruction.governanceAction.dataSources,
+          expected.dataSources,
+        );
+        console.log(
+          `  ${match ? "MATCH" : "MISMATCH"} expected ${JSON.stringify(expected.dataSources)} got ${JSON.stringify(instruction.governanceAction.dataSources)}`,
+        );
+        if (!match && argv["deployment-type"]) {
+          failed = true;
+        }
+        for (const chain of matchingEvmChains(
+          instruction.governanceAction.targetChainId,
+          cluster,
+        )) {
+          console.log(
+            `${chain.getId()}  SetDataSources emitters ${match ? "match" : "do not match"} ${deploymentType}`,
+          );
         }
       }
       if (instruction.governanceAction instanceof CosmosUpgradeContract) {
@@ -391,6 +586,30 @@ async function main() {
         }
       }
     }
+  }
+
+  for (const [targetChainId, group] of cutoverByTarget) {
+    if (group.upgrade && group.setDataSources && group.setWormhole) {
+      const ok = await verifyCutoverGroup(
+        targetChainId,
+        group,
+        cluster,
+        deploymentType,
+      );
+      if (!ok) failed = true;
+    } else if (
+      group.governanceTransfer &&
+      (group.upgrade || group.setDataSources || group.setWormhole)
+    ) {
+      console.error(
+        `FAIL: ${targetChainId} mixes ${group.governanceTransfer} with cutover actions`,
+      );
+      failed = true;
+    }
+  }
+
+  if (failed) {
+    throw new Error("Proposal failed cutover / SetDataSources checks");
   }
 }
 

--- a/contract_manager/scripts/evm_pro_cutover.ts
+++ b/contract_manager/scripts/evm_pro_cutover.ts
@@ -1,0 +1,109 @@
+import type { DataSource } from "@pythnetwork/xc-admin-common";
+
+import type { DeploymentType } from "../src/core/base";
+import type { EvmChain } from "../src/core/chains";
+import {
+  EvmPriceFeedContract,
+  EvmWormholeContract,
+} from "../src/core/contracts";
+import { DefaultStore } from "../src/node/utils/store";
+
+export const MAINNET_OPS_VAULT_ID =
+  "mainnet-beta_FVQyHcooAtThJ83XFrNnv74BcinbRH3bRmfFamAHBfuj";
+export const DEVNET_OPS_VAULT_ID =
+  "devnet_6baWtW1zTUVMSJHJQVxDUXWzqrQeYBr6mu31j3bTKwY3";
+
+export function getOpsVault(vault: "mainnet" | "devnet") {
+  const id = vault === "mainnet" ? MAINNET_OPS_VAULT_ID : DEVNET_OPS_VAULT_ID;
+  const found = DefaultStore.vaults[id];
+  if (!found) {
+    throw new Error(`Vault ${id} not found in DefaultStore`);
+  }
+  return found;
+}
+
+export function normalizeHex(value: string): string {
+  return value.replace(/^0x/i, "").toLowerCase();
+}
+
+export function dataSourcesEqual(a: DataSource[], b: DataSource[]): boolean {
+  if (a.length !== b.length) return false;
+  const keys = (sources: DataSource[]) =>
+    sources
+      .map((ds) => `${ds.emitterChain}:${normalizeHex(ds.emitterAddress)}`)
+      .sort();
+  const left = keys(a);
+  const right = keys(b);
+  return left.every((key, i) => key === right[i]);
+}
+
+export function governanceDataSourcesEqual(
+  a: DataSource,
+  b: DataSource,
+): boolean {
+  return (
+    a.emitterChain === b.emitterChain &&
+    normalizeHex(a.emitterAddress) === normalizeHex(b.emitterAddress)
+  );
+}
+
+export function isLegacyPriceFeedDeployment(
+  deploymentType: DeploymentType | undefined,
+): boolean {
+  return (
+    deploymentType === undefined ||
+    deploymentType === "stable" ||
+    deploymentType === "beta"
+  );
+}
+
+export function requireProCompatibleDeploymentType(
+  type: DeploymentType,
+): asserts type is "pro-compatible-staging" | "pro-compatible-production" {
+  if (
+    type !== "pro-compatible-staging" &&
+    type !== "pro-compatible-production"
+  ) {
+    throw new Error(
+      `deployment-type must be pro-compatible-production or pro-compatible-staging, got ${type}`,
+    );
+  }
+}
+
+/**
+ * Finds the legacy (stable / beta / unlabeled) Pyth proxy on an EVM chain.
+ * Side-by-side pro-compatible proxies are ignored so in-place cutover never
+ * targets a newly deployed address.
+ */
+export function findLegacyEvmPriceFeedContract(
+  chain: EvmChain,
+): EvmPriceFeedContract | undefined {
+  const matches: EvmPriceFeedContract[] = [];
+  for (const contract of Object.values(DefaultStore.contracts)) {
+    if (!(contract instanceof EvmPriceFeedContract)) continue;
+    if (contract.getChain().getId() !== chain.getId()) continue;
+    if (isLegacyPriceFeedDeployment(contract.deploymentType)) {
+      matches.push(contract);
+    }
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Multiple legacy EvmPriceFeedContract entries on ${chain.getId()}: ${matches
+        .map((contract) => contract.address)
+        .join(", ")}`,
+    );
+  }
+  return matches[0];
+}
+
+export function findStoredWormhole(chain: EvmChain, address: string) {
+  const normalized = normalizeHex(address);
+  for (const contract of Object.values(DefaultStore.wormhole_contracts)) {
+    if (!(contract instanceof EvmWormholeContract)) continue;
+    if (contract.getChain().getId() !== chain.getId()) continue;
+    if (normalizeHex(contract.address) === normalized) {
+      return contract;
+    }
+  }
+  return undefined;
+}

--- a/contract_manager/scripts/execute_evm_cutover_vaas.ts
+++ b/contract_manager/scripts/execute_evm_cutover_vaas.ts
@@ -1,0 +1,361 @@
+/** biome-ignore-all lint/suspicious/noConsole: CLI script */
+/* eslint-disable @typescript-eslint/no-floating-promises */
+/* eslint-disable unicorn/prefer-top-level-await */
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
+/* eslint-disable no-console */
+
+/**
+ * Executes an in-place Pro cutover on one legacy EVM Pyth proxy:
+ *
+ *   VAA₁ UpgradeContract          — its own transaction (skipped if already applied)
+ *   VAA₂ SetDataSources +
+ *   VAA₃ SetWormholeAddress       — one Multicall3 transaction
+ *
+ * Does not fall back to two sequential txs if Multicall3 is missing; that would
+ * leave a window where neither legacy nor Pro price updates verify.
+ *
+ * Usage: pnpm tsx scripts/execute_evm_cutover_vaas.ts \
+ *   --chain <chain> --private-key <key> --upgrade-sequence <n> \
+ *   --deployment-type pro-compatible-production|pro-compatible-staging
+ */
+
+import { parseVaa } from "@certusone/wormhole-sdk";
+import type { PythGovernanceAction } from "@pythnetwork/xc-admin-common";
+import {
+  decodeGovernancePayload,
+  EvmSetWormholeAddress,
+  EvmUpgradeContract,
+  SetDataSources,
+} from "@pythnetwork/xc-admin-common";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+import {
+  getDefaultDeploymentConfig,
+  toDeploymentType,
+  toPrivateKey,
+} from "../src/core/base";
+import { EvmChain } from "../src/core/chains";
+import { SubmittedWormholeMessage } from "../src/node/utils/governance";
+import { DefaultStore } from "../src/node/utils/store";
+import { COMMON_DEPLOY_OPTIONS } from "./common";
+import {
+  dataSourcesEqual,
+  findLegacyEvmPriceFeedContract,
+  getOpsVault,
+  governanceDataSourcesEqual,
+  normalizeHex,
+  requireProCompatibleDeploymentType,
+} from "./evm_pro_cutover";
+
+const MULTICALL3_ADDRESS = "0xcA11bde05977b3631167028862bE2a173976CA11";
+
+const MULTICALL3_ABI = [
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "address", name: "target", type: "address" },
+          { internalType: "bool", name: "allowFailure", type: "bool" },
+          { internalType: "bytes", name: "callData", type: "bytes" },
+        ],
+        internalType: "struct Multicall3.Call3[]",
+        name: "calls",
+        type: "tuple[]",
+      },
+    ],
+    name: "aggregate3",
+    outputs: [
+      {
+        components: [
+          { internalType: "bool", name: "success", type: "bool" },
+          { internalType: "bytes", name: "returnData", type: "bytes" },
+        ],
+        internalType: "struct Multicall3.Result[]",
+        name: "returnData",
+        type: "tuple[]",
+      },
+    ],
+    stateMutability: "payable",
+    type: "function",
+  },
+];
+
+const parser = yargs(hideBin(process.argv))
+  .scriptName("execute_evm_cutover_vaas.ts")
+  .usage(
+    "Executes cutover VAAs on a legacy EVM Pyth proxy: UpgradeContract alone, then SetDataSources+SetWormholeAddress via Multicall3.\n" +
+      "Usage: $0 --chain <chain> --private-key <private-key> --upgrade-sequence <n> --deployment-type <pro-compatible-production|pro-compatible-staging>",
+  )
+  .options({
+    chain: {
+      demandOption: true,
+      desc: "Chain whose legacy Pyth proxy should execute the cutover VAAs",
+      type: "string",
+    },
+    "data-sources-sequence": {
+      desc: "Vault sequence of the SetDataSources VAA. Defaults to upgrade-sequence + 1",
+      type: "number",
+    },
+    "deployment-type": {
+      demandOption: true,
+      desc: "Must be pro-compatible-production or pro-compatible-staging",
+      type: "string",
+    },
+    dryrun: {
+      default: false,
+      desc: "Fetch and decode VAAs without sending transactions",
+      type: "boolean",
+    },
+    "gas-price-multiplier": COMMON_DEPLOY_OPTIONS["gas-price-multiplier"],
+    "private-key": COMMON_DEPLOY_OPTIONS["private-key"],
+    save: {
+      default: false,
+      desc: "After success, assert on-chain state vs Pro config and set the store deploymentType",
+      type: "boolean",
+    },
+    "upgrade-sequence": {
+      demandOption: true,
+      desc: "Vault sequence of the UpgradeContract VAA (VAA₁)",
+      type: "number",
+    },
+    vault: {
+      choices: ["mainnet", "devnet"] as const,
+      desc: "Ops vault used to fetch VAAs. Defaults to mainnet for mainnet chains and devnet for testnet",
+      type: "string",
+    },
+    "wormhole-sequence": {
+      desc: "Vault sequence of the SetWormholeAddress VAA. Defaults to upgrade-sequence + 2",
+      type: "number",
+    },
+  });
+
+async function fetchVaultVaa(
+  vault: ReturnType<typeof getOpsVault>,
+  sequence: number,
+): Promise<Buffer> {
+  const submitted = new SubmittedWormholeMessage(
+    await vault.getEmitter(),
+    sequence,
+    vault.cluster,
+  );
+  return submitted.fetchVaa();
+}
+
+function requireAction<T extends PythGovernanceAction>(
+  vaa: Buffer,
+  sequence: number,
+  guard: (action: PythGovernanceAction | undefined) => action is T,
+  label: string,
+): T {
+  const parsed = parseVaa(vaa);
+  const action = decodeGovernancePayload(parsed.payload);
+  if (!guard(action)) {
+    throw new Error(
+      `Sequence ${sequence} is not ${label} (got ${action?.constructor.name ?? "unknown"})`,
+    );
+  }
+  return action;
+}
+
+async function main() {
+  const argv = await parser.argv;
+  const chain = DefaultStore.getChainOrThrow(argv.chain, EvmChain);
+  const deploymentType = toDeploymentType(argv.deploymentType);
+  requireProCompatibleDeploymentType(deploymentType);
+
+  const vaultChoice = argv.vault ?? (chain.isMainnet() ? "mainnet" : "devnet");
+  const vault = getOpsVault(vaultChoice);
+  const privateKey = toPrivateKey(argv.privateKey);
+  const upgradeSequence = argv.upgradeSequence;
+  const dataSourcesSequence = argv.dataSourcesSequence ?? upgradeSequence + 1;
+  const wormholeSequence = argv.wormholeSequence ?? upgradeSequence + 2;
+
+  const legacy = findLegacyEvmPriceFeedContract(chain);
+  if (!legacy) {
+    throw new Error(
+      `No legacy EvmPriceFeedContract (stable/beta/unlabeled) on ${chain.getId()}`,
+    );
+  }
+
+  console.log("Vault", vault.getId());
+  console.log("Chain", chain.getId());
+  console.log("Legacy proxy", legacy.address);
+  console.log(
+    `Sequences: upgrade=${upgradeSequence} dataSources=${dataSourcesSequence} wormhole=${wormholeSequence}`,
+  );
+
+  const upgradeVaa = await fetchVaultVaa(vault, upgradeSequence);
+  const dataSourcesVaa = await fetchVaultVaa(vault, dataSourcesSequence);
+  const wormholeVaa = await fetchVaultVaa(vault, wormholeSequence);
+
+  const upgradeAction = requireAction(
+    upgradeVaa,
+    upgradeSequence,
+    (action): action is EvmUpgradeContract =>
+      action instanceof EvmUpgradeContract,
+    "EvmUpgradeContract",
+  );
+  const dataSourcesAction = requireAction(
+    dataSourcesVaa,
+    dataSourcesSequence,
+    (action): action is SetDataSources => action instanceof SetDataSources,
+    "SetDataSources",
+  );
+  const wormholeAction = requireAction(
+    wormholeVaa,
+    wormholeSequence,
+    (action): action is EvmSetWormholeAddress =>
+      action instanceof EvmSetWormholeAddress,
+    "EvmSetWormholeAddress",
+  );
+
+  for (const [label, targetChainId] of [
+    ["UpgradeContract", upgradeAction.targetChainId],
+    ["SetDataSources", dataSourcesAction.targetChainId],
+    ["SetWormholeAddress", wormholeAction.targetChainId],
+  ] as const) {
+    if (targetChainId !== chain.wormholeChainName) {
+      throw new Error(
+        `${label} targets ${targetChainId}, not ${chain.wormholeChainName} (${chain.getId()})`,
+      );
+    }
+  }
+
+  console.log("Decoded actions:");
+  console.log("  UpgradeContract impl", upgradeAction.address);
+  console.log("  SetDataSources", dataSourcesAction.dataSources);
+  console.log("  SetWormholeAddress", wormholeAction.address);
+
+  if (argv.dryrun) {
+    console.log("Dry run; not sending transactions");
+    return;
+  }
+
+  const lastExecuted = await legacy.getLastExecutedGovernanceSequence();
+  const upgradeVaaSequence = Number(parseVaa(upgradeVaa).sequence.toString());
+  const dataSourcesVaaSequence = Number(
+    parseVaa(dataSourcesVaa).sequence.toString(),
+  );
+  const wormholeVaaSequence = Number(parseVaa(wormholeVaa).sequence.toString());
+
+  if (lastExecuted < upgradeVaaSequence) {
+    console.log("Executing UpgradeContract in its own transaction");
+    const result = await legacy.executeGovernanceInstruction(
+      privateKey,
+      upgradeVaa,
+    );
+    console.log("UpgradeContract tx", result.id);
+  } else {
+    console.log(
+      `Skipping UpgradeContract; lastExecutedGovernanceSequence=${lastExecuted} >= ${upgradeVaaSequence}`,
+    );
+  }
+
+  const lastAfterUpgrade = await legacy.getLastExecutedGovernanceSequence();
+  if (lastAfterUpgrade >= wormholeVaaSequence) {
+    console.log(
+      `Skipping SetDataSources+SetWormholeAddress; lastExecutedGovernanceSequence=${lastAfterUpgrade} >= ${wormholeVaaSequence}`,
+    );
+  } else if (lastAfterUpgrade >= dataSourcesVaaSequence) {
+    throw new Error(
+      `SetDataSources already applied (lastExecutedGovernanceSequence=${lastAfterUpgrade}) without SetWormholeAddress. Cannot same-tx retry; recover manually. Do not send the two VAAs sequentially.`,
+    );
+  } else {
+    const web3 = chain.getWeb3();
+    const code = await web3.eth.getCode(MULTICALL3_ADDRESS);
+    if (!code || code === "0x" || code === "0x0") {
+      throw new Error(
+        `Multicall3 is not deployed at ${MULTICALL3_ADDRESS} on ${chain.getId()}. ` +
+          "SetDataSources and SetWormholeAddress must execute in the same transaction; " +
+          "use a bundler or custom batcher. This script will not send two sequential txs.",
+      );
+    }
+
+    const { address: from } = web3.eth.accounts.wallet.add(privateKey);
+    const pythContract = legacy.getContract();
+    const dsCallData = pythContract.methods
+      .executeGovernanceInstruction("0x" + dataSourcesVaa.toString("hex"))
+      .encodeABI();
+    const whCallData = pythContract.methods
+      .executeGovernanceInstruction("0x" + wormholeVaa.toString("hex"))
+      .encodeABI();
+
+    const multicall = new web3.eth.Contract(MULTICALL3_ABI, MULTICALL3_ADDRESS);
+    const transactionObject = multicall.methods.aggregate3([
+      {
+        allowFailure: false,
+        callData: dsCallData,
+        target: legacy.address,
+      },
+      {
+        allowFailure: false,
+        callData: whCallData,
+        target: legacy.address,
+      },
+    ]);
+
+    console.log(
+      `Executing SetDataSources + SetWormholeAddress in one Multicall3 tx on ${legacy.address}`,
+    );
+    const result = await chain.estiamteAndSendTransaction(
+      transactionObject,
+      { from },
+      argv.gasPriceMultiplier,
+    );
+    console.log("Multicall3 tx", result.transactionHash);
+  }
+
+  if (!argv.save) {
+    return;
+  }
+
+  const expected = getDefaultDeploymentConfig(deploymentType);
+  const onChainWormhole = await legacy.getWormholeContract();
+  const onChainDataSources = await legacy.getDataSources();
+  const onChainGovernance = await legacy.getGovernanceDataSource();
+  const onChainSequence = await legacy.getLastExecutedGovernanceSequence();
+  const onChainFee = await legacy.getBaseUpdateFee();
+
+  const expectedWormhole = normalizeHex(wormholeAction.address);
+  const actualWormhole = normalizeHex(onChainWormhole.address);
+  if (actualWormhole !== expectedWormhole) {
+    throw new Error(
+      `On-chain wormhole() ${onChainWormhole.address} != SetWormholeAddress ${wormholeAction.address}`,
+    );
+  }
+  if (!dataSourcesEqual(onChainDataSources, expected.dataSources)) {
+    throw new Error(
+      `On-chain validDataSources do not match ${deploymentType} config. On-chain=${JSON.stringify(onChainDataSources)} expected=${JSON.stringify(expected.dataSources)}`,
+    );
+  }
+  if (
+    !governanceDataSourcesEqual(
+      onChainGovernance,
+      expected.governanceDataSource,
+    )
+  ) {
+    throw new Error(
+      `On-chain governanceDataSource changed. On-chain=${JSON.stringify(onChainGovernance)} expected=${JSON.stringify(expected.governanceDataSource)}`,
+    );
+  }
+  if (onChainSequence !== wormholeVaaSequence) {
+    throw new Error(
+      `lastExecutedGovernanceSequence=${onChainSequence}, expected VAA₃ sequence ${wormholeVaaSequence}`,
+    );
+  }
+  if (BigInt(onChainFee.amount) !== BigInt(expected.initialSingleUpdateFee)) {
+    throw new Error(
+      `singleUpdateFeeInWei=${onChainFee.amount}, expected ${expected.initialSingleUpdateFee}`,
+    );
+  }
+
+  legacy.deploymentType = deploymentType;
+  DefaultStore.contracts[legacy.getId()] = legacy;
+  DefaultStore.saveAllContracts();
+  console.log(
+    `Saved ${legacy.getId()} deploymentType=${deploymentType}. Historical legacy wormhole contracts are left in the store. Proxy address unchanged.`,
+  );
+}
+
+main();

--- a/contract_manager/scripts/migrate_evm_pricefeed_to_pro.ts
+++ b/contract_manager/scripts/migrate_evm_pricefeed_to_pro.ts
@@ -1,0 +1,222 @@
+/** biome-ignore-all lint/suspicious/noConsole: CLI script */
+/* eslint-disable @typescript-eslint/no-floating-promises */
+/* eslint-disable unicorn/prefer-top-level-await */
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
+/* eslint-disable no-console */
+
+/**
+ * In-place cutover of a legacy EVM Pyth proxy to Pro verification.
+ *
+ * Assumes singleUpdateFeeInWei is already 0 (set separately with
+ * generate_governance_set_fee_payload.ts). This script does not change the
+ * governance emitter or lastExecutedGovernanceSequence.
+ *
+ * Per chain it deploys a new PythUpgradable implementation (no new proxy) and
+ * a Pro WormholeReceiver if missing, then proposes three existing governance
+ * actions against the legacy proxy address:
+ *
+ *   [UpgradeContract]    → new PythUpgradable impl
+ *   [SetDataSources]     → Pro price emitter(s)
+ *   [SetWormholeAddress] → Pro WormholeReceiver
+ *
+ * Payload order in the vault proposal is VAA sequence order:
+ *   [U₁, DS₁, WH₁, U₂, DS₂, WH₂, …]
+ *
+ * Execution must still be UpgradeContract first, then SetDataSources and
+ * SetWormholeAddress in the same transaction per chain (see
+ * execute_evm_cutover_vaas.ts). VAA₁ can be earlier than VAA₂+VAA₃.
+ *
+ * Usage: pnpm tsx scripts/migrate_evm_pricefeed_to_pro.ts \
+ *   --chain <chain> --private-key <key> --ops-key-path <path> \
+ *   --std-output-dir <foundry-out/> \
+ *   --deployment-type pro-compatible-production|pro-compatible-staging
+ */
+
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+import type { DeploymentType } from "../src/core/base";
+import {
+  getDefaultDeploymentConfig,
+  toDeploymentType,
+  toPrivateKey,
+} from "../src/core/base";
+import { loadHotWallet } from "../src/node/utils/governance";
+import type { BaseDeployConfig } from "./common";
+import {
+  CHAIN_SELECTION_OPTIONS,
+  COMMON_DEPLOY_OPTIONS,
+  COMMON_UPGRADE_OPTIONS,
+  deployIfNotCached,
+  getOrDeployWormholeContract,
+  getSelectedChains,
+} from "./common";
+import {
+  findLegacyEvmPriceFeedContract,
+  getOpsVault,
+  governanceDataSourcesEqual,
+  requireProCompatibleDeploymentType,
+} from "./evm_pro_cutover";
+
+const CACHE_FILE = ".cache-migrate-evm-to-pro";
+
+type MigrateConfig = {
+  saveContract: boolean;
+  type: DeploymentType;
+} & BaseDeployConfig;
+
+const parser = yargs(hideBin(process.argv))
+  .scriptName("migrate_evm_pricefeed_to_pro.ts")
+  .usage(
+    "Migrates legacy EVM Pyth proxies in place to Pro-compatible verification.\n" +
+      `Uses a cache file (${CACHE_FILE}) to avoid deploying contracts twice.\n` +
+      "Does not change the governance emitter. Assumes fee is already 0.\n" +
+      "Usage: $0 --chain <chain> --private-key <private-key> --ops-key-path <ops-key-path> --std-output-dir <out/> --deployment-type <pro-compatible-production|pro-compatible-staging>",
+  )
+  .options({
+    ...CHAIN_SELECTION_OPTIONS,
+    "allow-nonzero-fee": {
+      default: false,
+      desc: "Allow migration when singleUpdateFeeInWei is not 0. Fee should normally be set to 0 first via generate_governance_set_fee_payload.ts",
+      type: "boolean",
+    },
+    "deployment-type": {
+      demandOption: true,
+      desc: "Must be pro-compatible-production (mainnet) or pro-compatible-staging (testnet). stable/beta are refused",
+      type: "string",
+    },
+    "gas-multiplier": COMMON_DEPLOY_OPTIONS["gas-multiplier"],
+    "gas-price-multiplier": COMMON_DEPLOY_OPTIONS["gas-price-multiplier"],
+    "ops-key-path": COMMON_UPGRADE_OPTIONS["ops-key-path"],
+    "private-key": COMMON_DEPLOY_OPTIONS["private-key"],
+    "save-contract": COMMON_DEPLOY_OPTIONS["save-contract"],
+    "std-output-dir": COMMON_DEPLOY_OPTIONS["std-output-dir"],
+    vault: {
+      choices: ["mainnet", "devnet"] as const,
+      desc: "Ops vault. Defaults to mainnet for mainnet chains and devnet for testnet chains",
+      type: "string",
+    },
+  });
+
+async function main() {
+  const argv = await parser.argv;
+  const selectedChains = getSelectedChains(argv);
+  const deploymentType = toDeploymentType(argv.deploymentType);
+  requireProCompatibleDeploymentType(deploymentType);
+
+  const vaultChoice =
+    argv.vault ?? (selectedChains[0]?.isMainnet() ? "mainnet" : "devnet");
+  const vault = getOpsVault(vaultChoice);
+
+  const config: MigrateConfig = {
+    gasMultiplier: argv.gasMultiplier,
+    gasPriceMultiplier: argv.gasPriceMultiplier,
+    jsonOutputDir: argv.stdOutputDir,
+    privateKey: toPrivateKey(argv.privateKey),
+    saveContract: argv.saveContract,
+    type: deploymentType,
+  };
+
+  console.log("Using cache file", CACHE_FILE);
+  console.log(
+    "Migrating legacy proxies on chains",
+    selectedChains.map((chain) => chain.getId()),
+  );
+  console.log("Deployment type", deploymentType);
+  console.log("Using vault", vault.getId());
+
+  const payloads: Buffer[] = [];
+  const migrated: string[] = [];
+
+  for (const chain of selectedChains) {
+    const legacy = findLegacyEvmPriceFeedContract(chain);
+    if (!legacy) {
+      const message = `No legacy EvmPriceFeedContract (stable/beta/unlabeled) on ${chain.getId()} — already pro-compatible or missing`;
+      if (argv.chain) {
+        throw new Error(message);
+      }
+      console.log(`Skipping ${chain.getId()}: ${message}`);
+      continue;
+    }
+
+    console.log(
+      `\nMigrating ${chain.getId()} legacy proxy ${legacy.address} (deploymentType=${legacy.deploymentType ?? "unlabeled"})`,
+    );
+
+    const fee = await legacy.getBaseUpdateFee();
+    if (BigInt(fee.amount) !== 0n && !argv.allowNonzeroFee) {
+      throw new Error(
+        `singleUpdateFeeInWei is ${fee.amount} on ${chain.getId()}; refuse to migrate unless fee is 0 (set via generate_governance_set_fee_payload.ts) or pass --allow-nonzero-fee`,
+      );
+    }
+    if (BigInt(fee.amount) !== 0n) {
+      console.log(
+        `WARNING: singleUpdateFeeInWei is ${fee.amount} on ${chain.getId()}; continuing because --allow-nonzero-fee was set`,
+      );
+    }
+
+    const expected = getDefaultDeploymentConfig(deploymentType);
+    const onChainGovernance = await legacy.getGovernanceDataSource();
+    if (
+      !governanceDataSourcesEqual(
+        onChainGovernance,
+        expected.governanceDataSource,
+      )
+    ) {
+      throw new Error(
+        `On-chain governanceDataSource on ${chain.getId()} does not match ${deploymentType} config. This path cannot retarget governance. On-chain=${JSON.stringify(onChainGovernance)} expected=${JSON.stringify(expected.governanceDataSource)}`,
+      );
+    }
+
+    const wormholeContract = await getOrDeployWormholeContract(
+      chain,
+      config,
+      CACHE_FILE,
+    );
+    console.log(
+      `Pro WormholeReceiver on ${chain.getId()}: ${wormholeContract.address} (deploymentType=${wormholeContract.deploymentType})`,
+    );
+
+    const newImpl = await deployIfNotCached(
+      CACHE_FILE,
+      chain,
+      config,
+      "PythUpgradable",
+      [],
+    );
+    console.log(
+      `PythUpgradable implementation on ${chain.getId()}: ${newImpl}`,
+    );
+
+    payloads.push(
+      chain.generateGovernanceUpgradePayload(newImpl.replace("0x", "")),
+    );
+    payloads.push(chain.generateGovernanceSetDataSources(expected.dataSources));
+    payloads.push(
+      chain.generateGovernanceSetWormholeAddressPayload(
+        wormholeContract.address.replace("0x", ""),
+      ),
+    );
+    migrated.push(chain.getId());
+  }
+
+  if (payloads.length === 0) {
+    throw new Error("No chains to migrate; no governance proposal created");
+  }
+
+  console.log(
+    "\nPayload order is VAA sequence order: [UpgradeContract, SetDataSources, SetWormholeAddress] per chain.",
+  );
+  console.log(
+    "Execute UpgradeContract first, then SetDataSources + SetWormholeAddress in the SAME transaction per chain (execute_evm_cutover_vaas.ts).",
+  );
+  console.log("Migrated chains:", migrated.join(", "));
+
+  const wallet = await loadHotWallet(argv["ops-key-path"]);
+  console.log("Using wallet", wallet.publicKey.toBase58());
+  vault.connect(wallet);
+  const proposal = await vault.proposeWormholeMessage(payloads);
+  console.log("Proposal address", proposal.address.toBase58());
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add `migrate_evm_pricefeed_to_pro.ts` to deploy a new `PythUpgradable` implementation (no new proxy) and a Pro Wormhole receiver if missing, then propose `[UpgradeContract, SetDataSources, SetWormholeAddress]` against the **legacy** proxy. Governance emitter is unchanged; fee is assumed already `0`.
- Add `execute_evm_cutover_vaas.ts` so VAA₁ is its own tx and VAA₂+VAA₃ run in one Multicall3 transaction (no sequential fallback).
- Extend `check_proposal.ts` to assert Pro data sources, the cutover triple, and to fail if a governance-emitter transfer is mixed in.

Companion to the Solidity change in #3973 (needed before executing the cutover; this PR is tooling only).

## Test plan
- [ ] Dry-run migrate on one testnet: `pnpm tsx scripts/migrate_evm_pricefeed_to_pro.ts --chain <testnet> --deployment-type pro-compatible-staging --private-key … --ops-key-path … --std-output-dir ../target_chains/ethereum/contracts/out`
- [ ] `check_proposal.ts --cluster <cluster> --proposal <addr>` — confirm upgrade digest, Pro data sources, Pro wormhole / half quorum, and no `AuthorizeGovernanceDataSourceTransfer`
- [ ] Execute with `execute_evm_cutover_vaas.ts` — VAA₁ separate; VAA₂+VAA₃ one tx; `--save` updates store `deploymentType`
- [ ] Confirm the script refuses `stable`/`beta` deployment types and already-pro proxies
- [ ] Confirm a chain without Multicall3 errors instead of sending two sequential txs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->