### PR TITLE
tejas/pfg 1556 trades lane trades channel okx trades

### DIFF
--- a/apps/okx-recorder/README.md
+++ b/apps/okx-recorder/README.md
@@ -3,20 +3,23 @@
 Subscribes to OKX perpetual-swap market data over the public websocket
 (`wss://ws.okx.com:8443/ws/v5/public`) for a configurable instrument list and
 persists **every** update to ClickHouse. Records the top-of-book (`bbo-tbt`)
-websocket lane and the settled funding-rate REST lane; the trades lane bolts
-onto the same pipeline.
+and trades (`trades`) websocket lanes plus the settled funding-rate REST lane.
 
 ## What it records
 
-One websocket connection multiplexes a `bbo-tbt` subscription per configured
-instrument. Each update is converted to a row and written to
-`default.okx_book_ticker`. The payload carries an exchange timestamp (`ts`),
+One websocket connection multiplexes a `bbo-tbt` and a `trades` subscription
+per configured instrument. Each update is converted to a row and written to its
+lane's table: top-of-book updates to `default.okx_book_ticker`, trade prints to
+`default.okx_trades`. Every payload carries an exchange timestamp (`ts`),
 recorded as `ts`; the recorder additionally stamps a client-side `received_at`
-when the frame arrives (so transport latency is measurable) and uses OKX's
-per-instrument `seqId` as the ordering tiebreaker. There is **no in-memory
-dedupe** (a deliberate deviation from `binance-recorder`): every received update
-is inserted, and ClickHouse's `ReplacingMergeTree` owns row identity via the
-table's ORDER BY keys, collapsing byte-identical insert retries at merge time.
+when the frame arrives (so transport latency is measurable). On the ToB lane
+OKX's per-instrument `seqId` is the ordering tiebreaker; on the trades lane it
+is `tradeId`, and the stored `count` field distinguishes aggregate prints (OKX
+aggregates fills at the same price/timestamp into one print) from single fills.
+There is **no in-memory dedupe** (a deliberate deviation from
+`binance-recorder`): every received update is inserted, and ClickHouse's
+`ReplacingMergeTree` owns row identity via each table's ORDER BY keys,
+collapsing byte-identical insert retries at merge time.
 
 Alongside the websocket, a REST poller fetches the **settled** funding rate
 (`/api/v5/public/funding-rate-history` — not the websocket predicted-rate
@@ -62,10 +65,11 @@ adding an OKX perp is a config change, no code change.
    bash scripts/local_e2e_check.sh
    ```
 
-   The check confirms rows have landed in `default.okx_book_ticker` and
-   `default.okx_funding_rates`, that funding rows are unique by
-   `(inst_id, funding_time)` after ReplacingMergeTree collapse, and that
-   `/ready` and `/metrics` respond.
+   The check confirms rows have landed in `default.okx_book_ticker`,
+   `default.okx_trades`, and `default.okx_funding_rates`, that funding rows
+   are unique by `(inst_id, funding_time)` after ReplacingMergeTree collapse,
+   and that `/ready` and `/metrics` respond. On a thin instrument the trades
+   assert may need a longer run before a print lands.
 
 ## Services & ports
 
@@ -87,17 +91,19 @@ Overview** dashboard.
 - `GET /ready` (health port) — ready only when ClickHouse is reachable **and
   every** configured instrument's ToB lane is fresh within
   `ready_stale_seconds`. An instrument that never streams therefore keeps
-  `/ready` red, surfacing the gap rather than masking it. The funding lane (and
-  the future trades lane) exposes last-event metrics but **never** gates
-  readiness — funding settles on an hours-scale cadence and sparseness is
-  expected, so its staleness is an alerting signal, not an outage.
+  `/ready` red, surfacing the gap rather than masking it. The trades and
+  funding lanes expose last-event metrics but **never** gate readiness —
+  trades can legitimately go quiet on a thin perp and funding settles on an
+  hours-scale cadence, so their staleness is an alerting signal, not an
+  outage.
 - `GET /metrics` (metrics port) — Prometheus exposition, including
   `okx_recorder_ready`, `okx_recorder_clickhouse_up`,
   `okx_recorder_insert_rows_total`, `okx_recorder_insert_latency_seconds`,
   `okx_recorder_insert_attempts_total{status}`, `okx_recorder_queue_depth`,
   `okx_recorder_queue_fill_ratio`, `okx_recorder_queue_drops_total{inst_id}`,
-  `okx_recorder_stream_reconnects_total`, and
-  `okx_recorder_tob_last_seen_unix_seconds{inst_id}`. The funding lane adds
+  `okx_recorder_stream_reconnects_total`,
+  `okx_recorder_tob_last_seen_unix_seconds{inst_id}`, and
+  `okx_recorder_trades_last_seen_unix_seconds{inst_id}`. The funding lane adds
   `okx_recorder_funding_poll_attempts_total{inst_id,status}`,
   `okx_recorder_funding_insert_attempts_total{status}`,
   `okx_recorder_funding_insert_rows_total`,
@@ -122,7 +128,8 @@ See [config.sample.yml](config.sample.yml) for all options:
 | `ws_url` | `wss://ws.okx.com:8443/ws/v5/public` | OKX public websocket endpoint |
 | `clickhouse.url` | _required_ | ClickHouse URL (`http`/`https` → `secure`) |
 | `clickhouse.user` / `password` | `default` / "" | Credentials |
-| `clickhouse.database` / `book_ticker_table` | `default` / `okx_book_ticker` | Target |
+| `clickhouse.database` | `default` | Target database |
+| `clickhouse.book_ticker_table` / `trades_table` | `okx_book_ticker` / `okx_trades` | Per-lane target tables |
 | `clickhouse.funding_rates_table` | `okx_funding_rates` | Funding lane target table |
 | `metrics_port` | `9095` | Prometheus metrics port |
 | `health_port` | `8085` | Health endpoint port |
@@ -138,9 +145,12 @@ See [config.sample.yml](config.sample.yml) for all options:
 
 ## Schema
 
-ClickHouse schema is in [`migrations/`](migrations/) (one file per table); for
-local dev it is auto-loaded via the ClickHouse Docker entrypoint. For
-production, apply it manually against the pyth-analytics cluster.
+ClickHouse schema is in [`migrations/`](migrations/) (one file per table:
+[`001-init.sql`](migrations/001-init.sql) for the book,
+[`002-funding-rates.sql`](migrations/002-funding-rates.sql) for funding,
+[`003-trades.sql`](migrations/003-trades.sql) for trades); for local dev all
+are auto-loaded via the ClickHouse Docker entrypoint. For production, apply
+them manually against the pyth-analytics cluster.
 
 > The compose ClickHouse only runs `/docker-entrypoint-initdb.d` migrations on
 > a **fresh** volume. If you have an older `okx-recorder_clickhouse-local-data`
@@ -167,15 +177,35 @@ ORDER BY (inst_id, received_at, seq_id)
 TTL toDateTime(received_at) + INTERVAL 90 DAY DELETE;
 ```
 
-- **`ReplacingMergeTree(ingested_at)`** + **`ORDER BY (inst_id, received_at, seq_id)`**
-  owns row identity: the recorder does no in-memory dedupe, and insert retries
-  (a flush that times out client-side but commits server-side, then is retried
-  byte-identical) collapse at merge time because the retried rows land on the
-  same ORDER BY key. Because `received_at` is one of those keys, a genuine
-  exchange re-send arrives with a new `received_at` and is persisted as a
-  distinct row by design.
+```sql
+CREATE TABLE default.okx_trades
+(
+    inst_id     LowCardinality(String),
+    trade_id    String,
+    px          Decimal(38, 12),
+    sz          Decimal(38, 12),
+    side        LowCardinality(String),
+    count       UInt32,
+    ts          DateTime64(3),
+    received_at DateTime64(3),
+    ingested_at DateTime64(3) DEFAULT now64(3)
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toYYYYMM(ts)
+ORDER BY (inst_id, ts, trade_id)
+TTL toDateTime(ts) + INTERVAL 90 DAY DELETE;
+```
+
+- **`ReplacingMergeTree(ingested_at)`** + each table's ORDER BY keys own row
+  identity: the recorder does no in-memory dedupe, and insert retries (a flush
+  that times out client-side but commits server-side, then is retried
+  byte-identical) collapse at merge time. On `okx_book_ticker`, `received_at`
+  is one of those keys, so a genuine exchange re-send arrives with a new
+  `received_at` and is persisted as a distinct row by design.
 - **`bid_*`/`ask_*` are `Nullable`** because either book side can be missing on
   `bbo-tbt` when the book is one-sided.
+- **`count`** on `okx_trades` is the number of fills OKX aggregated into the
+  print (same price/timestamp); `1` is a single fill, `>1` an aggregate print.
 - **`ts`** is the exchange timestamp from the payload; **`received_at`** is the
   client receipt time. The pair makes transport latency (`received_at − ts`)
   measurable.

--- a/apps/okx-recorder/config.sample.yml
+++ b/apps/okx-recorder/config.sample.yml
@@ -19,6 +19,7 @@ clickhouse:
   password: "recorder"
   database: "default"
   book_ticker_table: "okx_book_ticker"
+  trades_table: "okx_trades"
   funding_rates_table: "okx_funding_rates"
 
 metrics_port: 9095

--- a/apps/okx-recorder/docker-compose.local.yml
+++ b/apps/okx-recorder/docker-compose.local.yml
@@ -13,6 +13,7 @@ services:
       - clickhouse-local-data:/var/lib/clickhouse
       - ./migrations/001-init.sql:/docker-entrypoint-initdb.d/001-init.sql:ro
       - ./migrations/002-funding-rates.sql:/docker-entrypoint-initdb.d/002-funding-rates.sql:ro
+      - ./migrations/003-trades.sql:/docker-entrypoint-initdb.d/003-trades.sql:ro
 
   okx-recorder:
     build:

--- a/apps/okx-recorder/migrations/003-trades.sql
+++ b/apps/okx-recorder/migrations/003-trades.sql
@@ -1,0 +1,30 @@
+-- Target ClickHouse cluster: pyth-analytics
+--
+-- Apply manually against the pyth-analytics cluster for production. For local
+-- dev this is auto-loaded by the docker-compose ClickHouse entrypoint (see
+-- docker-compose.local.yml).
+--
+-- Trade prints from OKX's `trades` channel. As on the book table, no
+-- in-memory dedupe happens in the recorder: every received print is inserted,
+-- and ReplacingMergeTree(ingested_at) owns row identity via the ORDER BY keys.
+-- OKX aggregates fills at the same px/ts into one print; `count` is the number
+-- of fills aggregated (1 = a single fill) and trade_id is the id of the last
+-- fill in the aggregate, so aggregate prints stay distinguishable. Partitions
+-- and TTL key on the exchange `ts`, matching the ORDER BY.
+
+CREATE TABLE IF NOT EXISTS default.okx_trades
+(
+    inst_id     LowCardinality(String),
+    trade_id    String,
+    px          Decimal(38, 12),
+    sz          Decimal(38, 12),
+    side        LowCardinality(String),
+    count       UInt32,
+    ts          DateTime64(3),
+    received_at DateTime64(3),
+    ingested_at DateTime64(3) DEFAULT now64(3)
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toYYYYMM(ts)
+ORDER BY (inst_id, ts, trade_id)
+TTL toDateTime(ts) + INTERVAL 90 DAY DELETE;

--- a/apps/okx-recorder/scripts/local_e2e_check.sh
+++ b/apps/okx-recorder/scripts/local_e2e_check.sh
@@ -2,14 +2,15 @@
 set -euo pipefail
 
 # End-to-end check for the local Tilt stack: asserts rows have landed in
-# ClickHouse and the health/metrics endpoints respond. Later lanes (trades)
-# extend this script with their own table checks.
+# ClickHouse for every lane (ToB, trades, funding) and the health/metrics
+# endpoints respond.
 
 container_name="${CLICKHOUSE_CONTAINER_NAME:-okx-recorder-clickhouse-local}"
 user_name="${CLICKHOUSE_USER:-${CLICKHOUSE_LOCAL_USER:-recorder}}"
 password="${CLICKHOUSE_PASSWORD:-${CLICKHOUSE_LOCAL_PASSWORD:-recorder}}"
 database_name="${CLICKHOUSE_DATABASE:-default}"
 book_ticker_table="${CLICKHOUSE_BOOK_TICKER_TABLE:-okx_book_ticker}"
+trades_table="${CLICKHOUSE_TRADES_TABLE:-okx_trades}"
 funding_rates_table="${CLICKHOUSE_FUNDING_RATES_TABLE:-okx_funding_rates}"
 
 # Host ports the recorder publishes (see docker-compose.local.yml).
@@ -26,7 +27,20 @@ if [[ "${count}" -le 0 ]]; then
   exit 1
 fi
 
-# 2. Persisted settled-funding rows. The funding poller fires immediately at
+# 2. Persisted trade rows. Trades on a thin perp can be sparse — this check
+#    needs at least one print to have landed since the recorder started, so on
+#    a quiet market let the stack run longer and re-run the check. (Trade
+#    sparseness never fails /ready below; it only fails this row-count assert.)
+query="SELECT count() FROM ${database_name}.${trades_table}"
+trade_count="$(docker exec "${container_name}" clickhouse-client --user "${user_name}" --password "${password}" -q "${query}")"
+
+echo "local_e2e_check: table=${database_name}.${trades_table} rows=${trade_count}"
+if [[ "${trade_count}" -le 0 ]]; then
+  echo "local_e2e_check: no trade rows found yet; on a thin instrument wait for a trade to print and re-run."
+  exit 1
+fi
+
+# 3. Persisted settled-funding rows. The funding poller fires immediately at
 #    startup and re-fetches the trailing history window, so rows should land
 #    within seconds even though funding itself settles on an hours-scale
 #    cadence. Also assert idempotence: after ReplacingMergeTree collapse
@@ -49,7 +63,7 @@ if [[ "${dupes}" -ne 0 ]]; then
 fi
 echo "local_e2e_check: funding rows are unique by (inst_id, funding_time) after FINAL"
 
-# 3. Readiness endpoint responds 200 (ClickHouse reachable + every instrument's
+# 4. Readiness endpoint responds 200 (ClickHouse reachable + every instrument's
 #    ToB lane fresh).
 ready_status="$(curl -s -o /dev/null -w '%{http_code}' "${health_url}")"
 echo "local_e2e_check: GET ${health_url} -> ${ready_status}"
@@ -58,7 +72,7 @@ if [[ "${ready_status}" != "200" ]]; then
   exit 1
 fi
 
-# 4. Metrics endpoint exposes the recorder metrics, including the funding
+# 5. Metrics endpoint exposes the recorder metrics, including the funding
 #    lane's poll counter and last-event gauge (present once the startup poll
 #    has run; funding staleness is observable here but never gates /ready).
 metrics_payload="$(curl -sf "${metrics_url}")"

--- a/apps/okx-recorder/src/clickhouse.rs
+++ b/apps/okx-recorder/src/clickhouse.rs
@@ -8,13 +8,14 @@ use serde::Serialize;
 
 use crate::{
     config::ClickHouseTarget,
-    models::{BookTicker, FundingRate},
+    models::{BookTicker, FundingRate, Trade},
 };
 
 #[derive(Clone)]
 pub struct ClickHouseClient {
     client: Client,
     book_ticker_table: String,
+    trades_table: String,
     funding_rates_table: String,
 }
 
@@ -33,11 +34,12 @@ impl ClickHouseClient {
 
         Self {
             client,
-            // Bare table name: the client is already scoped to the database via
-            // `with_database`, so the insert target must NOT be qualified (a
-            // dotted name gets quoted as a single identifier and then prefixed
-            // with the connected database, yielding `db.`db.table``).
+            // Bare table names: the client is already scoped to the database
+            // via `with_database`, so an insert target must NOT be qualified
+            // (a dotted name gets quoted as a single identifier and then
+            // prefixed with the connected database, yielding `db.`db.table``).
             book_ticker_table: target.book_ticker_table,
+            trades_table: target.trades_table,
             funding_rates_table: target.funding_rates_table,
         }
     }
@@ -57,16 +59,8 @@ impl ClickHouseClient {
         }
 
         let start = Instant::now();
-        let client = if insert_async {
-            self.client
-                .clone()
-                .with_setting("async_insert", "1")
-                .with_setting("wait_for_async_insert", "1")
-        } else {
-            self.client.clone()
-        };
-
-        let mut insert = client
+        let mut insert = self
+            .insert_client(insert_async)
             .insert::<BookTickerRow>(&self.book_ticker_table)
             .await?;
         for ticker in tickers {
@@ -75,6 +69,29 @@ impl ClickHouseClient {
         insert.end().await?;
 
         Ok((tickers.len(), start.elapsed().as_secs_f64()))
+    }
+
+    /// Insert a batch of trade rows. Returns `(rows_written, latency_seconds)`.
+    pub async fn insert_trades_batch(
+        &self,
+        trades: &[Trade],
+        insert_async: bool,
+    ) -> Result<(usize, f64)> {
+        if trades.is_empty() {
+            return Ok((0, 0.0));
+        }
+
+        let start = Instant::now();
+        let mut insert = self
+            .insert_client(insert_async)
+            .insert::<TradeRow>(&self.trades_table)
+            .await?;
+        for trade in trades {
+            insert.write(&TradeRow::from(trade)).await?;
+        }
+        insert.end().await?;
+
+        Ok((trades.len(), start.elapsed().as_secs_f64()))
     }
 
     /// Insert a batch of settled funding-rate rows. Returns
@@ -89,16 +106,8 @@ impl ClickHouseClient {
         }
 
         let start = Instant::now();
-        let client = if insert_async {
-            self.client
-                .clone()
-                .with_setting("async_insert", "1")
-                .with_setting("wait_for_async_insert", "1")
-        } else {
-            self.client.clone()
-        };
-
-        let mut insert = client
+        let mut insert = self
+            .insert_client(insert_async)
             .insert::<FundingRateRow>(&self.funding_rates_table)
             .await?;
         for rate in rates {
@@ -107,6 +116,17 @@ impl ClickHouseClient {
         insert.end().await?;
 
         Ok((rates.len(), start.elapsed().as_secs_f64()))
+    }
+
+    fn insert_client(&self, insert_async: bool) -> Client {
+        if insert_async {
+            self.client
+                .clone()
+                .with_setting("async_insert", "1")
+                .with_setting("wait_for_async_insert", "1")
+        } else {
+            self.client.clone()
+        }
     }
 }
 
@@ -122,6 +142,35 @@ struct BookTickerRow {
     ts: DateTime<Utc>,
     #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]
     received_at: DateTime<Utc>,
+}
+
+#[derive(Row, Serialize)]
+struct TradeRow {
+    inst_id: String,
+    trade_id: String,
+    px: i128,
+    sz: i128,
+    side: String,
+    count: u32,
+    #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]
+    ts: DateTime<Utc>,
+    #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]
+    received_at: DateTime<Utc>,
+}
+
+impl From<&Trade> for TradeRow {
+    fn from(t: &Trade) -> Self {
+        Self {
+            inst_id: t.inst_id.clone(),
+            trade_id: t.trade_id.clone(),
+            px: decimal_to_d128(&t.px),
+            sz: decimal_to_d128(&t.sz),
+            side: t.side.clone(),
+            count: t.count,
+            ts: t.ts,
+            received_at: t.received_at,
+        }
+    }
 }
 
 impl From<&BookTicker> for BookTickerRow {

--- a/apps/okx-recorder/src/config.rs
+++ b/apps/okx-recorder/src/config.rs
@@ -26,6 +26,7 @@ pub struct ClickHouseTarget {
     pub secure: bool,
     pub database: String,
     pub book_ticker_table: String,
+    pub trades_table: String,
     pub funding_rates_table: String,
 }
 
@@ -63,6 +64,8 @@ struct ClickHouseConfig {
     database: String,
     #[serde(default = "default_book_ticker_table")]
     book_ticker_table: String,
+    #[serde(default = "default_trades_table")]
+    trades_table: String,
     #[serde(default = "default_funding_rates_table")]
     funding_rates_table: String,
 }
@@ -212,6 +215,7 @@ fn parse_clickhouse_target(input: ClickHouseConfig) -> Result<ClickHouseTarget, 
         secure: parsed.scheme() == "https",
         database: input.database,
         book_ticker_table: input.book_ticker_table,
+        trades_table: input.trades_table,
         funding_rates_table: input.funding_rates_table,
     })
 }
@@ -299,6 +303,10 @@ fn default_clickhouse_database() -> String {
 
 fn default_book_ticker_table() -> String {
     "okx_book_ticker".to_string()
+}
+
+fn default_trades_table() -> String {
+    "okx_trades".to_string()
 }
 
 fn default_funding_rates_table() -> String {

--- a/apps/okx-recorder/src/metrics.rs
+++ b/apps/okx-recorder/src/metrics.rs
@@ -11,10 +11,11 @@ use prometheus::{
 ///
 /// Covers the queue and ClickHouse-insert surface emitted by the stream worker
 /// and writer loop, plus the readiness/liveness surface emitted by the health
-/// probe and stream worker: a ClickHouse-up gauge, a ready-state gauge, and a
-/// per-instrument ToB last-seen timestamp. The funding lane adds its own poll,
-/// insert, and last-event metrics; like every non-ToB lane they feed dashboards
-/// and alerts but never gate `/ready`. `/metrics` exposition is served from
+/// probe and stream worker: a ClickHouse-up gauge, a ready-state gauge, and
+/// per-instrument ToB and trades last-seen timestamps. The funding lane adds
+/// its own poll, insert, and last-event metrics. Only the ToB gauge's
+/// freshness gates `/ready`; every other lane's metrics feed dashboards and
+/// alerts but never gate `/ready`. `/metrics` exposition is served from
 /// [`crate::health`].
 #[derive(Clone)]
 pub struct RecorderMetrics {
@@ -26,6 +27,7 @@ pub struct RecorderMetrics {
     pub insert_rows: Counter,
     pub insert_latency_seconds: Histogram,
     pub tob_last_seen_unix_seconds: GaugeVec,
+    pub trades_last_seen_unix_seconds: GaugeVec,
     pub funding_poll_attempts: CounterVec,
     pub funding_insert_attempts: CounterVec,
     pub funding_insert_rows: Counter,
@@ -77,6 +79,13 @@ impl RecorderMetrics {
             Opts::new(
                 "okx_recorder_tob_last_seen_unix_seconds",
                 "Unix timestamp of the last received top-of-book update per instrument",
+            ),
+            &["inst_id"],
+        )?;
+        let trades_last_seen_unix_seconds = GaugeVec::new(
+            Opts::new(
+                "okx_recorder_trades_last_seen_unix_seconds",
+                "Unix timestamp of the last received trade print per instrument (staleness signal only; never gates /ready)",
             ),
             &["inst_id"],
         )?;
@@ -135,6 +144,7 @@ impl RecorderMetrics {
         registry.register(Box::new(insert_rows.clone()))?;
         registry.register(Box::new(insert_latency_seconds.clone()))?;
         registry.register(Box::new(tob_last_seen_unix_seconds.clone()))?;
+        registry.register(Box::new(trades_last_seen_unix_seconds.clone()))?;
         registry.register(Box::new(funding_poll_attempts.clone()))?;
         registry.register(Box::new(funding_insert_attempts.clone()))?;
         registry.register(Box::new(funding_insert_rows.clone()))?;
@@ -153,6 +163,7 @@ impl RecorderMetrics {
             insert_rows,
             insert_latency_seconds,
             tob_last_seen_unix_seconds,
+            trades_last_seen_unix_seconds,
             funding_poll_attempts,
             funding_insert_attempts,
             funding_insert_rows,
@@ -189,6 +200,15 @@ impl RecorderMetrics {
     /// received.
     pub fn record_tob_seen(&self, inst_id: &str) {
         self.tob_last_seen_unix_seconds
+            .with_label_values(&[inst_id])
+            .set(unix_seconds_now());
+    }
+
+    /// Stamp the per-instrument trades last-seen gauge when a trade print is
+    /// received. Staleness derived from this gauge is observability-only and
+    /// never gates `/ready`.
+    pub fn record_trade_seen(&self, inst_id: &str) {
+        self.trades_last_seen_unix_seconds
             .with_label_values(&[inst_id])
             .set(unix_seconds_now());
     }

--- a/apps/okx-recorder/src/models.rs
+++ b/apps/okx-recorder/src/models.rs
@@ -8,16 +8,19 @@ use serde::Deserialize;
 /// OKX public websocket channel name for tick-by-tick top-of-book updates.
 pub const BBO_TBT_CHANNEL: &str = "bbo-tbt";
 
+/// OKX public websocket channel name for trade prints.
+pub const TRADES_CHANNEL: &str = "trades";
+
 /// A parsed row destined for ClickHouse, tagged by lane.
 ///
 /// Each websocket lane (channel) maps to its own ClickHouse table; the writer
-/// loop routes rows by variant. Currently only the ToB lane exists — the
-/// trades variant bolts on here when its lane lands. The funding lane arrives
-/// over REST (see [`FundingRate`]) and is inserted by its poller directly, so
-/// it never passes through this enum.
+/// loop routes rows by variant. The ToB and trades lanes flow through here.
+/// The funding lane arrives over REST (see [`FundingRate`]) and is inserted by
+/// its poller directly, so it never passes through this enum.
 #[derive(Clone, Debug, PartialEq)]
 pub enum LaneRow {
     BookTicker(BookTicker),
+    Trade(Trade),
 }
 
 /// A single OKX top-of-book (`bbo-tbt`) update for one instrument.
@@ -35,6 +38,30 @@ pub struct BookTicker {
     pub bid_qty: Option<Decimal>,
     pub ask_px: Option<Decimal>,
     pub ask_qty: Option<Decimal>,
+    /// Exchange timestamp (`ts` in the raw payload, epoch milliseconds).
+    pub ts: DateTime<Utc>,
+    /// Client receipt time, stamped when the websocket frame arrives.
+    pub received_at: DateTime<Utc>,
+}
+
+/// A single OKX trade print (`trades` channel) for one instrument.
+///
+/// OKX aggregates fills that execute at the same price and timestamp into one
+/// print: `count` is the number of fills the print aggregates (1 = a single
+/// fill), so aggregate prints stay distinguishable from single fills after the
+/// fact, and `trade_id` is the id of the last fill in the aggregate. As on the
+/// ToB lane, the exchange timestamp is kept as `ts` and `received_at` is
+/// stamped client-side when the frame arrives.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Trade {
+    pub inst_id: String,
+    pub trade_id: String,
+    pub px: Decimal,
+    pub sz: Decimal,
+    /// Taker side: `buy` or `sell`, as sent by OKX.
+    pub side: String,
+    /// Number of fills aggregated into this print.
+    pub count: u32,
     /// Exchange timestamp (`ts` in the raw payload, epoch milliseconds).
     pub ts: DateTime<Utc>,
     /// Client receipt time, stamped when the websocket frame arrives.
@@ -92,6 +119,25 @@ struct RawBboEntry {
     seq_id: i64,
 }
 
+/// A `trades` data entry. All decimals (and `count`) arrive as strings.
+/// `count` is defaulted to `"1"` when absent: OKX's non-aggregating variants
+/// of the channel omit it, and an un-aggregated print is a single fill.
+#[derive(Debug, Deserialize)]
+struct RawTradeEntry {
+    #[serde(rename = "tradeId")]
+    trade_id: String,
+    px: String,
+    sz: String,
+    side: String,
+    #[serde(default = "default_trade_count")]
+    count: String,
+    ts: String,
+}
+
+fn default_trade_count() -> String {
+    "1".to_string()
+}
+
 /// Parse one raw websocket text frame into a [`ParsedFrame`].
 ///
 /// A malformed frame is an error so the caller can drop it rather than poison
@@ -128,6 +174,23 @@ pub fn parse_frame(text: &str, received_at: DateTime<Utc>) -> Result<ParsedFrame
                 rows,
             })
         }
+        TRADES_CHANNEL => {
+            let data = frame.data.context("trades frame missing data")?;
+            let entries: Vec<RawTradeEntry> =
+                serde_json::from_value(data).context("malformed trades data entries")?;
+            let mut rows = Vec::with_capacity(entries.len());
+            for entry in entries {
+                rows.push(LaneRow::Trade(Trade::from_entry(
+                    &arg.inst_id,
+                    entry,
+                    received_at,
+                )?));
+            }
+            Ok(ParsedFrame::Data {
+                inst_id: arg.inst_id,
+                rows,
+            })
+        }
         other => Ok(ParsedFrame::UnhandledChannel {
             channel: other.to_string(),
         }),
@@ -136,12 +199,7 @@ pub fn parse_frame(text: &str, received_at: DateTime<Utc>) -> Result<ParsedFrame
 
 impl BookTicker {
     fn from_entry(inst_id: &str, entry: RawBboEntry, received_at: DateTime<Utc>) -> Result<Self> {
-        let raw_ts: i64 = entry
-            .ts
-            .parse()
-            .with_context(|| format!("invalid ts: {}", entry.ts))?;
-        let ts = DateTime::from_timestamp_millis(raw_ts)
-            .with_context(|| format!("ts out of range: {raw_ts}"))?;
+        let ts = parse_exchange_ts(&entry.ts)?;
         let (bid_px, bid_qty) = parse_best_level(&entry.bids, "bids")?;
         let (ask_px, ask_qty) = parse_best_level(&entry.asks, "asks")?;
 
@@ -156,6 +214,33 @@ impl BookTicker {
             received_at,
         })
     }
+}
+
+impl Trade {
+    fn from_entry(inst_id: &str, entry: RawTradeEntry, received_at: DateTime<Utc>) -> Result<Self> {
+        let ts = parse_exchange_ts(&entry.ts)?;
+        let count: u32 = entry
+            .count
+            .parse()
+            .with_context(|| format!("invalid trade count: {}", entry.count))?;
+
+        Ok(Self {
+            inst_id: inst_id.to_string(),
+            trade_id: entry.trade_id,
+            px: parse_decimal(&entry.px, "px")?,
+            sz: parse_decimal(&entry.sz, "sz")?,
+            side: entry.side,
+            count,
+            ts,
+            received_at,
+        })
+    }
+}
+
+/// Parse an OKX exchange timestamp (a string of epoch milliseconds).
+fn parse_exchange_ts(raw: &str) -> Result<DateTime<Utc>> {
+    let millis: i64 = raw.parse().with_context(|| format!("invalid ts: {raw}"))?;
+    DateTime::from_timestamp_millis(millis).with_context(|| format!("ts out of range: {millis}"))
 }
 
 /// Extract `(price, size)` from the best level of one book side.

--- a/apps/okx-recorder/src/models.rs
+++ b/apps/okx-recorder/src/models.rs
@@ -68,6 +68,16 @@ pub struct Trade {
     pub received_at: DateTime<Utc>,
 }
 
+/// A recorded websocket channel (lane), derived from a data frame's
+/// `arg.channel`. Carried on [`ParsedFrame::Data`] so callers can dispatch
+/// per-lane bookkeeping (freshness stamping) on the frame itself, even when
+/// the frame carries no rows.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Channel {
+    BboTbt,
+    Trades,
+}
+
 /// One frame received on the OKX public websocket, classified.
 #[derive(Debug)]
 pub enum ParsedFrame {
@@ -77,9 +87,14 @@ pub enum ParsedFrame {
         code: Option<String>,
         message: Option<String>,
     },
-    /// Data push for a recorded lane. `inst_id` comes from the frame's `arg`
-    /// and is shared by every row in the frame.
-    Data { inst_id: String, rows: Vec<LaneRow> },
+    /// Data push for a recorded lane. `channel` and `inst_id` come from the
+    /// frame's `arg` and are shared by every row in the frame; `rows` can be
+    /// empty (OKX may push a data frame with an empty `data` array).
+    Data {
+        channel: Channel,
+        inst_id: String,
+        rows: Vec<LaneRow>,
+    },
     /// Data push for a channel this recorder does not record.
     UnhandledChannel { channel: String },
 }
@@ -170,6 +185,7 @@ pub fn parse_frame(text: &str, received_at: DateTime<Utc>) -> Result<ParsedFrame
                 )?));
             }
             Ok(ParsedFrame::Data {
+                channel: Channel::BboTbt,
                 inst_id: arg.inst_id,
                 rows,
             })
@@ -187,6 +203,7 @@ pub fn parse_frame(text: &str, received_at: DateTime<Utc>) -> Result<ParsedFrame
                 )?));
             }
             Ok(ParsedFrame::Data {
+                channel: Channel::Trades,
                 inst_id: arg.inst_id,
                 rows,
             })

--- a/apps/okx-recorder/src/recorder.rs
+++ b/apps/okx-recorder/src/recorder.rs
@@ -12,7 +12,7 @@ use crate::{
     funding_client::poll_funding_once,
     health::HealthState,
     metrics::RecorderMetrics,
-    models::{BookTicker, FundingRate, LaneRow},
+    models::{BookTicker, FundingRate, LaneRow, Trade},
     stream_client::run_stream_worker,
 };
 
@@ -44,13 +44,13 @@ pub struct FundingRuntimeConfig {
 /// lane into its ClickHouse table. Ported from `binance-recorder`'s
 /// `RecorderRuntime`. The writer buffers every update with no in-memory dedupe
 /// — row identity is owned by ClickHouse (`ReplacingMergeTree(ingested_at)`
-/// over the table's ORDER BY keys). Because `received_at` is part of the ORDER
-/// BY, this collapses byte-identical insert retries only; a genuine exchange
-/// re-send arrives with a new `received_at` and is persisted as a distinct row
-/// by design. Follow-up websocket lanes (trades) add their own [`LaneRow`]
-/// variants and per-lane buffers here. The funding lane is REST instead: it
-/// polls on a minutes-scale cadence and inserts its small batches directly,
-/// bypassing the queue.
+/// over each table's ORDER BY keys). Because `received_at` is part of the book
+/// ticker's ORDER BY, this collapses byte-identical insert retries only; a
+/// genuine exchange re-send arrives with a new `received_at` and is persisted
+/// as a distinct row by design. Each websocket lane (ToB, trades) has its own
+/// [`LaneRow`] variant and per-lane buffer here. The funding lane is REST
+/// instead: it polls on a minutes-scale cadence and inserts its small batches
+/// directly, bypassing the queue.
 pub struct RecorderRuntime {
     ws_url: String,
     instruments: Vec<String>,
@@ -146,12 +146,15 @@ impl RecorderRuntime {
 
         let handle = tokio::spawn(async move {
             // Buffer every update: no in-memory dedupe, by design. ClickHouse's
-            // `ReplacingMergeTree(ingested_at)` owns row identity via the
-            // table's ORDER BY keys, which include `received_at` — so only
-            // insert retries (a flush that times out client-side but commits
-            // server-side) collapse at merge time. A genuine exchange re-send
-            // carries a new `received_at` and is persisted as a distinct row.
+            // `ReplacingMergeTree(ingested_at)` owns row identity via each
+            // table's ORDER BY keys — the book ticker's include `received_at`,
+            // so only insert retries (a flush that times out client-side but
+            // commits server-side) collapse at merge time, while a genuine
+            // exchange re-send carries a new `received_at` and is persisted as
+            // a distinct row. One buffer per lane keeps each insert
+            // single-table.
             let mut book_buffer: Vec<BookTicker> = Vec::with_capacity(batch_max_rows);
+            let mut trade_buffer: Vec<Trade> = Vec::with_capacity(batch_max_rows);
             let mut last_flush = Instant::now();
 
             loop {
@@ -166,6 +169,7 @@ impl RecorderRuntime {
                     Ok(Some(row)) => {
                         match row {
                             LaneRow::BookTicker(ticker) => book_buffer.push(ticker),
+                            LaneRow::Trade(trade) => trade_buffer.push(trade),
                         }
                         let size = receiver.len();
                         metrics.queue_depth.set(size as f64);
@@ -177,23 +181,35 @@ impl RecorderRuntime {
                     Err(_) => {}
                 }
 
+                let buffered = book_buffer.len().saturating_add(trade_buffer.len());
                 let should_flush = book_buffer.len() >= batch_max_rows
-                    || (!book_buffer.is_empty()
-                        && last_flush.elapsed().as_secs_f64() >= batch_flush_seconds);
+                    || trade_buffer.len() >= batch_max_rows
+                    || (buffered > 0 && last_flush.elapsed().as_secs_f64() >= batch_flush_seconds);
                 if should_flush {
-                    let batch = drain_batch(&mut book_buffer);
-                    flush_with_retry(&writer, &metrics, batch, stop_token.clone(), insert_async)
-                        .await;
+                    flush_lanes(
+                        &writer,
+                        &metrics,
+                        &mut book_buffer,
+                        &mut trade_buffer,
+                        &stop_token,
+                        insert_async,
+                    )
+                    .await;
                     last_flush = Instant::now();
                 }
             }
 
             // Bounded shutdown drain: flush whatever is still buffered instead of
             // dropping the last rows.
-            if !book_buffer.is_empty() {
-                let batch = drain_batch(&mut book_buffer);
-                flush_with_retry(&writer, &metrics, batch, stop_token, insert_async).await;
-            }
+            flush_lanes(
+                &writer,
+                &metrics,
+                &mut book_buffer,
+                &mut trade_buffer,
+                &stop_token,
+                insert_async,
+            )
+            .await;
         });
         self.handles.push(handle);
     }
@@ -308,50 +324,99 @@ impl RecorderRuntime {
     }
 }
 
-fn drain_batch(buffer: &mut Vec<BookTicker>) -> Vec<BookTicker> {
-    std::mem::take(buffer)
+/// One lane's drained batch, routed to its ClickHouse table by
+/// [`flush_with_retry`].
+enum LaneBatch {
+    BookTicker(Vec<BookTicker>),
+    Trade(Vec<Trade>),
+}
+
+impl LaneBatch {
+    fn len(&self) -> usize {
+        match self {
+            Self::BookTicker(rows) => rows.len(),
+            Self::Trade(rows) => rows.len(),
+        }
+    }
+
+    /// Human-readable lane name for logs.
+    fn lane(&self) -> &'static str {
+        match self {
+            Self::BookTicker(_) => "book ticker",
+            Self::Trade(_) => "trade",
+        }
+    }
+
+    async fn insert(
+        &self,
+        writer: &ClickHouseClient,
+        insert_async: bool,
+    ) -> anyhow::Result<(usize, f64)> {
+        match self {
+            Self::BookTicker(rows) => writer.insert_book_ticker_batch(rows, insert_async).await,
+            Self::Trade(rows) => writer.insert_trades_batch(rows, insert_async).await,
+        }
+    }
+}
+
+/// Drain every non-empty lane buffer and flush it as its own batch.
+async fn flush_lanes(
+    writer: &ClickHouseClient,
+    metrics: &RecorderMetrics,
+    book_buffer: &mut Vec<BookTicker>,
+    trade_buffer: &mut Vec<Trade>,
+    stop_token: &CancellationToken,
+    insert_async: bool,
+) {
+    if !book_buffer.is_empty() {
+        let batch = LaneBatch::BookTicker(std::mem::take(book_buffer));
+        flush_with_retry(writer, metrics, batch, stop_token, insert_async).await;
+    }
+    if !trade_buffer.is_empty() {
+        let batch = LaneBatch::Trade(std::mem::take(trade_buffer));
+        flush_with_retry(writer, metrics, batch, stop_token, insert_async).await;
+    }
 }
 
 async fn flush_with_retry(
     writer: &ClickHouseClient,
     metrics: &RecorderMetrics,
-    batch: Vec<BookTicker>,
-    stop_token: CancellationToken,
+    batch: LaneBatch,
+    stop_token: &CancellationToken,
     insert_async: bool,
 ) {
-    if batch.is_empty() {
-        return;
-    }
     loop {
         if stop_token.is_cancelled() {
             // On shutdown, make a single best-effort attempt rather than
             // retrying forever against an unreachable ClickHouse.
-            match writer.insert_book_ticker_batch(&batch, insert_async).await {
+            match batch.insert(writer, insert_async).await {
                 Ok((rows, latency)) => {
-                    record_insert_success(metrics, rows, latency);
+                    record_insert_success(metrics, &batch, rows, latency);
                 }
                 Err(err) => {
                     metrics.insert_attempts.with_label_values(&["error"]).inc();
                     tracing::error!(
                         rows = batch.len(),
+                        lane = batch.lane(),
                         error = ?err,
-                        "failed to insert book ticker batch during shutdown drain"
+                        "failed to insert batch during shutdown drain"
                     );
                 }
             }
             return;
         }
-        match writer.insert_book_ticker_batch(&batch, insert_async).await {
+        match batch.insert(writer, insert_async).await {
             Ok((rows, latency)) => {
-                record_insert_success(metrics, rows, latency);
+                record_insert_success(metrics, &batch, rows, latency);
                 return;
             }
             Err(err) => {
                 metrics.insert_attempts.with_label_values(&["error"]).inc();
                 tracing::error!(
                     rows = batch.len(),
+                    lane = batch.lane(),
                     error = ?err,
-                    "failed to insert book ticker batch"
+                    "failed to insert batch"
                 );
                 tokio::time::sleep(Duration::from_secs(1)).await;
             }
@@ -400,12 +465,12 @@ async fn flush_funding_with_retry(
     }
 }
 
-fn record_insert_success(metrics: &RecorderMetrics, rows: usize, latency: f64) {
+fn record_insert_success(metrics: &RecorderMetrics, batch: &LaneBatch, rows: usize, latency: f64) {
     metrics
         .insert_attempts
         .with_label_values(&["success"])
         .inc();
     metrics.insert_rows.inc_by(rows as f64);
     metrics.insert_latency_seconds.observe(latency);
-    tracing::debug!("inserted {} book ticker rows into ClickHouse", rows);
+    tracing::debug!("inserted {} {} rows into ClickHouse", rows, batch.lane());
 }

--- a/apps/okx-recorder/src/stream_client.rs
+++ b/apps/okx-recorder/src/stream_client.rs
@@ -12,26 +12,27 @@ use tokio_util::sync::CancellationToken;
 
 use crate::health::HealthState;
 use crate::metrics::RecorderMetrics;
-use crate::models::{parse_frame, LaneRow, ParsedFrame, BBO_TBT_CHANNEL};
+use crate::models::{parse_frame, LaneRow, ParsedFrame, BBO_TBT_CHANNEL, TRADES_CHANNEL};
 
 /// A connection that survives this long before failing is considered to have
 /// been healthy, so the reconnect backoff resets instead of compounding.
 const BACKOFF_RESET_AFTER: Duration = Duration::from_secs(60);
 
 /// Run the websocket worker: one connection to the OKX public endpoint
-/// multiplexing a `bbo-tbt` subscription per configured instrument, reconnected
-/// with jittered exponential backoff for the life of the process.
+/// multiplexing a `bbo-tbt` and a `trades` subscription per configured
+/// instrument, reconnected with jittered exponential backoff for the life of
+/// the process.
 ///
 /// Each data frame is stamped with a client-side `received_at`, parsed into
 /// [`LaneRow`]s, and `try_send`-ed into the writer channel. A full channel
 /// increments the per-instrument `queue_drops` metric and drops the row
 /// (bounded buffer, observable drops) rather than blocking the read loop.
 ///
-/// OKX closes a connection that has been idle for 30 seconds; the trades lane
-/// will bring an application-level ping keepalive with it. Until then an idle
+/// OKX closes a connection that has been idle for 30 seconds; an
+/// application-level ping keepalive is a follow-up. Until then an idle
 /// connection (all instruments halted) surfaces as a server close, and this
-/// loop re-subscribes after backoff. Additional channel subscriptions (trades)
-/// extend [`subscribe_payload`] and the `ParsedFrame::Data` dispatch below.
+/// loop re-subscribes after backoff. Additional channel subscriptions extend
+/// [`subscribe_payload`] and the `ParsedFrame::Data` dispatch below.
 pub async fn run_stream_worker(
     ws_url: String,
     inst_ids: Vec<String>,
@@ -119,14 +120,15 @@ async fn stream_once(
     }
 }
 
-/// The single subscribe frame sent after connect: one `bbo-tbt` arg per
-/// instrument, multiplexed on this connection. Follow-up lanes append their
-/// channel args here.
+/// The single subscribe frame sent after connect: one `bbo-tbt` and one
+/// `trades` arg per instrument, multiplexed on this connection. Follow-up
+/// lanes append their channel args here.
 fn subscribe_payload(inst_ids: &[String]) -> serde_json::Value {
-    let args: Vec<serde_json::Value> = inst_ids
-        .iter()
-        .map(|inst_id| json!({ "channel": BBO_TBT_CHANNEL, "instId": inst_id }))
-        .collect();
+    let mut args = Vec::with_capacity(inst_ids.len().saturating_mul(2));
+    for inst_id in inst_ids {
+        args.push(json!({ "channel": BBO_TBT_CHANNEL, "instId": inst_id }));
+        args.push(json!({ "channel": TRADES_CHANNEL, "instId": inst_id }));
+    }
     json!({ "op": "subscribe", "args": args })
 }
 
@@ -140,10 +142,21 @@ fn handle_text_frame(
     match parse_frame(text, received_at) {
         Ok(ParsedFrame::Data { inst_id, rows }) => {
             // Freshness keys on receipt, not insert success: a frame arriving
-            // for `inst_id` proves the ToB lane is live even if the bounded
-            // queue later drops the rows.
-            health.set_instrument_seen(&inst_id);
-            metrics.record_tob_seen(&inst_id);
+            // for `inst_id` proves its lane is live even if the bounded queue
+            // later drops the rows. Every row in a frame belongs to the same
+            // lane, so the first row identifies it. Only the ToB lane feeds
+            // /ready; trades freshness is a metric-only staleness signal (a
+            // quiet trades lane on a thin perp is data, not an outage).
+            match rows.first() {
+                Some(LaneRow::BookTicker(_)) => {
+                    health.set_instrument_seen(&inst_id);
+                    metrics.record_tob_seen(&inst_id);
+                }
+                Some(LaneRow::Trade(_)) => {
+                    metrics.record_trade_seen(&inst_id);
+                }
+                None => {}
+            }
             for row in rows {
                 match sender.try_send(row) {
                     Ok(()) => {}

--- a/apps/okx-recorder/src/stream_client.rs
+++ b/apps/okx-recorder/src/stream_client.rs
@@ -12,7 +12,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::health::HealthState;
 use crate::metrics::RecorderMetrics;
-use crate::models::{parse_frame, LaneRow, ParsedFrame, BBO_TBT_CHANNEL, TRADES_CHANNEL};
+use crate::models::{parse_frame, Channel, LaneRow, ParsedFrame, BBO_TBT_CHANNEL, TRADES_CHANNEL};
 
 /// A connection that survives this long before failing is considered to have
 /// been healthy, so the reconnect backoff resets instead of compounding.
@@ -140,22 +140,26 @@ fn handle_text_frame(
 ) {
     let received_at = Utc::now();
     match parse_frame(text, received_at) {
-        Ok(ParsedFrame::Data { inst_id, rows }) => {
+        Ok(ParsedFrame::Data {
+            channel,
+            inst_id,
+            rows,
+        }) => {
             // Freshness keys on receipt, not insert success: a frame arriving
-            // for `inst_id` proves its lane is live even if the bounded queue
-            // later drops the rows. Every row in a frame belongs to the same
-            // lane, so the first row identifies it. Only the ToB lane feeds
-            // /ready; trades freshness is a metric-only staleness signal (a
-            // quiet trades lane on a thin perp is data, not an outage).
-            match rows.first() {
-                Some(LaneRow::BookTicker(_)) => {
+            // for `inst_id` proves its lane is live even if the frame carries
+            // no rows (OKX can push a data frame with an empty `data` array)
+            // or the bounded queue later drops them, so stamping dispatches on
+            // the frame's channel rather than its rows. Only the ToB lane
+            // feeds /ready; trades freshness is a metric-only staleness signal
+            // (a quiet trades lane on a thin perp is data, not an outage).
+            match channel {
+                Channel::BboTbt => {
                     health.set_instrument_seen(&inst_id);
                     metrics.record_tob_seen(&inst_id);
                 }
-                Some(LaneRow::Trade(_)) => {
+                Channel::Trades => {
                     metrics.record_trade_seen(&inst_id);
                 }
-                None => {}
             }
             for row in rows {
                 match sender.try_send(row) {

--- a/apps/okx-recorder/tests/test_config.rs
+++ b/apps/okx-recorder/tests/test_config.rs
@@ -8,7 +8,7 @@ use std::{
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
-const ENV_KEYS: [&str; 13] = [
+const ENV_KEYS: [&str; 14] = [
     "OKX_RECORDER__INSTRUMENTS",
     "OKX_RECORDER__WS_URL",
     "OKX_RECORDER__CLICKHOUSE__URL",
@@ -16,6 +16,7 @@ const ENV_KEYS: [&str; 13] = [
     "OKX_RECORDER__CLICKHOUSE__PASSWORD",
     "OKX_RECORDER__CLICKHOUSE__DATABASE",
     "OKX_RECORDER__CLICKHOUSE__BOOK_TICKER_TABLE",
+    "OKX_RECORDER__CLICKHOUSE__TRADES_TABLE",
     "OKX_RECORDER__CLICKHOUSE__FUNDING_RATES_TABLE",
     "OKX_RECORDER__METRICS_PORT",
     "OKX_RECORDER__HEALTH_PORT",
@@ -41,6 +42,7 @@ clickhouse:
   password: "recorder"
   database: "default"
   book_ticker_table: "okx_book_ticker"
+  trades_table: "okx_trades_custom"
 metrics_port: 9095
 health_port: 8085
 batch_max_rows: 5000
@@ -62,6 +64,7 @@ batch_flush_seconds: 1.5
     assert_eq!(config.clickhouse.port, 8123);
     assert!(!config.clickhouse.secure);
     assert_eq!(config.clickhouse.book_ticker_table, "okx_book_ticker");
+    assert_eq!(config.clickhouse.trades_table, "okx_trades_custom");
 
     let _ = fs::remove_file(config_file);
 }
@@ -96,6 +99,7 @@ clickhouse:
     assert_eq!(config.clickhouse.username, "default");
     assert_eq!(config.clickhouse.database, "default");
     assert_eq!(config.clickhouse.book_ticker_table, "okx_book_ticker");
+    assert_eq!(config.clickhouse.trades_table, "okx_trades");
     assert_eq!(config.clickhouse.funding_rates_table, "okx_funding_rates");
     // Funding lane defaults: the public history endpoint on a 5-minute poll.
     assert_eq!(

--- a/apps/okx-recorder/tests/test_models.rs
+++ b/apps/okx-recorder/tests/test_models.rs
@@ -27,11 +27,32 @@ fn parse_single_row(frame: &str) -> okx_recorder::models::BookTicker {
     match parse_frame(frame, received_at()).expect("should parse") {
         ParsedFrame::Data { rows, .. } => {
             assert_eq!(rows.len(), 1);
-            let LaneRow::BookTicker(ticker) = rows.into_iter().next().unwrap();
-            ticker
+            match rows.into_iter().next().unwrap() {
+                LaneRow::BookTicker(ticker) => ticker,
+                other => panic!("expected book ticker row, got {other:?}"),
+            }
         }
         other => panic!("expected data frame, got {other:?}"),
     }
+}
+
+fn parse_trade_rows(frame: &str) -> Vec<okx_recorder::models::Trade> {
+    match parse_frame(frame, received_at()).expect("should parse") {
+        ParsedFrame::Data { rows, .. } => rows
+            .into_iter()
+            .map(|row| match row {
+                LaneRow::Trade(trade) => trade,
+                other => panic!("expected trade row, got {other:?}"),
+            })
+            .collect(),
+        other => panic!("expected data frame, got {other:?}"),
+    }
+}
+
+fn parse_single_trade(frame: &str) -> okx_recorder::models::Trade {
+    let mut trades = parse_trade_rows(frame);
+    assert_eq!(trades.len(), 1);
+    trades.remove(0)
 }
 
 #[test]
@@ -277,13 +298,186 @@ fn parse_frame_classifies_error_event() {
 #[test]
 fn parse_frame_classifies_unhandled_channel() {
     let frame = r#"{
-        "arg": { "channel": "trades", "instId": "OPENAI-USDT-SWAP" },
-        "data": [{ "instId": "OPENAI-USDT-SWAP", "tradeId": "1", "px": "1", "sz": "1", "side": "buy", "ts": "1700000000456" }]
+        "arg": { "channel": "mark-price", "instId": "OPENAI-USDT-SWAP" },
+        "data": [{ "instId": "OPENAI-USDT-SWAP", "markPx": "111.05", "ts": "1700000000456" }]
     }"#;
     match parse_frame(frame, received_at()).expect("should parse") {
-        ParsedFrame::UnhandledChannel { channel } => assert_eq!(channel, "trades"),
+        ParsedFrame::UnhandledChannel { channel } => assert_eq!(channel, "mark-price"),
         other => panic!("expected unhandled-channel frame, got {other:?}"),
     }
+}
+
+#[test]
+fn parse_trades_frame_maps_fields() {
+    let frame = r#"{
+        "arg": { "channel": "trades", "instId": "OPENAI-USDT-SWAP" },
+        "data": [
+            {
+                "instId": "OPENAI-USDT-SWAP",
+                "tradeId": "130639474",
+                "px": "111.05",
+                "sz": "0.12060306",
+                "side": "buy",
+                "count": "1",
+                "ts": "1700000000456"
+            }
+        ]
+    }"#;
+    let trade = parse_single_trade(frame);
+
+    assert_eq!(trade.inst_id, "OPENAI-USDT-SWAP");
+    assert_eq!(trade.trade_id, "130639474");
+    assert_eq!(trade.px, Decimal::from_str("111.05").unwrap());
+    assert_eq!(trade.sz, Decimal::from_str("0.12060306").unwrap());
+    assert_eq!(trade.side, "buy");
+    assert_eq!(trade.count, 1);
+    assert_eq!(
+        trade.ts,
+        Utc.timestamp_millis_opt(1_700_000_000_456)
+            .single()
+            .unwrap()
+    );
+    assert_eq!(trade.received_at, received_at());
+}
+
+#[test]
+fn parse_trades_frame_keeps_aggregate_count() {
+    // OKX aggregates fills at the same px/ts into one print; `count` > 1 marks
+    // an aggregate print and must survive parsing.
+    let frame = r#"{
+        "arg": { "channel": "trades", "instId": "ANTHROPIC-USDT-SWAP" },
+        "data": [
+            {
+                "instId": "ANTHROPIC-USDT-SWAP",
+                "tradeId": "130639480",
+                "px": "22.5",
+                "sz": "3.75",
+                "side": "sell",
+                "count": "7",
+                "ts": "1700000000456"
+            }
+        ]
+    }"#;
+    let trade = parse_single_trade(frame);
+    assert_eq!(trade.count, 7);
+    assert_eq!(trade.side, "sell");
+}
+
+#[test]
+fn parse_trades_frame_defaults_missing_count_to_one() {
+    // Non-aggregating variants of the channel omit `count`; a print without it
+    // is a single fill.
+    let frame = r#"{
+        "arg": { "channel": "trades", "instId": "OPENAI-USDT-SWAP" },
+        "data": [
+            {
+                "instId": "OPENAI-USDT-SWAP",
+                "tradeId": "130639475",
+                "px": "111.06",
+                "sz": "1",
+                "side": "buy",
+                "ts": "1700000000456"
+            }
+        ]
+    }"#;
+    let trade = parse_single_trade(frame);
+    assert_eq!(trade.count, 1);
+}
+
+#[test]
+fn parse_trades_frame_preserves_string_decimal_precision() {
+    let frame = r#"{
+        "arg": { "channel": "trades", "instId": "ANTHROPIC-USDT-SWAP" },
+        "data": [
+            {
+                "instId": "ANTHROPIC-USDT-SWAP",
+                "tradeId": "1",
+                "px": "0.000001234567891",
+                "sz": "123456789.000000000001",
+                "side": "buy",
+                "count": "1",
+                "ts": "1700000000456"
+            }
+        ]
+    }"#;
+    let trade = parse_single_trade(frame);
+    assert_eq!(trade.px, Decimal::from_str("0.000001234567891").unwrap());
+    assert_eq!(
+        trade.sz,
+        Decimal::from_str("123456789.000000000001").unwrap()
+    );
+}
+
+#[test]
+fn parse_trades_frame_handles_multiple_prints() {
+    let frame = r#"{
+        "arg": { "channel": "trades", "instId": "OPENAI-USDT-SWAP" },
+        "data": [
+            { "tradeId": "10", "px": "111.05", "sz": "1", "side": "buy", "count": "1", "ts": "1700000000456" },
+            { "tradeId": "11", "px": "111.06", "sz": "2", "side": "sell", "count": "3", "ts": "1700000000457" }
+        ]
+    }"#;
+    let trades = parse_trade_rows(frame);
+    assert_eq!(trades.len(), 2);
+    assert_eq!(trades[0].trade_id, "10");
+    assert_eq!(trades[1].trade_id, "11");
+    assert_eq!(trades[1].count, 3);
+}
+
+#[test]
+fn parse_trades_frame_handles_empty_data_array() {
+    let frame = r#"{
+        "arg": { "channel": "trades", "instId": "OPENAI-USDT-SWAP" },
+        "data": []
+    }"#;
+    match parse_frame(frame, received_at()).expect("should parse") {
+        ParsedFrame::Data { inst_id, rows } => {
+            assert_eq!(inst_id, "OPENAI-USDT-SWAP");
+            assert!(rows.is_empty());
+        }
+        other => panic!("expected data frame, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_trades_frame_errors_on_bad_decimal() {
+    let frame = r#"{
+        "arg": { "channel": "trades", "instId": "OPENAI-USDT-SWAP" },
+        "data": [
+            { "tradeId": "1", "px": "not-a-number", "sz": "1", "side": "buy", "count": "1", "ts": "1700000000456" }
+        ]
+    }"#;
+    let err = parse_frame(frame, received_at()).unwrap_err();
+    assert!(
+        format!("{err:#}").contains("px"),
+        "error should name the field: {err:#}"
+    );
+}
+
+#[test]
+fn parse_trades_frame_errors_on_bad_count() {
+    let frame = r#"{
+        "arg": { "channel": "trades", "instId": "OPENAI-USDT-SWAP" },
+        "data": [
+            { "tradeId": "1", "px": "111.05", "sz": "1", "side": "buy", "count": "many", "ts": "1700000000456" }
+        ]
+    }"#;
+    let err = parse_frame(frame, received_at()).unwrap_err();
+    assert!(
+        format!("{err:#}").contains("count"),
+        "error should name the field: {err:#}"
+    );
+}
+
+#[test]
+fn parse_trades_frame_errors_on_bad_ts() {
+    let frame = r#"{
+        "arg": { "channel": "trades", "instId": "OPENAI-USDT-SWAP" },
+        "data": [
+            { "tradeId": "1", "px": "111.05", "sz": "1", "side": "buy", "count": "1", "ts": "not-millis" }
+        ]
+    }"#;
+    assert!(parse_frame(frame, received_at()).is_err());
 }
 
 #[test]

--- a/apps/okx-recorder/tests/test_models.rs
+++ b/apps/okx-recorder/tests/test_models.rs
@@ -1,5 +1,5 @@
 use chrono::{TimeZone, Utc};
-use okx_recorder::models::{parse_frame, LaneRow, ParsedFrame};
+use okx_recorder::models::{parse_frame, Channel, LaneRow, ParsedFrame};
 use rust_decimal::Decimal;
 use std::str::FromStr;
 
@@ -202,7 +202,15 @@ fn parse_frame_handles_empty_data_array() {
         "data": []
     }"#;
     match parse_frame(frame, received_at()).expect("should parse") {
-        ParsedFrame::Data { inst_id, rows } => {
+        ParsedFrame::Data {
+            channel,
+            inst_id,
+            rows,
+        } => {
+            // The lane identity must survive an empty data array: the stream
+            // worker stamps ToB freshness from the frame's channel, so an
+            // empty bbo-tbt frame still counts as ToB liveness.
+            assert_eq!(channel, Channel::BboTbt);
             assert_eq!(inst_id, "OPENAI-USDT-SWAP");
             assert!(rows.is_empty());
         }
@@ -431,7 +439,12 @@ fn parse_trades_frame_handles_empty_data_array() {
         "data": []
     }"#;
     match parse_frame(frame, received_at()).expect("should parse") {
-        ParsedFrame::Data { inst_id, rows } => {
+        ParsedFrame::Data {
+            channel,
+            inst_id,
+            rows,
+        } => {
+            assert_eq!(channel, Channel::Trades);
             assert_eq!(inst_id, "OPENAI-USDT-SWAP");
             assert!(rows.is_empty());
         }


### PR DESCRIPTION
Resolves PFG-1556. Part of the PFG-1553 okx-recorder stack (3/4), on top of #3976.

Adds the trades lane on the existing single WS connection: subscribes the OKX `trades` channel per configured instId, parses prints into `TradeRow` (px, sz, side, tradeId, `count`, exchange `ts`, client `received_at`), and batch-inserts into `okx_trades` via a per-lane buffer with a `LaneBatch`-routed flush.

- **Schema** (`migrations/003-trades.sql`): `ReplacingMergeTree(ingested_at)`, ORDER BY `(inst_id, ts, trade_id)`, monthly partitions, 90-day TTL. Partition/TTL key on exchange `ts` to match the ORDER BY (deliberate divergence from the book table, which keys on `received_at`).
- `count` stores OKX's same-px/ts fill aggregation (defaults to 1 when absent) so aggregate prints are distinguishable from single fills.
- Trades freshness exported as `okx_recorder_trades_last_seen_unix_seconds{inst_id}`; `/ready` remains ToB+ClickHouse only — a no-trade hour on a thin perp is data, not an outage.
- `local_e2e_check.sh` gains a trades-row assert (needs ≥1 print since stack start — documented; thin-market caveat).

Validation: build, tests (aggregated prints, missing `count`, empty `data`, multi-print frames, string-decimal precision, bad-field errors), clippy `-D warnings`, fmt, pre-commit all pass. DDL round-tripped via clickhouse-local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)