### PR TITLE
docs: recommend the ai-context MCP and surface stale auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,50 @@ Pyth Crosschain is a monorepo for the components that make up the Pyth protocols
 The primary languages are **Rust** (Hermes, Fortuna, Argus, on-chain SDKs, and
 other services) and **TypeScript** (SDKs, web apps, tooling).
 
+## The `ai-context` MCP is required
+
+*For agents working on behalf of a Douro Labs / Pyth teammate. External
+contributors have no access to this hub and can skip this section.*
+
+Our team's operational skills live in the private
+[`ai-context`](https://github.com/dourolabs/ai-context) hub, served to agents by
+the **ai-context MCP server**. For this repo it owns the procedures for cutting
+release tags and deployment PRs for Pyth services, rolling those deployments
+out, triaging production alerts, and reading logs from the platform clusters.
+The hub is the authoritative source for those procedures — it is not a hint and
+it is not optional.
+
+**Before you start a task the hub might cover — anything operational, and
+anything you are unsure about — ask it: call its `route_task` tool.** If it
+routes you to a skill, follow that skill instead of improvising.
+
+**If the hub's tools (`route_task`, `list_skills` / `get_skill`, `list_access` /
+`get_access`, `search_hub`, ...) are not in your tool list, or a call to one
+fails with an authentication error, stop and tell your human:**
+
+> The `ai-context` MCP is not connected — its auth has most likely gone stale.
+> Please re-authenticate (Claude Code: `/mcp` -> `ai-context` ->
+> **Authenticate**) and tell me when it is done. I am not going to proceed
+> without it.
+
+Then wait for them. Do **not**:
+
+- quietly carry on without the hub and work the task out from first principles;
+- improvise a procedure the hub already defines — hand-rolling a deployment
+  rollout is the exact failure this rule exists to prevent;
+- fall back to a local `npx skills add` copy of the skills, which is a
+  point-in-time snapshot and goes stale;
+- route around the auth failure with tunnels, proxies, or someone else's token.
+
+If you are running headless with no human to ask, fail the task with that
+message rather than substituting your own procedure.
+
+Stale auth is the normal failure mode here, not an exotic one: the MCP access
+token lasts about an hour, and its refresh window closes after 14 days without a
+connection. The failure is quiet — the tools simply are not there — so noticing
+it is your job. Setup and troubleshooting live in
+[`access/ai-context-mcp.md`](https://github.com/dourolabs/ai-context/blob/main/access/ai-context-mcp.md).
+
 ## Standards
 
 Read [`standards/AGENTS.md`](standards/AGENTS.md) before writing code — it is the


### PR DESCRIPTION
## Problem

When the `ai-context` MCP server's OAuth token goes stale, the failure is silent: its tools simply stop appearing in the agent's tool list. Agents observed in the wild treat that as permission to carry on — they brute-force a task a skill would have answered, or hand-roll a procedure the hub defines.

## Change

Adds a `## The ai-context MCP is highly recommended` section to `AGENTS.md`, above Standards:

- names the hub as the authoritative source for this repo's operational procedures (release tags, deployment PRs, rollouts, alert triage, cluster logs);
- tells the agent to call `route_task` before starting and follow whatever skill it routes to;
- leads with why the hub goes stale quietly (~1 hour access token, 14-day refresh window, tools vanish with no error) so noticing it reads as the agent's job;
- makes a missing tool list or an auth error something the agent must **say out loud**, with a verbatim message to send the human;
- scopes the wait-for-a-human stop to operational work (releases, rollouts, production cluster changes, alert triage); ordinary code and docs changes may proceed without the hub as long as the agent says it is doing so;
- forbids the three failure modes that stay wrong either way — improvising a documented procedure, reading a stale local `npx skills add` copy, routing around the auth failure;
- says what to do when running headless with nobody to ask.

The re-authentication message carries per-client recovery: Claude Code's `/mcp` -> `ai-context` -> **Authenticate**, plus a link to `access/ai-context-mcp.md` for Cursor, Gemini/Antigravity, Codex, and the headless bearer path — so a non-Claude session is not told to do something its client cannot do.

This repo is public, so the section opens with a scope note: it addresses agents working for a Douro Labs / Pyth teammate, and external contributors can skip it. No endpoints, hostnames, or credentials appear in the text — the only pointers are the private repo and its access entry, which 404 for anyone outside the org.

Matching sections are going into `pyth-network/deployments` and `pyth-network/pyth-lazer`; `dourolabs/ai-context` already carries the same rule inside its ground rules.

Docs only, no code touched.