### PR TITLE
docs(developer-hub): document futures chain metadata fields

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/pro/futures-terminology.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/futures-terminology.mdx
@@ -1,10 +1,10 @@
 ---
 title: Futures Terminology
-description: Understanding futures contract ticker symbols and expiration dates on Pyth Pro
+description: Understanding futures feed ticker symbols and expiration dates on Pyth Pro
 slug: /price-feeds/pro/futures-terminology
 ---
 
-Pyth Pro provides price feeds for futures contracts across multiple asset classes including commodities and more. This guide explains how to interpret futures ticker symbols.
+Pyth Pro provides price feeds for futures feeds across multiple asset classes including commodities and more. This guide explains how to interpret futures ticker symbols.
 
 ## Ticker Symbol Format
 
@@ -21,7 +21,7 @@ For example: `WTIJ6` breaks down as:
 
 ## Month Codes
 
-Futures contracts use single-letter codes to represent expiration months:
+Futures feeds use single-letter codes to represent expiration months:
 
 | Code | Month     |
 | ---- | --------- |
@@ -51,7 +51,7 @@ The year is represented by the **last digit** of the year:
 
 ### Crude Oil (WTI)
 
-| Symbol | Contract | Expiration |
+| Symbol | feed | Expiration |
 | ------ | -------- | ---------- |
 | WTIJ6  | WTI April 2026 | Apr 21, 2026 |
 | WTIK6  | WTI May 2026 | May 19, 2026 |
@@ -59,7 +59,7 @@ The year is represented by the **last digit** of the year:
 
 ### Brent Crude Oil
 
-| Symbol  | Contract | Expiration |
+| Symbol  | feed | Expiration |
 | ------- | -------- | ---------- |
 | BRENTK6 | Brent May 2026 | Mar 31, 2026 |
 | BRENTM6 | Brent June 2026 | Apr 30, 2026 |
@@ -67,7 +67,7 @@ The year is represented by the **last digit** of the year:
 
 ### Copper
 
-| Symbol | Contract | Expiration |
+| Symbol | feed | Expiration |
 | ------ | -------- | ---------- |
 | CCH6   | Copper March 2026 | Mar 27, 2026 |
 | CCK6   | Copper May 2026 | May 27, 2026 |
@@ -75,7 +75,7 @@ The year is represented by the **last digit** of the year:
 
 ### Natural Gas
 
-| Symbol | Contract | Expiration |
+| Symbol | feed | Expiration |
 | ------ | -------- | ---------- |
 | NGDJ6  | HH Natural Gas April 2026 | Apr 28, 2026 |
 | NGDK6  | HH Natural Gas May 2026 | May 27, 2026 |
@@ -83,14 +83,14 @@ The year is represented by the **last digit** of the year:
 
 ### LS Gasoil
 
-| Symbol | Contract | Expiration |
+| Symbol | feed | Expiration |
 | ------ | -------- | ---------- |
 | GOJ6   | LS Gasoil April 2026 | Apr 10, 2026 |
 | GOK6   | LS Gasoil May 2026 | May 12, 2026 |
 
 ### Corn
 
-| Symbol | Contract | Expiration |
+| Symbol | feed | Expiration |
 | ------ | -------- | ---------- |
 | COH6   | Corn March 2026 | Mar 13, 2026 |
 | COK6   | Corn May 2026 | May 14, 2026 |
@@ -131,7 +131,7 @@ On Pyth, futures symbols include the asset class prefix. The table below lists a
 
 ## Chain Metadata
 
