### PR TITLE
tejas/pfg 1557 funding lane rest poller okx funding rates

### DIFF
--- a/apps/okx-recorder/README.md
+++ b/apps/okx-recorder/README.md
@@ -142,6 +142,12 @@ ClickHouse schema is in [`migrations/`](migrations/) (one file per table); for
 local dev it is auto-loaded via the ClickHouse Docker entrypoint. For
 production, apply it manually against the pyth-analytics cluster.
 
+> The compose ClickHouse only runs `/docker-entrypoint-initdb.d` migrations on
+> a **fresh** volume. If you have an older `okx-recorder_clickhouse-local-data`
+> volume from before a migration landed, run `docker volume rm
+> okx-recorder_clickhouse-local-data` (or apply the new migration manually) —
+> otherwise inserts into the newer tables (e.g. funding) will fail.
+
 ```sql
 CREATE TABLE default.okx_book_ticker
 (

--- a/apps/okx-recorder/README.md
+++ b/apps/okx-recorder/README.md
@@ -2,8 +2,9 @@
 
 Subscribes to OKX perpetual-swap market data over the public websocket
 (`wss://ws.okx.com:8443/ws/v5/public`) for a configurable instrument list and
-persists **every** update to ClickHouse. Currently records the top-of-book
-(`bbo-tbt`) lane; trades and funding lanes bolt onto the same pipeline.
+persists **every** update to ClickHouse. Records the top-of-book (`bbo-tbt`)
+websocket lane and the settled funding-rate REST lane; the trades lane bolts
+onto the same pipeline.
 
 ## What it records
 
@@ -16,6 +17,16 @@ per-instrument `seqId` as the ordering tiebreaker. There is **no in-memory
 dedupe** (a deliberate deviation from `binance-recorder`): every received update
 is inserted, and ClickHouse's `ReplacingMergeTree` owns row identity via the
 table's ORDER BY keys, collapsing byte-identical insert retries at merge time.
+
+Alongside the websocket, a REST poller fetches the **settled** funding rate
+(`/api/v5/public/funding-rate-history` — not the websocket predicted-rate
+stream) per configured instrument every `funding_poll_seconds` and writes it to
+`default.okx_funding_rates`. Each poll re-fetches the last
+`funding_history_limit` events, so overlapping windows are re-inserted on every
+poll; that is deliberate — inserts are idempotent by `(inst_id, funding_time)`
+via `ReplacingMergeTree`, and the overlap self-heals short outages. Funding
+rows carry the exchange settlement time (`funding_time`) plus a client-side
+`received_at`.
 
 The seeded instruments are the pre-launch AI-lab perpetuals on OKX:
 `OPENAI-USDT-SWAP, ANTHROPIC-USDT-SWAP`. Instruments are config-driven only —
@@ -51,7 +62,9 @@ adding an OKX perp is a config change, no code change.
    bash scripts/local_e2e_check.sh
    ```
 
-   The check confirms rows have landed in `default.okx_book_ticker` and that
+   The check confirms rows have landed in `default.okx_book_ticker` and
+   `default.okx_funding_rates`, that funding rows are unique by
+   `(inst_id, funding_time)` after ReplacingMergeTree collapse, and that
    `/ready` and `/metrics` respond.
 
 ## Services & ports
@@ -74,16 +87,24 @@ Overview** dashboard.
 - `GET /ready` (health port) — ready only when ClickHouse is reachable **and
   every** configured instrument's ToB lane is fresh within
   `ready_stale_seconds`. An instrument that never streams therefore keeps
-  `/ready` red, surfacing the gap rather than masking it. Future trades/funding
-  lanes expose last-event-age metrics but **never** gate readiness — trades can
-  legitimately go quiet and funding updates on a slow cadence.
+  `/ready` red, surfacing the gap rather than masking it. The funding lane (and
+  the future trades lane) exposes last-event metrics but **never** gates
+  readiness — funding settles on an hours-scale cadence and sparseness is
+  expected, so its staleness is an alerting signal, not an outage.
 - `GET /metrics` (metrics port) — Prometheus exposition, including
   `okx_recorder_ready`, `okx_recorder_clickhouse_up`,
   `okx_recorder_insert_rows_total`, `okx_recorder_insert_latency_seconds`,
   `okx_recorder_insert_attempts_total{status}`, `okx_recorder_queue_depth`,
   `okx_recorder_queue_fill_ratio`, `okx_recorder_queue_drops_total{inst_id}`,
   `okx_recorder_stream_reconnects_total`, and
-  `okx_recorder_tob_last_seen_unix_seconds{inst_id}`.
+  `okx_recorder_tob_last_seen_unix_seconds{inst_id}`. The funding lane adds
+  `okx_recorder_funding_poll_attempts_total{inst_id,status}`,
+  `okx_recorder_funding_insert_attempts_total{status}`,
+  `okx_recorder_funding_insert_rows_total`,
+  `okx_recorder_funding_insert_latency_seconds`, and
+  `okx_recorder_funding_last_event_unix_seconds{inst_id}` (exchange settlement
+  time of the newest settled funding event — alert on its age, don't gate on
+  it).
 
 ## Configuration
 
@@ -102,6 +123,7 @@ See [config.sample.yml](config.sample.yml) for all options:
 | `clickhouse.url` | _required_ | ClickHouse URL (`http`/`https` → `secure`) |
 | `clickhouse.user` / `password` | `default` / "" | Credentials |
 | `clickhouse.database` / `book_ticker_table` | `default` / `okx_book_ticker` | Target |
+| `clickhouse.funding_rates_table` | `okx_funding_rates` | Funding lane target table |
 | `metrics_port` | `9095` | Prometheus metrics port |
 | `health_port` | `8085` | Health endpoint port |
 | `ready_stale_seconds` | `10` | Per-instrument ToB freshness window for `/ready` |
@@ -110,11 +132,14 @@ See [config.sample.yml](config.sample.yml) for all options:
 | `batch_flush_seconds` | `2.0` | Max time before a partial batch is flushed |
 | `reconnect_max_backoff_seconds` | `30` | Jittered websocket reconnect backoff ceiling |
 | `insert_async` | `true` | Use ClickHouse async inserts |
+| `funding_history_url` | the OKX public endpoint | Settled funding-rate-history REST endpoint |
+| `funding_poll_seconds` | `300` | Funding poll interval; must be >= 60 |
+| `funding_history_limit` | `10` | History rows requested per poll (1–100) |
 
 ## Schema
 
-ClickHouse schema is in [`migrations/001-init.sql`](migrations/001-init.sql);
-for local dev it is auto-loaded via the ClickHouse Docker entrypoint. For
+ClickHouse schema is in [`migrations/`](migrations/) (one file per table); for
+local dev it is auto-loaded via the ClickHouse Docker entrypoint. For
 production, apply it manually against the pyth-analytics cluster.
 
 ```sql
@@ -150,3 +175,27 @@ TTL toDateTime(received_at) + INTERVAL 90 DAY DELETE;
   measurable.
 - **Monthly partitions** with a **90-day TTL** keep storage bounded, consistent
   with the sibling recorders.
