### PR TITLE
docs(developer-hub): mark XAUM/USD.RR Pro-compatible on Sui push feeds

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json
@@ -270,7 +270,7 @@
       "time_difference": 10,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "XAGM/USD.RR",


### PR DESCRIPTION
Flips the Sui mainnet sponsored push feed `XAUM/USD.RR` (Matrixdock Gold) from
`coming_soon` to `available` in the Pro-compatible column, mirroring how
`XAGM/USD.RR` was flipped.

## What changed

`apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json`
— `XAUM/USD.RR` `pro_compatible_status`: `coming_soon` → `available`. This is the
field the `SponsoredFeedsTable` badge on `/price-feeds/core/push-feeds/sui`
renders, and it is the only place in the docs that carries a Pro-compatible
designation for this feed. No changelog entry — not needed for this change.

## Merge ordering — please land the deployments PR first

`pro_compatible_status` is a derived, point-in-time field. Per
`apps/developer-hub/scripts/sync-sui-push-feed-status.ts`, a Sui feed is
`available` only when its Core feed ID appears in **both**:

1. the upgraded pusher config
   (`environments/platform-{yellow,green}/sui-price-pusher-mainnet/price-config-pro-compatible.yaml`
   in `pyth-network/deployments`), and
2. the Pro-compatible Hermes listing
   (`GET https://pyth.dourolabs.app/hermes/v2/price_feeds`).

Condition 2 already holds for XAUM
(`d7db067954e28f51a96fd50c6d51775094025ced2d60af61ec9803e553471c88`, symbol
`Crypto.Index.XAUM/USD`). Condition 1 does **not** yet — XAUM is still a
commented-out block in both pro-compatible pusher configs, and a separate
`pyth-network/deployments` PR uncomments it. Until that lands, running
`pnpm run sync:sui-push-feed-status` reports drift on `XAUM/USD.RR`; with it
applied, the script reports zero drift against this branch. That script is not
wired into CI, so nothing here is gated on the ordering — but the docs claim is
only true once the pusher config change ships.

## Verification

- `pnpm turbo run test:format test:lint test:types build test:unit
  test:lint:stylelint --filter=@pythnetwork/developer-hub` — 47/47 tasks green.
- `pnpm run sync:sui-push-feed-status` run against a local copy of the
  deployments tree with the XAUM block uncommented: zero drift across all 40
  Sui feeds, and no other feed's status changes.