### PR TITLE
ci(docker): derive docker-*.yml path filters from Dockerfile COPY lines

### DIFF
--- a/.github/workflows/ci-docker-workflow-paths.yml
+++ b/.github/workflows/ci-docker-workflow-paths.yml
@@ -1,0 +1,24 @@
+name: Check Docker Workflow Paths
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/**
+      - "**/Dockerfile"
+      - "**/Dockerfile.*"
+      - scripts/check-docker-workflow-paths.py
+  push:
+    branches: [main]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .tool-versions
+      - name: Install PyYAML
+        run: pip install pyyaml
+      - name: Check that docker-*.yml paths filters cover their build inputs
+        run: python3 scripts/check-docker-workflow-paths.py

--- a/.github/workflows/docker-bulk-trade-pusher.yml
+++ b/.github/workflows/docker-bulk-trade-pusher.yml
@@ -5,7 +5,20 @@ on:
       - bulk-trade-pusher-v*
   pull_request:
     paths:
+      # This image builds the root Cargo workspace with `cargo build --locked`, so the
+      # filter has to cover every path its Dockerfile COPYs — not just its own crate.
+      # `scripts/check-docker-workflow-paths.py` derives this list from those COPY lines.
+      - ".github/workflows/docker-bulk-trade-pusher.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "apps/argus/**"
+      - "apps/fortuna/**"
+      - "apps/hermes/client/rust/**"
       - "apps/pyth-lazer-pusher/**"
+      - "apps/quorum/**"
+      - "lazer/contracts/cardano/cli/rust/**"
+      - "pythnet/pythnet_sdk/**"
+      - "target_chains/starknet/tools/test_vaas/**"
   workflow_dispatch:
     inputs:
       dispatch_description:

--- a/.github/workflows/docker-fortuna.yml
+++ b/.github/workflows/docker-fortuna.yml
@@ -5,7 +5,21 @@ on:
       - fortuna-v*
   pull_request:
     paths:
+      # This image builds the root Cargo workspace with `cargo build --locked`, so the
+      # filter has to cover every path its Dockerfile COPYs — not just its own crate.
+      # `scripts/check-docker-workflow-paths.py` derives this list from those COPY lines.
+      - ".github/workflows/docker-fortuna.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "apps/argus/**"
       - "apps/fortuna/**"
+      - "apps/hermes/client/rust/**"
+      - "apps/pyth-lazer-pusher/**"
+      - "apps/quorum/**"
+      - "lazer/contracts/cardano/cli/rust/**"
+      - "pythnet/pythnet_sdk/**"
+      - "target_chains/ethereum/entropy_sdk/solidity/abis/**"
+      - "target_chains/starknet/tools/test_vaas/**"
   workflow_dispatch:
     inputs:
       dispatch_description:

--- a/.github/workflows/docker-hermes.yml
+++ b/.github/workflows/docker-hermes.yml
@@ -5,7 +5,9 @@ on:
       - hermes-v*
   pull_request:
     paths:
+      - ".github/workflows/docker-hermes.yml"
       - "apps/hermes/server/**"
+      - "pythnet/pythnet_sdk/**"
   workflow_dispatch:
     inputs:
       dispatch_description:

--- a/.github/workflows/docker-hip-3-pusher.yml
+++ b/.github/workflows/docker-hip-3-pusher.yml
@@ -5,6 +5,7 @@ on:
       - hip-3-pusher-v*
   pull_request:
     paths:
+      - ".github/workflows/docker-hip-3-pusher.yml"
       - "apps/hip-3-pusher/**"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/docker-quorum.yml
+++ b/.github/workflows/docker-quorum.yml
@@ -5,7 +5,20 @@ on:
       - quorum-v*
   pull_request:
     paths:
+      # This image builds the root Cargo workspace with `cargo build --locked`, so the
+      # filter has to cover every path its Dockerfile COPYs — not just its own crate.
+      # `scripts/check-docker-workflow-paths.py` derives this list from those COPY lines.
+      - ".github/workflows/docker-quorum.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "apps/argus/**"
+      - "apps/fortuna/**"
+      - "apps/hermes/client/rust/**"
+      - "apps/pyth-lazer-pusher/**"
       - "apps/quorum/**"
+      - "lazer/contracts/cardano/cli/rust/**"
+      - "pythnet/pythnet_sdk/**"
+      - "target_chains/starknet/tools/test_vaas/**"
   workflow_dispatch:
     inputs:
       dispatch_description:

--- a/apps/pyth-lazer-pusher/mock/bulk-trade-mock-validator/Dockerfile
+++ b/apps/pyth-lazer-pusher/mock/bulk-trade-mock-validator/Dockerfile
@@ -21,7 +21,7 @@ COPY --from=planner /src/recipe.json recipe.json
 RUN --mount=type=cache,target=/src/target/ \
     --mount=type=cache,target=/usr/local/cargo/git/ \
     --mount=type=cache,target=/usr/local/cargo/registry/ \
-    cargo chef cook --release --recipe-path recipe.json -p bulk-trade-mock-validator
+    cargo chef cook --release --locked --recipe-path recipe.json -p bulk-trade-mock-validator
 
 # Copy source and build
 COPY . .

--- a/scripts/check-docker-workflow-paths.py
+++ b/scripts/check-docker-workflow-paths.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Check that every `docker-*.yml` `paths:` filter covers what its image builds from.
+
+Several images build from the repo root and `COPY` sibling Cargo workspace members
+plus the root `Cargo.lock`, so a filter scoped to a single app directory silently
+skips rebuilds when a sibling member or the lockfile changes. Since those builds run
+`cargo build --locked`, the resulting breakage surfaces on an unrelated PR instead of
+the one that caused it. Deriving the expected filter from the Dockerfile's own `COPY`
+sources keeps the two from drifting apart.
+
+Run from the repository root: `python3 scripts/check-docker-workflow-paths.py`
+"""
+
+from __future__ import annotations
+
+import posixpath
+import re
+import shlex
+import sys
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_DIR = Path(".github/workflows")
+BUILD_PUSH_ACTION = "docker/build-push-action"
+
+
+def parse_triggers(workflow: dict) -> dict:
+    # PyYAML resolves the bare `on:` key to the boolean True (YAML 1.1).
+    return workflow.get("on", workflow.get(True, {}))
+
+
+def iter_steps(workflow: dict):
+    for job in (workflow.get("jobs") or {}).values():
+        yield from job.get("steps") or []
+
+
+def find_builds(workflow: dict) -> list[tuple[str, str]]:
+    """Return (context, dockerfile) pairs the workflow builds, repo-root relative."""
+    builds = []
+    for step in iter_steps(workflow):
+        uses = step.get("uses") or ""
+        if uses.split("@")[0] == BUILD_PUSH_ACTION:
+            with_ = step.get("with") or {}
+            if with_.get("file"):
+                builds.append((str(with_.get("context", ".")), str(with_["file"])))
+            continue
+        run = step.get("run")
+        if not run:
+            continue
+        for command in re.split(r"\bdocker build\b", run.replace("\\\n", " "))[1:]:
+            command = command.split("\n")[0]
+            dockerfile = re.search(r"-f\s+(\S+)", command)
+            args = [a for a in command.split() if not a.startswith("-")]
+            if dockerfile and args:
+                builds.append((args[-1], dockerfile.group(1)))
+    return builds
+
+
+def copy_sources(dockerfile: Path) -> list[str]:
+    """Return the `COPY` source arguments of a Dockerfile, ignoring stage copies."""
+    text = dockerfile.read_text().replace("\\\n", " ")
+    sources = []
+    for line in text.splitlines():
+        instruction, _, rest = line.strip().partition(" ")
+        if instruction.upper() != "COPY":
+            continue
+        args = shlex.split(rest)
+        if any(a.startswith("--from=") for a in args):
+            continue
+        args = [a for a in args if not a.startswith("--")]
+        sources.extend(args[:-1])
+    return sources
+
+
+def required_paths(context: str, dockerfile: Path) -> list[str] | None:
+    """Repo-relative paths the build consumes, or None if it consumes the whole context."""
+    base = posixpath.normpath(context)
+    paths = []
+    for source in copy_sources(dockerfile):
+        resolved = posixpath.normpath(posixpath.join(base, source))
+        if resolved in (".", ".."):
+            return None
+        paths.append(resolved)
+    return paths
+
+
+def is_covered(path: str, patterns: list[str]) -> bool:
+    for pattern in patterns:
+        if pattern == path:
+            return True
+        if pattern.endswith("/**"):
+            prefix = pattern[:-3]
+            if path == prefix or path.startswith(prefix + "/"):
+                return True
+    return False
+
+
+def suggest(path: str) -> str:
+    return f"{path}/**" if Path(path).is_dir() else path
+
+
+def check(workflow_file: Path) -> list[str]:
+    workflow = yaml.safe_load(workflow_file.read_text())
+    pull_request = parse_triggers(workflow).get("pull_request")
+    if not isinstance(pull_request, dict) or "paths" not in pull_request:
+        return []
+
+    patterns = pull_request["paths"]
+    self_path = workflow_file.as_posix()
+    required = {self_path}
+    for context, dockerfile in find_builds(workflow):
+        paths = required_paths(context, Path(dockerfile))
+        if paths is None:
+            # The build context is the whole repo, so no filter can be derived from it.
+            return []
+        required.update(paths)
+
+    missing = sorted(p for p in required if not is_covered(p, patterns))
+    return [suggest(p) for p in missing]
+
+
+def main() -> int:
+    failures = {}
+    for workflow_file in sorted(WORKFLOW_DIR.glob("docker-*.yml")):
+        missing = check(workflow_file)
+        if missing:
+            failures[workflow_file] = missing
+
+    for workflow_file, missing in failures.items():
+        print(f"{workflow_file}: `paths:` is missing entries the build depends on:")
+        for entry in missing:
+            print(f'      - "{entry}"')
+
+    if failures:
+        print(
+            "\nAdd the entries above to each workflow's `on.pull_request.paths`, or "
+            "update the Dockerfile's COPY lines if the dependency is no longer real."
+        )
+        return 1
+
+    print("All docker-*.yml paths filters cover their build inputs.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

`9fd777376` switched the `fortuna`, `quorum` and `bulk-trade-pusher` images to build the **real root Cargo workspace**: they now `COPY Cargo.toml Cargo.lock ./` plus every workspace member and run `cargo build --locked -p <crate>` from `/src`. Their `paths:` filters were left matching a single app directory.

So a `cargo update`, a dependency bump, or an edit to a sibling workspace member lands on `main` without rebuilding any of these images. Because the builds are now `--locked`, a lockfile desync fails hard — and that failure shows up on the next unrelated PR touching `apps/fortuna/**`, or at release time, instead of on the PR that caused it. The `--locked` hardening was right; nothing was enforcing it.

## What changed

**Path filters now cover the whole build context.** `docker-fortuna.yml`, `docker-quorum.yml` and `docker-bulk-trade-pusher.yml` list `Cargo.toml`, `Cargo.lock` and every workspace member their Dockerfile `COPY`s. `docker-hermes.yml` gains `pythnet/pythnet_sdk/**`. All of them (plus `docker-hip-3-pusher.yml`) also list their own workflow file, so workflow edits self-test — matching what the recorder workflows already did.

**A checker so they can't drift again.** `scripts/check-docker-workflow-paths.py` reads each `docker-*.yml`, resolves the Dockerfile and build context it uses, parses that Dockerfile's `COPY` sources, and fails if any resolved path is not covered by the `paths:` filter. It prints the missing entries ready to paste. `ci-docker-workflow-paths.yml` runs it on any change to a workflow or a Dockerfile. Workflows whose Dockerfile copies the entire context (`COPY ./ .` in `Dockerfile.node`) are skipped — no filter is derivable from a whole-repo context.

**`cargo chef cook --locked`.** `apps/pyth-lazer-pusher/mock/bulk-trade-mock-validator/Dockerfile` was the last cargo invocation in any Dockerfile without `--locked`. It is also the step that compiles the dependency graph, which is where a malicious `build.rs` would run — the final artifact was already pinned by the `cargo build --locked` on line 31, so this closes the build-time-code-execution gap rather than an artifact-integrity one.

`git grep -nE 'cargo (build|install|chef cook)' -- '*Dockerfile*' | grep -v -- --locked` is now empty.

## Verifying `cargo chef cook --locked`

cargo-chef reconstructs a skeleton workspace from `recipe.json`, so whether `--locked` is satisfiable there had to be checked rather than assumed. With cargo-chef 0.1.73 (the pinned version):

- `cargo chef cook --help` lists `--locked` ("Require Cargo.lock is up to date").
- Running `cargo chef prepare` on this tree, then `cargo chef cook --release --locked --recipe-path recipe.json -p bulk-trade-mock-validator` in a directory containing only `recipe.json`, resolves cleanly — the lockfile cargo-chef restores from the recipe satisfies `--locked`.
- Negative control: bumping `prometheus` from `0.13` to `0.14` in the hydrated skeleton makes resolution fail with `error: the lock file ... needs to be updated but --locked was passed to prevent this`. So the flag is doing real work, not silently passing.

## Notes and decisions

### `docker-hermes.yml` does not consume the root lockfile

`apps/hermes/server` is in the root `Cargo.toml`'s `exclude` list (pinned Solana version) and carries its own `Cargo.lock`. Its Dockerfile copies only `apps/hermes/server` and `pythnet/pythnet_sdk` and builds from `/src/apps/hermes/server`. Adding root `Cargo.toml`/`Cargo.lock` to its filter would be noise that the checker would (correctly) not ask for, so its filter gained only `pythnet/pythnet_sdk/**` and its own workflow file. A root-lockfile-only change does not, and should not, rebuild hermes.

### Rebuild noise

Over the last 180 days, commits touching the union of everything now filtered on for the three root-workspace images: **20 of 665**, against **13 of 665** under the old three filters. Worst case a single commit triggers 4 image builds (`pythnet/pythnet_sdk`, which really is an input to all four). PR builds do not push (`push: ${{ github.event_name != 'pull_request' }}`), so the cost is runner time. That is small enough that a shared "rust images" matrix workflow is not worth the indirection; the checker keeps the per-workflow lists honest. Worth knowing: the `--mount=type=cache` registry caches do not persist between GitHub runners, so each of these is a cold build.

### `apps/argus/Dockerfile` still has no workflow

Nothing in CI builds it, and `9fd777376` changed which binary it ships (`fortuna` at Rust 1.82 → `argus` at 1.89). It is an untested, unpublished Dockerfile. Whether to wire up a `docker-argus.yml` or delete it is a product call, not a CI one, so it is filed separately rather than decided here. Note that the checker already covers `apps/argus/**` as an input to the other three images, so a lockfile desync caused by argus will now be caught even while argus itself is unbuilt.