### PR TITLE
docs(price-feeds): set HyperEVM USH and USDN deviation to 5

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/hyperevm-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/hyperevm-mainnet.json
@@ -60,7 +60,7 @@
       "alias": "USH/USD",
       "id": "eaa30c1ef2d9f4fde45d6e699bfda5187b3de200ea4cbab25d676b260ab728c1",
       "time_difference": 3600,
-      "price_deviation": 2,
+      "price_deviation": 5,
       "confidence_ratio": 100,
       "pro_compatible_status": "coming_soon"
     },
@@ -316,7 +316,7 @@
       "alias": "USDN/USD",
       "id": "ee8e0a7de474035b5cbc1a5f762a74d654e5006b25bfe18f390cc5a3915b88ac",
       "time_difference": 3600,
-      "price_deviation": 1,
+      "price_deviation": 5,
       "confidence_ratio": 100,
       "pro_compatible_status": "coming_soon"
     },


### PR DESCRIPTION
Bump the `price_deviation` shown for USH/USD and USDN/USD in the HyperEVM mainnet push-feeds documentation listing to `5`, so the docs stay aligned with the pyth-network/deployments HyperEVM price-pusher config (companion PR).

Companion PR (pusher config): https://github.com/pyth-network/deployments/pull/5585

## Feeds changed

| Alias    | Core ID (prefix)    | price_deviation before → after | time_difference | confidence_ratio | pro_compatible_status |
| -------- | ------------------- | ------------------------------ | --------------- | ---------------- | --------------------- |
| USH/USD  | `eaa30c1e…728c1` | `2 → 5`                      | `3600` (unchanged) | `100` (unchanged) | `coming_soon` (unchanged) |
| USDN/USD | `ee8e0a7d…b88ac` | `1 → 5`                      | `3600` (unchanged) | `100` (unchanged) | `coming_soon` (unchanged) |

## Files

- `apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/evm/hyperevm-mainnet.json`

## Verification

- Parsed the JSON and asserted `price_deviation == 5` on the two target IDs while `time_difference`, `confidence_ratio`, and `pro_compatible_status` remain unchanged.
- Confirmed no other feed entries in the file were touched (e.g. MHYPE/USD's `price_deviation: 2` is preserved).
- `git merge-tree origin/main HEAD` shows no conflicts against the current `main`.
- Data-only JSON change under `content/docs/…/data/`; no app code, routing, MDX schema, or generated docs are affected, so no lint/type/build gate applies.