### PR TITLE
build(docker): pin Rust image builds to the committed Cargo.lock

### DIFF
--- a/apps/argus/Dockerfile
+++ b/apps/argus/Dockerfile
@@ -1,18 +1,27 @@
-ARG RUST_VERSION=1.82.0
+ARG RUST_VERSION=1.89.0
 
 FROM rust:${RUST_VERSION} AS build
 
 # Build
 WORKDIR /src
+# `cargo build --locked` refuses to rewrite Cargo.lock, and cargo prunes entries
+# for absent workspace members, so every member listed in the root Cargo.toml has
+# to be in the context even though only one is built.
+COPY Cargo.toml Cargo.lock ./
+COPY apps/argus apps/argus
 COPY apps/fortuna apps/fortuna
-COPY pythnet pythnet
+COPY apps/hermes/client/rust apps/hermes/client/rust
+COPY apps/pyth-lazer-pusher apps/pyth-lazer-pusher
+COPY apps/quorum apps/quorum
+COPY lazer/contracts/cardano/cli/rust lazer/contracts/cardano/cli/rust
+COPY pythnet/pythnet_sdk pythnet/pythnet_sdk
+COPY target_chains/starknet/tools/test_vaas target_chains/starknet/tools/test_vaas
 COPY target_chains/ethereum/entropy_sdk/solidity/abis target_chains/ethereum/entropy_sdk/solidity/abis
 
-WORKDIR /src/apps/fortuna
-
-RUN --mount=type=cache,target=/root/.cargo/registry cargo build --release
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    cargo build --locked --release -p argus
 
 
 FROM rust:${RUST_VERSION}
 # Copy artifacts from other images
-COPY --from=build /src/apps/fortuna/target/release/fortuna /usr/local/bin/
+COPY --from=build /src/target/release/argus /usr/local/bin/

--- a/apps/binance-recorder/Dockerfile
+++ b/apps/binance-recorder/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
 WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
-RUN cargo build --release
+RUN cargo build --locked --release
 
 FROM debian:bookworm-slim
 

--- a/apps/fortuna/Dockerfile
+++ b/apps/fortuna/Dockerfile
@@ -4,14 +4,22 @@ FROM rust:${RUST_VERSION} AS build
 
 # Build
 WORKDIR /src
+# `cargo build --locked` refuses to rewrite Cargo.lock, and cargo prunes entries
+# for absent workspace members, so every member listed in the root Cargo.toml has
+# to be in the context even though only one is built.
+COPY Cargo.toml Cargo.lock ./
+COPY apps/argus apps/argus
 COPY apps/fortuna apps/fortuna
-COPY pythnet pythnet
-COPY Cargo.lock .
+COPY apps/hermes/client/rust apps/hermes/client/rust
+COPY apps/pyth-lazer-pusher apps/pyth-lazer-pusher
+COPY apps/quorum apps/quorum
+COPY lazer/contracts/cardano/cli/rust lazer/contracts/cardano/cli/rust
+COPY pythnet/pythnet_sdk pythnet/pythnet_sdk
+COPY target_chains/starknet/tools/test_vaas target_chains/starknet/tools/test_vaas
 COPY target_chains/ethereum/entropy_sdk/solidity/abis target_chains/ethereum/entropy_sdk/solidity/abis
 
 RUN --mount=type=cache,target=/root/.cargo/registry \
-    printf "[workspace]\nresolver = \"2\"\nmembers = [\"apps/fortuna\",\"pythnet/pythnet_sdk\"]" > Cargo.toml && \
-    cargo build --release -p fortuna
+    cargo build --locked --release -p fortuna
 
 
 FROM rust:${RUST_VERSION}

--- a/apps/hermes/server/Dockerfile
+++ b/apps/hermes/server/Dockerfile
@@ -12,7 +12,7 @@ COPY pythnet/pythnet_sdk pythnet/pythnet_sdk
 
 WORKDIR /src/apps/hermes/server
 
-RUN --mount=type=cache,target=/root/.cargo/registry cargo build --release
+RUN --mount=type=cache,target=/root/.cargo/registry cargo build --locked --release
 
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*

--- a/apps/okx-recorder/Dockerfile
+++ b/apps/okx-recorder/Dockerfile
@@ -5,7 +5,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 # Every TLS-touching dependency is pinned to rustls, so no OpenSSL headers are
 # needed at build time (unlike binance-recorder, whose SDK pulls native-tls).
