### PR TITLE
deploy(pro-compatible) Sei EVM Mainnet Core contracts

### DIFF
--- a/contract_manager/src/store/contracts/EvmLazerContracts.json
+++ b/contract_manager/src/store/contracts/EvmLazerContracts.json
@@ -183,5 +183,10 @@
     "address": "0xACeA761c27A909d4D3895128EBe6370FDE2dF481",
     "chain": "etherlink",
     "type": "EvmLazerContract"
+  },
+  {
+    "address": "0xACeA761c27A909d4D3895128EBe6370FDE2dF481",
+    "chain": "sei_evm_mainnet",
+    "type": "EvmLazerContract"
   }
 ]

--- a/contract_manager/src/store/contracts/EvmPriceFeedContracts.json
+++ b/contract_manager/src/store/contracts/EvmPriceFeedContracts.json
@@ -1158,5 +1158,11 @@
     "chain": "etherlink",
     "type": "EvmPriceFeedContract",
     "deploymentType": "pro-compatible-production"
+  },
+  {
+    "address": "0x16392B49EA47D4A21bb17F69aA9E7aD570284838",
+    "chain": "sei_evm_mainnet",
+    "type": "EvmPriceFeedContract",
+    "deploymentType": "pro-compatible-production"
   }
 ]

--- a/contract_manager/src/store/contracts/EvmWormholeContracts.json
+++ b/contract_manager/src/store/contracts/EvmWormholeContracts.json
@@ -1180,5 +1180,11 @@
     "chain": "etherlink",
     "type": "EvmWormholeContract",
     "deploymentType": "pro-compatible-production"
+  },
+  {
+    "address": "0x1038B16B2783936408351664Ff115C1c44971EF5",
+    "chain": "sei_evm_mainnet",
+    "type": "EvmWormholeContract",
+    "deploymentType": "pro-compatible-production"
   }
 ]


### PR DESCRIPTION
Registers the pro-compatible Core deployment and the PythLazer deployment on `sei_evm_mainnet` (chain id 1329).

## Addresses

**Core (`deploymentType: pro-compatible-production`)**

| role | address |
|---|---|
| proxy | `0x16392B49EA47D4A21bb17F69aA9E7aD570284838` |
| PythUpgradable impl | `0xc4CD37d432F699dAf3fCf1Ad75c5Ab6107A27da3` |
| WormholeReceiver | `0x1038B16B2783936408351664Ff115C1c44971EF5` |
| ReceiverSetup | `0xA5F1987F5b922f7730d709F9DC725cFfB1BF5E9a` |
| ReceiverImplementationHalf | `0xCd76c50c3210C5AaA9c39D53A4f95BFd8b1a3a19` |

**PythLazer**

| role | address |
|---|---|
| proxy | `0xACeA761c27A909d4D3895128EBe6370FDE2dF481` (canonical fleet address) |
| impl | `0xD8f4A467AbeC64Bc944eee1325B9007879B6555b` (v0.2.0) |

The legacy Core entry `0x2880aB15...` is left untouched; the new row is distinguished by `deploymentType`.

## On-chain verification

Core:

- `version()` = `1.4.6`, `getValidTimePeriod()` = 60, `singleUpdateFeeInWei()` = 0
- `wormhole()` points at the new receiver; ERC1967 impl slot points at `0xc4CD37d4...`
- `validDataSources()` = exactly one entry, `(26, 0x507974686e6574...)` (pro emitter)
- receiver `chainId()` = 50078, matching `xc_admin_common/src/chains.ts`
- guardian set 0 has 5 keys (pro half-quorum)
- **live pro payload replayed against the new proxy and accepted** (VAAs are chain-agnostic, sourced from the Optimism pro contract)
- negatives behave: a hermes mainnet-guardian VAA reverts `InvalidWormholeVaa()`, an unknown feed reverts `PriceFeedNotFound()`
- impl bytecode is byte-identical to the Etherlink 1.4.6 impl `0x59F78DE2...` once the UUPS `__self` immutable is masked

PythLazer:

- proxy runtime is a 183-byte ERC1967Proxy; impl slot resolves correctly
- `verification_fee()` = 1 wei
- re-calling `initialize()` reverts `InvalidInitialization()`
- `owner()` = `0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E`, the Sei `EvmExecutorContract`, so the governance handoff is done

## Notes

Scoped to Sei only. Store-file trailing-newline conventions are preserved per file (`EvmLazerContracts.json` intentionally has none), so the diff is 17 insertions with no incidental churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->