-Every dated contract belongs to a **chain**: the family of contracts on the same underlying that differ only by expiration. The symbols API exposes three chain-level fields on each contract, with identical values across the whole chain. See [Symbology & Reference Data](/price-feeds/pro/symbology-reference#futures) for the full field definitions.
+Every dated feed belongs to a **chain**: the family of feeds on the same underlying that differ only by expiration. The symbols API exposes three chain-level fields on each feed, with identical values across the whole chain. See [Symbology & Reference Data](/price-feeds/pro/symbology-reference#futures) for the full field definitions.
 
 For the WTI chain (`WTIV6`, `WTIX6`, `WTIZ6`, ...):
 
@@ -171,19 +171,19 @@ For the WTI chain (`WTIV6`, `WTIX6`, `WTIZ6`, ...):
 
 `symbol_chain_id` is the bare symbol root (`WTI`), not a fully-qualified Pyth symbol. `expiration_pattern` is the chain's full annual expiration cycle, written as month abbreviations; `availability_pattern` is the subset Pyth prices, written as the [month codes](#month-codes) above.
 
-Values are per-chain. WTI expires monthly and Pyth prices every month, so both patterns cover all twelve. Copper (`CC`) also expires monthly, but its `availability_pattern` is `["H", "K", "N", "U", "Z"]` — only the March, May, July, September, and December contracts are published.
+Values are per-chain. WTI expires monthly and Pyth prices every month, so both patterns cover all twelve. Copper (`CC`) also expires monthly, but its `availability_pattern` is `["H", "K", "N", "U", "Z"]` — only the March, May, July, September, and December feeds are published.
 
 ## Expiration and Rollover
 
-Futures contracts expire on specific dates. When a contract approaches expiration:
+Futures feeds expire on specific dates. When a feed approaches expiration:
 
-1. **Liquidity shifts** to the next contract month
-2. **Price feeds transition** to the new front-month contract
+1. **Liquidity shifts** to the next feed month
+2. **Price feeds transition** to the new front-month feed
 3. **Rollover dates** vary by commodity — check the [Symbology and Reference Data API](https://pyth.dourolabs.app/v1/symbols) for exact expiration dates, or see [Symbology & Reference Data](/price-feeds/pro/symbology-reference) for the field definitions
 
-Which contract months exist at all is given by the chain's `expiration_pattern`, and which of those Pyth publishes by its `availability_pattern` — see [Chain Metadata](#chain-metadata) above.
+Which feed months exist at all is given by the chain's `expiration_pattern`, and which of those Pyth publishes by its `availability_pattern` — see [Chain Metadata](#chain-metadata) above.
 
-**Expiration Handling:** Ensure your application handles contract rollovers gracefully. Monitor for feed transitions as contracts approach expiration.
+**Expiration Handling:** Ensure your application handles feed rollovers gracefully. Monitor for feed transitions as feeds approach expiration.
 
 ## Additional Resources
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/futures-terminology.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/futures-terminology.mdx
@@ -129,6 +129,50 @@ On Pyth, futures symbols include the asset class prefix. The table below lists a
 | Hang Seng | HKH | `Equity.HK.HKHH6/HKD` |
 | FTSE China A50 Index | FCD | `Equity.US.FCDH6/USD` |
 
+## Chain Metadata
+
+Every dated contract belongs to a **chain**: the family of contracts on the same underlying that differ only by expiration. The symbols API exposes three chain-level fields on each contract, with identical values across the whole chain. See [Symbology & Reference Data](/price-feeds/pro/symbology-reference#futures) for the full field definitions.
+
+For the WTI chain (`WTIV6`, `WTIX6`, `WTIZ6`, ...):
+
+```json
+{
+  "symbol_chain_id": "WTI",
+  "expiration_pattern": [
+    "jan",
+    "feb",
+    "mar",
+    "apr",
+    "may",
+    "jun",
+    "jul",
+    "aug",
+    "sep",
+    "oct",
+    "nov",
+    "dec"
+  ],
+  "availability_pattern": [
+    "F",
+    "G",
+    "H",
+    "J",
+    "K",
+    "M",
+    "N",
+    "Q",
+    "U",
+    "V",
+    "X",
+    "Z"
+  ]
+}
+```
+
+`symbol_chain_id` is the bare symbol root (`WTI`), not a fully-qualified Pyth symbol. `expiration_pattern` is the chain's full annual expiration cycle, written as month abbreviations; `availability_pattern` is the subset Pyth prices, written as the [month codes](#month-codes) above.
+
+Values are per-chain. WTI expires monthly and Pyth prices every month, so both patterns cover all twelve. Copper (`CC`) also expires monthly, but its `availability_pattern` is `["H", "K", "N", "U", "Z"]` — only the March, May, July, September, and December contracts are published.
+
 ## Expiration and Rollover
 
 Futures contracts expire on specific dates. When a contract approaches expiration:
@@ -136,6 +180,8 @@ Futures contracts expire on specific dates. When a contract approaches expiratio
 1. **Liquidity shifts** to the next contract month
 2. **Price feeds transition** to the new front-month contract
 3. **Rollover dates** vary by commodity — check the [Symbology and Reference Data API](https://pyth.dourolabs.app/v1/symbols) for exact expiration dates, or see [Symbology & Reference Data](/price-feeds/pro/symbology-reference) for the field definitions
+
+Which contract months exist at all is given by the chain's `expiration_pattern`, and which of those Pyth publishes by its `availability_pattern` — see [Chain Metadata](#chain-metadata) above.
 
 **Expiration Handling:** Ensure your application handles contract rollovers gracefully. Monitor for feed transitions as contracts approach expiration.
 

--- a/apps/developer-hub/content/docs/price-feeds/pro/symbology-reference.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/symbology-reference.mdx
@@ -166,7 +166,7 @@ Every feed is returned as a single JSON object with the same top-level shape. Th
 }
 ```
 
-Dated-future feeds are point-in-time: after `expiration_time` the contract's `state` becomes `inactive`, and later contracts in the same chain are listed separately. `symbol_chain_id` (`CA`) is what ties them together. Query the API for the current set.
+Dated-future feeds are point-in-time: after `expiration_time` the feed's `state` becomes `inactive`, and later feeds in the same chain are listed separately. `symbol_chain_id` (`CA`) is what ties them together. Query the API for the current set.
 
 </Tab>
 <Tab value="Funding rate">
@@ -295,11 +295,11 @@ Pick an example or paste a `schedule` string to decode it into market hours:
 
 ### Futures
 
-`expiration_time` describes an individual dated contract. The other three fields describe the **chain** that contract belongs to — the family of contracts measuring the same underlying at different expirations — and carry the same values on every contract in the chain.
+`expiration_time` describes an individual dated feed. The other three fields describe the **chain** that feed belongs to — the family of feeds measuring the same underlying at different expirations — and carry the same values on every feed in the chain.
 
 | Field                  | Type        | Description                                                                                     |
 | ---------------------- | ----------- | ----------------------------------------------------------------------------------------------- |
-| `expiration_time`      | `string?`   | Expiration timestamp (RFC 3339) for a dated futures contract, e.g. `2026-12-15T13:30:00-05:00`. |
+| `expiration_time`      | `string?`   | Expiration timestamp (RFC 3339) for a dated futures feed, e.g. `2026-12-15T13:30:00-05:00`. |
 | `symbol_chain_id`      | `string?`   | Root symbol for the chain of all the futures that measure the same underlying with different expiration times, e.g. `CA` for the cocoa chain that `CAZ6` belongs to. Note this is the bare root, not a fully-qualified `symbol`. `null` for feeds that are not part of a futures chain. |
 | `expiration_pattern`   | `string[]?` | The total set of expirations per a single year applicable to the chain, as lowercase three-letter month abbreviations, e.g. `["mar", "may", "jul", "sep", "dec"]`. |
 | `availability_pattern` | `string[]?` | The subset of expirations per single year already priced or expected to be priced by Pyth, as [month codes](/price-feeds/pro/futures-terminology#month-codes), e.g. `["H", "K", "N", "U", "Z"]`. |
@@ -307,7 +307,7 @@ Pick an example or paste a `schedule` string to decode it into market hours:
 <Callout type="warn" title="The two patterns use different encodings">
   `expiration_pattern` lists **month abbreviations** (`mar`), `availability_pattern` lists **month codes** (`H`). Normalize before comparing them. The two often differ in length as well as encoding: copper (`CC`) expires in all twelve months but Pyth prices only `["H", "K", "N", "U", "Z"]`.
 
-  Chains with no fixed annual cycle — such as the LME 3-month contracts (`Metal.AL3M/USD`) — report `["none"]` for both.
+  Chains with no fixed annual cycle — such as the LME 3-month feeds (`Metal.AL3M/USD`) — report `["none"]` for both.
 </Callout>
 
 ### Corporate actions

--- a/apps/developer-hub/content/docs/price-feeds/pro/symbology-reference.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/pro/symbology-reference.mdx
@@ -128,7 +128,7 @@ Every feed is returned as a single JSON object with the same top-level shape. Th
 </Tab>
 <Tab value="Futures">
 
-`CAZ6`, a dated commodity future (cocoa, Dec 2026) with an `expiration_time`:
+`CAZ6`, a dated commodity future (cocoa, Dec 2026) with an `expiration_time` and chain-level metadata (`symbol_chain_id`, `expiration_pattern`, `availability_pattern`):
 
 ```json
 {
@@ -159,11 +159,14 @@ Every feed is returned as a single JSON object with the same top-level shape. Th
   "hermes_id": "7452a0c6aa220280021272c3cebaaa0f32cc910cd14ea43460ff8ae2d1e773ea",
   "nasdaq_symbol": null,
   "quote_currency": "USD",
+  "symbol_chain_id": "CA",
+  "expiration_pattern": ["mar", "may", "jul", "sep", "dec"],
+  "availability_pattern": ["H", "K", "N", "U", "Z"],
   "groups": []
 }
 ```
 
-Dated-future feeds are point-in-time: after `expiration_time` the contract's `state` becomes `inactive`, and later contracts in the same family are listed separately. Query the API for the current set.
+Dated-future feeds are point-in-time: after `expiration_time` the contract's `state` becomes `inactive`, and later contracts in the same chain are listed separately. `symbol_chain_id` (`CA`) is what ties them together. Query the API for the current set.
 
 </Tab>
 <Tab value="Funding rate">
@@ -290,11 +293,27 @@ Pick an example or paste a `schedule` string to decode it into market hours:
   ]}
 />
 
-### Futures & derivatives
+### Futures
+
+`expiration_time` describes an individual dated contract. The other three fields describe the **chain** that contract belongs to — the family of contracts measuring the same underlying at different expirations — and carry the same values on every contract in the chain.
+
+| Field                  | Type        | Description                                                                                     |
+| ---------------------- | ----------- | ----------------------------------------------------------------------------------------------- |
+| `expiration_time`      | `string?`   | Expiration timestamp (RFC 3339) for a dated futures contract, e.g. `2026-12-15T13:30:00-05:00`. |
+| `symbol_chain_id`      | `string?`   | Root symbol for the chain of all the futures that measure the same underlying with different expiration times, e.g. `CA` for the cocoa chain that `CAZ6` belongs to. Note this is the bare root, not a fully-qualified `symbol`. `null` for feeds that are not part of a futures chain. |
+| `expiration_pattern`   | `string[]?` | The total set of expirations per a single year applicable to the chain, as lowercase three-letter month abbreviations, e.g. `["mar", "may", "jul", "sep", "dec"]`. |
+| `availability_pattern` | `string[]?` | The subset of expirations per single year already priced or expected to be priced by Pyth, as [month codes](/price-feeds/pro/futures-terminology#month-codes), e.g. `["H", "K", "N", "U", "Z"]`. |
+
+<Callout type="warn" title="The two patterns use different encodings">
+  `expiration_pattern` lists **month abbreviations** (`mar`), `availability_pattern` lists **month codes** (`H`). Normalize before comparing them. The two often differ in length as well as encoding: copper (`CC`) expires in all twelve months but Pyth prices only `["H", "K", "N", "U", "Z"]`.
+
+  Chains with no fixed annual cycle — such as the LME 3-month contracts (`Metal.AL3M/USD`) — report `["none"]` for both.
+</Callout>
+
+### Corporate actions
 
 | Field               | Type        | Description                                                                                     |
 | ------------------- | ----------- | ----------------------------------------------------------------------------------------------- |
-| `expiration_time`   | `string?`   | Expiration timestamp (RFC 3339) for a dated futures contract, e.g. `2026-12-15T13:30:00-05:00`. |
 | `corporate_actions` | `object[]?` | Corporate actions on an equity feed. Each entry has an `event_type` (e.g. `SPLIT`), an `activation` block with the effective date (e.g. `us_equity_ex_date.ex_date`), and `adjustment_factor_numerator` / `adjustment_factor_denominator`. See the [Equity example](#example-response). |
 
 ## Accessing the data


### PR DESCRIPTION
The `/v1/symbols` response carries three chain-level fields on futures feeds that the docs never mentioned: `symbol_chain_id`, `expiration_pattern`, and `availability_pattern`. This documents them across the two pages that cover futures metadata.

## Symbology & Reference Data

- Split the **Futures & derivatives** field-reference section into **Futures** and **Corporate actions**. `corporate_actions` is an equity concept and was only sharing a table with `expiration_time` for lack of a home.
- Added the three chain fields to the Futures table, alongside a note that they are chain-level — every dated contract in a chain carries identical values, so they describe the family rather than the individual contract.
- Added a callout for the encoding mismatch between the two patterns (see below) and for the `["none"]` case on chains with no fixed annual cycle.
- Updated the `CAZ6` example response to include the three fields.

## Futures Terminology

- New **Chain Metadata** section between "Pyth Symbol Format" and "Expiration and Rollover", with a worked WTI example and a pointer to the symbology page for full field definitions.
- Cross-reference from "Expiration and Rollover", which is where a reader hits the rollover question that these fields answer.

## Field types and values

All types and example values were read off a live `GET /v1/symbols` response (3745 feeds, 182 with a non-null `symbol_chain_id` spanning 29 chains) rather than inferred:

- `symbol_chain_id` — `string?`. The **bare symbol root** (`"WTI"`, `"CA"`, `"EM"`), not a fully-qualified Pyth symbol. The docs call this out explicitly since the natural guess is wrong.
- `expiration_pattern` — `string[]?` of lowercase three-letter month abbreviations, e.g. `["mar", "may", "jul", "sep", "dec"]`.
- `availability_pattern` — `string[]?` of single-letter futures month codes, e.g. `["H", "K", "N", "U", "Z"]`.

The two patterns encode the same concept in **different alphabets**, which is why the callout exists — a reader intersecting them naively gets an empty set. Chains whose contracts have no annual cycle (the LME 3-month metals, `Metal.AL3M/USD`) report `["none"]` for both.

Copper is used as the contrast example because WTI's two patterns happen to cover all twelve months, which hides the subset relationship the fields exist to express.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/4017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->