-RUN cargo build --release
+RUN cargo build --locked --release
 
 FROM debian:bookworm-slim
 

--- a/apps/ondo-recorder/Dockerfile
+++ b/apps/ondo-recorder/Dockerfile
@@ -3,7 +3,7 @@ FROM rust:1.86-slim AS builder
 WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
-RUN cargo build --release
+RUN cargo build --locked --release
 
 FROM debian:bookworm-slim
 

--- a/apps/pyth-lazer-pusher/bulk-trade-pusher/Dockerfile
+++ b/apps/pyth-lazer-pusher/bulk-trade-pusher/Dockerfile
@@ -6,12 +6,21 @@ ARG RUST_VERSION=1.88.0
 FROM rust:${RUST_VERSION} AS build
 
 WORKDIR /src
+# `cargo build --locked` refuses to rewrite Cargo.lock, and cargo prunes entries
+# for absent workspace members, so every member listed in the root Cargo.toml has
+# to be in the context even though only one is built.
+COPY Cargo.toml Cargo.lock ./
+COPY apps/argus apps/argus
+COPY apps/fortuna apps/fortuna
+COPY apps/hermes/client/rust apps/hermes/client/rust
 COPY apps/pyth-lazer-pusher apps/pyth-lazer-pusher
-COPY Cargo.lock .
+COPY apps/quorum apps/quorum
+COPY lazer/contracts/cardano/cli/rust lazer/contracts/cardano/cli/rust
+COPY pythnet/pythnet_sdk pythnet/pythnet_sdk
+COPY target_chains/starknet/tools/test_vaas target_chains/starknet/tools/test_vaas
 
 RUN --mount=type=cache,target=/root/.cargo/registry \
-    printf '[workspace]\nresolver = "2"\nmembers = ["apps/pyth-lazer-pusher/pusher-utils","apps/pyth-lazer-pusher/pusher-base","apps/pyth-lazer-pusher/websocket-delivery","apps/pyth-lazer-pusher/bulk-trade-pusher"]\n\n[workspace.lints.rust]\nunsafe_code = "deny"\n\n[workspace.lints.clippy]\nexpect_used = "warn"\nunwrap_used = "warn"\n' > Cargo.toml && \
-    cargo build --release -p bulk-pusher
+    cargo build --locked --release -p bulk-pusher
 
 
 # Runtime

--- a/apps/pyth-lazer-pusher/mock/bulk-trade-mock-validator/Dockerfile
+++ b/apps/pyth-lazer-pusher/mock/bulk-trade-mock-validator/Dockerfile
@@ -1,8 +1,8 @@
 # Bulk Trade Mock Validator - Production Build
-# Build from repo root: docker build -f mock/bulk-trade-mock-validator/Dockerfile .
+# Build from repo root: docker build -f apps/pyth-lazer-pusher/mock/bulk-trade-mock-validator/Dockerfile .
 
 FROM rust:1.91.1 AS chef
-RUN cargo install cargo-chef@0.1.73
+RUN cargo install cargo-chef@0.1.73 --locked
 WORKDIR /src
 
 FROM chef AS planner

--- a/apps/pyth-lazer-pusher/tilt/bulk/Dockerfile.dev
+++ b/apps/pyth-lazer-pusher/tilt/bulk/Dockerfile.dev
@@ -1,27 +1,29 @@
 # Development Dockerfile - builds ALL binaries for local dev with Tilt
 # For production, use per-crate Dockerfiles (e.g., bulk-trade-pusher/Dockerfile)
 #
-# Build context should be apps/pyth-lazer-pusher/
+# Build context should be the repo root
 
 FROM rust:1.88 AS builder
 
 WORKDIR /src
 
