### PR TITLE
add(price-feeds): document Pyth Pro colocation data centers

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/api/websocket.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/api/websocket.mdx
@@ -12,7 +12,7 @@ slug: /price-feeds/pro/api/websocket
 | Secondary | `wss://pyth-lazer-1.dourolabs.app/v1/stream` |
 | Tertiary  | `wss://pyth-lazer-2.dourolabs.app/v1/stream` |
 
-Connect to all three endpoints for redundancy during deployments. See [Subscribe to Prices](/price-feeds/pro/subscribe-to-prices) for a detailed guide on establishing connections.
+Connect to all three endpoints for redundancy during deployments. See [Subscribe to Prices](/price-feeds/pro/subscribe-to-prices) for a detailed guide on establishing connections, and [Colocation](/price-feeds/pro/colocation) for the data centers these endpoints are served from.
 
 ## Messages
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/colocation.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/colocation.mdx
@@ -1,0 +1,23 @@
+---
+title: Colocation
+description: Pyth Pro data center locations and how to colocate for the lowest latency
+slug: /price-feeds/pro/colocation
+---
+
+Pyth Pro runs in three Equinix data centers in the Tokyo metro area:
+
+| Facility     | Metro         |
+| ------------ | ------------- |
+| Equinix TY8  | Tokyo, Japan  |
+| Equinix TY10 | Tokyo, Japan  |
+| Equinix TY15 | Tokyo, Japan  |
+
+Latency-sensitive consumers should colocate in one of these three facilities. Anywhere else, the network path to Tokyo dominates every other source of latency.
+
+## Choosing a Facility
+
+Any of the three is a good choice. At any given time one of the zones acts as the leader and delivers the lowest latency, but the leader changes over time and the advantage is marginal — roughly 1 ms compared to the other two zones. There is no need to pick a facility based on which zone is currently leading.
+
+## Connecting
+
+Colocation does not change how you connect. Use the same endpoints described in the [WebSocket API](/price-feeds/pro/api/websocket) reference, and keep connections open to all three of them for redundancy — see [Subscribe to Prices](/price-feeds/pro/subscribe-to-prices).

--- a/apps/developer-hub/content/docs/price-feeds/pro/faq.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/faq.mdx
@@ -186,7 +186,7 @@ Latency spikes can occur due to:
 
 1. **Single connection:** Connect to all three WebSocket endpoints for redundancy.
 2. **Router issues:** Occasionally the routing layer may experience delays.
-3. **Network path:** Check your network latency to our endpoints.
+3. **Network path:** Check your network latency to our endpoints. If you are not colocated in Tokyo, the network path dominates — see [Colocation](/price-feeds/pro/colocation).
 
 For high availability:
 
@@ -198,7 +198,7 @@ For high availability:
 
 #### Q. What are the Pyth Pro data center locations?
 
-Pyth Pro infrastructure is deployed across multiple data centers for low latency and redundancy, including multiple facilities in the Tokyo region. Additional regions are available. Contact support for details relevant to your latency requirements.
+Pyth Pro runs in Equinix TY8, TY10, and TY15 in the Tokyo metro area. Colocating in any of the three gives the best latency — see [Colocation](/price-feeds/pro/colocation).
 
 #### Q. What is the precision of Pyth Pro timestamps?
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/meta.json
+++ b/apps/developer-hub/content/docs/price-feeds/pro/meta.json
@@ -15,6 +15,7 @@
     "api",
     "payload-reference",
     "rate-limits",
+    "colocation",
     "error-codes",
     "faq",
     "price-feed-ids",


### PR DESCRIPTION
Pyth Pro runs in Equinix TY8, TY10, and TY15 in the Tokyo metro area, but the docs never said so — the FAQ deliberately deflected the question to "multiple facilities in the Tokyo region. Contact support."

Adds a `Colocation` page under **Resources** naming the three facilities, stating that latency-sensitive consumers should colocate in one of them, and explaining the leader zone: one zone leads at any given time, the leader changes, and the advantage over the other two is ~1 ms — so there is no need to pick a facility based on which one is currently leading.

- New page `content/docs/price-feeds/pro/colocation.mdx`, added to `pro/meta.json` under `---Resources---` after `rate-limits`.
- FAQ's "What are the Pyth Pro data center locations?" now answers concretely and links to the new page; the latency-spikes answer notes that the network path dominates when not colocated in Tokyo.
- WebSocket API base-URL section links to the page for where the endpoints are served from.

The page deliberately does not map the three `pyth-lazer-{0,1,2}` endpoints to specific facilities — that mapping isn't public and would go stale.

Verified with `pnpm turbo run test:format test:lint test:types` from `apps/developer-hub` (46/46 tasks pass, including the production build). The new route renders — `/price-feeds/pro/colocation` appears in the build output and `sitemap.xml`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->