+
+```sql
+CREATE TABLE default.okx_funding_rates
+(
+    inst_id       LowCardinality(String),
+    funding_time  DateTime64(3),
+    funding_rate  Decimal(38, 18),
+    realized_rate Nullable(Decimal(38, 18)),
+    received_at   DateTime64(3),
+    ingested_at   DateTime64(3) DEFAULT now64(3)
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toYYYYMM(funding_time)
+ORDER BY (inst_id, funding_time)
+TTL toDateTime(funding_time) + INTERVAL 90 DAY DELETE;
+```
+
+- **Idempotent by `(inst_id, funding_time)`**: the poller re-fetches
+  overlapping history windows every poll and re-inserts them; the ORDER BY key
+  plus `ReplacingMergeTree(ingested_at)` collapses the duplicates at merge
+  time. Read with `FINAL` (or aggregate) if pre-merge exactness matters.
+- **`Decimal(38, 18)`** (not the ToB table's `Decimal(38, 12)`) because OKX
+  reports funding rates with up to ~17 decimal places.
+- **`realized_rate` is `Nullable`** because OKX can omit it.

--- a/apps/okx-recorder/alerts.sample.yml
+++ b/apps/okx-recorder/alerts.sample.yml
@@ -54,3 +54,12 @@ groups:
         annotations:
           summary: "OKX recorder instrument ToB lane is stale"
           description: "An instrument has not received a top-of-book update for over 60 seconds (may be unlisted on OKX)."
+
+      - alert: OkxRecorderFundingStale
+        expr: time() - okx_recorder_funding_last_event_unix_seconds > 86400
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "OKX recorder funding lane is stale"
+          description: "An instrument has no settled funding event for over 24 hours. Funding settles on an 8h cadence for these perps, so the generous threshold tolerates a missed settlement without paging."

--- a/apps/okx-recorder/config.sample.yml
+++ b/apps/okx-recorder/config.sample.yml
@@ -19,6 +19,7 @@ clickhouse:
   password: "recorder"
   database: "default"
   book_ticker_table: "okx_book_ticker"
+  funding_rates_table: "okx_funding_rates"
 
 metrics_port: 9095
 health_port: 8085
@@ -28,3 +29,12 @@ batch_max_rows: 10000
 batch_flush_seconds: 2.0
 reconnect_max_backoff_seconds: 30
 insert_async: true
+
+# Funding lane: REST poller for the SETTLED funding rate (funding-rate-history
+# endpoint, not the websocket predicted-rate stream). Each poll re-fetches the
+# last `funding_history_limit` events per instrument (OKX caps limit at 100);
+# the overlap is harmless because inserts are idempotent by
+# (inst_id, funding_time). Funding staleness never gates /ready.
+funding_history_url: "https://www.okx.com/api/v5/public/funding-rate-history"
+funding_poll_seconds: 300
+funding_history_limit: 10

--- a/apps/okx-recorder/docker-compose.local.yml
+++ b/apps/okx-recorder/docker-compose.local.yml
@@ -12,6 +12,7 @@ services:
     volumes:
       - clickhouse-local-data:/var/lib/clickhouse
       - ./migrations/001-init.sql:/docker-entrypoint-initdb.d/001-init.sql:ro
+      - ./migrations/002-funding-rates.sql:/docker-entrypoint-initdb.d/002-funding-rates.sql:ro
 
   okx-recorder:
     build:

--- a/apps/okx-recorder/migrations/002-funding-rates.sql
+++ b/apps/okx-recorder/migrations/002-funding-rates.sql
@@ -1,0 +1,28 @@
+-- Target ClickHouse cluster: pyth-analytics
+--
+-- Apply manually against the pyth-analytics cluster for production. For local
+-- dev this is auto-loaded by the docker-compose ClickHouse entrypoint (see
+-- docker-compose.local.yml).
+--
+-- Settled funding events from the funding-rate-history REST poller (the
+-- SETTLED rate, not the websocket predicted-rate stream). One event per
+-- (inst_id, funding_time): every poll re-fetches a trailing history window and
+-- re-inserts overlapping rows, and ReplacingMergeTree(ingested_at) collapses
+-- the duplicates at merge time, making the poller idempotent with no
+-- client-side dedupe. Rates are Decimal(38, 18) — not the ToB table's
+-- Decimal(38, 12) — because OKX reports funding rates with up to ~17 decimal
+-- places. realized_rate is Nullable because OKX can omit it.
+
+CREATE TABLE IF NOT EXISTS default.okx_funding_rates
+(
+    inst_id       LowCardinality(String),
+    funding_time  DateTime64(3),
+    funding_rate  Decimal(38, 18),
+    realized_rate Nullable(Decimal(38, 18)),
+    received_at   DateTime64(3),
+    ingested_at   DateTime64(3) DEFAULT now64(3)
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toYYYYMM(funding_time)
+ORDER BY (inst_id, funding_time)
+TTL toDateTime(funding_time) + INTERVAL 90 DAY DELETE;

--- a/apps/okx-recorder/scripts/local_e2e_check.sh
+++ b/apps/okx-recorder/scripts/local_e2e_check.sh
@@ -37,7 +37,7 @@ count="$(docker exec "${container_name}" clickhouse-client --user "${user_name}"
 
 echo "local_e2e_check: table=${database_name}.${funding_rates_table} rows=${count}"
 if [[ "${count}" -le 0 ]]; then
-  echo "local_e2e_check: no funding rows found yet; ensure the recorder is up and the configured instruments are listed on OKX (the first poll runs at startup)."
+  echo "local_e2e_check: no funding rows found yet; ensure the recorder is up and the configured instruments are listed on OKX (the first poll runs at startup). Note: a brand-new pre-launch perp legitimately has no settled funding history yet, so zero rows for such an instrument is expected."
   exit 1
 fi
 

--- a/apps/okx-recorder/scripts/local_e2e_check.sh
+++ b/apps/okx-recorder/scripts/local_e2e_check.sh
@@ -2,14 +2,15 @@
 set -euo pipefail
 
 # End-to-end check for the local Tilt stack: asserts rows have landed in
-# ClickHouse and the health/metrics endpoints respond. Later lanes (trades,
-# funding) extend this script with their own table checks.
+# ClickHouse and the health/metrics endpoints respond. Later lanes (trades)
+# extend this script with their own table checks.
 
 container_name="${CLICKHOUSE_CONTAINER_NAME:-okx-recorder-clickhouse-local}"
 user_name="${CLICKHOUSE_USER:-${CLICKHOUSE_LOCAL_USER:-recorder}}"
 password="${CLICKHOUSE_PASSWORD:-${CLICKHOUSE_LOCAL_PASSWORD:-recorder}}"
 database_name="${CLICKHOUSE_DATABASE:-default}"
 book_ticker_table="${CLICKHOUSE_BOOK_TICKER_TABLE:-okx_book_ticker}"
+funding_rates_table="${CLICKHOUSE_FUNDING_RATES_TABLE:-okx_funding_rates}"
 
 # Host ports the recorder publishes (see docker-compose.local.yml).
 health_url="${HEALTH_URL:-http://localhost:8085/ready}"
@@ -25,7 +26,30 @@ if [[ "${count}" -le 0 ]]; then
   exit 1
 fi
 
-# 2. Readiness endpoint responds 200 (ClickHouse reachable + every instrument's
+# 2. Persisted settled-funding rows. The funding poller fires immediately at
+#    startup and re-fetches the trailing history window, so rows should land
+#    within seconds even though funding itself settles on an hours-scale
+#    cadence. Also assert idempotence: after ReplacingMergeTree collapse
+#    (FINAL), no (inst_id, funding_time) pair may appear twice, no matter how
+#    many overlapping polls have run.
+query="SELECT count() FROM ${database_name}.${funding_rates_table}"
+count="$(docker exec "${container_name}" clickhouse-client --user "${user_name}" --password "${password}" -q "${query}")"
+
+echo "local_e2e_check: table=${database_name}.${funding_rates_table} rows=${count}"
+if [[ "${count}" -le 0 ]]; then
+  echo "local_e2e_check: no funding rows found yet; ensure the recorder is up and the configured instruments are listed on OKX (the first poll runs at startup)."
+  exit 1
+fi
+
+query="SELECT count() FROM (SELECT inst_id, funding_time FROM ${database_name}.${funding_rates_table} FINAL GROUP BY inst_id, funding_time HAVING count() > 1)"
+dupes="$(docker exec "${container_name}" clickhouse-client --user "${user_name}" --password "${password}" -q "${query}")"
+if [[ "${dupes}" -ne 0 ]]; then
+  echo "local_e2e_check: found ${dupes} duplicated (inst_id, funding_time) pairs after FINAL; funding inserts are not idempotent."
+  exit 1
+fi
+echo "local_e2e_check: funding rows are unique by (inst_id, funding_time) after FINAL"
+
+# 3. Readiness endpoint responds 200 (ClickHouse reachable + every instrument's
 #    ToB lane fresh).
 ready_status="$(curl -s -o /dev/null -w '%{http_code}' "${health_url}")"
 echo "local_e2e_check: GET ${health_url} -> ${ready_status}"
@@ -34,11 +58,20 @@ if [[ "${ready_status}" != "200" ]]; then
   exit 1
 fi
 
-# 3. Metrics endpoint exposes the recorder metrics.
-if ! curl -sf "${metrics_url}" | grep -q "okx_recorder_"; then
+# 4. Metrics endpoint exposes the recorder metrics, including the funding
+#    lane's poll counter and last-event gauge (present once the startup poll
+#    has run; funding staleness is observable here but never gates /ready).
+metrics_payload="$(curl -sf "${metrics_url}")"
+if ! grep -q "okx_recorder_" <<<"${metrics_payload}"; then
   echo "local_e2e_check: ${metrics_url} did not expose okx_recorder_* metrics."
   exit 1
 fi
-echo "local_e2e_check: GET ${metrics_url} -> exposing okx_recorder_* metrics"
+for metric in okx_recorder_funding_poll_attempts_total okx_recorder_funding_last_event_unix_seconds; do
+  if ! grep -q "${metric}" <<<"${metrics_payload}"; then
+    echo "local_e2e_check: ${metrics_url} did not expose ${metric}."
+    exit 1
+  fi
+done
+echo "local_e2e_check: GET ${metrics_url} -> exposing okx_recorder_* metrics (incl. funding lane)"
 
 echo "local_e2e_check: OK"

--- a/apps/okx-recorder/src/clickhouse.rs
+++ b/apps/okx-recorder/src/clickhouse.rs
@@ -6,12 +6,16 @@ use clickhouse::{Client, Row};
 use rust_decimal::Decimal;
 use serde::Serialize;
 
-use crate::{config::ClickHouseTarget, models::BookTicker};
+use crate::{
+    config::ClickHouseTarget,
+    models::{BookTicker, FundingRate},
+};
 
 #[derive(Clone)]
 pub struct ClickHouseClient {
     client: Client,
     book_ticker_table: String,
+    funding_rates_table: String,
 }
 
 impl ClickHouseClient {
@@ -34,6 +38,7 @@ impl ClickHouseClient {
             // dotted name gets quoted as a single identifier and then prefixed
             // with the connected database, yielding `db.`db.table``).
             book_ticker_table: target.book_ticker_table,
+            funding_rates_table: target.funding_rates_table,
         }
     }
 
@@ -71,6 +76,38 @@ impl ClickHouseClient {
 
         Ok((tickers.len(), start.elapsed().as_secs_f64()))
     }
+
+    /// Insert a batch of settled funding-rate rows. Returns
+    /// `(rows_written, latency_seconds)`.
+    pub async fn insert_funding_batch(
+        &self,
+        rates: &[FundingRate],
+        insert_async: bool,
+    ) -> Result<(usize, f64)> {
+        if rates.is_empty() {
+            return Ok((0, 0.0));
+        }
+
+        let start = Instant::now();
+        let client = if insert_async {
+            self.client
+                .clone()
+                .with_setting("async_insert", "1")
+                .with_setting("wait_for_async_insert", "1")
+        } else {
+            self.client.clone()
+        };
+
+        let mut insert = client
+            .insert::<FundingRateRow>(&self.funding_rates_table)
+            .await?;
+        for rate in rates {
+            insert.write(&FundingRateRow::from(rate)).await?;
+        }
+        insert.end().await?;
+
+        Ok((rates.len(), start.elapsed().as_secs_f64()))
+    }
 }
 
 #[derive(Row, Serialize)]
@@ -102,6 +139,29 @@ impl From<&BookTicker> for BookTickerRow {
     }
 }
 
