### PR TITLE
fix(entropy): stop hiding Etherlink from the Entropy chainlist

### DIFF
--- a/apps/developer-hub/src/components/EntropyTable/entropy-api-data-fetcher.test.ts
+++ b/apps/developer-hub/src/components/EntropyTable/entropy-api-data-fetcher.test.ts
@@ -35,12 +35,16 @@ describe("fetchEntropyDeployments", () => {
     ).toEqual(["base"]);
   });
 
+  it("keeps etherlink, which reports no network id but is not deprecated", async () => {
+    mockApi([apiChain("base", 8453), apiChain("etherlink-testnet", 0)]);
+
+    expect(
+      Object.keys(await fetchEntropyDeployments("https://example.com")),
+    ).toEqual(["base", "etherlink-testnet"]);
+  });
+
   it("drops deprecated deployments the API reports without a network id", async () => {
-    mockApi([
-      apiChain("base", 8453),
-      apiChain("taiko", 0),
-      apiChain("etherlink-testnet", 0),
-    ]);
+    mockApi([apiChain("base", 8453), apiChain("taiko", 0)]);
 
     expect(
       Object.keys(await fetchEntropyDeployments("https://example.com")),

--- a/contract_manager/src/store/contracts/EvmEntropyContracts.json
+++ b/contract_manager/src/store/contracts/EvmEntropyContracts.json
@@ -62,13 +62,11 @@
   {
     "address": "0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509",
     "chain": "etherlink_testnet",
-    "deprecated": true,
     "type": "EvmEntropyContract"
   },
   {
     "address": "0x23f0e8FAeE7bbb405E7A7C3d60138FCfd43d7509",
     "chain": "etherlink",
-    "deprecated": true,
     "type": "EvmEntropyContract"
   },
   {


### PR DESCRIPTION
## Summary

Removes `"deprecated": true` from the `etherlink` and `etherlink_testnet` Entropy deployments, so Etherlink is advertised in the chainlist again. Adds a regression test.

#3997 flagged **14** deployments; only **12** belong to the seven chains in the deprecation notice. This restores the count to 12.

## Rationale

Etherlink was never part of the [deprecation notice](https://dev-forum.pyth.network/t/deprecation-notice-pyth-entropy-deprecation-for-selected-chains-august-15-2026/816) — that PR's own changelog entry lists exactly ZetaChain, Unichain, Taiko, Tabi, Story, Blast and Sei EVM, and does not mention Etherlink.

Etherlink is live. Both production keepers are configured for chain `42793` (contract `0x23f0e8…`) in `pyth-network/deployments`, and the green keeper logged ~1,400 etherlink lines over a 30-minute sample.

The likely cause is documented in the code itself: `entropy-api-data-fetcher.tsx` matches deprecated chains by name as well as network id, because "Fortuna reports network_id 0 for the chains whose RPC it cannot reach". `etherlink-testnet` reports `network_id` 0 today because its sole eRPC upstream returns HTTP 403 — so it resembled the genuinely deprecated chains and was swept in, taking `etherlink` mainnet with it. An unreachable chain is not a deprecated one; the 403 is a separate operational issue.

## How has this been tested?

- [x] Current tests cover my changes
- [x] Added new tests
- [x] Manually tested the code

- Added `keeps etherlink, which reports no network id but is not deprecated`, which fails without this change.
- Adjusted the existing `drops deprecated deployments the API reports without a network id` case to use `taiko` alone, since it previously relied on `etherlink-testnet` being deprecated. It still exercises the name-matching path.
- `apps/developer-hub` unit tests: **6 suites / 70 tests passing** against a locally rebuilt `contract_manager`, which emits 12 deprecated deployments with neither etherlink entry flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/4000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->