### PR TITLE
tejas/pfg 1555 connection resilience client initiated ping keepalive

### DIFF
--- a/apps/okx-recorder/README.md
+++ b/apps/okx-recorder/README.md
@@ -40,6 +40,19 @@ adding an OKX perp is a config change, no code change.
 > staleness** in `/ready` rather than a crash. Verify each instrument is
 > actually listed on OKX before relying on its data.
 
+## Connection resilience
+
+OKX terminates a websocket with no traffic for 30 seconds, and thin pre-IPO
+perps have genuinely quiet stretches, so the recorder runs a client-initiated
+keepalive: after `ping_idle_seconds` (default 15) without an inbound frame it
+sends a literal `ping` text frame and expects OKX's literal `pong` back. Any
+inbound frame counts as liveness; a connection still silent
+`pong_timeout_seconds` (default 5) after a ping is presumed dead, torn down,
+and reconnected with jittered exponential backoff (ceiling
+`reconnect_max_backoff_seconds`), re-subscribing every configured instrument.
+Recovery is observable via `okx_recorder_stream_reconnects_total`,
+`okx_recorder_keepalive_pings_total`, and `okx_recorder_pong_timeouts_total`.
+
 ## Quick start (local dev)
 
 1. Copy the sample config and (optionally) the env file:
@@ -102,6 +115,7 @@ Overview** dashboard.
   `okx_recorder_insert_attempts_total{status}`, `okx_recorder_queue_depth`,
   `okx_recorder_queue_fill_ratio`, `okx_recorder_queue_drops_total{inst_id}`,
   `okx_recorder_stream_reconnects_total`,
+  `okx_recorder_keepalive_pings_total`, `okx_recorder_pong_timeouts_total`,
   `okx_recorder_tob_last_seen_unix_seconds{inst_id}`, and
   `okx_recorder_trades_last_seen_unix_seconds{inst_id}`. The funding lane adds
   `okx_recorder_funding_poll_attempts_total{inst_id,status}`,
@@ -138,6 +152,8 @@ See [config.sample.yml](config.sample.yml) for all options:
 | `batch_max_rows` | `10000` | Max rows per ClickHouse insert batch |
 | `batch_flush_seconds` | `2.0` | Max time before a partial batch is flushed |
 | `reconnect_max_backoff_seconds` | `30` | Jittered websocket reconnect backoff ceiling |
+| `ping_idle_seconds` | `15` | Idle time without an inbound frame before a keepalive `ping`; must be 1–29 |
+| `pong_timeout_seconds` | `5` | Silence after a `ping` before the connection is presumed dead; must be 1–60 |
 | `insert_async` | `true` | Use ClickHouse async inserts |
 | `funding_history_url` | the OKX public endpoint | Settled funding-rate-history REST endpoint |
 | `funding_poll_seconds` | `300` | Funding poll interval; must be >= 60 |

--- a/apps/okx-recorder/config.sample.yml
+++ b/apps/okx-recorder/config.sample.yml
@@ -29,6 +29,16 @@ queue_max_rows: 50000
 batch_max_rows: 10000
 batch_flush_seconds: 2.0
 reconnect_max_backoff_seconds: 30
+
+# Client-initiated keepalive: OKX terminates a connection with no traffic for
+# 30s, and thin pre-IPO perps have genuinely quiet stretches. After
+# ping_idle_seconds without any inbound frame the recorder sends a "ping" text
+# frame; if nothing (the "pong" reply, or any data) arrives within
+# pong_timeout_seconds the connection is presumed dead and reconnected with
+# backoff. ping_idle_seconds must stay below 30.
+ping_idle_seconds: 15
+pong_timeout_seconds: 5
+
 insert_async: true
 
 # Funding lane: REST poller for the SETTLED funding rate (funding-rate-history