+#[derive(Row, Serialize)]
+struct FundingRateRow {
+    inst_id: String,
+    #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]
+    funding_time: DateTime<Utc>,
+    funding_rate: i128,
+    realized_rate: Option<i128>,
+    #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]
+    received_at: DateTime<Utc>,
+}
+
+impl From<&FundingRate> for FundingRateRow {
+    fn from(r: &FundingRate) -> Self {
+        Self {
+            inst_id: r.inst_id.clone(),
+            funding_time: r.funding_time,
+            funding_rate: decimal_to_rate_d128(&r.funding_rate),
+            realized_rate: r.realized_rate.as_ref().map(decimal_to_rate_d128),
+            received_at: r.received_at,
+        }
+    }
+}
+
 /// Convert a `Decimal` to its `Decimal(38, 12)` (`Decimal128`) wire
 /// representation (i128).
 ///
@@ -117,6 +177,26 @@ fn decimal_to_d128(value: &Decimal) -> i128 {
         tracing::warn!(
             value = %value,
             "Decimal value too large to rescale to Decimal(38, 12); writing 0"
+        );
+        return 0;
+    }
+    scaled.mantissa()
+}
+
+/// Convert a `Decimal` to its `Decimal(38, 18)` (`Decimal128`) wire
+/// representation (i128), used by the funding-rate columns: OKX reports
+/// funding rates with up to ~17 decimal places, so scale 12 would truncate
+/// them. Same failure mode as [`decimal_to_d128`] — a value with more than
+/// 20 digits left of the decimal point (impossible for a funding rate) is
+/// logged and written as 0.
+fn decimal_to_rate_d128(value: &Decimal) -> i128 {
+    const SCALE: u32 = 18;
+    let mut scaled = *value;
+    scaled.rescale(SCALE);
+    if scaled.scale() != SCALE {
+        tracing::warn!(
+            value = %value,
+            "Decimal value too large to rescale to Decimal(38, 18); writing 0"
         );
         return 0;
     }

--- a/apps/okx-recorder/src/config.rs
+++ b/apps/okx-recorder/src/config.rs
@@ -26,6 +26,7 @@ pub struct ClickHouseTarget {
     pub secure: bool,
     pub database: String,
     pub book_ticker_table: String,
+    pub funding_rates_table: String,
 }
 
 /// Full multi-instrument recorder config. Mirrors `binance-recorder`'s
@@ -46,6 +47,9 @@ pub struct AppConfig {
     pub batch_flush_seconds: f64,
     pub reconnect_max_backoff_seconds: u64,
     pub insert_async: bool,
+    pub funding_history_url: String,
+    pub funding_poll_seconds: u64,
+    pub funding_history_limit: u32,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -59,6 +63,8 @@ struct ClickHouseConfig {
     database: String,
     #[serde(default = "default_book_ticker_table")]
     book_ticker_table: String,
+    #[serde(default = "default_funding_rates_table")]
+    funding_rates_table: String,
 }
 
 impl AppConfig {
@@ -110,6 +116,37 @@ impl AppConfig {
                 default_reconnect_max_backoff_seconds,
             )?,
             insert_async: get_or_default(&loaded, "insert_async", default_insert_async)?,
+            funding_history_url: get_or_default(
+                &loaded,
+                "funding_history_url",
+                default_funding_history_url,
+            )?,
+            funding_poll_seconds: {
+                let value = get_or_default(
+                    &loaded,
+                    "funding_poll_seconds",
+                    default_funding_poll_seconds,
+                )?;
+                if value < 60 {
+                    return Err(ConfigError::Invalid(
+                        "funding_poll_seconds must be >= 60".to_string(),
+                    ));
+                }
+                value
+            },
+            funding_history_limit: {
+                let value: u32 = get_or_default(
+                    &loaded,
+                    "funding_history_limit",
+                    default_funding_history_limit,
+                )?;
+                if !(1..=100).contains(&value) {
+                    return Err(ConfigError::Invalid(
+                        "funding_history_limit must be between 1 and 100".to_string(),
+                    ));
+                }
+                value
+            },
         })
     }
 
