### PR TITLE
feat: make migration safer

### DIFF
--- a/target_chains/solana/programs/core-bridge/src/legacy/processor/close_guardian_set.rs
+++ b/target_chains/solana/programs/core-bridge/src/legacy/processor/close_guardian_set.rs
@@ -1,8 +1,8 @@
 use crate::{
     error::CoreBridgeError,
     legacy::instruction::EmptyArgs,
-    sdk::legacy::AccountVariant,
-    state::{GuardianSet, LEGACY_GUARDIANS},
+    sdk::legacy::{AccountVariant, LegacyAnchorized},
+    state::{Config, GuardianSet, LEGACY_GUARDIANS},
 };
 use anchor_lang::prelude::*;
 
@@ -13,10 +13,17 @@ pub struct CloseGuardianSet<'info> {
 
     #[account(
         mut,
+        seeds = [Config::SEED_PREFIX],
+        bump,
+    )]
+    config: Account<'info, LegacyAnchorized<Config>>,
+
+    #[account(
+        mut,
         close = recipient,
         seeds = [
             GuardianSet::SEED_PREFIX,
-            guardian_set.inner().index.to_be_bytes().as_ref()
+            config.guardian_set_index.to_be_bytes().as_ref()
         ],
         bump,
         // At least one guardian is from the legacy guardian sets.
@@ -40,6 +47,8 @@ impl<'info> crate::legacy::utils::ProcessLegacyInstruction<'info, EmptyArgs>
 
 /// Processor to remove a guardian set account containing a legacy guardian.
 /// This instruction is permissionless - anyone can call it.
-fn close_guardian_set(_ctx: Context<CloseGuardianSet>, _args: EmptyArgs) -> Result<()> {
+fn close_guardian_set(ctx: Context<CloseGuardianSet>, _args: EmptyArgs) -> Result<()> {
+    ctx.accounts.config.guardian_set_index =
+        ctx.accounts.config.guardian_set_index.saturating_sub(1);
     Ok(())
 }

--- a/target_chains/solana/programs/pyth-solana-receiver/tests/test_migrate_guardian_set.rs
+++ b/target_chains/solana/programs/pyth-solana-receiver/tests/test_migrate_guardian_set.rs
@@ -63,9 +63,6 @@ const MAINNET_BRIDGE_FIXTURE: &str = concat!(
     "/tests/fixtures/wormhole_core_bridge_solana_mainnet.so"
 );
 
-/// Guardian set index mainnet is at today, and therefore the highest index this test creates.
-const CURRENT_MAINNET_GUARDIAN_SET_INDEX: u32 = 7;
-
 fn loader_account(state: &UpgradeableLoaderState, elf: Option<&[u8]>) -> Account {
     let mut data = bincode::serialize(state).unwrap();
     if let Some(elf) = elf {
@@ -186,6 +183,7 @@ fn close_guardian_set_instruction(recipient: Pubkey, guardian_set_index: u32) ->
         program_id: BRIDGE_ID,
         accounts: vec![
             AccountMeta::new(recipient, false),
+            AccountMeta::new(bridge_address(), false),
             AccountMeta::new(
                 get_guardian_set_address(BRIDGE_ID, guardian_set_index),
                 false,
@@ -239,8 +237,12 @@ async fn post_encoded_vaa(
     encoded_vaa.pubkey()
 }
 
+fn bridge_address() -> Pubkey {
+    Pubkey::find_program_address(&[BridgeConfig::SEED_PREFIX], &BRIDGE_ID).0
+}
+
 async fn bridge_config(program_simulator: &mut ProgramSimulator) -> BridgeConfig {
-    let address = Pubkey::find_program_address(&[BridgeConfig::SEED_PREFIX], &BRIDGE_ID).0;
+    let address = bridge_address();
     let account = program_simulator
         .get_account(address)
         .await
@@ -361,15 +363,12 @@ async fn test_migrate_guardian_set_from_mainnet_bridge() {
             .unwrap();
     }
 
+    let current_guardian_set_index = bridge_config(&mut program_simulator)
+        .await
+        .guardian_set_index;
+
     assert_eq!(
-        bridge_config(&mut program_simulator)
-            .await
-            .guardian_set_index,
-        CURRENT_MAINNET_GUARDIAN_SET_INDEX,
-        "the bridge tracks mainnet's current guardian set index"
-    );
-    assert_eq!(
-        guardian_set(&mut program_simulator, CURRENT_MAINNET_GUARDIAN_SET_INDEX)
+        guardian_set(&mut program_simulator, current_guardian_set_index)
             .await
             .unwrap()
             .keys
@@ -455,7 +454,7 @@ async fn test_migrate_guardian_set_from_mainnet_bridge() {
     // in, so nothing below would dispatch to the new code without this.
     program_simulator.advance_slot().await.unwrap();
 
-    for guardian_set_index in 0..=CURRENT_MAINNET_GUARDIAN_SET_INDEX {
+    for guardian_set_index in (0..=current_guardian_set_index).rev() {
         program_simulator
             .process_ix_with_default_compute_limit(
                 close_guardian_set_instruction(payer.pubkey(), guardian_set_index),
@@ -466,7 +465,7 @@ async fn test_migrate_guardian_set_from_mainnet_bridge() {
             .unwrap();
     }
 
-    for guardian_set_index in 0..=CURRENT_MAINNET_GUARDIAN_SET_INDEX {
+    for guardian_set_index in 0..=current_guardian_set_index {
         assert!(
             program_simulator
                 .get_account(get_guardian_set_address(BRIDGE_ID, guardian_set_index))


### PR DESCRIPTION
## Summary

This PR adds the requirement that the `close_guardian_set` deletes the current guardian set. This guarantees that the Pyth multisig guardian set can only be installed after all the other guardian sets have been deleted.  

## Rationale

To make the chance of leaving guardian accounts from the old configuration 0.

## How has this been tested?

- [x] Current tests cover my changes
- [ ] Added new tests
- [ ] Manually tested the code

<!-- Describe the steps you've taken to verify the changes -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/4021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->