### PR TITLE
add(developer-hub): Aug 14–21 public changelog entries; fix shims sunset date

### DIFF
--- a/apps/developer-hub/content/changelog/2026-08-12-pyth-core-benchmarks-tradingview-shims-deprecation.mdx
+++ b/apps/developer-hub/content/changelog/2026-08-12-pyth-core-benchmarks-tradingview-shims-deprecation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Pyth Benchmarks TradingView shims sunset on August 18
+title: Pyth Benchmarks TradingView shims sunset on August 26
 date: 2026-08-12
 product: pyth-core
 type: deprecation
@@ -7,9 +7,9 @@ area: apis
 ---
 
 The Pyth Benchmarks `/v1/shims/tradingview/*` endpoints and
-`/v1/price_differences` are being deprecated as part of the August 18, 2026
-Pyth Core upgrade. Charting apps that depend on those endpoints need to migrate
-to Pyth Pro's History API.
+`/v1/price_differences` are being deprecated as part of the August 26, 2026
+(16:00 UTC) Pyth Core upgrade. Charting apps that depend on those endpoints
+need to migrate to Pyth Pro's History API.
 
 **Why it matters:** TradingView chart integrations need a supported historical
 price source before the shim endpoints are sunset. Remaining Benchmarks

--- a/apps/developer-hub/content/changelog/2026-08-17-pyth-core-upgrade-moves-to-august-26.mdx
+++ b/apps/developer-hub/content/changelog/2026-08-17-pyth-core-upgrade-moves-to-august-26.mdx
@@ -1,0 +1,24 @@
+---
+title: Pyth Core upgrade moves to August 26, 2026 at 16:00 UTC
+date: 2026-08-17
+product: pyth-core
+type: deprecation
+area: network
+---
+
+The Pyth Core upgrade cutover is now scheduled for **August 26, 2026 at
+16:00 UTC**, moved back from the previously announced August 18 date.
+Everything keyed to the cutover moves with it: from that moment every Hermes
+request requires a Pyth API Key, and the Benchmarks `/v1/shims/tradingview/*`
+endpoints are retired in favor of the Pyth Pro History API.
+
+**Why it matters:** integrations that were racing the August 18 deadline have
+an extra week to prepare. The requirements themselves are unchanged — only the
+date moved.
+
+**What to do:** if you have not prepared yet, use the extra time: get a Pyth
+API Key and walk through the preparation guide before August 26. If you have
+already migrated, no action is required.
+
+- [Prepare for the upgrade](/price-feeds/core/upgrade/preparing)
+- [Pyth Core upgrade overview](/price-feeds/core/upgrade)

--- a/apps/developer-hub/content/changelog/2026-08-17-pyth-pro-sei-evm-mainnet.mdx
+++ b/apps/developer-hub/content/changelog/2026-08-17-pyth-pro-sei-evm-mainnet.mdx
@@ -1,0 +1,25 @@
+---
+title: Sei joins the Pyth Pro-compatible contract upgrade
+date: 2026-08-17
+product: pyth-pro
+type: feature
+area: contracts
+---
+
+Sei Mainnet (EVM) is now covered by the Pyth Pro-compatible contract upgrade.
+Apps on Sei can point their integrations at the upgraded Pyth contract and
+consume the same Pyth Pro-backed price updates already available on other
+upgraded EVM chains.
+
+**Why it matters:** the upgraded contract is the single integration surface
+for Pyth on EVM going forward, and adding Sei keeps Sei apps aligned with the
+same feed catalog and update semantics as the rest of the upgraded network.
+Legacy Sei consumers keep working — the previous Pyth contract address is
+unchanged.
+
+**What to do:** if you are starting a new integration on Sei, use the upgraded
+(Pro-compatible) address from the EVM contract addresses page. If you are
+migrating an existing Sei app, follow the standard EVM migration steps.
+
+- [EVM contract addresses (upgraded and current)](/price-feeds/core/contract-addresses/evm)
+- [Migrate an app to Pyth](/price-feeds/core/migrate-an-app-to-pyth)