@@ -175,6 +212,7 @@ fn parse_clickhouse_target(input: ClickHouseConfig) -> Result<ClickHouseTarget, 
         secure: parsed.scheme() == "https",
         database: input.database,
         book_ticker_table: input.book_ticker_table,
+        funding_rates_table: input.funding_rates_table,
     })
 }
 
@@ -233,6 +271,24 @@ fn default_insert_async() -> bool {
     true
 }
 
+fn default_funding_history_url() -> String {
+    "https://www.okx.com/api/v5/public/funding-rate-history".to_string()
+}
+
+/// Funding settles on an hours-scale cadence, so a minutes-scale poll leaves
+/// generous headroom while staying far under OKX's public rate limits. Values
+/// below one minute are rejected as pointless hammering.
+fn default_funding_poll_seconds() -> u64 {
+    300
+}
+
+/// How many history rows to request per poll (`limit` query parameter; OKX
+/// caps it at 100). Each poll re-fetches this trailing window, so the overlap
+/// both self-heals short outages and exercises the sink's idempotence.
+fn default_funding_history_limit() -> u32 {
+    10
+}
+
 fn default_clickhouse_user() -> String {
     "default".to_string()
 }
@@ -243,4 +299,8 @@ fn default_clickhouse_database() -> String {
 
 fn default_book_ticker_table() -> String {
     "okx_book_ticker".to_string()
+}
+
+fn default_funding_rates_table() -> String {
+    "okx_funding_rates".to_string()
 }

--- a/apps/okx-recorder/src/funding_client.rs
+++ b/apps/okx-recorder/src/funding_client.rs
@@ -1,0 +1,116 @@
+use std::{collections::HashMap, time::Duration};
+
+use chrono::Utc;
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    metrics::RecorderMetrics,
+    models::{parse_funding_history, FundingRate},
+};
+
+/// Poll the settled funding-rate history once for every configured instrument
+/// and return the combined batch. Mirrors `hyperliquid-recorder`'s
+/// `poll_funding_once`: a failed instrument is skipped (with a jittered
+/// per-instrument backoff before the next one) rather than failing the whole
+/// poll, so one delisted instrument cannot starve the others. Overlap with
+/// previously recorded windows is expected — the sink is idempotent by
+/// `(inst_id, funding_time)`.
+#[allow(clippy::too_many_arguments)]
+pub async fn poll_funding_once(
+    http: &reqwest::Client,
+    history_url: &str,
+    instruments: &[String],
+    history_limit: u32,
+    max_backoff_seconds: u64,
+    metrics: &RecorderMetrics,
+    backoff: &mut HashMap<String, u64>,
+    stop_token: &CancellationToken,
+) -> Vec<FundingRate> {
+    let mut batch: Vec<FundingRate> = Vec::new();
+
+    for inst_id in instruments {
+        if stop_token.is_cancelled() {
+            return batch;
+        }
+
+        match fetch_funding_history(http, history_url, inst_id, history_limit).await {
+            Ok(body) => {
+                let received_at = Utc::now();
+                match parse_funding_history(&body, inst_id, received_at) {
+                    Ok(rows) => {
+                        tracing::debug!(
+                            inst_id = %inst_id,
+                            rows = rows.len(),
+                            "funding-rate-history poll ok"
+                        );
+                        metrics
+                            .funding_poll_attempts
+                            .with_label_values(&[inst_id, "success"])
+                            .inc();
+                        backoff.insert(inst_id.clone(), 1);
+                        batch.extend(rows);
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            inst_id = %inst_id,
+                            error = ?err,
+                            "funding-rate-history parse error"
+                        );
+                        metrics
+                            .funding_poll_attempts
+                            .with_label_values(&[inst_id, "error"])
+                            .inc();
+                        sleep_backoff(backoff, inst_id, max_backoff_seconds).await;
+                    }
+                }
+            }
+            Err(err) => {
+                tracing::warn!(
+                    inst_id = %inst_id,
+                    error = ?err,
+                    "funding-rate-history request failed"
+                );
+                metrics
+                    .funding_poll_attempts
+                    .with_label_values(&[inst_id, "error"])
+                    .inc();
+                sleep_backoff(backoff, inst_id, max_backoff_seconds).await;
+            }
+        }
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    batch
+}
+
+async fn fetch_funding_history(
+    http: &reqwest::Client,
+    url: &str,
+    inst_id: &str,
+    limit: u32,
+) -> anyhow::Result<String> {
+    let response = http
+        .get(url)
+        .query(&[("instId", inst_id), ("limit", &limit.to_string())])
+        .send()
+        .await?;
+    let status = response.status();
+    let body = response.text().await?;
+    if !status.is_success() {
+        anyhow::bail!("funding-rate-history request failed ({status}): {body}");
+    }
+    Ok(body)
+}
+
+async fn sleep_backoff(
+    backoff: &mut HashMap<String, u64>,
+    inst_id: &str,
+    max_backoff_seconds: u64,
+) {
+    let current = backoff.get(inst_id).copied().unwrap_or(1);
+    let jittered_ms = fastrand::u64(0..=current.saturating_mul(1000));
+    tokio::time::sleep(Duration::from_millis(jittered_ms)).await;
+    let next = current.saturating_mul(2).min(max_backoff_seconds.max(1));
+    backoff.insert(inst_id.to_string(), next);
+}

--- a/apps/okx-recorder/src/lib.rs
+++ b/apps/okx-recorder/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod clickhouse;
 pub mod config;
+pub mod funding_client;
 pub mod health;
 pub mod metrics;
 pub mod models;

--- a/apps/okx-recorder/src/main.rs
+++ b/apps/okx-recorder/src/main.rs
@@ -7,7 +7,7 @@ use okx_recorder::{
     config::AppConfig,
     health::{start_http_servers, HealthState},
     metrics::RecorderMetrics,
-    recorder::{RecorderRuntime, WriterRuntimeConfig},
+    recorder::{FundingRuntimeConfig, RecorderRuntime, WriterRuntimeConfig},
 };
 use tokio::signal::unix::{signal, SignalKind};
 
@@ -49,6 +49,11 @@ async fn run() -> Result<()> {
             batch_max_rows: config.batch_max_rows,
             batch_flush_seconds: config.batch_flush_seconds,
             queue_max_rows: config.queue_max_rows,
+        },
+        FundingRuntimeConfig {
+            history_url: config.funding_history_url,
+            poll_seconds: config.funding_poll_seconds,
+            history_limit: config.funding_history_limit,
         },
         metrics,
         health,

