### PR TITLE
chore(entropy): remove Tabi from Entropy deployments

### DIFF
--- a/apps/developer-hub/src/components/EntropyTable/entropy-api-data-fetcher.tsx
+++ b/apps/developer-hub/src/components/EntropyTable/entropy-api-data-fetcher.tsx
@@ -4,12 +4,12 @@ import { z } from "zod";
 import { EntropyDeploymentsConfig } from "./entropy-deployments-config";
 
 const ApiChainConfigSchema = z.object({
+  contract_addr: z.string(),
+  default_fee: z.number(),
+  gas_limit: z.number(),
   name: z.string(),
   network_id: z.number(),
-  contract_addr: z.string(),
   reveal_delay_blocks: z.number(),
-  gas_limit: z.number(),
-  default_fee: z.number(),
 });
 
 export type EntropyDeployment = {
@@ -39,11 +39,11 @@ const apiChainConfigToEntrySchema = ApiChainConfigSchema.transform((chain) => {
 
   const deployment: EntropyDeployment = {
     address: chain.contract_addr,
+    default_fee: chain.default_fee,
     delay: `${String(chain.reveal_delay_blocks)} block${
       chain.reveal_delay_blocks === 1 ? "" : "s"
     }`,
     gasLimit: String(chain.gas_limit),
-    default_fee: chain.default_fee,
     ...(rpc ? { rpc } : {}),
     ...(explorer ? { explorer } : {}),
     ...(nativeCurrency ? { nativeCurrency } : {}),

--- a/apps/developer-hub/src/components/EntropyTable/entropy-api-data-fetcher.tsx
+++ b/apps/developer-hub/src/components/EntropyTable/entropy-api-data-fetcher.tsx
@@ -65,7 +65,6 @@ const HIDDEN_CHAINS = new Set([
   "sei-evm-testnet",
   "story",
   "story-testnet",
-  "tabi-testnet",
   "taiko",
   "unichain",
   "unichain-sepolia",

--- a/apps/entropy-explorer/next.config.js
+++ b/apps/entropy-explorer/next.config.js
@@ -35,7 +35,6 @@ const config = {
   images: {
     remotePatterns: [
       new URL("https://icons.llamao.fi/icons/chains/*?w=20&h=20"),
-      new URL("https://www.tabichain.com/images/new2/tabi.svg"),
     ],
   },
 

--- a/apps/entropy-explorer/src/entropy-deployments.tsx
+++ b/apps/entropy-explorer/src/entropy-deployments.tsx
@@ -444,16 +444,6 @@ export const EntropyDeployments = {
     name: "Story Aeneid Testnet",
     rpc: "https://aeneid.storyrpc.io",
   },
-  "tabi-testnet-v2": {
-    address: "0xEbe57e8045F2F230872523bbff7374986E45C486",
-    chainId: 9788,
-    explorerAccountTemplate: "https://testnetv2.tabiscan.com/address/$ADDRESS",
-    explorerTxTemplate: "https://testnetv2.tabiscan.com/tx/$ADDRESS",
-    icon: "https://www.tabichain.com/images/new2/tabi.svg",
-    isTestnet: true,
-    name: "Tabi Testnet v2",
-    rpc: "https://rpc.testnetv2.tabichain.com",
-  },
   "taiko-alethia": {
     address: "0x26DD80569a8B23768A1d80869Ed7339e07595E85",
     chainId: 167_000,

--- a/contract_manager/src/store/contracts/EvmEntropyContracts.json
+++ b/contract_manager/src/store/contracts/EvmEntropyContracts.json
@@ -145,11 +145,6 @@
     "type": "EvmEntropyContract"
   },
   {
-    "address": "0xEbe57e8045F2F230872523bbff7374986E45C486",
-    "chain": "tabi_testnet",
-    "type": "EvmEntropyContract"
-  },
-  {
     "address": "0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320",
     "chain": "berachain_mainnet",
     "type": "EvmEntropyContract"


### PR DESCRIPTION
Entropy support on Tabi ends **August 15, 2026** per the [deprecation notice](https://dev-forum.pyth.network/t/deprecation-notice-pyth-entropy-deprecation-for-selected-chains-august-15-2026/816). This removes the Tabi wiring from the Entropy surfaces in this repo.

Tabi is the only chain touched here — the other seven chains in the same notice (ZetaChain, Unichain, Taiko, Story, Blast, Etherlink, Sei EVM) ship as independent PRs.

## What changed

- **`contract_manager/src/store/contracts/EvmEntropyContracts.json`** — drop the `tabi_testnet` Entropy contract.
- **`apps/entropy-explorer/src/entropy-deployments.tsx`** — drop the `tabi-testnet-v2` deployment.
- **`apps/entropy-explorer/next.config.js`** — drop the `www.tabichain.com` image remote pattern, which only existed for that deployment's icon.
- **`apps/developer-hub/src/components/EntropyTable/entropy-api-data-fetcher.tsx`** — drop `tabi-testnet` from `HIDDEN_CHAINS`. That entry was a stopgap that hid the chain while Fortuna still served it; once Fortuna stops returning it from `/v1/chains/configs` the filter has nothing to match.

**Merge ordering:** the companion PR pyth-network/deployments#5632 removes the `tabi-testnet` keeper from `fortuna-staging`, which is what actually drops Tabi from the chainlist API. Land that one first so the `HIDDEN_CHAINS` removal here cannot briefly resurface Tabi on the testnet chainlist.

Tabi never had a mainnet Entropy deployment — only `tabi-testnet` / `tabi-testnet-v2` existed — so there is nothing mainnet-side to remove.

## Not touched

The Tabi price feed, Wormhole, and executor contracts are not part of the Entropy deprecation and stay in place, along with the `tabi_testnet` entry in `EvmChains.json` and its Wormhole chain ID in `xc_admin_common`, which those contracts depend on.

## Lint follow-on

The second commit sorts two object literals in `entropy-api-data-fetcher.tsx`. Biome's `useSortedKeys` assist already flags them on `main`, and CI only lints files a PR touches, so editing that file surfaces them. Applied via `biome check --write`; no behaviour change.

## Validation

- `pnpm test:lint` — clean.
- `pnpm turbo test:types --filter @pythnetwork/entropy-explorer --filter @pythnetwork/developer-hub --filter @pythnetwork/contract-manager` — 46 tasks green, including the developer-hub and entropy-explorer Next builds.
- `pnpm turbo test:unit` over the same filters — 42 tasks green.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/3993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->