--- a/apps/okx-recorder/src/config.rs
+++ b/apps/okx-recorder/src/config.rs
@@ -47,6 +47,8 @@ pub struct AppConfig {
     pub batch_max_rows: usize,
     pub batch_flush_seconds: f64,
     pub reconnect_max_backoff_seconds: u64,
+    pub ping_idle_seconds: u64,
+    pub pong_timeout_seconds: u64,
     pub insert_async: bool,
     pub funding_history_url: String,
     pub funding_poll_seconds: u64,
@@ -118,6 +120,16 @@ impl AppConfig {
                 "reconnect_max_backoff_seconds",
                 default_reconnect_max_backoff_seconds,
             )?,
+            ping_idle_seconds: parse_ping_idle_seconds(get_or_default(
+                &loaded,
+                "ping_idle_seconds",
+                default_ping_idle_seconds,
+            )?)?,
+            pong_timeout_seconds: parse_pong_timeout_seconds(get_or_default(
+                &loaded,
+                "pong_timeout_seconds",
+                default_pong_timeout_seconds,
+            )?)?,
             insert_async: get_or_default(&loaded, "insert_async", default_insert_async)?,
             funding_history_url: get_or_default(
                 &loaded,
@@ -220,6 +232,39 @@ fn parse_clickhouse_target(input: ClickHouseConfig) -> Result<ClickHouseTarget, 
     })
 }
 
