### PR TITLE
fix(entropy): correct the August 4 chainlist deprecation changelog

### DIFF
--- a/apps/developer-hub/content/changelog/2026-08-04-entropy-chainlist-drops-deprecated-networks.mdx
+++ b/apps/developer-hub/content/changelog/2026-08-04-entropy-chainlist-drops-deprecated-networks.mdx
@@ -1,5 +1,5 @@
 ---
-title: Entropy chainlist no longer advertises eight chains scheduled for August 15 deprecation
+title: Entropy chainlist no longer advertises seven chains scheduled for August 15 deprecation
 date: 2026-08-04
 product: entropy
 type: deprecation
@@ -7,29 +7,36 @@ area: network
 ---
 
 Entropy continues to run on every currently supported network. Separately, on
-**August 15, 2026**, Entropy is being deprecated on eight specific chains, and
+**August 15, 2026**, Entropy is being deprecated on seven specific chains, and
 the Entropy chainlist no longer advertises those chains so new integrators do
 not pick them up.
 
 Chains scheduled for deprecation on **August 15, 2026**:
 
-| Chain      | Networks              |
-| ---------- | --------------------- |
-| ZetaChain  | Mainnet and testnet   |
-| Unichain   | Mainnet and testnet   |
-| Taiko      | Mainnet and testnet   |
-| Tabi       | Mainnet and testnet   |
-| Story      | Mainnet and testnet   |
-| Blast      | Mainnet and testnet   |
-| Etherlink  | Mainnet and testnet   |
-| Sei EVM    | Mainnet and testnet   |
+| Chain     | Networks            |
+| --------- | ------------------- |
+| ZetaChain | Mainnet and testnet |
+| Unichain  | Mainnet and testnet |
+| Taiko     | Mainnet             |
+| Tabi      | Testnet             |
+| Story     | Mainnet and testnet |
+| Blast     | Mainnet and testnet |
+| Sei EVM   | Mainnet and testnet |
+
+Taiko only ever ran an Entropy keeper on mainnet and Tabi only on testnet, so
+those are the only networks affected for those two chains.
+
+**Etherlink is not affected.** An earlier revision of this entry listed Etherlink
+among the deprecated chains and the chainlist briefly stopped advertising it.
+That was a mistake: Entropy is still fully supported on Etherlink mainnet and
+testnet, and no migration is required.
 
 **Why it matters:** this is a per-chain deprecation, not a change to the
 Entropy product. Apps running Entropy on any of the other supported chains
-keep working exactly as before. Only apps deployed on one of the eight chains
+keep working exactly as before. Only apps deployed on one of the seven chains
 listed above need to take action ahead of the August 15 date.
 
-**What to do:** if your application uses Entropy on any of the eight chains
+**What to do:** if your application uses Entropy on any of the seven chains
 above, plan a migration off that chain before **August 15, 2026**.
 Applications on any other Entropy-supported network do not need to do
 anything.


### PR DESCRIPTION
## Summary

Corrects `2026-08-04-entropy-chainlist-drops-deprecated-networks.mdx`, which announced **eight** chains scheduled for the August 15 Entropy deprecation and listed **Etherlink** among them.

- eight → seven, in the title and both body references
- drops the Etherlink row
- Taiko `Mainnet and testnet` → `Mainnet`; Tabi → `Testnet`
- adds an explicit "Etherlink is not affected" note

## Rationale

Raised by review on #4000. Etherlink was never part of the [deprecation notice](https://dev-forum.pyth.network/t/deprecation-notice-pyth-entropy-deprecation-for-selected-chains-august-15-2026/816) that this entry links, which names seven chains: ZetaChain, Unichain, Taiko, Tabi, Story, Blast and Sei EVM. Entropy is still served on Etherlink — both production keepers are configured for chain `42793` and are actively fulfilling requests.

This is the public-facing half of the same mistake #4000 fixes in `contract_manager`. Left uncorrected, the entry tells Etherlink integrators to plan a migration off a chain that is fully supported, so it keeps the explicit note rather than silently dropping the row — anyone who already read the earlier revision needs to see that it was withdrawn.

The Taiko/Tabi network scope was also wrong, and already stated correctly in the August 18 entry (`2026-08-18-entropy-removed-from-seven-chains.mdx`): "Taiko only ever ran an Entropy keeper on mainnet and Tabi only on testnet."

Independent of #3999 and #4000 — different file, any merge order.

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [x] Manually tested the code

- `apps/developer-hub` unit tests: 6 suites / 69 tests passing, including the changelog feed suite.
- `tsc --noEmit` reports an identical error count with and without this change (13 either way — all pre-existing in this sandbox from unbuilt Next types and ungenerated changelog data), confirming a content-only edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/4001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->