### PR TITLE
chore(entropy): flag deprecated Entropy deployments and hide them from the chainlist

### DIFF
--- a/apps/developer-hub/content/changelog/2026-08-18-entropy-removed-from-seven-chains.mdx
+++ b/apps/developer-hub/content/changelog/2026-08-18-entropy-removed-from-seven-chains.mdx
@@ -1,0 +1,38 @@
+---
+title: Entropy removed from seven deprecated chains
+date: 2026-08-18
+product: entropy
+type: breaking-change
+area: network
+---
+
+Following the **August 15, 2026** deprecation date, Pyth Entropy no longer runs
+on seven of the chains named in the deprecation notice. The default provider has
+stopped serving requests on these networks, and they no longer appear in the
+Entropy chainlist.
+
+| Chain     | Networks removed    |
+| --------- | ------------------- |
+| ZetaChain | Mainnet and testnet |
+| Unichain  | Mainnet and testnet |
+| Taiko     | Mainnet             |
+| Tabi      | Testnet             |
+| Story     | Mainnet and testnet |
+| Blast     | Mainnet and testnet |
+| Sei EVM   | Mainnet and testnet |
+
+Entropy is deprecated on all seven chains. Taiko only ever ran an Entropy keeper
+on mainnet and Tabi only on testnet, so those are the only networks with anything
+to remove.
+
+**Why it matters:** requests to the default provider on these networks are no
+longer fulfilled. Entropy on every other supported network is unaffected, as are
+Pyth price feeds on all of the chains above — including Sei, where price feeds
+remain fully supported.
+
+**What to do:** if your application still calls Entropy on one of these chains,
+migrate to a [supported network](/entropy/chainlist). Past requests on these
+networks stay browsable in the Entropy Explorer.
+
+- [Deprecation notice: Pyth Entropy deprecation for selected chains (August 15, 2026)](https://dev-forum.pyth.network/t/deprecation-notice-pyth-entropy-deprecation-for-selected-chains-august-15-2026/816)
+- [Entropy chainlist](/entropy/chainlist)

--- a/apps/developer-hub/content/docs/entropy/debug-callback-failures.mdx
+++ b/apps/developer-hub/content/docs/entropy/debug-callback-failures.mdx
@@ -36,8 +36,8 @@ The chain ID and contract address can be retrieved from [Chainlist and Fee Detai
 Export these values as environment variables for later use:
 
 ```bash copy
-export CHAIN_ID=blast
-export ENTROPY_ADDRESS=0x5744Cbf430D99456a0A8771208b674F27f8EF0Fb
+export CHAIN_ID=base
+export ENTROPY_ADDRESS=0x6E7D74FA7d5c90FEF9F0512987605a6d546181Bb
 
 ```
 

--- a/apps/developer-hub/src/components/EntropyTable/entropy-api-data-fetcher.test.ts
+++ b/apps/developer-hub/src/components/EntropyTable/entropy-api-data-fetcher.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment node
+ */
+import { fetchEntropyDeployments } from "./entropy-api-data-fetcher";
+
+const apiChain = (name: string, network_id: number) => ({
+  contract_addr: "0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320",
+  default_fee: 1,
+  gas_limit: 500_000,
+  name,
+  network_id,
+  reveal_delay_blocks: 1,
+});
+
+const mockApi = (chains: ReturnType<typeof apiChain>[]) => {
+  globalThis.fetch = jest.fn().mockResolvedValue({
+    json: () => Promise.resolve(chains),
+  }) as unknown as typeof fetch;
+};
+
+describe("fetchEntropyDeployments", () => {
+  it("keeps chains without a deprecated deployment", async () => {
+    mockApi([apiChain("base", 8453), apiChain("kaia", 8217)]);
+
+    expect(
+      Object.keys(await fetchEntropyDeployments("https://example.com")),
+    ).toEqual(["base", "kaia"]);
+  });
+
+  it("drops deprecated deployments matched by network id", async () => {
+    mockApi([apiChain("base", 8453), apiChain("sei-evm", 1329)]);
+
+    expect(
+      Object.keys(await fetchEntropyDeployments("https://example.com")),
+    ).toEqual(["base"]);
+  });
+
+  it("drops deprecated deployments the API reports without a network id", async () => {
+    mockApi([
+      apiChain("base", 8453),
+      apiChain("taiko", 0),
+      apiChain("etherlink-testnet", 0),
+    ]);
+
+    expect(
+      Object.keys(await fetchEntropyDeployments("https://example.com")),
+    ).toEqual(["base"]);
+  });
+});

--- a/apps/developer-hub/src/components/EntropyTable/entropy-api-data-fetcher.tsx
+++ b/apps/developer-hub/src/components/EntropyTable/entropy-api-data-fetcher.tsx
@@ -1,16 +1,22 @@
+import {
+  evmChains,
+  evmEntropyContracts,
+} from "@pythnetwork/contract-manager/utils/utils";
 import * as chains from "viem/chains";
 import { z } from "zod";
 
 import { EntropyDeploymentsConfig } from "./entropy-deployments-config";
 
 const ApiChainConfigSchema = z.object({
+  contract_addr: z.string(),
+  default_fee: z.number(),
+  gas_limit: z.number(),
   name: z.string(),
   network_id: z.number(),
-  contract_addr: z.string(),
   reveal_delay_blocks: z.number(),
-  gas_limit: z.number(),
-  default_fee: z.number(),
 });
+
+type ApiChainConfig = z.infer<typeof ApiChainConfigSchema>;
 
 export type EntropyDeployment = {
   address: string;
@@ -26,7 +32,7 @@ function getChainData(network_id: number) {
   return Object.values(chains).find((chain) => chain.id === network_id);
 }
 
-const apiChainConfigToEntrySchema = ApiChainConfigSchema.transform((chain) => {
+const apiChainConfigToEntry = (chain: ApiChainConfig) => {
   const viemChainData = getChainData(chain.network_id);
 
   const configOverride = EntropyDeploymentsConfig[chain.network_id];
@@ -39,46 +45,53 @@ const apiChainConfigToEntrySchema = ApiChainConfigSchema.transform((chain) => {
 
   const deployment: EntropyDeployment = {
     address: chain.contract_addr,
+    default_fee: chain.default_fee,
     delay: `${String(chain.reveal_delay_blocks)} block${
       chain.reveal_delay_blocks === 1 ? "" : "s"
     }`,
     gasLimit: String(chain.gas_limit),
-    default_fee: chain.default_fee,
     ...(rpc ? { rpc } : {}),
     ...(explorer ? { explorer } : {}),
     ...(nativeCurrency ? { nativeCurrency } : {}),
   };
 
   return [chain.name, deployment] as const;
-});
+};
 
-const entropyDeploymentsSchema = z.array(apiChainConfigToEntrySchema);
+const entropyDeploymentsSchema = z.array(ApiChainConfigSchema);
 
-// Entropy support ends August 15, 2026 for the chains below; see
-// https://dev-forum.pyth.network/t/deprecation-notice-pyth-entropy-deprecation-for-selected-chains-august-15-2026/816
-const HIDDEN_CHAINS = new Set([
-  "blast",
-  "blast-testnet",
-  "etherlink",
-  "etherlink-testnet",
-  "sei-evm",
-  "sei-evm-testnet",
-  "story",
-  "story-testnet",
-  "tabi-testnet",
-  "taiko",
-  "unichain",
-  "unichain-sepolia",
-  "zetachain",
-  "zetachain-testnet",
-]);
+// Deployments flagged as deprecated in contract_manager stay in the store for ops
+// tooling but are not advertised in the chainlist. Fortuna reports network_id 0 for
+// the chains whose RPC it cannot reach, so match on the chain name as well: Fortuna
+// spells it with dashes and without the `_mainnet` suffix (`sei_evm_mainnet` becomes
+// `sei-evm`).
+const deprecatedDeployments = evmEntropyContracts.filter(
+  (contract) => contract.deprecated,
+);
+const DEPRECATED_NETWORK_IDS = new Set(
+  deprecatedDeployments.flatMap((contract) => {
+    const chain = evmChains.find(({ id }) => id === contract.chain);
+    return chain ? [chain.networkId] : [];
+  }),
+);
+const DEPRECATED_CHAIN_NAMES = new Set(
+  deprecatedDeployments.map((contract) =>
+    contract.chain.replace(/_mainnet$/, "").replaceAll("_", "-"),
+  ),
+);
+
+const isDeprecated = (chain: ApiChainConfig) =>
+  DEPRECATED_NETWORK_IDS.has(chain.network_id) ||
+  DEPRECATED_CHAIN_NAMES.has(chain.name);
 
 export async function fetchEntropyDeployments(
   url: string,
 ): Promise<Record<string, EntropyDeployment>> {
   const response = await fetch(url);
-  const entries = entropyDeploymentsSchema.parse(await response.json());
+  const apiChains = entropyDeploymentsSchema.parse(await response.json());
   return Object.fromEntries(
-    entries.filter(([name]) => !HIDDEN_CHAINS.has(name)),
+    apiChains
+      .filter((chain) => !isDeprecated(chain))
+      .map((chain) => apiChainConfigToEntry(chain)),
   );
 }

--- a/apps/entropy-tester/config.sample.json
+++ b/apps/entropy-tester/config.sample.json
@@ -8,8 +8,8 @@
     "interval": "6h"
   },
   {
-    "chain-id": "blast",
+    "chain-id": "base",
     "interval": "10m",
-    "rpc-endpoint": "https://rpc.blast.io"
+    "rpc-endpoint": "https://mainnet.base.org"
   }
 ]

--- a/contract_manager/src/core/contracts/evm.ts
+++ b/contract_manager/src/core/contracts/evm.ts
@@ -1,3 +1,5 @@
+/** biome-ignore-all lint/suspicious/noConsole: utils used through CLI */
+/** biome-ignore-all lint/suspicious/useAwait: legacy code */
 /* eslint-disable tsdoc/syntax */
 /* eslint-disable @typescript-eslint/await-thenable */
 /* eslint-disable no-console */
@@ -197,6 +199,7 @@ export class EvmEntropyContract extends Storable {
   constructor(
     public chain: EvmChain,
     public address: string,
+    public deprecated = false,
   ) {
     super();
   }
@@ -220,13 +223,13 @@ export class EvmEntropyContract extends Storable {
 
   static fromJson(
     chain: Chain,
-    parsed: { type: string; address: string },
+    parsed: { type: string; address: string; deprecated?: boolean },
   ): EvmEntropyContract {
     if (parsed.type !== EvmEntropyContract.type)
       throw new Error("Invalid type");
     if (!(chain instanceof EvmChain))
       throw new Error(`Wrong chain type ${chain}`);
-    return new EvmEntropyContract(chain, parsed.address);
+    return new EvmEntropyContract(chain, parsed.address, parsed.deprecated);
   }
 
   // Generates a payload for the newAdmin to call acceptAdmin on the entropy contracts
@@ -296,6 +299,7 @@ export class EvmEntropyContract extends Storable {
     return {
       address: this.address,
       chain: this.chain.getId(),
+      ...(this.deprecated ? { deprecated: true } : {}),
       type: EvmEntropyContract.type,
     };
   }
@@ -1056,7 +1060,10 @@ export class EvmLazerContract extends Storable {
       const pubkeySlot = await web3.eth.getStorageAt(this.address, 2 * i);
       const pubkey = BigInt(pubkeySlot);
       if (pubkey === 0n) continue;
-      const expiresAtSlot = await web3.eth.getStorageAt(this.address, 2 * i + 1);
+      const expiresAtSlot = await web3.eth.getStorageAt(
+        this.address,
+        2 * i + 1,
+      );
       signers.push({
         address: web3.utils.toChecksumAddress(
           "0x" + pubkey.toString(16).padStart(40, "0"),

--- a/contract_manager/src/store/contracts/EvmEntropyContracts.json
+++ b/contract_manager/src/store/contracts/EvmEntropyContracts.json
@@ -7,6 +7,7 @@
   {
     "address": "0x98046Bd286715D3B0BC227Dd7a956b83D8978603",
     "chain": "blast_s2_testnet",
+    "deprecated": true,
     "type": "EvmEntropyContract"
   },
   {
@@ -32,16 +33,19 @@
   {
     "address": "0x5744Cbf430D99456a0A8771208b674F27f8EF0Fb",
     "chain": "blast",
+    "deprecated": true,
     "type": "EvmEntropyContract"
   },
   {
     "address": "0x4374e5a8b9C22271E9EB878A2AA31DE97DF15DAF",
     "chain": "zetachain_testnet",
+    "deprecated": true,
     "type": "EvmEntropyContract"
   },
   {
     "address": "0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320",
     "chain": "zetachain",
+    "deprecated": true,
     "type": "EvmEntropyContract"
   },
   {
@@ -52,21 +56,25 @@
   {
     "address": "0x98046Bd286715D3B0BC227Dd7a956b83D8978603",
     "chain": "sei_evm_mainnet",
+    "deprecated": true,
     "type": "EvmEntropyContract"
   },
   {
     "address": "0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509",
     "chain": "etherlink_testnet",
+    "deprecated": true,
     "type": "EvmEntropyContract"
   },
   {
     "address": "0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509",
     "chain": "etherlink",
+    "deprecated": true,
     "type": "EvmEntropyContract"
   },
   {
     "address": "0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320",
     "chain": "sei_evm_testnet",
+    "deprecated": true,
     "type": "EvmEntropyContract"
   },
   {
@@ -122,6 +130,7 @@
   {
     "address": "0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320",
     "chain": "unichain",
+    "deprecated": true,
     "type": "EvmEntropyContract"
   },
   {
@@ -137,6 +146,7 @@
   {
     "address": "0x8D254a21b3C86D32F7179855531CE99164721933",
     "chain": "unichain_sepolia",
+    "deprecated": true,
     "type": "EvmEntropyContract"
   },
   {
@@ -147,6 +157,7 @@
   {
     "address": "0xEbe57e8045F2F230872523bbff7374986E45C486",
     "chain": "tabi_testnet",
+    "deprecated": true,
     "type": "EvmEntropyContract"
   },
   {
@@ -162,11 +173,13 @@
   {
     "address": "0xdF21D137Aadc95588205586636710ca2890538d5",
     "chain": "story",
+    "deprecated": true,
     "type": "EvmEntropyContract"
   },
   {
     "address": "0x5744Cbf430D99456a0A8771208b674F27f8EF0Fb",
     "chain": "story_testnet",
+    "deprecated": true,
     "type": "EvmEntropyContract"
   },
   {
@@ -202,6 +215,12 @@
   {
     "address": "0x825c0390f379C631f3Cf11A82a37D20BddF93c07",
     "chain": "monad_testnet",
+    "type": "EvmEntropyContract"
+  },
+  {
+    "address": "0x26DD80569a8B23768A1d80869Ed7339e07595E85",
+    "chain": "taiko_mainnet",
+    "deprecated": true,
     "type": "EvmEntropyContract"
   }
 ]

--- a/contract_manager/src/utils/utils.ts
+++ b/contract_manager/src/utils/utils.ts
@@ -3,6 +3,9 @@ import * as chains from "viem/chains";
 import evmChainsData from "../store/chains/EvmChains.json" with {
   type: "json",
 };
+import evmEntropyContractsData from "../store/contracts/EvmEntropyContracts.json" with {
+  type: "json",
+};
 import evmLazerContractsData from "../store/contracts/EvmLazerContracts.json" with {
   type: "json",
 };
@@ -23,13 +26,23 @@ export type EvmLazerContractEntry = (typeof evmLazerContractsData)[number];
 export type EvmPriceFeedContractEntry =
   (typeof evmPriceFeedContractsData)[number];
 
+export type EvmEntropyContractEntry = {
+  address: string;
+  chain: string;
+  deprecated?: boolean;
+  type: string;
+};
+
 export const evmChains: readonly EvmChainEntry[] = evmChainsData;
+export const evmEntropyContracts: readonly EvmEntropyContractEntry[] =
+  evmEntropyContractsData;
 export const evmLazerContracts: readonly EvmLazerContractEntry[] =
   evmLazerContractsData;
 export const evmPriceFeedContracts: readonly EvmPriceFeedContractEntry[] =
   evmPriceFeedContractsData;
 
-export type SolanaLazerContractEntry = (typeof solanaLazerContractsData)[number];
+export type SolanaLazerContractEntry =
+  (typeof solanaLazerContractsData)[number];
 
 export const solanaLazerContracts: readonly SolanaLazerContractEntry[] =
   solanaLazerContractsData;


### PR DESCRIPTION
Entropy support for seven chains ended on **August 15, 2026**
([deprecation notice](https://dev-forum.pyth.network/t/deprecation-notice-pyth-entropy-deprecation-for-selected-chains-august-15-2026/816)).
The keepers stop serving them in `pyth-network/deployments`; this is the pyth-crosschain side.

Review feedback on the first revision of this PR was to **keep** the deployments in
`contract_manager` and mark them deprecated rather than delete them, and to drive the docs
chainlist off that flag. That is what this does — no deployment record is removed.

## What changed

- **`contract_manager/src/store/contracts/EvmEntropyContracts.json`** — every deployment
  covered by the notice now carries `"deprecated": true`: the 11 records for the seven chains
  (ZetaChain, Unichain, Taiko, Tabi, Story, Blast, Sei EVM — mainnet and/or testnet each), plus
  Etherlink mainnet and testnet, which the notice also covers and which the chainlist has
  hidden since August 1. Keeping the records means `transfer_balance_entropy_chains.ts`,
  `fetch_accrued_entropy_dao_fees.ts`, and `entropy-accept-admin-and-ownership.ts` still reach
  these chains, so any remaining provider balance or accrued DAO fee can still be swept.
- **`taiko_mainnet` is added** as a new record, also flagged. Taiko is one of the seven chains
  but its Entropy deployment was never registered here, so there was nothing to flag and the
  chainlist would have had to keep hiding it by name. The address
  `0x26DD80569a8B23768A1d80869Ed7339e07595E85` comes from the live keeper config and was
  verified on-chain (see below).
- **`EvmEntropyContract`** round-trips `deprecated` through `fromJson` / `toJson`, so
  `Store.saveAllContracts()` does not silently erase the flags the next time a deploy script
  saves the store. Verified by loading the store and diffing `toJson()` against the file.
- **`contract_manager/src/utils/utils.ts`** exports `evmEntropyContracts`, next to the
  existing `evmChains` / `evmLazerContracts` / `evmPriceFeedContracts` exports the docs
  already consume.
- **`apps/developer-hub/src/components/EntropyTable/entropy-api-data-fetcher.tsx`** — the
  hardcoded `HIDDEN_CHAINS` list is gone; the chainlist now hides whatever `contract_manager`
  flags as deprecated. Fortuna names chains itself and reports `network_id: 0` for chains whose
  RPC it cannot reach (`taiko`, `tabi-testnet` and `etherlink-testnet` today), so a deployment
  is matched on either the network id or the chain id spelled Fortuna-style (`sei_evm_mainnet`
  → `sei-evm`). Three unit tests cover the live, matched-by-id, and matched-by-name cases.
- **Docs and samples** — `debug-callback-failures.mdx` and `apps/entropy-tester/config.sample.json`
  used Blast as their worked example; both now use Base. A changelog entry announces the
  removal.
- **`apps/entropy-explorer/src/entropy-deployments.tsx` is deliberately untouched.**
  `GET /v1/logs` keeps returning history for these chains (~1M rows for Blast alone) and the
  Explorer throws `Invalid chain id` for any row it cannot map to a deployment, which fails the
  whole page. This matches the B3 and Sanko sunsets, which also kept their Explorer entries.

## Verification

- **Chainlist output is unchanged.** Replaying both live Fortuna configs
  (`fortuna.dourolabs.app` and `fortuna-staging.dourolabs.app`) through the new filter hides
  exactly the 14 names the deleted `HIDDEN_CHAINS` set hid — `blast`, `blast-testnet`,
  `etherlink`, `etherlink-testnet`, `sei-evm`, `sei-evm-testnet`, `story`, `story-testnet`,
  `tabi-testnet`, `taiko`, `unichain`, `unichain-sepolia`, `zetachain`, `zetachain-testnet` —
  and keeps all 23 other chains.
- **Taiko address checked on-chain** against `https://rpc.mainnet.taiko.xyz` (chain id
  `0x28c58` = 167000): the address has code, `version()` returns `0.4.0`, and
  `getDefaultProvider()` returns `0x52DeaA1c84233F7bb8C8A45baeDE41091c616506`, the same default
  provider as the Base mainnet deployment.
- **Store round-trip**: 42 Entropy contracts load, 14 report `deprecated`, and re-serializing
  them reproduces `EvmEntropyContracts.json` exactly.
- `pnpm turbo test:types` (includes the developer-hub production build), `pnpm run test:unit`
  in `apps/developer-hub` (6 suites / 69 tests), `biome ci --changed`, and
  `pre-commit run --from-ref origin/main --to-ref HEAD` all pass.

Sei price feeds are untouched: this is Entropy-only. Sei keeps its entries in `EvmChains.json`,
`EvmWormholeContracts.json`, `EvmExecutorContracts.json`, and `EvmLazerContracts.json`.