### PR TITLE
docs(developer-hub): move Pyth Core upgrade to August 26, 2026 at 16:00 UTC

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/create-tradingview-charts.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/create-tradingview-charts.mdx
@@ -12,7 +12,7 @@ The TradingView integration allows users to view Pyth prices on their own websit
 <UpgradeCallout chain="index" />
 
 <Callout type="warn">
-  The Benchmarks endpoints below stay at the same URLs after the upgrade, but from **August 18, 2026** every request must include an `Authorization: Bearer $PYTH_API_KEY` header. Get a Pyth API Key on the [billing page](https://app.pyth.com/billing/plans?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=benchmarks-tv-billing).
+  The Benchmarks endpoints below stay at the same URLs after the upgrade, but from **August 26, 2026 at 16:00 UTC** every request must include an `Authorization: Bearer $PYTH_API_KEY` header. Get a Pyth API Key on the [billing page](https://app.pyth.com/billing/plans?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=benchmarks-tv-billing).
 </Callout>
 
 ## Choosing an Implementation Method for TradingView Integration

--- a/apps/developer-hub/content/docs/price-feeds/core/create-your-first-pyth-app/evm/part-2.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/create-your-first-pyth-app/evm/part-2.mdx
@@ -113,7 +113,7 @@ curl -s -H "Authorization: Bearer $PYTH_API_KEY" \
 <Tab value="Current endpoint">
 
 ```bash copy
-# Authentication becomes required on August 18, 2026.
+# Authentication becomes required on August 26, 2026 at 16:00 UTC.
 curl -s -H "Authorization: Bearer $PYTH_API_KEY" \
   "https://hermes.pyth.network/v2/updates/price/latest?&ids[]=$ETH_USD_ID" | jq -r ".binary.data[0]" > price_update.txt
 ```

--- a/apps/developer-hub/content/docs/price-feeds/core/fetch-price-updates.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/fetch-price-updates.mdx
@@ -51,7 +51,7 @@ curl -X 'GET' \
 <Tab value="Current endpoint">
 
 ```bash copy
-# Authentication becomes required on August 18, 2026.
+# Authentication becomes required on August 26, 2026 at 16:00 UTC.
 curl -X 'GET' \
   -H "Authorization: Bearer $PYTH_API_KEY" \
   'https://hermes.pyth.network/v2/updates/price/latest?ids%5B%5D=0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43&ids%5B%5D=0xc96458d393fe9deb7a7d63a0ac41e2898a67a7750dbd166673279e06c868df0a'

--- a/apps/developer-hub/content/docs/price-feeds/core/getting-started.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/getting-started.mdx
@@ -4,7 +4,7 @@ description: Explore key resources to begin integrating Pyth price feeds
 slug: /price-feeds/core/getting-started
 ---
 
-Integrating Pyth price feeds is quick and easy. Pyth price feeds are permissionless on-chain. From **August 18, 2026**, calling the Hermes price API requires a Pyth API Key — see the upgrade callout below.
+Integrating Pyth price feeds is quick and easy. Pyth price feeds are permissionless on-chain. From **August 26, 2026 at 16:00 UTC**, calling the Hermes price API requires a Pyth API Key — see the upgrade callout below.
 
 <UpgradeCallout chain="index" />
 

--- a/apps/developer-hub/content/docs/price-feeds/core/how-pyth-works/cross-chain.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/how-pyth-works/cross-chain.mdx
@@ -10,7 +10,7 @@ shows how prices are delivered from Pythnet to target chains.
 <UpgradeCallout chain="index" />
 
 <Callout type="info">
-  The architecture described on this page reflects the **pre-upgrade** cross-chain flow (Wormhole guardians). After **August 18, 2026**, Wormhole is replaced by a 5-router 3-of-5 quorum. See [How the Pyth Core upgrade works](/price-feeds/core/upgrade/how-it-works) for the post-upgrade architecture.
+  The architecture described on this page reflects the **pre-upgrade** cross-chain flow (Wormhole guardians). After **August 26, 2026 at 16:00 UTC**, Wormhole is replaced by a 5-router 3-of-5 quorum. See [How the Pyth Core upgrade works](/price-feeds/core/upgrade/how-it-works) for the post-upgrade architecture.
 </Callout>
 
 <figure className="image-container">

--- a/apps/developer-hub/content/docs/price-feeds/core/how-pyth-works/hermes.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/how-pyth-works/hermes.mdx
@@ -38,7 +38,7 @@ $ curl -H "Authorization: Bearer $PYTH_API_KEY" \
 <Tab value="Current endpoint">
 
 ```bash
-# Authentication becomes required on August 18, 2026.
+# Authentication becomes required on August 26, 2026 at 16:00 UTC.
 $ curl -H "Authorization: Bearer $PYTH_API_KEY" \
   "https://hermes.pyth.network/api/latest_price_feeds?ids[]=0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace"
 ```

--- a/apps/developer-hub/content/docs/price-feeds/core/schedule-price-updates/using-price-pusher.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/schedule-price-updates/using-price-pusher.mdx
@@ -12,7 +12,7 @@ Anyone can operate this service to keep on-chain Pyth prices current based on co
 
 <UpgradeCallout chain="index" />
 
-From **August 18, 2026** onward the Price Pusher must be configured with a Pyth API Key. Pass it via the `--hermes-access-token <YOUR_KEY>` command-line flag so its Hermes calls can authenticate against the upgraded backend.
+From **August 26, 2026 at 16:00 UTC** onward the Price Pusher must be configured with a Pyth API Key. Pass it via the `--hermes-access-token <YOUR_KEY>` command-line flag so its Hermes calls can authenticate against the upgraded backend.
 
 The `--hermes-access-token` flag was added in [Price Pusher v10.5.0](https://github.com/pyth-network/pyth-crosschain/commit/bab960de82fc881fd3c9397627d4e1831aeec934). Make sure you are running v10.5.0 or later. Refer to the project README for setup instructions and configuration details.
 

--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/contracts.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/contracts.mdx
@@ -26,7 +26,7 @@ Pyth has three kinds of on-chain contracts. This page explains how to tell them 
 |                          | What it is                                                                                                                       | Built for                                                                                |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | **Pyth Core (current)**  | The contract you integrated against today. Keeps a **shared price on-chain** that any contract can read                            | Existing integrations                                                                      |
-| **Pyth Core (upgraded)** | The **same interface and feed IDs** at a new address, with richer data and more customization. Still keeps the shared price on-chain | Upgrading your existing integration before August 18: swap the [contract address and the Hermes endpoint together](/price-feeds/core/upgrade/preparing), with an API key |
+| **Pyth Core (upgraded)** | The **same interface and feed IDs** at a new address, with richer data and more customization. Still keeps the shared price on-chain | Upgrading your existing integration before August 26: swap the [contract address and the Hermes endpoint together](/price-feeds/core/upgrade/preparing), with an API key |
 | **Pyth Pro**             | A different model: **no price stored on-chain**. Each transaction carries its own millisecond-fresh signed price, verified on the spot | Latency-critical trading priced per transaction: perps fills, RFQ and quote-based execution |
 
 ## The real difference between upgraded Core and Pro
@@ -50,7 +50,7 @@ Pyth has three kinds of on-chain contracts. This page explains how to tell them 
   If not, take a look at [**Pyth Pro**](/price-feeds/pro).
 </Callout>
 
-## What happens on August 18, 2026
+## What happens on August 26, 2026 at 16:00 UTC
 
 - Your **current contract is upgraded in place**. It starts accepting the new data payloads automatically. You keep your address, and your feed IDs don't change; nearly all feeds carry over ([check yours](https://pythdata.app/explore?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=contract-addresses)).\*
 - `hermes.pyth.network` is **redirected to the upgraded backend**. The URL keeps working, but every request needs a [Pyth API Key](https://pythdata.app/signup?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=contract-addresses) from that day on.
@@ -61,7 +61,7 @@ Pyth has three kinds of on-chain contracts. This page explains how to tell them 
 ## The two mistakes this page exists to prevent
 
 1. **Swapping a Core integration to a Pro address.** Pro has a different interface, different feed IDs, and no stored price to read, so it isn't a drop-in replacement for a Core integration. If you're upgrading Core, you want the **upgraded Core** address (listed below).
-2. **Swapping the contract address without moving your data source, or vice versa.** Each endpoint's payloads verify only on its own contract generation. Swap both together, or wait and let August 18 switch both for you (expect a brief switchover window; see the [wait-path guidance](/price-feeds/core/upgrade/preparing#waiting-for-the-automatic-upgrade)).
+2. **Swapping the contract address without moving your data source, or vice versa.** Each endpoint's payloads verify only on its own contract generation. Swap both together, or wait and let August 26 switch both for you (expect a brief switchover window; see the [wait-path guidance](/price-feeds/core/upgrade/preparing#waiting-for-the-automatic-upgrade)).
 
 **Where to go next:** the [upgrade guide](/price-feeds/core/upgrade/preparing) for the how, or the [Pyth Pro docs](/price-feeds/pro) if per-transaction pricing is what you need. All addresses, all three kinds, are below.
 

--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/how-it-works.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/how-it-works.mdx
@@ -95,7 +95,7 @@ Here is a side-by-side comparison of the two architectures:
 
 ## What this means for consumers
 
-Pyth Core will be upgraded on **August 18**. To avoid potential oracle downtime,
+Pyth Core will be upgraded on **August 26, 2026 at 16:00 UTC**. To avoid potential oracle downtime,
 make sure you take the appropriate steps by following the [upgrade guide](/price-feeds/core/upgrade/preparing).
 You can also view the [upgraded Pyth Core Contract addresses](/price-feeds/core/upgrade/contracts)
 for the new contract addresses on each supported chain.

--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/index.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/index.mdx
@@ -1,26 +1,26 @@
 ---
 title: "Pyth Core Upgrade"
-description: "Pyth Core is upgrading on August 18, 2026. Prepare your integration."
+description: "Pyth Core is upgrading on August 26, 2026 at 16:00 UTC. Prepare your integration."
 full: true
 ---
 
 import { Card, Cards } from "fumadocs-ui/components/card";
 
-Pyth Network is upgrading [Pyth Core](/price-feeds/core) on **August 18, 2026**. This upgrade replaces Pyth Core's underlying data infrastructure with an improved version while preserving the existing Hermes API surface and on-chain contract interface.
+Pyth Network is upgrading [Pyth Core](/price-feeds/core) on **August 26, 2026 at 16:00 UTC**. This upgrade replaces Pyth Core's underlying data infrastructure with an improved version while preserving the existing Hermes API surface and on-chain contract interface.
 
 ## What you get
 - **Higher-frequency updates** for faster price moves.
 - **Additional price feeds** beyond the current Core catalog.
 - **Lower latency** across the data path.
 
-Most existing integrations keep working through the cutover. [Prepare for the upgrade](/price-feeds/core/upgrade/preparing) to check whether you're covered. The one new requirement is authentication on Hermes: every Hermes user needs a [Pyth API Key](https://pythdata.app/signup?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=overview) by August 18, 2026.
+Most existing integrations keep working through the cutover. [Prepare for the upgrade](/price-feeds/core/upgrade/preparing) to check whether you're covered. The one new requirement is authentication on Hermes: every Hermes user needs a [Pyth API Key](https://pythdata.app/signup?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=overview) by August 26, 2026 at 16:00 UTC.
 
 ## Next steps
 
 <Cards>
   <Card
     title="Prepare for the upgrade"
-    description="Step-by-step migration guide before the August 18 cutover."
+    description="Step-by-step migration guide before the August 26 cutover."
     href="/price-feeds/core/upgrade/preparing"
   />
   <Card

--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/index.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Preparing for the Pyth Core upgrade"
-description: "Everything you need to upgrade your Pyth Core integration before August 18, 2026."
+description: "Everything you need to upgrade your Pyth Core integration before August 26, 2026 at 16:00 UTC."
 full: true
 ---
 
@@ -18,14 +18,14 @@ import {
 
 <ActiveStepHighlighter />
 
-Pyth Network is upgrading [Pyth Core](/price-feeds/core) on **August 18, 2026**. Your existing integration keeps working: the on-chain Pyth contract is upgraded by the Pyth DAO on August 18 (except on [Sui](/price-feeds/core/upgrade/preparing/sui), which requires a manual swap), and [Hermes](/api-reference/pyth-core/hermes) requests are redirected to the upgraded backend automatically. The one new requirement is authentication on Hermes: every Hermes user needs a Pyth API Key by **August 18**.
+Pyth Network is upgrading [Pyth Core](/price-feeds/core) on **August 26, 2026 at 16:00 UTC**. Your existing integration keeps working: the on-chain Pyth contract is upgraded by the Pyth DAO on August 26 (except on [Sui](/price-feeds/core/upgrade/preparing/sui), which requires a manual swap), and [Hermes](/api-reference/pyth-core/hermes) requests are redirected to the upgraded backend automatically. The one new requirement is authentication on Hermes: every Hermes user needs a Pyth API Key by **August 26**.
 
 For background on what's changing and why, see the [upgrade overview](/price-feeds/core/upgrade). For a walkthrough of the signers, data flow, and contracts behind the upgrade, see [How the Pyth Core upgrade works](/price-feeds/core/upgrade/how-it-works).
 
 <Callout type="warn">
-  **All Hermes users need a Pyth API Key by August 18, 2026** — the upgraded
-  Hermes endpoint requires authentication, even for users who wait for the
-  automatic upgrade. [Register at Pyth Terminal →](https://pythdata.app/signup?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=callout-top)
+  **All Hermes users need a Pyth API Key by August 26, 2026 at 16:00 UTC** —
+  the upgraded Hermes endpoint requires authentication, even for users who wait
+  for the automatic upgrade. [Register at Pyth Terminal →](https://pythdata.app/signup?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=callout-top)
 </Callout>
 
 ## Does this apply to you?
@@ -76,7 +76,7 @@ After Step 1, choose how and when to move to the upgraded infrastructure. Your c
 
 |                  | Early upgrade (recommended)                | Wait for automatic                                                   |
 | ---------------- | ------------------------------------------ | -------------------------------------------------------------------- |
-| Timing           | You choose                                 | August 18, 2026                                                        |
+| Timing           | You choose                                 | August 26, 2026 at 16:00 UTC                                                        |
 | Downtime         | Up to you                                       | Brief, during the switch                                             |
 | Hermes endpoint  | Switch to the new Hermes endpoint now             | Start using `hermes.pyth.network` with an API key before the cutover               |
 | Contract address | You swap to the upgraded Pyth Core Contract       | DAO upgrades the current Pyth Core Contract for you                             |
@@ -85,7 +85,7 @@ After Step 1, choose how and when to move to the upgraded infrastructure. Your c
 
 ## Early upgrade
 
-This is the recommended path, as it makes the **August 18 cutover a non-event for your integration**. Please note that if you swap the endpoint but not the contract address or vice versa you won't be able to verify price updates. 
+This is the recommended path, as it makes the **August 26 cutover a non-event for your integration**. Please note that if you swap the endpoint but not the contract address or vice versa you won't be able to verify price updates.
 
 <Steps>
 <Step>
@@ -137,7 +137,7 @@ Swap your existing Pyth contract address for the [upgraded Pyth Core Contract](/
 
 View all upgraded [Pyth Core Contract addresses](/price-feeds/core/upgrade/contracts).
 
-After the swap, you're done before the August 18 cutover. 
+After the swap, you're done before the August 26 cutover.
 
 </Step>
 </Steps>
@@ -168,7 +168,7 @@ After the swap, you're done before the August 18 cutover.
   This path does not apply on Sui. Apps reference the Pyth package by object ID, and the DAO cannot swap that for you. Follow the [Sui upgrade guide](/price-feeds/core/upgrade/preparing/sui) instead.
 </Callout>
 
-At the cutover on August 18, the Pyth DAO upgrades your on-chain contract a few moments *before* `hermes.pyth.network` starts serving the upgraded payload.
+At the cutover on August 26, the Pyth DAO upgrades your on-chain contract a few moments *before* `hermes.pyth.network` starts serving the upgraded payload.
 During that brief gap, the price updates served by `hermes.pyth.network` cannot verify against your upgraded contract, while those served by `pyth.dourolabs.app/hermes` can.
 
 A potential strategy to stay live without timing the switch yourself is to fetch from both URLs every request and submit whichever payload verifies:
@@ -221,19 +221,19 @@ Nearly all current Pyth Core feeds remain available after the upgrade, with new 
     Hermes code breaks at the cutover *if* your client is still pointed at `hermes.pyth.network` without an API key. Please follow the steps mentioned [above](#waiting-for-the-automatic-upgrade).
   </Accordion>
   <Accordion title="When exactly does Hermes redirect?">
-    On August 18, 2026. Exact switch timing is announced closer to the date. From that point, `hermes.pyth.network` serves the upgraded data and requires API key authentication.
+    On August 26, 2026 at 16:00 UTC. From that point, `hermes.pyth.network` serves the upgraded data and requires API key authentication.
   </Accordion>
   <Accordion title="Can I test before upgrading?">
     Yes. The upgraded endpoint (`pyth.dourolabs.app/hermes`) and the upgraded Pyth Core Contract are both available on testnets today. See the upgraded [Pyth Core Contract addresses](/price-feeds/core/upgrade/contracts) for addresses.
   </Accordion>
   <Accordion title="What if my chain isn't supported?">
-    Contact the team. Several chains are in active discussion and may be supported by August 18. For others, custom arrangements are possible. See the [upgraded Pyth Core Contract addresses](/price-feeds/core/upgrade/contracts) for the full list.
+    Contact the team. Several chains are in active discussion and may be supported by August 26. For others, custom arrangements are possible. See the [upgraded Pyth Core Contract addresses](/price-feeds/core/upgrade/contracts) for the full list.
   </Accordion>
   <Accordion title="Are all my feeds available after the upgrade?">
     Nearly all current Pyth Core feeds remain available after the upgrade, with new ones added. Look up your specific feeds on the [feed explorer](https://pythdata.app/explore?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=feed-explorer-faq). If a feed you depend on isn't listed, [contact the team](#get-help).
   </Accordion>
   <Accordion title="I read prices on-chain only (push feeds, no Hermes) — do I need an API key?">
-    No. The API key is only required for Hermes (REST/SSE) requests. If your integration reads prices directly from the Pyth contract on-chain and never calls Hermes, you don't need to register. Your contract will be upgraded automatically on August 18, or you can swap it early (see the [Early upgrade](#early-upgrade) section).
+    No. The API key is only required for Hermes (REST/SSE) requests. If your integration reads prices directly from the Pyth contract on-chain and never calls Hermes, you don't need to register. Your contract will be upgraded automatically on August 26, or you can swap it early (see the [Early upgrade](#early-upgrade) section).
   </Accordion>
   <Accordion title="My code uses the Hermes REST/SSE API directly — what changes for me?">
     Routes and response shapes are unchanged. The upgraded endpoint is a drop-in replacement. The differences are *which URL* you call and *whether you send the `Authorization: Bearer $PYTH_API_KEY` header*:

--- a/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/sui.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/upgrade/preparing/sui.mdx
@@ -19,7 +19,7 @@ These notes complement the [main upgrade guide](/price-feeds/core/upgrade/prepar
     </>
   }
 >
-  There is no automatic upgrade path on Sui. Apps reference the Pyth package by object ID, and the DAO cannot swap that for you. Complete the steps below before **August 18, 2026**.
+  There is no automatic upgrade path on Sui. Apps reference the Pyth package by object ID, and the DAO cannot swap that for you. Complete the steps below before **August 26, 2026 at 16:00 UTC**.
 </Callout>
 
 <Steps>

--- a/apps/developer-hub/content/docs/price-feeds/core/use-historical-price-data.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-historical-price-data.mdx
@@ -12,7 +12,7 @@ This guide explains how to integrate **Pyth Benchmarks** to access historical pr
 <UpgradeCallout chain="index" />
 
 <Callout type="warn">
-  The Benchmarks endpoints stay at the same URLs after the upgrade, but from **August 18, 2026** every request must include an `Authorization: Bearer $PYTH_API_KEY` header. Get a Pyth API Key on the [billing page](https://app.pyth.com/billing/plans?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=benchmarks-historical-billing).
+  The Benchmarks endpoints stay at the same URLs after the upgrade, but from **August 26, 2026 at 16:00 UTC** every request must include an `Authorization: Bearer $PYTH_API_KEY` header. Get a Pyth API Key on the [billing page](https://app.pyth.com/billing/plans?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=benchmarks-historical-billing).
 </Callout>
 
 <Callout type="info" title="Benchmarks Terminology">

--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/solana.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/solana.mdx
@@ -157,7 +157,7 @@ To use price update accounts, the frontend code needs to perform two different t
 
 #### Fetch price updates
 
-Use `HermesClient` from `@pythnetwork/hermes-client` to fetch Pyth price updates from Hermes. The new endpoint `pyth.dourolabs.app/hermes` is the upgraded backend (recommended); the current `hermes.pyth.network` keeps working until cutover and requires an API key from August 18, 2026:
+Use `HermesClient` from `@pythnetwork/hermes-client` to fetch Pyth price updates from Hermes. The new endpoint `pyth.dourolabs.app/hermes` is the upgraded backend (recommended); the current `hermes.pyth.network` keeps working until cutover and requires an API key from August 26, 2026 at 16:00 UTC:
 
 <Tabs items={["Upgraded endpoint", "Current endpoint"]}>
 <Tab value="Upgraded endpoint">
@@ -177,7 +177,7 @@ const priceServiceConnection = new HermesClient(
 ```typescript copy
 import { HermesClient } from "@pythnetwork/hermes-client";
 
-// Authentication becomes required on August 18, 2026.
+// Authentication becomes required on August 26, 2026 at 16:00 UTC.
 const priceServiceConnection = new HermesClient(
   "https://hermes.pyth.network",
   { accessToken: process.env.PYTH_API_KEY },

--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/sui.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/sui.mdx
@@ -12,7 +12,7 @@ This guide explains how to use real-time Pyth data in Sui applications.
 <UpgradeCallout chain="sui" />
 
 <Callout type="info">
-  After **August 18, 2026**, replace the Pyth package `rev` below with
+  After **August 26, 2026 at 16:00 UTC**, replace the Pyth package `rev` below with
   `sui-pro-compatible-contract-mainnet` (or `sui-pro-compatible-contract-testnet`)
   and update the Pyth State / Wormhole State IDs to the [upgraded Sui addresses](/price-feeds/core/upgrade/contracts#sui).
   See the [upgrade guide](/price-feeds/core/upgrade/preparing) for details.
@@ -146,7 +146,7 @@ import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 /// Step 1: Get the off-chain data.
 const connection = new SuiPriceServiceConnection(
   "https://pyth.dourolabs.app/hermes", // upgraded endpoint
-  // Or: "https://hermes.pyth.network" — auth required from August 18, 2026
+  // Or: "https://hermes.pyth.network" — auth required from August 26, 2026 at 16:00 UTC
   {
     accessToken: process.env.PYTH_API_KEY,
     // Provide this option to retrieve signed price updates for on-chain contracts!
@@ -255,7 +255,7 @@ npm run example-relay -- --feed-id "5a035d5440f5c163069af66062bac6c79377bf88396f
 
 ### Contract Addresses
 
-Consult [Sui Contract Addresses](../../contract-addresses/sui) to find the current package IDs, or the [upgraded Sui addresses](/price-feeds/core/upgrade/contracts#sui) for the post-August 18, 2026 upgrade.
+Consult [Sui Contract Addresses](../../contract-addresses/sui) to find the current package IDs, or the [upgraded Sui addresses](/price-feeds/core/upgrade/contracts#sui) for the post-August 26, 2026 upgrade.
 
 ### Pyth Price Feed IDs
 

--- a/apps/developer-hub/src/components/MigrationBanner/index.tsx
+++ b/apps/developer-hub/src/components/MigrationBanner/index.tsx
@@ -19,11 +19,11 @@ export const MigrationBanner = () => {
   return (
     <Banner className="bg-violet-950 text-violet-100 hover:bg-violet-900">
       <Link
-        href="/price-feeds/core/upgrade/preparing"
         className="hover:underline"
+        href="/price-feeds/core/upgrade/preparing"
       >
-        Pyth Core upgrade August 18, 2026. Every Core user will need an API Key.
-        Learn more →
+        Pyth Core upgrade August 26, 2026 at 16:00 UTC. Every Core user will
+        need an API Key. Learn more →
       </Link>
     </Banner>
   );

--- a/apps/developer-hub/src/components/MigrationFlow/BranchToggle.tsx
+++ b/apps/developer-hub/src/components/MigrationFlow/BranchToggle.tsx
@@ -15,14 +15,14 @@ type Option = {
 
 const OPTIONS: Option[] = [
   {
-    value: "now",
-    title: "Early upgrade",
     caption: "Recommended · zero downtime · ~30 min",
+    title: "Early upgrade",
+    value: "now",
   },
   {
-    value: "wait",
+    caption: "DAO upgrades contract on August 26",
     title: "Wait for automatic",
-    caption: "DAO upgrades contract on August 18",
+    value: "wait",
   },
 ];
 
@@ -36,16 +36,21 @@ const HEADING_IDS: Record<MigrationPath, string> = {
 const BranchToggleInner = () => {
   const [path, setPath] = useMigrationPath();
   return (
-    <div className={styles.toggle} role="radiogroup" aria-label="Choose your upgrade path">
+    <div
+      aria-label="Choose your upgrade path"
+      className={styles.toggle}
+      role="radiogroup"
+    >
       {OPTIONS.map((option) => {
         const selected = path === option.value;
         return (
           <button
-            key={option.value}
-            type="button"
-            role="radio"
             aria-checked={selected}
-            className={clsx(styles.toggleOption, selected && styles.toggleOptionSelected)}
+            className={clsx(
+              styles.toggleOption,
+              selected && styles.toggleOptionSelected,
+            )}
+            key={option.value}
             onClick={() => {
               if (selected) return;
               void setPath(option.value);
@@ -53,6 +58,8 @@ const BranchToggleInner = () => {
                 .getElementById(HEADING_IDS[option.value])
                 ?.scrollIntoView({ behavior: "smooth", block: "start" });
             }}
+            role="radio"
+            type="button"
           >
             <span className={styles.toggleTitle}>{option.title}</span>
             <span className={styles.toggleCaption}>{option.caption}</span>
@@ -70,10 +77,10 @@ export const BranchToggle = () => (
   <Suspense
     fallback={
       <div
+        aria-busy="true"
+        aria-label="Choose your upgrade path"
         className={styles.toggle}
         role="radiogroup"
-        aria-label="Choose your upgrade path"
-        aria-busy="true"
       />
     }
   >

--- a/apps/developer-hub/src/components/MigrationFlow/UpgradeCallout.tsx
+++ b/apps/developer-hub/src/components/MigrationFlow/UpgradeCallout.tsx
@@ -17,17 +17,17 @@ type Chain =
   | "ton";
 
 const CHAIN_LABELS: Record<Exclude<Chain, "index">, string> = {
-  evm: "EVM",
-  sui: "Sui",
-  solana: "Solana",
   aptos: "Aptos",
   cosmwasm: "CosmWasm",
+  evm: "EVM",
   fuel: "Fuel",
   iota: "IOTA",
   movement: "Movement",
   near: "NEAR",
+  solana: "Solana",
   stacks: "Stacks",
   starknet: "Starknet",
+  sui: "Sui",
   ton: "TON",
 };
 
@@ -36,7 +36,7 @@ const SUPPORTED_PARTIAL = new Set<Chain>(["evm"]);
 
 type Props = { chain: Chain };
 
-const TITLE = "Pyth Core upgrades on August 18, 2026";
+const TITLE = "Pyth Core upgrades on August 26, 2026 at 16:00 UTC";
 
 export const UpgradeCallout = ({ chain }: Props) => {
   const upgradeGuide = "/price-feeds/core/upgrade/preparing";
@@ -45,7 +45,7 @@ export const UpgradeCallout = ({ chain }: Props) => {
 
   if (chain === "index") {
     return (
-      <Callout type="warn" title={TITLE}>
+      <Callout title={TITLE} type="warn">
         <ul className="list-disc pl-5 my-0! space-y-1">
           <li>
             We recommend new integrations use the{" "}
@@ -56,8 +56,9 @@ export const UpgradeCallout = ({ chain }: Props) => {
           </li>
           <li>
             Existing integrations using the current addresses will be
-            automatically upgraded by the DAO on <strong>August 18, 2026</strong>.
-            See the <Link href={upgradeGuide}>upgrade guide</Link> for details.
+            automatically upgraded by the DAO on{" "}
+            <strong>August 26, 2026 at 16:00 UTC</strong>. See the{" "}
+            <Link href={upgradeGuide}>upgrade guide</Link> for details.
           </li>
         </ul>
       </Callout>
@@ -70,8 +71,8 @@ export const UpgradeCallout = ({ chain }: Props) => {
   if (SUPPORTED_SIMPLE.has(chain)) {
     return (
       <Callout
+        title={`Pyth Core on ${label} is upgrading on August 26, 2026 at 16:00 UTC`}
         type="warn"
-        title={`Pyth Core on ${label} is upgrading on August 18, 2026`}
       >
         <ul className="list-disc pl-5 my-0! space-y-1">
           <li>
@@ -80,8 +81,9 @@ export const UpgradeCallout = ({ chain }: Props) => {
           </li>
           <li>
             Existing integrations using the current addresses will be
-            automatically upgraded by the DAO on <strong>August 18, 2026</strong>.
-            See the <Link href={upgradeGuide}>upgrade guide</Link> for details.
+            automatically upgraded by the DAO on{" "}
+            <strong>August 26, 2026 at 16:00 UTC</strong>. See the{" "}
+            <Link href={upgradeGuide}>upgrade guide</Link> for details.
           </li>
         </ul>
       </Callout>
@@ -91,8 +93,8 @@ export const UpgradeCallout = ({ chain }: Props) => {
   if (SUPPORTED_PARTIAL.has(chain)) {
     return (
       <Callout
+        title={`Pyth Core on ${label} chains is upgrading on August 26, 2026 at 16:00 UTC`}
         type="warn"
-        title={`Pyth Core on ${label} chains is upgrading on August 18, 2026`}
       >
         <ul className="list-disc pl-5 my-0! space-y-1">
           <li>
@@ -101,8 +103,9 @@ export const UpgradeCallout = ({ chain }: Props) => {
           </li>
           <li>
             Existing integrations on {label} chains in the upgrade will be
-            automatically upgraded by the DAO on <strong>August 18, 2026</strong>.
-            See the <Link href={upgradeGuide}>upgrade guide</Link> for details.
+            automatically upgraded by the DAO on{" "}
+            <strong>August 26, 2026 at 16:00 UTC</strong>. See the{" "}
+            <Link href={upgradeGuide}>upgrade guide</Link> for details.
           </li>
           <li>
             <a href={contactMail}>Contact the team</a> if your chain isn&apos;t
@@ -115,8 +118,8 @@ export const UpgradeCallout = ({ chain }: Props) => {
 
   return (
     <Callout
+      title={`Pyth Core will no longer support ${label} after August 26, 2026 at 16:00 UTC`}
       type="warn"
-      title={`Pyth Core will no longer support ${label} after August 18, 2026`}
     >
       <ul className="list-disc pl-5 my-0! space-y-1">
         <li>

--- a/apps/developer-hub/src/components/Pages/Homepage/index.tsx
+++ b/apps/developer-hub/src/components/Pages/Homepage/index.tsx
@@ -25,7 +25,7 @@ export const Homepage = () => {
         <div className={styles.migrationFeature}>
           <div className={styles.migrationFeatureText}>
             <h2 className={styles.migrationFeatureTitle}>
-              Pyth Core is upgrading on August 18, 2026
+              Pyth Core is upgrading on August 26, 2026 at 16:00 UTC
             </h2>
             <p className={styles.migrationFeatureBody}>
               All Pyth Core users must register for an API Key


### PR DESCRIPTION
Moves the Pyth Core upgrade date on developer-hub from **August 18, 2026** to **August 26, 2026**, and states the exact cutover time (**16:00 UTC**) alongside it.

## What changed

- Every mention of the upgrade/cutover date across the Pyth Core docs, the homepage hero, the migration banner, the migration-flow branch toggle, and the `UpgradeCallout` component now reads August 26 instead of August 18.
- Where a page states a full date as the moment something happens (the upgrade, the Hermes redirect, the API-key requirement), it now reads `August 26, 2026 at 16:00 UTC`. Short in-page references that are shorthand for the same event ("the August 26 cutover", "post-August 26, 2026 upgrade") keep the bare date so the copy stays readable.
- Dropped one now-contradictory sentence in the "When exactly does Hermes redirect?" FAQ — it said "Exact switch timing is announced closer to the date", which no longer holds now that the answer states 16:00 UTC.

No other copy was added or changed.

## Incidental

The four touched `.tsx` files were already non-conformant with the repo's Biome config on `main`. Since `scripts/biome-ci` lints *changed* files, `biome check --write` was run on them; the resulting attribute/key sorting and JSX re-wrapping is unrelated formatting churn that CI would otherwise fail on. Trailing whitespace was stripped from two lines in `preparing/index.mdx` that this change already touches (the `trailing-whitespace` pre-commit hook).

## Verification

- `pnpm turbo test:types --filter=@pythnetwork/developer-hub` (runs `next build` first) — passes.
- `biome check` on the touched `.tsx` files — clean.
- Ran the dev server and confirmed the upgrade overview, preparing, how-it-works, contracts, and getting-started pages plus the homepage and banner all render the new date and time.