### PR TITLE
docs(sui): mark XAUM/USD.RR as pro-compatible available

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json
+++ b/apps/developer-hub/content/docs/price-feeds/core/push-feeds/data/sui/sui-mainnet.json
@@ -270,7 +270,7 @@
       "time_difference": 10,
       "price_deviation": 0.5,
       "confidence_ratio": 100,
-      "pro_compatible_status": "coming_soon"
+      "pro_compatible_status": "available"
     },
     {
       "alias": "XAGM/USD.RR",


### PR DESCRIPTION
Updates the Sui mainnet push-feed data to change XAUM/USD.RR's pro_compatible_status from coming_soon to available. The feed is now active in the upgraded Sui pusher on both deployment environments (see companion PRs in pyth-network/deployments). All other fields and records are unchanged.

Companion PRs:
- platform-green deployment: https://github.com/pyth-network/deployments/pull/5724
- platform-yellow deployment: https://github.com/pyth-network/deployments/pull/5725