-# Copy source
-COPY pusher-utils pusher-utils
-COPY pusher-base pusher-base
-COPY websocket-delivery websocket-delivery
-COPY bulk-trade-pusher bulk-trade-pusher
-COPY mock mock
-COPY bulk-trade-cli bulk-trade-cli
-
-# Create workspace Cargo.toml on the fly (no Cargo.lock in context)
-RUN printf '[workspace]\nresolver = "2"\nmembers = ["pusher-utils", "pusher-base", "websocket-delivery", "bulk-trade-pusher", "bulk-trade-cli", "mock/bulk-trade-mock-validator"]\n\n[workspace.lints.rust]\nunsafe_code = "deny"\n\n[workspace.lints.clippy]\nunwrap_used = "warn"\nexpect_used = "warn"\npanic = "warn"\nindexing_slicing = "warn"\n' > Cargo.toml
+# `cargo build --locked` refuses to rewrite Cargo.lock, and cargo prunes entries
+# for absent workspace members, so every member listed in the root Cargo.toml has
+# to be in the context even though only the lazer pusher crates are built.
+COPY Cargo.toml Cargo.lock ./
+COPY apps/argus apps/argus
+COPY apps/fortuna apps/fortuna
+COPY apps/hermes/client/rust apps/hermes/client/rust
+COPY apps/pyth-lazer-pusher apps/pyth-lazer-pusher
+COPY apps/quorum apps/quorum
+COPY lazer/contracts/cardano/cli/rust lazer/contracts/cardano/cli/rust
+COPY pythnet/pythnet_sdk pythnet/pythnet_sdk
+COPY target_chains/starknet/tools/test_vaas target_chains/starknet/tools/test_vaas
 
 # Build all binaries
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/src/target \
-    cargo build && \
+    cargo build --locked -p bulk-pusher -p bulk-trade-mock-validator -p bulk-trade-cli && \
     cp target/debug/bulk-pusher /bulk-pusher && \
     cp target/debug/bulk-trade-mock-validator /bulk-trade-mock-validator && \
     cp target/debug/bulk-trade-cli /bulk-trade-cli

--- a/apps/pyth-lazer-pusher/tilt/bulk/Tiltfile
+++ b/apps/pyth-lazer-pusher/tilt/bulk/Tiltfile
@@ -35,18 +35,23 @@ print('Topology: %d pushers, %d validators' % (NUM_PUSHERS, NUM_VALIDATORS))
 # Create namespace
 namespace_create('lazer-pusher-dev')
 
-# Build the container image (context is apps/pyth-lazer-pusher/)
+# Build the container image (context is the repo root, so the build sees the
+# workspace Cargo.lock and can build with --locked)
 docker_build(
     REGISTRY + '/pyth-lazer-pusher',
-    '../..',
+    '../../../..',
     dockerfile='Dockerfile.dev',
     only=[
-        'pusher-utils',
-        'pusher-base',
-        'websocket-delivery',
-        'bulk-trade-pusher',
-        'mock',
-        'bulk-trade-cli',
+        'Cargo.toml',
+        'Cargo.lock',
+        'apps/argus',
+        'apps/fortuna',
+        'apps/hermes/client/rust',
+        'apps/pyth-lazer-pusher',
+        'apps/quorum',
+        'lazer/contracts/cardano/cli/rust',
+        'pythnet/pythnet_sdk',
+        'target_chains/starknet/tools/test_vaas',
     ],
 )
 

--- a/apps/quorum/Dockerfile
+++ b/apps/quorum/Dockerfile
@@ -6,13 +6,23 @@ RUN apt-get update && apt-get install --yes \
 
 # Build
 WORKDIR /src
-COPY ./apps/quorum apps/quorum
+# `cargo build --locked` refuses to rewrite Cargo.lock, and cargo prunes entries
+# for absent workspace members, so every member listed in the root Cargo.toml has
+# to be in the context even though only one is built.
+COPY Cargo.toml Cargo.lock ./
+COPY apps/argus apps/argus
+COPY apps/fortuna apps/fortuna
+COPY apps/hermes/client/rust apps/hermes/client/rust
+COPY apps/pyth-lazer-pusher apps/pyth-lazer-pusher
+COPY apps/quorum apps/quorum
+COPY lazer/contracts/cardano/cli/rust lazer/contracts/cardano/cli/rust
+COPY pythnet/pythnet_sdk pythnet/pythnet_sdk
+COPY target_chains/starknet/tools/test_vaas target_chains/starknet/tools/test_vaas
 
-WORKDIR /src/apps/quorum
-
-RUN --mount=type=cache,target=/root/.cargo/registry cargo build --release
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    cargo build --locked --release -p quorum
 
 # Copy artifacts from other images
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
-COPY --from=build /src/apps/quorum/target/release/quorum /usr/local/bin/
+COPY --from=build /src/target/release/quorum /usr/local/bin/


### PR DESCRIPTION
Every Rust `Dockerfile` in the repo now builds with `--locked`, so an image build resolves to the dependency graph committed in `Cargo.lock` instead of re-resolving against crates.io at build time. Today a build kicked off during a crates.io compromise window would happily pull the malicious version even though the committed lockfile pins a safe one.

