### PR TITLE
chore(entropy): drop ZetaChain from Entropy chain lists

### DIFF
--- a/apps/developer-hub/src/components/EntropyTable/entropy-api-data-fetcher.tsx
+++ b/apps/developer-hub/src/components/EntropyTable/entropy-api-data-fetcher.tsx
@@ -69,8 +69,6 @@ const HIDDEN_CHAINS = new Set([
   "taiko",
   "unichain",
   "unichain-sepolia",
-  "zetachain",
-  "zetachain-testnet",
 ]);
 
 export async function fetchEntropyDeployments(

--- a/apps/entropy-explorer/src/entropy-deployments.tsx
+++ b/apps/entropy-explorer/src/entropy-deployments.tsx
@@ -495,27 +495,6 @@ export const EntropyDeployments = {
     name: "Unichain Sepolia Testnet",
     rpc: "https://sepolia.unichain.org",
   },
-  "zetachain-mainnet": {
-    address: "0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320",
-    chainId: 7000,
-    explorerAccountTemplate:
-      "https://zetachain.blockscout.com/address/$ADDRESS",
-    explorerTxTemplate: "https://zetachain.blockscout.com/tx/$ADDRESS",
-    icon: "https://icons.llamao.fi/icons/chains/rsz_zetachain.jpg?w=20&h=20",
-    isTestnet: false,
-    name: "ZetaChain Mainnet",
-    rpc: "https://zetachain-evm.blockpi.network/v1/rpc/public",
-  },
-  "zetachain-testnet": {
-    address: "0x4374e5a8b9C22271E9EB878A2AA31DE97DF15DAF",
-    chainId: 7001,
-    explorerAccountTemplate: "https://explorer.zetachain.com/address/$ADDRESS",
-    explorerTxTemplate: "https://explorer.zetachain.com/tx/$ADDRESS",
-    icon: "https://icons.llamao.fi/icons/chains/rsz_zetachain.jpg?w=20&h=20",
-    isTestnet: true,
-    name: "ZetaChain Testnet",
-    rpc: "https://zetachain-athens-evm.blockpi.network/v1/rpc/public",
-  },
 } as const satisfies Record<string, EntropyDeployment>;
 
 export const isValidDeploymentSlug = (

--- a/apps/entropy-explorer/src/requests.ts
+++ b/apps/entropy-explorer/src/requests.ts
@@ -60,50 +60,60 @@ export const getRequests = async ({
         const parsed = fortunaSchema.safeParse(await response.json());
         return parsed.success
           ? Result.Success({
-              currentPage: parsed.data.requests.map((request) => {
-                const common = {
-                  chain: getChain(request.network_id),
-                  gasLimit: request.gas_limit,
-                  provider: request.provider,
-                  requestTimestamp: request.created_at,
-                  requestTxHash: request.request_tx_hash,
-                  sender: request.sender,
-                  sequenceNumber: request.sequence,
-                  userContribution: request.user_random_number,
-                };
-                switch (request.state.state) {
-                  case "completed": {
-                    const completedCommon = {
-                      ...common,
-                      callbackTimestamp: request.last_updated_at,
-                      callbackTxHash: request.state.reveal_tx_hash,
-                      gasUsed: request.state.gas_used,
-                      providerContribution:
-                        request.state.provider_random_number,
-                      randomNumber: request.state.combined_random_number,
-                    };
-                    return request.state.callback_failed
-                      ? Request.CallbackErrored({
-                          ...completedCommon,
-                          reason: request.state.callback_return_value,
-                        })
-                      : Request.Complete({
-                          ...completedCommon,
-                        });
+              currentPage: parsed.data.requests
+                .map((request) => {
+                  const chain = getChain(request.network_id);
+                  // Fortuna keeps serving history for chains that have since
+                  // been retired, so a row can reference a deployment that is
+                  // no longer listed here. Drop those instead of failing the
+                  // whole page.
+                  if (chain === undefined) {
+                    return undefined;
                   }
-                  case "pending": {
-                    return Request.Pending(common);
+                  const common = {
+                    chain,
+                    gasLimit: request.gas_limit,
+                    provider: request.provider,
+                    requestTimestamp: request.created_at,
+                    requestTxHash: request.request_tx_hash,
+                    sender: request.sender,
+                    sequenceNumber: request.sequence,
+                    userContribution: request.user_random_number,
+                  };
+                  switch (request.state.state) {
+                    case "completed": {
+                      const completedCommon = {
+                        ...common,
+                        callbackTimestamp: request.last_updated_at,
+                        callbackTxHash: request.state.reveal_tx_hash,
+                        gasUsed: request.state.gas_used,
+                        providerContribution:
+                          request.state.provider_random_number,
+                        randomNumber: request.state.combined_random_number,
+                      };
+                      return request.state.callback_failed
+                        ? Request.CallbackErrored({
+                            ...completedCommon,
+                            reason: request.state.callback_return_value,
+                          })
+                        : Request.Complete({
+                            ...completedCommon,
+                          });
+                    }
+                    case "pending": {
+                      return Request.Pending(common);
+                    }
+                    case "failed": {
+                      return Request.Failed({
+                        ...common,
+                        providerContribution:
+                          request.state.provider_random_number,
+                        reason: request.state.reason.replace(/^Reverted: /, ""),
+                      });
+                    }
                   }
-                  case "failed": {
-                    return Request.Failed({
-                      ...common,
-                      providerContribution:
-                        request.state.provider_random_number,
-                      reason: request.state.reason.replace(/^Reverted: /, ""),
-                    });
-                  }
-                }
-              }),
+                })
+                .filter((request) => request !== undefined),
               numPages: Math.ceil(parsed.data.total_results / pageSize),
             })
           : Result.ErrorResult(parsed.error);
@@ -298,16 +308,10 @@ const toFortunaStatus = (status: string) => {
   }
 };
 
-const getChain = (networkId: number) => {
-  const chain = Object.values(EntropyDeployments).find(
+const getChain = (networkId: number) =>
+  Object.values(EntropyDeployments).find(
     (deployment) => deployment.chainId === networkId,
   );
-  if (chain) {
-    return chain;
-  } else {
-    throw new Error(`Invalid chain id: ${networkId.toString()}`);
-  }
-};
 
 const getFortunaUrl = (chainSlug: ChainSlug) => {
   switch (chainSlug) {

--- a/contract_manager/src/store/contracts/EvmEntropyContracts.json
+++ b/contract_manager/src/store/contracts/EvmEntropyContracts.json
@@ -35,16 +35,6 @@
     "type": "EvmEntropyContract"
   },
   {
-    "address": "0x4374e5a8b9C22271E9EB878A2AA31DE97DF15DAF",
-    "chain": "zetachain_testnet",
-    "type": "EvmEntropyContract"
-  },
-  {
-    "address": "0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320",
-    "chain": "zetachain",
-    "type": "EvmEntropyContract"
-  },
-  {
     "address": "0x6E7D74FA7d5c90FEF9F0512987605a6d546181Bb",
     "chain": "base",
     "type": "EvmEntropyContract"


### PR DESCRIPTION
Entropy support ended on **ZetaChain** on August 15, 2026 ([deprecation notice](https://dev-forum.pyth.network/t/deprecation-notice-pyth-entropy-deprecation-for-selected-chains-august-15-2026/816)).

- `contract_manager`: remove the `zetachain` (`0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320`) and `zetachain_testnet` (`0x4374e5a8b9C22271E9EB878A2AA31DE97DF15DAF`) `EvmEntropyContract` entries.
- `apps/entropy-explorer`: remove the `zetachain-mainnet` (7000) and `zetachain-testnet` (7001) entries from `EntropyDeployments`.
- `apps/developer-hub`: remove `"zetachain"` / `"zetachain-testnet"` from the `HIDDEN_CHAINS` filter. That filter hides chains the Fortuna API still advertises; once the keeper drops ZetaChain the API stops returning it and the entries are dead weight.

### `getChain` no longer throws on an unlisted chain

Deleting the two `EntropyDeployments` entries is not safe on its own. `getRequests` maps every row Fortuna returns through `getChain(request.network_id)`, which threw `Invalid chain id` for any id missing from `EntropyDeployments`. Fortuna only validates `network_id` against its configured chains when the caller *supplies* one (`apps/fortuna/src/api/explorer.rs`), and the explorer's `all-mainnet` / `all-testnet` views deliberately send no `network_id` — so the unfiltered history query keeps returning rows for retired chains forever. The throw is caught and converted to `Result.ErrorResult`, which replaces the entire request list with an error page.

This is not hypothetical: mainnet Fortuna still serves ZetaChain history today.

```console
$ curl -s 'https://fortuna.dourolabs.app/v1/logs?min_timestamp=2023-10-01T00:00:00.000Z&max_timestamp=2033-10-01T00:00:00.000Z&limit=3&network_id=7000'
{"requests":[{"chain_id":"zetachain","network_id":7000,"provider":"0x52deaa1c...","sequence":54120,
  "created_at":"2025-11-11T18:01:07.307Z","request_tx_hash":"0xabe5981a59e774ad2f9f1ec307db614d0c8e9036c7c6f561595756ace07bc05c", ...
  "total_results":54108}
```

So `getChain` now returns `undefined` for an unknown network id and the mapping skips those rows instead of failing the page. Requests on retired chains simply stop appearing, which is the intent of the removal.

Every other `EntropyDeployments` consumer (`search-controls.tsx`, `results.tsx`, `getChainName`, `getChainNetworkId`) is keyed by slug rather than by network id and cannot observe an id that is no longer listed.

### Known limitation: pagination still counts the skipped rows

`numPages` derives from Fortuna's `total_results`, and Fortuna applies `limit`/`offset` before the client filter runs — so on the aggregate views a page can render slightly short. Measured today, ZetaChain is 54,108 of 4,887,237 mainnet rows (~1.1%) and its traffic stopped around November 2025, so a wholly-empty page is very unlikely; an empty page degrades to the `NoResults` state rather than an error either way. Fixing it properly needs `/v1/logs` to accept a *set* of network ids (or to exclude unconfigured chains by default), which is a Fortuna API change and is tracked separately. This is strictly better than the current hard error.

### Deliberately not touched

- `EvmChains.json`, `EvmPriceFeedContracts.json`, `EvmWormholeContracts.json`, `EvmExecutorContracts.json`, `xc_admin_common/chains.ts`, and `price-feeds/core/current-fees.mdx` all reference ZetaChain for **Pyth Core price feeds**, which are unaffected by the Entropy deprecation.
- `contract_manager/scripts/generate_entropy_set_fee_config_q1_2026.sample.json` is a dated sample input, left as historical record.
- The 2026-08-04 changelog entry announcing the deprecation is left as published history.
- The `HIDDEN_CHAINS` set itself still hides the six other deprecated chains, so the constant and its filter stay until the last of them is removed.

### Merge ordering

`HIDDEN_CHAINS` is the only thing keeping ZetaChain out of the public Entropy chainlist while the keeper still serves it. **Merge this after the `pyth-network/deployments` PRs that drop ZetaChain from the fortuna configs have rolled out**, otherwise ZetaChain reappears in the docs chainlist as a supported chain in the interim.

### Validation

- `pnpm turbo run test:types test:lint test:format test --filter=@pythnetwork/entropy-explorer --filter=@pythnetwork/developer-hub --filter=@pythnetwork/contract-manager` — 50/50 tasks pass, including the developer-hub Next.js build.
- `biome check` on the four changed files reports the same 2 pre-existing `sort-keys` errors as on `origin/main`; no new findings.
- Live Fortuna API queried directly to confirm the retired-chain history problem is real and to measure its size (see above).
- `git merge-tree origin/main HEAD` — no conflicts.

### PR set (ZetaChain only)

Merge in this order:

1. pyth-network/deployments#5639 — drop `zetachain-testnet` from the green + yellow fortuna-staging keepers
2. pyth-network/deployments#5640 — drop `zetachain` from `platform-green/fortuna`
3. pyth-network/deployments#5641 — drop `zetachain` from `platform-yellow/fortuna`
4. pyth-network/deployments#5642 — drop the ZetaChain upstreams from eRPC
5. this PR — drop ZetaChain from the Entropy contract store, the Entropy Explorer chain list, and the docs chainlist hide-filter

The other chains in the same deprecation notice ship as independent PR sets.