--- a/apps/developer-hub/content/changelog/2026-08-18-pyth-core-fogo-ihub-push-feed.mdx
+++ b/apps/developer-hub/content/changelog/2026-08-18-pyth-core-fogo-ihub-push-feed.mdx
@@ -1,0 +1,23 @@
+---
+title: IHUB/FOGO is now live on Fogo Mainnet push feeds
+date: 2026-08-18
+product: pyth-core
+type: feature
+area: market-data
+---
+
+A sponsored push feed for `IHUB/FOGO` is now listed on Fogo Mainnet. The feed
+updates on-chain at a 0.5% price-deviation threshold or a 60-second heartbeat,
+whichever comes first, so apps on Fogo can read the price directly on-chain
+without scheduling their own updates.
+
+**Why it matters:** Fogo apps that need IHUB pricing can consume a
+continuously refreshed on-chain feed instead of pulling and posting updates
+themselves.
+
+**What to do:** find the `IHUB/FOGO` account address on the Fogo push-feeds
+page and read it like any other sponsored feed. Existing integrations are
+unchanged.
+
+- [Push feeds on Fogo](/price-feeds/core/push-feeds/fogo)
+- [Push feeds overview](/price-feeds/core/push-feeds)

--- a/apps/developer-hub/content/changelog/2026-08-19-pyth-core-update-fees-zeroed.mdx
+++ b/apps/developer-hub/content/changelog/2026-08-19-pyth-core-update-fees-zeroed.mdx
@@ -1,0 +1,23 @@
+---
+title: Pyth Core update fees are now zero on mainnet EVM chains
+date: 2026-08-19
+product: pyth-core
+type: feature
+area: contracts
+---
+
+Following the passed governance proposal OP-PIP-128, the Pyth Core update fee
+is set to **0** across all mainnet EVM deployments as part of the Pyth Core
+sunset. Passing `0` as `msg.value` to `updatePriceFeeds` is sufficient on
+every mainnet EVM network.
+
+**Why it matters:** posting price updates on EVM no longer costs a per-update
+protocol fee, which simplifies fee handling and removes a small recurring cost
+from every update transaction.
+
+**What to do:** no action is required. Integrations that query `getUpdateFee`
+on-chain keep working and now receive 0 — on-chain remains the authoritative
+source for the fee on any given network.
+
+- [Current fees](/price-feeds/core/current-fees)
+- [OP-PIP-128: Pyth Core Sunset — Fee Zeroing & Balance Repatriation](https://forum.pyth.network/t/passed-op-pip-128-pyth-core-sunset-fee-zeroing-balance-repatriation/2662)


### PR DESCRIPTION
## Summary

Adds the Aug 14–21, 2026 batch of public changelog entries to the Pyth Developer Hub and fixes one stale published entry whose sunset date was invalidated by the rescheduled Pyth Core upgrade cutover.

### New entries (`apps/developer-hub/content/changelog/`)

- `2026-08-17-pyth-pro-sei-evm-mainnet.mdx` — Sei Mainnet (EVM) joins the Pyth Pro-compatible contract upgrade.
- `2026-08-17-pyth-core-upgrade-moves-to-august-26.mdx` — Pyth Core upgrade cutover moves from August 18 to **August 26, 2026 at 16:00 UTC**.
- `2026-08-18-pyth-core-fogo-ihub-push-feed.mdx` — Sponsored `IHUB/FOGO` push feed live on Fogo Mainnet (0.5% deviation / 60s heartbeat).
- `2026-08-19-pyth-core-update-fees-zeroed.mdx` — Pyth Core `updatePriceFeeds` fee set to 0 on all mainnet EVM chains following OP-PIP-128.

### Amendment

- `2026-08-12-pyth-core-benchmarks-tradingview-shims-deprecation.mdx` — retitle and update the body from "August 18" to "August 26, 2026 (16:00 UTC)" to match the rescheduled cutover. The filename (stable anchor slug) and the forum-notice URL (whose slug contains `august-18-2026`) are preserved unchanged. This mirrors the treatment of the Aug 19 correction to the August 4 Entropy chainlist entry (PR #4001).

### Verification

- Frontmatter schema (from `apps/developer-hub/source.config.ts`) validated against every entry with a standalone zod parse — all 14 files (existing plus new) pass with the exact `product`/`type`/`area`/`date` enums enforced by the collection schema.
- `pnpm turbo run build` / `test:types` for `@pythnetwork/developer-hub` could not be executed in the sandbox: a pre-existing TypeScript incompatibility in the upstream `@pythnetwork/price-service-sdk` build fails during workspace prep and is unrelated to these MDX-only changes. Reporting rather than claiming these ran.
- Biome (`test:lint`) ignores `content/**/*.mdx`, so no Biome step applies to this diff.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/4020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->