--- a/apps/okx-recorder/src/metrics.rs
+++ b/apps/okx-recorder/src/metrics.rs
@@ -12,9 +12,10 @@ use prometheus::{
 /// Covers the queue and ClickHouse-insert surface emitted by the stream worker
 /// and writer loop, plus the readiness/liveness surface emitted by the health
 /// probe and stream worker: a ClickHouse-up gauge, a ready-state gauge, and a
-/// per-instrument ToB last-seen timestamp. Future lanes add their own last-seen
-/// gauges here (e.g. trades/funding), which feed dashboards and alerts but
-/// never gate `/ready`. `/metrics` exposition is served from [`crate::health`].
+/// per-instrument ToB last-seen timestamp. The funding lane adds its own poll,
+/// insert, and last-event metrics; like every non-ToB lane they feed dashboards
+/// and alerts but never gate `/ready`. `/metrics` exposition is served from
+/// [`crate::health`].
 #[derive(Clone)]
 pub struct RecorderMetrics {
     registry: Registry,
@@ -25,6 +26,11 @@ pub struct RecorderMetrics {
     pub insert_rows: Counter,
     pub insert_latency_seconds: Histogram,
     pub tob_last_seen_unix_seconds: GaugeVec,
+    pub funding_poll_attempts: CounterVec,
+    pub funding_insert_attempts: CounterVec,
+    pub funding_insert_rows: Counter,
+    pub funding_insert_latency_seconds: Histogram,
+    pub funding_last_event_unix_seconds: GaugeVec,
     pub stream_reconnects: Counter,
     pub clickhouse_up: Gauge,
     pub ready_state: Gauge,
@@ -74,6 +80,41 @@ impl RecorderMetrics {
             ),
             &["inst_id"],
         )?;
+        let funding_poll_attempts = CounterVec::new(
+            Opts::new(
+                "okx_recorder_funding_poll_attempts_total",
+                "Total funding-rate-history poll attempts by instrument and outcome",
+            ),
+            &["inst_id", "status"],
+        )?;
+        let funding_insert_attempts = CounterVec::new(
+            Opts::new(
+                "okx_recorder_funding_insert_attempts_total",
+                "Total ClickHouse insert attempts for funding batches",
+            ),
+            &["status"],
+        )?;
+        let funding_insert_rows = Counter::with_opts(Opts::new(
+            "okx_recorder_funding_insert_rows_total",
+            "Total funding rows inserted into ClickHouse",
+        ))?;
+        let funding_insert_latency_seconds = Histogram::with_opts(
+            HistogramOpts::new(
+                "okx_recorder_funding_insert_latency_seconds",
+                "ClickHouse funding insert latency in seconds",
+            )
+            .buckets(vec![0.01, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0]),
+        )?;
+        let funding_last_event_unix_seconds = GaugeVec::new(
+            Opts::new(
+                "okx_recorder_funding_last_event_unix_seconds",
+                "Exchange settlement timestamp (unix seconds) of the most recent settled \
+                 funding event observed per instrument. Funding settles on an hours-scale \
+                 cadence, so an age of several hours is normal — alert on it, never gate \
+                 readiness with it.",
+            ),
+            &["inst_id"],
+        )?;
         let stream_reconnects = Counter::with_opts(Opts::new(
             "okx_recorder_stream_reconnects_total",
             "Total websocket reconnect attempts after a connection failure",
@@ -94,6 +135,11 @@ impl RecorderMetrics {
         registry.register(Box::new(insert_rows.clone()))?;
         registry.register(Box::new(insert_latency_seconds.clone()))?;
         registry.register(Box::new(tob_last_seen_unix_seconds.clone()))?;
+        registry.register(Box::new(funding_poll_attempts.clone()))?;
+        registry.register(Box::new(funding_insert_attempts.clone()))?;
+        registry.register(Box::new(funding_insert_rows.clone()))?;
+        registry.register(Box::new(funding_insert_latency_seconds.clone()))?;
+        registry.register(Box::new(funding_last_event_unix_seconds.clone()))?;
         registry.register(Box::new(stream_reconnects.clone()))?;
         registry.register(Box::new(clickhouse_up.clone()))?;
         registry.register(Box::new(ready_state.clone()))?;
@@ -107,6 +153,11 @@ impl RecorderMetrics {
             insert_rows,
             insert_latency_seconds,
             tob_last_seen_unix_seconds,
+            funding_poll_attempts,
+            funding_insert_attempts,
+            funding_insert_rows,
+            funding_insert_latency_seconds,
+            funding_last_event_unix_seconds,
             stream_reconnects,
             clickhouse_up,
             ready_state,
@@ -140,6 +191,20 @@ impl RecorderMetrics {
         self.tob_last_seen_unix_seconds
             .with_label_values(&[inst_id])
             .set(unix_seconds_now());
+    }
+
+    /// Advance the per-instrument settled-funding last-event gauge to
+    /// `funding_time` (exchange settlement time). Monotone max: polls return a
+    /// trailing history window, so older events in the same batch must not
+    /// rewind the gauge.
+    pub fn record_funding_event(&self, inst_id: &str, funding_time: chrono::DateTime<chrono::Utc>) {
+        let gauge = self
+            .funding_last_event_unix_seconds
+            .with_label_values(&[inst_id]);
+        let new_value = funding_time.timestamp_millis() as f64 / 1000.0;
+        if new_value > gauge.get() {
+            gauge.set(new_value);
+        }
     }
 
     pub fn to_prometheus_payload(&self) -> Result<Vec<u8>> {

--- a/apps/okx-recorder/src/models.rs
+++ b/apps/okx-recorder/src/models.rs
@@ -10,9 +10,11 @@ pub const BBO_TBT_CHANNEL: &str = "bbo-tbt";
 
 /// A parsed row destined for ClickHouse, tagged by lane.
 ///
-/// Each lane (channel or poller) maps to its own ClickHouse table; the writer
-/// loop routes rows by variant. Currently only the ToB lane exists — trades and
-/// funding variants bolt on here when their lanes land.
+/// Each websocket lane (channel) maps to its own ClickHouse table; the writer
+/// loop routes rows by variant. Currently only the ToB lane exists — the
+/// trades variant bolts on here when its lane lands. The funding lane arrives
+/// over REST (see [`FundingRate`]) and is inserted by its poller directly, so
+/// it never passes through this enum.
 #[derive(Clone, Debug, PartialEq)]
 pub enum LaneRow {
     BookTicker(BookTicker),
@@ -187,6 +189,116 @@ fn parse_best_level(
     ))
 }
 
-fn parse_decimal(value: &str, side: &str) -> Result<Decimal> {
-    Decimal::from_str(value).with_context(|| format!("invalid decimal in {side} level: {value}"))
+fn parse_decimal(value: &str, field: &str) -> Result<Decimal> {
+    Decimal::from_str(value).with_context(|| format!("invalid decimal in {field}: {value}"))
+}
+
+/// A single settled OKX funding event for one instrument, from the
+/// `funding-rate-history` REST endpoint. This is the SETTLED rate — not the
+/// websocket predicted-rate stream. `(inst_id, funding_time)` identifies the
+/// event: every poll re-fetches the trailing history window and re-inserts
+/// overlapping rows, and `ReplacingMergeTree(ingested_at)` collapses the
+/// duplicates, making the poller idempotent with no client-side dedupe.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FundingRate {
+    pub inst_id: String,
+    pub funding_rate: Decimal,
+    /// OKX's realized rate for the period; can be absent.
+    pub realized_rate: Option<Decimal>,
+    /// Exchange settlement timestamp (`fundingTime` in the raw payload, epoch
+    /// milliseconds).
+    pub funding_time: DateTime<Utc>,
+    /// Client receipt time, stamped when the REST response arrives.
+    pub received_at: DateTime<Utc>,
+}
+
+/// REST envelope for `/api/v5/public/funding-rate-history`: `code` is `"0"` on
+/// success, anything else is an error described by `msg`. `data` lists the
+/// most recent settled funding events first.
+#[derive(Debug, Deserialize)]
+struct RawFundingHistoryResponse {
+    code: String,
+    #[serde(default)]
+    msg: String,
+    #[serde(default)]
+    data: Vec<RawFundingHistoryEntry>,
+}
+
+/// One settled funding event. Decimals and the epoch-millis `fundingTime`
+/// arrive as strings, like everything on the OKX REST API.
+#[derive(Debug, Deserialize)]
+struct RawFundingHistoryEntry {
+    #[serde(rename = "instId")]
+    inst_id: String,
+    #[serde(rename = "fundingRate")]
+    funding_rate: String,
+    #[serde(rename = "realizedRate", default)]
+    realized_rate: Option<String>,
+    #[serde(rename = "fundingTime")]
+    funding_time: String,
+}
+
+/// Parse one `funding-rate-history` REST response body into [`FundingRate`]
+/// rows for `inst_id_hint` (the instrument the request asked for).
+///
+/// An error-code response or a malformed body is an error so the caller can
+/// drop the poll rather than store half-parsed rows. An entry for a different
+/// instrument than requested is dropped with a warning instead of failing the
+/// whole poll. `received_at` is supplied by the caller (stamped when the
+/// response arrives).
+pub fn parse_funding_history(
+    body: &str,
+    inst_id_hint: &str,
+    received_at: DateTime<Utc>,
+) -> Result<Vec<FundingRate>> {
+    let response: RawFundingHistoryResponse =
+        serde_json::from_str(body).context("malformed funding-rate-history response")?;
+    if response.code != "0" {
+        anyhow::bail!(
+            "funding-rate-history error response (code {}): {}",
+            response.code,
+            response.msg
+        );
+    }
+
+    let mut rows = Vec::with_capacity(response.data.len());
+    for entry in response.data {
+        if entry.inst_id != inst_id_hint {
+            tracing::warn!(
+                expected = inst_id_hint,
+                got = %entry.inst_id,
+                "funding-rate-history instrument mismatch; dropping row"
+            );
+            continue;
+        }
+        rows.push(FundingRate::from_entry(entry, received_at)?);
+    }
+    Ok(rows)
+}
+
+impl FundingRate {
+    fn from_entry(entry: RawFundingHistoryEntry, received_at: DateTime<Utc>) -> Result<Self> {
+        let raw_time: i64 = entry
+            .funding_time
+            .parse()
+            .with_context(|| format!("invalid fundingTime: {}", entry.funding_time))?;
+        let funding_time = DateTime::from_timestamp_millis(raw_time)
+            .with_context(|| format!("fundingTime out of range: {raw_time}"))?;
+        let funding_rate = parse_decimal(&entry.funding_rate, "fundingRate")?;
+        // An absent or empty realizedRate is a missing value, not an error.
+        let realized_rate = entry
+            .realized_rate
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .map(|value| parse_decimal(value, "realizedRate"))
+            .transpose()?;
+
+        Ok(Self {
+            inst_id: entry.inst_id,
+            funding_rate,
+            realized_rate,
+            funding_time,
+            received_at,
+        })
+    }
 }

--- a/apps/okx-recorder/src/recorder.rs
+++ b/apps/okx-recorder/src/recorder.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use tokio::{
     sync::mpsc,
@@ -9,9 +9,10 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     clickhouse::ClickHouseClient,
+    funding_client::poll_funding_once,
     health::HealthState,
     metrics::RecorderMetrics,
-    models::{BookTicker, LaneRow},
+    models::{BookTicker, FundingRate, LaneRow},
     stream_client::run_stream_worker,
 };
 
@@ -22,6 +23,13 @@ pub struct WriterRuntimeConfig {
     pub queue_max_rows: usize,
 }
 
+#[derive(Clone, Debug)]
+pub struct FundingRuntimeConfig {
+    pub history_url: String,
+    pub poll_seconds: u64,
+    pub history_limit: u32,
+}
+
 /// Orchestrates the recorder pipeline: a single multiplexed websocket worker
 /// feeds an mpsc channel of [`LaneRow`]s, and a writer loop batch-inserts each
 /// lane into its ClickHouse table. Ported from `binance-recorder`'s
@@ -30,14 +38,17 @@ pub struct WriterRuntimeConfig {
 /// over the table's ORDER BY keys). Because `received_at` is part of the ORDER
 /// BY, this collapses byte-identical insert retries only; a genuine exchange
 /// re-send arrives with a new `received_at` and is persisted as a distinct row
-/// by design. Follow-up lanes (trades, funding) add their own [`LaneRow`]
-/// variants and per-lane buffers here.
+/// by design. Follow-up websocket lanes (trades) add their own [`LaneRow`]
+/// variants and per-lane buffers here. The funding lane is REST instead: it
+/// polls on a minutes-scale cadence and inserts its small batches directly,
+/// bypassing the queue.
 pub struct RecorderRuntime {
     ws_url: String,
     instruments: Vec<String>,
     reconnect_max_backoff_seconds: u64,
     writer: ClickHouseClient,
     writer_config: WriterRuntimeConfig,
+    funding_config: FundingRuntimeConfig,
     metrics: Arc<RecorderMetrics>,
     health: HealthState,
     insert_async: bool,
@@ -53,6 +64,7 @@ impl RecorderRuntime {
         reconnect_max_backoff_seconds: u64,
         writer: ClickHouseClient,
         writer_config: WriterRuntimeConfig,
+        funding_config: FundingRuntimeConfig,
         metrics: Arc<RecorderMetrics>,
         health: HealthState,
         insert_async: bool,
@@ -63,6 +75,7 @@ impl RecorderRuntime {
             reconnect_max_backoff_seconds,
             writer,
             writer_config,
+            funding_config,
             metrics,
             health,
             insert_async,
@@ -99,6 +112,7 @@ impl RecorderRuntime {
         });
         self.handles.push(handle);
 
+        self.spawn_funding_loop();
         self.spawn_health_probe_loop();
     }
 
@@ -175,6 +189,70 @@ impl RecorderRuntime {
         self.handles.push(handle);
     }
 
+    /// Poll the settled funding-rate history for every configured instrument
+    /// on a minutes-scale cadence and insert each poll's batch directly.
+    /// Funding settles hourly at most, so each poll yields a handful of rows —
+    /// no queueing or batching needed. Every poll re-fetches a trailing history
+    /// window; the resulting duplicates are collapsed by
+    /// `ReplacingMergeTree(ingested_at)` over `(inst_id, funding_time)`, so
+    /// re-polling is idempotent by design. This lane feeds the funding
+    /// last-event metric but never touches `HealthState` — funding staleness
+    /// must not gate `/ready`.
+    fn spawn_funding_loop(&mut self) {
+        let history_url = self.funding_config.history_url.clone();
+        let instruments = self.instruments.clone();
+        let poll_seconds = self.funding_config.poll_seconds;
+        let history_limit = self.funding_config.history_limit;
+        let max_backoff = self.reconnect_max_backoff_seconds;
+        let writer = self.writer.clone();
+        let metrics = self.metrics.clone();
+        let insert_async = self.insert_async;
+        let stop_token = self.stop_token.clone();
+
+        let handle = tokio::spawn(async move {
+            let http = reqwest::Client::new();
+            let mut backoff: HashMap<String, u64> = HashMap::new();
+            let mut ticker = tokio::time::interval(Duration::from_secs(poll_seconds.max(1)));
+            ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+            while stop_token
+                .run_until_cancelled(async {
+                    ticker.tick().await;
+
+                    let batch = poll_funding_once(
+                        &http,
+                        &history_url,
+                        &instruments,
+                        history_limit,
+                        max_backoff,
+                        &metrics,
+                        &mut backoff,
+                        &stop_token,
+                    )
+                    .await;
+
+                    for row in &batch {
+                        metrics.record_funding_event(&row.inst_id, row.funding_time);
+                    }
+
+                    if !batch.is_empty() {
+                        flush_funding_with_retry(
+                            &writer,
+                            &metrics,
+                            batch,
+                            stop_token.clone(),
+                            insert_async,
+                        )
+                        .await;
+                    }
+                })
+                .await
+                .is_some()
+            {}
+        });
+        self.handles.push(handle);
+    }
+
     /// Periodically ping ClickHouse and refresh the readiness gauges.
     /// Per-instrument ToB freshness is driven from the stream worker; this loop
     /// owns only the ClickHouse-up and overall-ready signals.
@@ -246,6 +324,47 @@ async fn flush_with_retry(
                     error = ?err,
                     "failed to insert book ticker batch"
                 );
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        }
+    }
+}
+
+async fn flush_funding_with_retry(
+    writer: &ClickHouseClient,
+    metrics: &RecorderMetrics,
+    batch: Vec<FundingRate>,
+    stop_token: CancellationToken,
+    insert_async: bool,
+) {
+    loop {
+        match writer.insert_funding_batch(&batch, insert_async).await {
+            Ok((rows, latency)) => {
+                metrics
+                    .funding_insert_attempts
+                    .with_label_values(&["success"])
+                    .inc();
+                metrics.funding_insert_rows.inc_by(rows as f64);
+                metrics.funding_insert_latency_seconds.observe(latency);
+                tracing::debug!("inserted {} funding rows into ClickHouse", rows);
+                return;
+            }
+            Err(err) => {
+                metrics
+                    .funding_insert_attempts
+                    .with_label_values(&["error"])
+                    .inc();
+                tracing::error!(
+                    rows = batch.len(),
+                    error = ?err,
+                    "failed to insert funding batch"
+                );
+                // On shutdown, drop the batch instead of retrying against an
+                // unreachable ClickHouse: the next poll after restart
+                // re-fetches the same window, so a dropped batch self-heals.
+                if stop_token.is_cancelled() {
+                    return;
+                }
                 tokio::time::sleep(Duration::from_secs(1)).await;
             }
         }

--- a/apps/okx-recorder/src/recorder.rs
+++ b/apps/okx-recorder/src/recorder.rs
@@ -16,6 +16,15 @@ use crate::{
     stream_client::run_stream_worker,
 };
 
+/// Overall per-request deadline for funding-history polls. The poll loop is
+/// sequential, so a request that never completes would otherwise stall the
+/// funding lane forever without incrementing any error counter.
+const FUNDING_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// TCP connect deadline for funding-history polls, stricter than the overall
+/// request timeout so an unreachable endpoint fails fast.
+const FUNDING_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
 #[derive(Clone, Debug)]
 pub struct WriterRuntimeConfig {
     pub batch_max_rows: usize,
@@ -209,8 +218,28 @@ impl RecorderRuntime {
         let insert_async = self.insert_async;
         let stop_token = self.stop_token.clone();
 
+        // Explicit timeouts so a hung endpoint surfaces as a normal
+        // per-instrument poll error (error counter + backoff) instead of
+        // stalling the sequential poll loop indefinitely.
+        let http = match reqwest::Client::builder()
+            .timeout(FUNDING_REQUEST_TIMEOUT)
+            .connect_timeout(FUNDING_CONNECT_TIMEOUT)
+            .build()
+        {
+            Ok(http) => http,
+            Err(err) => {
+                // Builder failure means the TLS backend could not initialize;
+                // leave the funding lane down and let the funding staleness
+                // alert surface it rather than polling without timeouts.
+                tracing::error!(
+                    error = ?err,
+                    "failed to build funding HTTP client; funding lane disabled"
+                );
+                return;
+            }
+        };
+
         let handle = tokio::spawn(async move {
-            let http = reqwest::Client::new();
             let mut backoff: HashMap<String, u64> = HashMap::new();
             let mut ticker = tokio::time::interval(Duration::from_secs(poll_seconds.max(1)));
             ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);

--- a/apps/okx-recorder/tests/test_config.rs
+++ b/apps/okx-recorder/tests/test_config.rs
@@ -8,7 +8,7 @@ use std::{
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
-const ENV_KEYS: [&str; 9] = [
+const ENV_KEYS: [&str; 13] = [
     "OKX_RECORDER__INSTRUMENTS",
     "OKX_RECORDER__WS_URL",
     "OKX_RECORDER__CLICKHOUSE__URL",
@@ -16,8 +16,12 @@ const ENV_KEYS: [&str; 9] = [
     "OKX_RECORDER__CLICKHOUSE__PASSWORD",
     "OKX_RECORDER__CLICKHOUSE__DATABASE",
     "OKX_RECORDER__CLICKHOUSE__BOOK_TICKER_TABLE",
+    "OKX_RECORDER__CLICKHOUSE__FUNDING_RATES_TABLE",
     "OKX_RECORDER__METRICS_PORT",
     "OKX_RECORDER__HEALTH_PORT",
+    "OKX_RECORDER__FUNDING_HISTORY_URL",
+    "OKX_RECORDER__FUNDING_POLL_SECONDS",
+    "OKX_RECORDER__FUNDING_HISTORY_LIMIT",
 ];
 
 #[test]
@@ -88,10 +92,18 @@ clickhouse:
     assert_eq!(config.ready_stale_seconds, 10);
     assert_eq!(config.reconnect_max_backoff_seconds, 30);
     assert!(config.insert_async);
-    // ClickHouse target falls back to the default user/database/table.
+    // ClickHouse target falls back to the default user/database/tables.
     assert_eq!(config.clickhouse.username, "default");
     assert_eq!(config.clickhouse.database, "default");
     assert_eq!(config.clickhouse.book_ticker_table, "okx_book_ticker");
+    assert_eq!(config.clickhouse.funding_rates_table, "okx_funding_rates");
+    // Funding lane defaults: the public history endpoint on a 5-minute poll.
+    assert_eq!(
+        config.funding_history_url,
+        "https://www.okx.com/api/v5/public/funding-rate-history"
+    );
+    assert_eq!(config.funding_poll_seconds, 300);
+    assert_eq!(config.funding_history_limit, 10);
 
     let _ = fs::remove_file(config_file);
 }
@@ -201,6 +213,60 @@ instruments:
     assert!(result.is_err(), "missing ClickHouse URL should fail");
 
     let _ = fs::remove_file(config_file);
+}
+
+#[test]
+fn test_funding_poll_seconds_below_minute_rejected() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    clear_env_vars(ENV_KEYS);
+
+    let config_file = temp_yaml_path("okx-config-funding-poll");
+    let yaml = r#"
+clickhouse:
+  url: "http://127.0.0.1:8123"
+funding_poll_seconds: 5
+"#;
+    fs::write(&config_file, yaml).expect("write yaml config");
+    let result = AppConfig::from_sources(Some(&config_file));
+    assert!(result.is_err(), "sub-minute funding poll should fail");
+    let message = result.err().map(|err| err.to_string()).unwrap_or_default();
+    assert!(
+        message.contains("funding_poll_seconds"),
+        "unexpected error: {message}"
+    );
+
+    let _ = fs::remove_file(config_file);
+}
+
+#[test]
+fn test_funding_history_limit_out_of_range_rejected() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    clear_env_vars(ENV_KEYS);
+
+    // OKX caps the history `limit` query parameter at 100.
+    for bad_limit in ["0", "101"] {
+        let config_file = temp_yaml_path("okx-config-funding-limit");
+        let yaml = format!(
+            r#"
+clickhouse:
+  url: "http://127.0.0.1:8123"
+funding_history_limit: {bad_limit}
+"#
+        );
+        fs::write(&config_file, yaml).expect("write yaml config");
+        let result = AppConfig::from_sources(Some(&config_file));
+        assert!(
+            result.is_err(),
+            "funding_history_limit {bad_limit} should fail"
+        );
+        let message = result.err().map(|err| err.to_string()).unwrap_or_default();
+        assert!(
+            message.contains("funding_history_limit"),
+            "unexpected error: {message}"
+        );
+
+        let _ = fs::remove_file(config_file);
+    }
 }
 
 fn clear_env_vars<'a>(keys: impl IntoIterator<Item = &'a str>) {

--- a/apps/okx-recorder/tests/test_funding_models.rs
+++ b/apps/okx-recorder/tests/test_funding_models.rs
@@ -1,0 +1,176 @@
+use chrono::{TimeZone, Utc};
+use okx_recorder::models::parse_funding_history;
+use rust_decimal::Decimal;
+use std::str::FromStr;
+
+/// A real `funding-rate-history` response shape: string decimals (up to ~17
+/// decimal places) and epoch-millis `fundingTime` strings, most recent first.
+fn sample_funding_response() -> &'static str {
+    r#"{
+        "code": "0",
+        "msg": "",
+        "data": [
+            {
+                "formulaType": "withRate",
+                "fundingRate": "0.0000887121109659",
+                "fundingTime": "1786550400000",
+                "instId": "OPENAI-USDT-SWAP",
+                "instType": "SWAP",
+                "method": "current_period",
+                "realizedRate": "0.0000887121109658"
+            },
+            {
+                "formulaType": "withRate",
+                "fundingRate": "-0.0000665167980022",
+                "fundingTime": "1786521600000",
+                "instId": "OPENAI-USDT-SWAP",
+                "instType": "SWAP",
+                "method": "current_period",
+                "realizedRate": "-0.0000665167980022"
+            }
+        ]
+    }"#
+}
+
+fn received_at() -> chrono::DateTime<Utc> {
+    Utc.timestamp_millis_opt(1_786_550_500_123)
+        .single()
+        .unwrap()
+}
+
+#[test]
+fn parse_funding_history_maps_fields() {
+    let rows = parse_funding_history(sample_funding_response(), "OPENAI-USDT-SWAP", received_at())
+        .expect("should parse");
+
+    assert_eq!(rows.len(), 2);
+    let first = &rows[0];
+    assert_eq!(first.inst_id, "OPENAI-USDT-SWAP");
+    assert_eq!(
+        first.funding_rate,
+        Decimal::from_str("0.0000887121109659").unwrap()
+    );
+    assert_eq!(
+        first.realized_rate,
+        Some(Decimal::from_str("0.0000887121109658").unwrap())
+    );
+    assert_eq!(
+        first.funding_time,
+        Utc.timestamp_millis_opt(1_786_550_400_000)
+            .single()
+            .unwrap()
+    );
+    assert_eq!(first.received_at, received_at());
+
+    // Negative rates are valid: longs get paid.
+    let second = &rows[1];
+    assert_eq!(
+        second.funding_rate,
+        Decimal::from_str("-0.0000665167980022").unwrap()
+    );
+    assert_eq!(
+        second.funding_time,
+        Utc.timestamp_millis_opt(1_786_521_600_000)
+            .single()
+            .unwrap()
+    );
+}
+
+#[test]
+fn parse_funding_history_handles_missing_and_empty_realized_rate() {
+    let body = r#"{
+        "code": "0",
+        "msg": "",
+        "data": [
+            { "instId": "OPENAI-USDT-SWAP", "fundingRate": "0.0001", "fundingTime": "1786550400000" },
+            { "instId": "OPENAI-USDT-SWAP", "fundingRate": "0.0002", "fundingTime": "1786521600000", "realizedRate": "" }
+        ]
+    }"#;
+    let rows =
+        parse_funding_history(body, "OPENAI-USDT-SWAP", received_at()).expect("should parse");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].realized_rate, None);
+    assert_eq!(rows[1].realized_rate, None);
+}
+
+#[test]
+fn parse_funding_history_handles_empty_data() {
+    let body = r#"{ "code": "0", "msg": "", "data": [] }"#;
+    let rows =
+        parse_funding_history(body, "OPENAI-USDT-SWAP", received_at()).expect("should parse");
+    assert!(rows.is_empty());
+}
+
+#[test]
+fn parse_funding_history_drops_mismatched_instrument() {
+    // A row for a different instrument than requested is dropped, not fatal.
+    let body = r#"{
+        "code": "0",
+        "msg": "",
+        "data": [
+            { "instId": "ANTHROPIC-USDT-SWAP", "fundingRate": "0.0001", "fundingTime": "1786550400000" },
+            { "instId": "OPENAI-USDT-SWAP", "fundingRate": "0.0002", "fundingTime": "1786550400000" }
+        ]
+    }"#;
+    let rows =
+        parse_funding_history(body, "OPENAI-USDT-SWAP", received_at()).expect("should parse");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].inst_id, "OPENAI-USDT-SWAP");
+}
+
+#[test]
+fn parse_funding_history_errors_on_error_code() {
+    // OKX reports a bad instrument as an error-code envelope with HTTP 200.
+    let body = r#"{
+        "code": "51001",
+        "msg": "Instrument ID doesn't exist.",
+        "data": []
+    }"#;
+    let err = parse_funding_history(body, "NOT-A-REAL-SWAP", received_at()).unwrap_err();
+    let message = format!("{err:#}");
+    assert!(
+        message.contains("51001"),
+        "error should carry the code: {message}"
+    );
+    assert!(
+        message.contains("Instrument ID doesn't exist."),
+        "error should carry the message: {message}"
+    );
+}
+
+#[test]
+fn parse_funding_history_errors_on_bad_funding_rate() {
+    let body = r#"{
+        "code": "0",
+        "msg": "",
+        "data": [
+            { "instId": "OPENAI-USDT-SWAP", "fundingRate": "not-a-number", "fundingTime": "1786550400000" }
+        ]
+    }"#;
+    let err = parse_funding_history(body, "OPENAI-USDT-SWAP", received_at()).unwrap_err();
+    assert!(
+        format!("{err:#}").contains("fundingRate"),
+        "error should name the field: {err:#}"
+    );
+}
+
+#[test]
+fn parse_funding_history_errors_on_bad_funding_time() {
+    let body = r#"{
+        "code": "0",
+        "msg": "",
+        "data": [
+            { "instId": "OPENAI-USDT-SWAP", "fundingRate": "0.0001", "fundingTime": "not-millis" }
+        ]
+    }"#;
+    let err = parse_funding_history(body, "OPENAI-USDT-SWAP", received_at()).unwrap_err();
+    assert!(
+        format!("{err:#}").contains("fundingTime"),
+        "error should name the field: {err:#}"
+    );
+}
+
+#[test]
+fn parse_funding_history_errors_on_non_json() {
+    assert!(parse_funding_history("<html>502</html>", "OPENAI-USDT-SWAP", received_at()).is_err());
+}