+/// OKX terminates a connection with no traffic for 30 seconds, so the keepalive
+/// ping must fire strictly inside that window to be of any use.
+const OKX_IDLE_DISCONNECT_SECONDS: u64 = 30;
+
+/// Sanity ceiling for the pong timeout: a live OKX endpoint answers a ping
+/// within milliseconds, so waiting longer than this only delays the reconnect.
+const MAX_PONG_TIMEOUT_SECONDS: u64 = 60;
+
+/// Validate the idle threshold after which the keepalive ping is sent: it must
+/// be non-zero and beat OKX's server-side idle disconnect.
+fn parse_ping_idle_seconds(value: u64) -> Result<u64, ConfigError> {
+    if value == 0 || value >= OKX_IDLE_DISCONNECT_SECONDS {
+        return Err(ConfigError::Invalid(format!(
+            "ping_idle_seconds must be between 1 and {} (OKX drops connections \
+             idle for {}s); got {value}",
+            OKX_IDLE_DISCONNECT_SECONDS - 1,
+            OKX_IDLE_DISCONNECT_SECONDS,
+        )));
+    }
+    Ok(value)
+}
+
+/// Validate the window after a keepalive ping within which a pong (or any
+/// frame) must arrive before the connection is presumed dead.
+fn parse_pong_timeout_seconds(value: u64) -> Result<u64, ConfigError> {
+    if value == 0 || value > MAX_PONG_TIMEOUT_SECONDS {
+        return Err(ConfigError::Invalid(format!(
+            "pong_timeout_seconds must be between 1 and {MAX_PONG_TIMEOUT_SECONDS}; got {value}"
+        )));
+    }
+    Ok(value)
+}
+
 fn required_string(value: Option<String>, key: &str) -> Result<String, ConfigError> {
     match value {
         Some(value) if !value.trim().is_empty() => Ok(value),
@@ -269,6 +314,16 @@ fn default_batch_flush_seconds() -> f64 {
 /// `stream_client`.
 fn default_reconnect_max_backoff_seconds() -> u64 {
     30
+}
+
+/// Idle threshold before a client-initiated keepalive ping, comfortably inside
+/// OKX's 30-second idle disconnect.
+fn default_ping_idle_seconds() -> u64 {
+    15
+}
+
+fn default_pong_timeout_seconds() -> u64 {
+    5
 }
 
 fn default_insert_async() -> bool {

--- a/apps/okx-recorder/src/main.rs
+++ b/apps/okx-recorder/src/main.rs
@@ -8,6 +8,7 @@ use okx_recorder::{
     health::{start_http_servers, HealthState},
     metrics::RecorderMetrics,
     recorder::{FundingRuntimeConfig, RecorderRuntime, WriterRuntimeConfig},
+    stream_client::KeepaliveConfig,
 };
 use tokio::signal::unix::{signal, SignalKind};
 
@@ -44,6 +45,10 @@ async fn run() -> Result<()> {
         config.ws_url,
         config.instruments,
         config.reconnect_max_backoff_seconds,
+        KeepaliveConfig {
+            ping_idle: Duration::from_secs(config.ping_idle_seconds),
+            pong_timeout: Duration::from_secs(config.pong_timeout_seconds),
+        },
         writer_client,
         WriterRuntimeConfig {
             batch_max_rows: config.batch_max_rows,

--- a/apps/okx-recorder/src/metrics.rs
+++ b/apps/okx-recorder/src/metrics.rs
@@ -13,10 +13,11 @@ use prometheus::{
 /// and writer loop, plus the readiness/liveness surface emitted by the health
 /// probe and stream worker: a ClickHouse-up gauge, a ready-state gauge, and
 /// per-instrument ToB and trades last-seen timestamps. The funding lane adds
-/// its own poll, insert, and last-event metrics. Only the ToB gauge's
-/// freshness gates `/ready`; every other lane's metrics feed dashboards and
-/// alerts but never gate `/ready`. `/metrics` exposition is served from
-/// [`crate::health`].
+/// its own poll, insert, and last-event metrics. Connection resilience is
+/// observable via the reconnect, keepalive-ping, and pong-timeout counters.
+/// Only the ToB gauge's freshness gates `/ready`; every other lane's metrics
+/// feed dashboards and alerts but never gate `/ready`. `/metrics` exposition
+/// is served from [`crate::health`].
 #[derive(Clone)]
 pub struct RecorderMetrics {
     registry: Registry,
@@ -34,6 +35,8 @@ pub struct RecorderMetrics {
     pub funding_insert_latency_seconds: Histogram,
     pub funding_last_event_unix_seconds: GaugeVec,
     pub stream_reconnects: Counter,
+    pub keepalive_pings: Counter,
+    pub pong_timeouts: Counter,
     pub clickhouse_up: Gauge,
     pub ready_state: Gauge,
 }
@@ -128,6 +131,14 @@ impl RecorderMetrics {
             "okx_recorder_stream_reconnects_total",
             "Total websocket reconnect attempts after a connection failure",
         ))?;
+        let keepalive_pings = Counter::with_opts(Opts::new(
+            "okx_recorder_keepalive_pings_total",
+            "Total keepalive pings sent on an idle websocket connection",
+        ))?;
+        let pong_timeouts = Counter::with_opts(Opts::new(
+            "okx_recorder_pong_timeouts_total",
+            "Total connections presumed dead after a keepalive ping went unanswered",
+        ))?;
         let clickhouse_up = Gauge::with_opts(Opts::new(
             "okx_recorder_clickhouse_up",
             "Whether ClickHouse is currently reachable (1/0)",
@@ -151,6 +162,8 @@ impl RecorderMetrics {
         registry.register(Box::new(funding_insert_latency_seconds.clone()))?;
         registry.register(Box::new(funding_last_event_unix_seconds.clone()))?;
         registry.register(Box::new(stream_reconnects.clone()))?;
+        registry.register(Box::new(keepalive_pings.clone()))?;
+        registry.register(Box::new(pong_timeouts.clone()))?;
         registry.register(Box::new(clickhouse_up.clone()))?;
         registry.register(Box::new(ready_state.clone()))?;
 
@@ -170,6 +183,8 @@ impl RecorderMetrics {
             funding_insert_latency_seconds,
             funding_last_event_unix_seconds,
             stream_reconnects,
+            keepalive_pings,
+            pong_timeouts,
             clickhouse_up,
             ready_state,
         })

--- a/apps/okx-recorder/src/recorder.rs
+++ b/apps/okx-recorder/src/recorder.rs
@@ -13,7 +13,7 @@ use crate::{
     health::HealthState,
     metrics::RecorderMetrics,
     models::{BookTicker, FundingRate, LaneRow, Trade},
-    stream_client::run_stream_worker,
+    stream_client::{run_stream_worker, KeepaliveConfig},
 };
 
 /// Overall per-request deadline for funding-history polls. The poll loop is
@@ -55,6 +55,7 @@ pub struct RecorderRuntime {
     ws_url: String,
     instruments: Vec<String>,
     reconnect_max_backoff_seconds: u64,
+    keepalive: KeepaliveConfig,
     writer: ClickHouseClient,
     writer_config: WriterRuntimeConfig,
     funding_config: FundingRuntimeConfig,
@@ -71,6 +72,7 @@ impl RecorderRuntime {
         ws_url: String,
         instruments: Vec<String>,
         reconnect_max_backoff_seconds: u64,
+        keepalive: KeepaliveConfig,
         writer: ClickHouseClient,
         writer_config: WriterRuntimeConfig,
         funding_config: FundingRuntimeConfig,
@@ -82,6 +84,7 @@ impl RecorderRuntime {
             ws_url,
             instruments,
             reconnect_max_backoff_seconds,
+            keepalive,
             writer,
             writer_config,
             funding_config,
@@ -104,6 +107,7 @@ impl RecorderRuntime {
         let ws_url = self.ws_url.clone();
         let instruments = self.instruments.clone();
         let reconnect_max_backoff_seconds = self.reconnect_max_backoff_seconds;
+        let keepalive = self.keepalive;
         let metrics = self.metrics.clone();
         let health = self.health.clone();
         let stop_token = self.stop_token.clone();
@@ -112,6 +116,7 @@ impl RecorderRuntime {
                 ws_url,
                 instruments,
                 reconnect_max_backoff_seconds,
+                keepalive,
                 tx,
                 metrics,
                 health,

--- a/apps/okx-recorder/src/stream_client.rs
+++ b/apps/okx-recorder/src/stream_client.rs
@@ -18,6 +18,99 @@ use crate::models::{parse_frame, Channel, LaneRow, ParsedFrame, BBO_TBT_CHANNEL,
 /// been healthy, so the reconnect backoff resets instead of compounding.
 const BACKOFF_RESET_AFTER: Duration = Duration::from_secs(60);
 
+/// OKX's application-level keepalive is text-frame based: the client sends the
+/// literal string `ping` and the server answers with the literal string `pong`.
+const PING_FRAME: &str = "ping";
+const PONG_FRAME: &str = "pong";
+
+/// Timing knobs for the client-initiated keepalive. OKX terminates a
+/// connection with no traffic for 30 seconds, and thin pre-IPO perps have
+/// genuinely quiet stretches, so the client must ping well inside that window.
+#[derive(Clone, Copy, Debug)]
+pub struct KeepaliveConfig {
+    /// Send a [`PING_FRAME`] after this long without any inbound frame.
+    pub ping_idle: Duration,
+    /// Presume the connection dead when no frame (a [`PONG_FRAME`] or any
+    /// data) arrives within this long of a keepalive ping.
+    pub pong_timeout: Duration,
+}
+
+/// What the stream loop must do when the keepalive deadline fires.
+#[derive(Debug, PartialEq, Eq)]
+enum KeepaliveAction {
+    /// The connection has been idle past the ping threshold: send a ping.
+    SendPing,
+    /// No frame arrived within the timeout after a ping: the connection is
+    /// dead, tear it down and reconnect.
+    ConnectionDead,
+    /// Woken before the deadline actually elapsed: nothing to do.
+    Wait,
+}
+
+/// Pure ping-scheduling / pong-timeout decision logic, kept free of any socket
+/// so it is unit-testable. The stream loop feeds it inbound-frame timestamps
+/// and deadline wakeups; it answers with the next deadline and the action to
+/// take when that deadline fires.
+struct KeepaliveState {
+    config: KeepaliveConfig,
+    /// When the last inbound frame arrived.
+    last_inbound: Instant,
+    /// When the outstanding keepalive ping was sent; `None` when no pong is
+    /// awaited.
+    ping_sent_at: Option<Instant>,
+}
+
+impl KeepaliveState {
+    fn new(config: KeepaliveConfig, now: Instant) -> Self {
+        Self {
+            config,
+            last_inbound: now,
+            ping_sent_at: None,
+        }
+    }
+
+    /// Record an inbound frame. Any frame — a pong, data, or an event — proves
+    /// the connection alive, so this clears the outstanding ping and restarts
+    /// the idle clock.
+    fn on_inbound(&mut self, now: Instant) {
+        self.last_inbound = now;
+        self.ping_sent_at = None;
+    }
+
+    /// The next instant the stream loop must wake to act on keepalive: the
+    /// pong deadline while a ping is outstanding, the idle-ping threshold
+    /// otherwise.
+    fn deadline(&self) -> Instant {
+        match self.ping_sent_at {
+            Some(sent_at) => sent_at + self.config.pong_timeout,
+            None => self.last_inbound + self.config.ping_idle,
+        }
+    }
+
+    /// Decide what to do at `now`, assuming the caller woke because
+    /// [`Self::deadline`] fired. A wake before the deadline is a
+    /// [`KeepaliveAction::Wait`] so a spurious wakeup never double-pings.
+    fn on_deadline(&mut self, now: Instant) -> KeepaliveAction {
+        match self.ping_sent_at {
+            Some(sent_at) => {
+                if now >= sent_at + self.config.pong_timeout {
+                    KeepaliveAction::ConnectionDead
+                } else {
+                    KeepaliveAction::Wait
+                }
+            }
+            None => {
+                if now >= self.last_inbound + self.config.ping_idle {
+                    self.ping_sent_at = Some(now);
+                    KeepaliveAction::SendPing
+                } else {
+                    KeepaliveAction::Wait
+                }
+            }
+        }
+    }
+}
+
 /// Run the websocket worker: one connection to the OKX public endpoint
 /// multiplexing a `bbo-tbt` and a `trades` subscription per configured
 /// instrument, reconnected with jittered exponential backoff for the life of
@@ -28,15 +121,18 @@ const BACKOFF_RESET_AFTER: Duration = Duration::from_secs(60);
 /// increments the per-instrument `queue_drops` metric and drops the row
 /// (bounded buffer, observable drops) rather than blocking the read loop.
 ///
-/// OKX closes a connection that has been idle for 30 seconds; an
-/// application-level ping keepalive is a follow-up. Until then an idle
-/// connection (all instruments halted) surfaces as a server close, and this
-/// loop re-subscribes after backoff. Additional channel subscriptions extend
-/// [`subscribe_payload`] and the `ParsedFrame::Data` dispatch below.
+/// OKX closes a connection that has been idle for 30 seconds, so a
+/// client-initiated keepalive (see [`KeepaliveConfig`]) pings during quiet
+/// stretches; a missed pong tears the connection down and this loop
+/// re-subscribes every instrument after backoff. Additional channel
+/// subscriptions extend [`subscribe_payload`] and the `ParsedFrame::Data`
+/// dispatch below.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_stream_worker(
     ws_url: String,
     inst_ids: Vec<String>,
     max_backoff_seconds: u64,
+    keepalive: KeepaliveConfig,
     sender: mpsc::Sender<LaneRow>,
     metrics: Arc<RecorderMetrics>,
     health: HealthState,
@@ -45,7 +141,17 @@ pub async fn run_stream_worker(
     let mut delay_seconds = 1_u64;
     while !stop_token.is_cancelled() {
         let connected_at = Instant::now();
-        match stream_once(&ws_url, &inst_ids, &sender, &metrics, &health, &stop_token).await {
+        match stream_once(
+            &ws_url,
+            &inst_ids,
+            keepalive,
+            &sender,
+            &metrics,
+            &health,
+            &stop_token,
+        )
+        .await
+        {
             // A clean return means stop was requested.
             Ok(()) => return,
             Err(err) => {
@@ -72,6 +178,7 @@ pub async fn run_stream_worker(
 async fn stream_once(
     ws_url: &str,
     inst_ids: &[String],
+    keepalive_config: KeepaliveConfig,
     sender: &mpsc::Sender<LaneRow>,
     metrics: &RecorderMetrics,
     health: &HealthState,
@@ -88,6 +195,7 @@ async fn stream_once(
         .await
         .context("send subscribe frame")?;
 
+    let mut keepalive = KeepaliveState::new(keepalive_config, Instant::now());
     loop {
         tokio::select! {
             () = stop_token.cancelled() => {
@@ -97,14 +205,37 @@ async fn stream_once(
                 }
                 return Ok(());
             }
+            () = tokio::time::sleep_until(keepalive.deadline()) => {
+                match keepalive.on_deadline(Instant::now()) {
+                    KeepaliveAction::SendPing => {
+                        metrics.keepalive_pings.inc();
+                        tracing::debug!("connection idle; sending keepalive ping");
+                        ws.send(Message::Text(PING_FRAME.to_string()))
+                            .await
+                            .context("send keepalive ping")?;
+                    }
+                    KeepaliveAction::ConnectionDead => {
+                        metrics.pong_timeouts.inc();
+                        bail!(
+                            "no pong within {}s of keepalive ping; presuming connection dead",
+                            keepalive_config.pong_timeout.as_secs()
+                        );
+                    }
+                    KeepaliveAction::Wait => {}
+                }
+            }
             message = ws.next() => {
+                keepalive.on_inbound(Instant::now());
                 match message {
+                    // The literal `pong` answers our keepalive ping; its
+                    // arrival was already recorded by `on_inbound` above.
+                    Some(Ok(Message::Text(text))) if text == PONG_FRAME => {}
                     Some(Ok(Message::Text(text))) => {
                         handle_text_frame(&text, sender, metrics, health);
                     }
                     // tungstenite answers protocol pings internally; OKX's
-                    // application-level ping/pong is text-frame based and owned
-                    // by the trades-lane follow-up.
+                    // application-level keepalive is the text-frame
+                    // `ping`/`pong` handled above.
                     Some(Ok(Message::Ping(_) | Message::Pong(_))) => {}
                     Some(Ok(Message::Binary(_) | Message::Frame(_))) => {}
                     Some(Ok(Message::Close(frame))) => {
@@ -208,5 +339,106 @@ async fn jittered_backoff(delay_seconds: u64, stop_token: &CancellationToken) {
     tokio::select! {
         () = stop_token.cancelled() => {}
         () = tokio::time::sleep(Duration::from_millis(jittered_ms)) => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PING_IDLE: Duration = Duration::from_secs(15);
+    const PONG_TIMEOUT: Duration = Duration::from_secs(5);
+
+    fn state_at(now: Instant) -> KeepaliveState {
+        KeepaliveState::new(
+            KeepaliveConfig {
+                ping_idle: PING_IDLE,
+                pong_timeout: PONG_TIMEOUT,
+            },
+            now,
+        )
+    }
+
+    #[test]
+    fn test_quiet_connection_pings_at_idle_threshold() {
+        let t0 = Instant::now();
+        let mut state = state_at(t0);
+        assert_eq!(state.deadline(), t0 + PING_IDLE);
+        assert_eq!(state.on_deadline(t0 + PING_IDLE), KeepaliveAction::SendPing);
+        // With the ping outstanding, the next deadline is the pong timeout.
+        assert_eq!(state.deadline(), t0 + PING_IDLE + PONG_TIMEOUT);
+    }
+
+    #[test]
+    fn test_inbound_traffic_defers_the_ping() {
+        let t0 = Instant::now();
+        let mut state = state_at(t0);
+        state.on_inbound(t0 + Duration::from_secs(10));
+        assert_eq!(state.deadline(), t0 + Duration::from_secs(10) + PING_IDLE);
+        // A wake at the original deadline is before the deferred one: no ping.
+        assert_eq!(state.on_deadline(t0 + PING_IDLE), KeepaliveAction::Wait);
+        assert_eq!(state.deadline(), t0 + Duration::from_secs(10) + PING_IDLE);
+    }
+
+    #[test]
+    fn test_missing_pong_declares_connection_dead() {
+        let t0 = Instant::now();
+        let mut state = state_at(t0);
+        let ping_at = t0 + PING_IDLE;
+        assert_eq!(state.on_deadline(ping_at), KeepaliveAction::SendPing);
+        assert_eq!(
+            state.on_deadline(ping_at + PONG_TIMEOUT),
+            KeepaliveAction::ConnectionDead
+        );
+    }
+
+    #[test]
+    fn test_any_inbound_frame_clears_the_outstanding_ping() {
+        let t0 = Instant::now();
+        let mut state = state_at(t0);
+        let ping_at = t0 + PING_IDLE;
+        assert_eq!(state.on_deadline(ping_at), KeepaliveAction::SendPing);
+        // A pong — or any data frame — arrives before the timeout: back on the
+        // idle schedule, counted from the frame's arrival.
+        let pong_at = ping_at + Duration::from_secs(2);
+        state.on_inbound(pong_at);
+        assert_eq!(state.deadline(), pong_at + PING_IDLE);
+        assert_eq!(
+            state.on_deadline(ping_at + PONG_TIMEOUT),
+            KeepaliveAction::Wait
+        );
+    }
+
+    #[test]
+    fn test_early_wake_never_double_pings_or_kills() {
+        let t0 = Instant::now();
+        let mut state = state_at(t0);
+        // Woken before the idle threshold: no ping.
+        assert_eq!(
+            state.on_deadline(t0 + PING_IDLE - Duration::from_secs(1)),
+            KeepaliveAction::Wait
+        );
+        let ping_at = t0 + PING_IDLE;
+        assert_eq!(state.on_deadline(ping_at), KeepaliveAction::SendPing);
+        // Woken again before the pong timeout: neither a second ping nor a
+        // premature death sentence.
+        assert_eq!(
+            state.on_deadline(ping_at + PONG_TIMEOUT - Duration::from_secs(1)),
+            KeepaliveAction::Wait
+        );
+    }
+
+    #[test]
+    fn test_idle_ping_cycle_repeats_after_each_pong() {
+        let t0 = Instant::now();
+        let mut state = state_at(t0);
+        let mut now = t0;
+        for _ in 0..3 {
+            now += PING_IDLE;
+            assert_eq!(state.on_deadline(now), KeepaliveAction::SendPing);
+            now += Duration::from_secs(1);
+            state.on_inbound(now);
+            assert_eq!(state.deadline(), now + PING_IDLE);
+        }
     }
 }

--- a/apps/okx-recorder/tests/test_config.rs
+++ b/apps/okx-recorder/tests/test_config.rs
@@ -94,6 +94,8 @@ clickhouse:
     assert_eq!(config.batch_flush_seconds, 2.0);
     assert_eq!(config.ready_stale_seconds, 10);
     assert_eq!(config.reconnect_max_backoff_seconds, 30);
+    assert_eq!(config.ping_idle_seconds, 15);
+    assert_eq!(config.pong_timeout_seconds, 5);
     assert!(config.insert_async);
     // ClickHouse target falls back to the default user/database/tables.
     assert_eq!(config.clickhouse.username, "default");
@@ -200,6 +202,58 @@ clickhouse:
     assert!(config.clickhouse.secure);
 
     let _ = fs::remove_file(config_file);
+}
+
+#[test]
+fn test_ping_idle_seconds_must_beat_okx_idle_disconnect() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    clear_env_vars(ENV_KEYS);
+
+    // 0 disables the keepalive and >=30 fires after OKX has already dropped
+    // the connection; both are rejected.
+    for bad_value in [0, 30, 3600] {
+        let config_file = temp_yaml_path("okx-config-bad-ping-idle");
+        let yaml = format!(
+            r#"
+clickhouse:
+  url: "http://127.0.0.1:8123"
+ping_idle_seconds: {bad_value}
+"#
+        );
+        fs::write(&config_file, yaml).expect("write yaml config");
+        let result = AppConfig::from_sources(Some(&config_file));
+        let message = result.err().map(|err| err.to_string()).unwrap_or_default();
+        assert!(
+            message.contains("ping_idle_seconds"),
+            "ping_idle_seconds = {bad_value} should be rejected; got: {message}"
+        );
+        let _ = fs::remove_file(config_file);
+    }
+}
+
+#[test]
+fn test_pong_timeout_seconds_bounds_enforced() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    clear_env_vars(ENV_KEYS);
+
+    for bad_value in [0, 61] {
+        let config_file = temp_yaml_path("okx-config-bad-pong-timeout");
+        let yaml = format!(
+            r#"
+clickhouse:
+  url: "http://127.0.0.1:8123"
+pong_timeout_seconds: {bad_value}
+"#
+        );
+        fs::write(&config_file, yaml).expect("write yaml config");
+        let result = AppConfig::from_sources(Some(&config_file));
+        let message = result.err().map(|err| err.to_string()).unwrap_or_default();
+        assert!(
+            message.contains("pong_timeout_seconds"),
+            "pong_timeout_seconds = {bad_value} should be rejected; got: {message}"
+        );
+        let _ = fs::remove_file(config_file);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Resolves PFG-1555. Part of the PFG-1553 okx-recorder stack (4/4), on top of #3977.

Hardens the stream client for OKX's 30s idle disconnect — a must-have for thin pre-IPO perps with genuinely quiet stretches (and a gap the Lazer okx-publisher still has an open TODO on).

- Pure `KeepaliveState` state machine (private to `stream_client.rs`): after `ping_idle_seconds` (default 15, validated 1–29 to stay inside OKX's 30s window) with no inbound frame, send the literal `ping` text frame; any inbound frame proves liveness (the literal `pong` is special-cased away from the JSON parser); no frame within `pong_timeout_seconds` (default 5) → tear down, reconnect with the existing jittered backoff, resubscribe all channels.
- New counters: `okx_recorder_keepalive_pings_total`, `okx_recorder_pong_timeouts_total`.
- The ping → `Text("pong")` contract was sanity-checked live against `wss://ws.okx.com:8443/ws/v5/public`.

Validation: build, 51 tests total at this layer (6 keepalive state-machine tests), clippy `-D warnings`, fmt, pre-commit all pass. Top of stack is tree-identical to the branch that was integration-tested with all lanes combined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)