### PR TITLE
docs(agents): point agents at shared package barrels before writing TS app or UI code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,19 @@ Read [`standards/AGENTS.md`](standards/AGENTS.md) before writing code — it is 
 primary entry point for how we write code here. It indexes the cross-cutting style,
 testing, services, and review standards, plus the Rust and TypeScript clusters.
 
+## TypeScript apps and UI
+
+Before writing a utility or a component in a TypeScript app or web UI
+(`apps/insights`, `apps/developer-hub`, `apps/entropy-explorer`,
+`governance/xc_admin/packages/xc_admin_frontend`, …), check what
+[`packages/shared-lib`](packages/shared-lib) and
+[`packages/component-library`](packages/component-library) already export, and
+prefer reusing those over reimplementing them. Neither package has a root
+barrel: the `exports` map in each `package.json` is the authoritative list of
+importable subpaths, and each subpath resolves to a barrel under `src/` — e.g.
+[`shared-lib/src/util/index.ts`](packages/shared-lib/src/util/index.ts) and
+[`component-library/src/Button/index.tsx`](packages/component-library/src/Button/index.tsx).
+
 ## Tooling
 
 - Tool versions are pinned in [`.tool-versions`](.tool-versions) (Node, pnpm, Rust,


### PR DESCRIPTION
Adds a short "TypeScript apps and UI" section to the root `AGENTS.md` telling agents to check what the shared packages already export before writing a utility or component.

Agent runs on the web apps have repeatedly re-implemented utilities and components that already ship from `packages/shared-lib` and `packages/component-library`. The note makes that check a documented expectation.

The trigger is scoped to TypeScript app / UI work rather than to the `apps/` directory: roughly half of `apps/` is Rust services (argus, fortuna, hermes, quorum, the recorders, …) for which the shared packages are irrelevant, while `governance/xc_admin/packages/xc_admin_frontend` is a real frontend that lives outside `apps/`.

Neither package has a root barrel — both are built with `ts-duality` and expose subpath exports — so the note points at the `exports` map in each `package.json` as the authoritative list of importable subpaths, with one example barrel from each package rather than an exhaustive list.

`CLAUDE.md` is a two-line pointer to `AGENTS.md`, so no mirrored edit was needed there.