### PR TITLE
add(developer-hub): IHUB/FOGO to Fogo mainnet push feeds

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/fogo-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/fogo-mainnet.json
@@ -55,6 +55,14 @@
       "time_difference": 60,
       "price_deviation": 0.5,
       "confidence_ratio": 100
+    },
+    {
+      "alias": "IHUB/FOGO",
+      "account_address": "HvgxzFhCBDm86cJsffLQMaQbzALNFJwsSDvG2e3uxG5F",
+      "id": "efe499a19819c72e8e5c5a872c328b96dc965f5076f11b621a3084093a2a1c97",
+      "time_difference": 60,
+      "price_deviation": 0.5,
+      "confidence_ratio": 100
     }
   ]
 }


### PR DESCRIPTION
Adds the `IHUB/FOGO` push feed entry to `apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/svm/fogo-mainnet.json` so the sponsored-feeds table on the "Push Feeds on Fogo" page reflects what the Fogo mainnet pushers actually publish.

| field | value |
| --- | --- |
| alias | `IHUB/FOGO` |
| id | `efe499a19819c72e8e5c5a872c328b96dc965f5076f11b621a3084093a2a1c97` |
| account_address (Fogo mainnet, shard 0) | `HvgxzFhCBDm86cJsffLQMaQbzALNFJwsSDvG2e3uxG5F` |
| time_difference | `60` |
| price_deviation | `0.5` |
| confidence_ratio | `100` |

Parameters match the platform-yellow (primary) Fogo mainnet pusher, matching the existing convention used by every other feed in this file.

## Verification

- Feed exists on `hermes.pyth.network`: `GET /v2/price_feeds?query=IHUB` returns id `efe499a19819c72e8e5c5a872c328b96dc965f5076f11b621a3084093a2a1c97`, asset type `Crypto Redemption Rate`, symbol `Crypto.IHUB/FOGO.RR`, display symbol `IHUB/FOGO`.
- The `account_address` was derived with the same `getPriceFeedAccountForProgram(shardId=0, feedId, pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT)` PDA that the SDK uses; the derivation was cross-checked against the existing `FOGO/USD`, `USDC/USD`, `IFOGO/FOGO`, and `STFOGO/FOGO` entries in this file — all four match their committed `account_address` values.
- JSON parses cleanly (`python -m json.tool`), feed count 7 → 8, no other entries changed.

## Related PRs

The deployments-side pusher changes ship in two paired PRs (one instance per PR, per the deployments repo rule):

- pyth-network/deployments#5628 — platform-yellow (primary)
- pyth-network/deployments#5629 — platform-green (backup)