### PR DESCRIPTION
Resolves PFG-1557. Part of the PFG-1553 okx-recorder stack (2/4), on top of #3975.

Adds the funding lane: a new `src/funding_client.rs` (hyperliquid-recorder's poller pattern, per-instrument jittered backoff) polls `/api/v5/public/funding-rate-history?instId=…` on a configurable interval (`funding_poll_seconds`, default 300) and records the **settled** rate into `okx_funding_rates`.

- **Schema** (`migrations/002-funding-rates.sql`): `ReplacingMergeTree(ingested_at)`, ORDER BY `(inst_id, funding_time)`, monthly partitions, 90-day TTL; `Decimal(38,18)` preserves OKX's ~17-decimal rates. Inserts are idempotent by `(inst_id, funding_time)`.
- Funding batches deliberately bypass the WS mpsc queue and insert directly (sparse REST data, hyperliquid pattern).
- Metrics: poll attempts by status, insert attempt/rows/latency, `funding_last_event_unix_seconds` (monotone-max settlement time). `/ready` is untouched — funding sparseness never gates readiness.
- `local_e2e_check.sh` gains funding-row and idempotence (unique `(inst_id, funding_time)` after `FINAL`) asserts.

Validation: build, tests (8 new funding parse tests validated against the live endpoint shape, 3 config tests), clippy `-D warnings`, fmt, pre-commit all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)