## Images that had no lockfile at all

`apps/argus`, `apps/quorum` and `apps/pyth-lazer-pusher/tilt/bulk/Dockerfile.dev` had **no `Cargo.lock` in the build context**. `argus` and `quorum` built from inside the crate directory (implicit single-crate workspace); the Tilt image synthesized a throwaway workspace manifest. All three re-resolved the entire graph on every build.

`--locked` cannot simply be bolted onto that shape. Cargo garbage-collects lock entries for workspace members that are absent from the context, and that counts as a lockfile rewrite, so `--locked` hard-fails:

```
error: cannot update the lock file /src/Cargo.lock because --locked was passed to prevent this
```

(Reproduced against the existing `apps/fortuna` context: the root lock has 1189 packages, the pruned one 906 — removals only, no version changes.)

The fix is to put the real root `Cargo.toml` + `Cargo.lock` in the context along with every workspace member, and build with `-p <crate>` from `/src`. Only the named crate is compiled; the other members are present purely so cargo does not prune the lock. That is ~1.5 MB of extra source. This is now the shape used by `argus`, `fortuna`, `quorum`, `bulk-trade-pusher` and `Dockerfile.dev`, so there is one lockfile of record.

`fortuna` and `bulk-trade-pusher` already copied the root lock but synthesized a *reduced* workspace manifest, which hits the same pruning problem; they move to the same shape and drop the inline `printf` manifests.

## `apps/argus/Dockerfile` was stale

It was a verbatim copy of fortuna's Dockerfile from the port in #2464: it copied `apps/fortuna`, built it, and shipped the **`fortuna`** binary — the `argus` crate never entered the context. It also pinned Rust 1.82.0, which no longer builds the workspace. It now builds and ships `argus` at the repo's pinned toolchain (1.89.0).

Nothing consumes this image today — there is no `docker-argus.yml` workflow and no reference to it in `pyth-network/deployments` — so switching the shipped binary carries no rollout risk.

## Tilt dev image

`Dockerfile.dev`'s build context moves from `apps/pyth-lazer-pusher/` to the repo root so it can see the workspace lockfile; the Tiltfile's `docker_build` context and `only` list move with it. A bare `cargo build` there would now build the whole monorepo workspace, so it is scoped to the three binaries the image actually extracts (`bulk-pusher`, `bulk-trade-mock-validator`, `bulk-trade-cli`).

## Everything else

`--locked` added to the remaining `cargo build` invocations (`hermes/server`, `binance-recorder`, `okx-recorder`, `ondo-recorder`) and to `cargo install cargo-chef@0.1.73` in the mock-validator image, which re-resolved cargo-chef's own graph on every build. `hyperliquid-recorder` was already correct and is untouched. The mock validator's build-command comment was pointing at a path that only works from `apps/pyth-lazer-pusher/`, where there is no manifest — corrected to the repo-root path the `COPY . .` actually requires.

`grep -rn 'cargo \(build\|install\)' --include='Dockerfile*' .` now shows `--locked` on every hit.

## Verification

Docker is not available in this environment, so each build context was reconstructed on disk file-for-file (tracked files under each `COPY` source, with the root `.dockerignore` patterns applied) and `cargo check --locked --release -p <crate>` run inside it. This exercises the two things a Dockerfile change can break — a missing source file and a lockfile that `--locked` rejects. Full detail, including commands and the lock-pruning reproduction, is in the verification comment on the issue.

All of `argus`, `fortuna`, `quorum`, `bulk-pusher`, `hermes`, the three lazer dev binaries and the three recorders resolve and compile against the committed lockfiles with no lockfile change. `cargo fmt --check` and `cargo clippy --all-targets -- --deny warnings` are clean for `quorum` and `fortuna` (the two crates whose pre-commit hooks this diff's paths trigger).

The `docker-fortuna`, `docker-quorum`, `docker-hermes`, `docker-bulk-trade-pusher` and the three recorder workflows all filter on paths this diff touches, so they run on this PR and will do the real end-to-end build.

## Follow-up worth noting

The `docker-*.yml` path filters key only on `apps/<name>/**`. Now that these images genuinely depend on the root `Cargo.lock`, a lockfile-only change will not re-run them. Adding `Cargo.lock` to those filters belongs with the CI-workflow pinning work rather than here.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/4004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->