### PR TITLE
feat(contract_manager): decode SVM instructions in check_proposal

### DIFF
--- a/contract_manager/scripts/check_proposal.ts
+++ b/contract_manager/scripts/check_proposal.ts
@@ -3,15 +3,23 @@ import { createHash } from "node:crypto";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import type { BN } from "@coral-xyz/anchor";
 import { Wallet } from "@coral-xyz/anchor";
 import type { PythCluster } from "@pythnetwork/client/lib/cluster";
 import { getPythClusterApiUrl } from "@pythnetwork/client/lib/cluster";
+import { PythSolanaReceiver } from "@pythnetwork/pyth-solana-receiver";
+import type { MultisigInstruction } from "@pythnetwork/xc-admin-common";
 import {
+  AnchorMultisigInstruction,
+  BpfUpgradableLoaderInstruction,
   CosmosUpgradeContract,
   EvmExecute,
   EvmSetWormholeAddress,
   EvmUpgradeContract,
+  ExecutePostedVaa,
+  getProgramName,
   getProposalInstructions,
+  MultisigInstructionProgram,
   MultisigParser,
   SetFee,
   UpdateTrustedSigner256Bit,
@@ -21,7 +29,7 @@ import {
   WormholeMultisigInstruction,
 } from "@pythnetwork/xc-admin-common";
 import type { AccountMeta } from "@solana/web3.js";
-import { Keypair, PublicKey } from "@solana/web3.js";
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
 import SquadsMeshClass from "@sqds/mesh";
 import Web3 from "web3";
 import yargs from "yargs";
@@ -32,6 +40,7 @@ import {
   EvmChain,
   IotaChain,
   SuiChain,
+  SvmChain,
 } from "../src/core/chains";
 import { IotaLazerContract, SuiLazerContract } from "../src/core/contracts";
 import {
@@ -53,13 +62,236 @@ function getSquadsMesh() {
   );
 }
 
-function evmChainsFor(targetChainId: string, cluster: PythCluster): EvmChain[] {
-  return Object.values(DefaultStore.chains).filter(
+// wormholeChainName is unique per deployment, so it identifies the target chain on
+// its own. Filtering on the multisig's cluster instead would drop the testnet chains
+// that mainnet-beta proposals legitimately target.
+function evmChainsFor(targetChainId: string): EvmChain[] {
+  const chains = Object.values(DefaultStore.chains).filter(
     (chain): chain is EvmChain =>
-      chain instanceof EvmChain &&
-      chain.isMainnet() === (cluster === "mainnet-beta") &&
-      chain.wormholeChainName === targetChainId,
+      chain instanceof EvmChain && chain.wormholeChainName === targetChainId,
   );
+  if (chains.length === 0) {
+    console.log(`  NO CHAIN IN STORE FOR ${targetChainId} — not checked`);
+  }
+  return chains;
+}
+
+function svmChainFor(
+  targetChainId: string,
+  cluster: PythCluster,
+): SvmChain | undefined {
+  const chains = Object.values(DefaultStore.chains).filter(
+    (chain): chain is SvmChain =>
+      chain instanceof SvmChain && chain.wormholeChainName === targetChainId,
+  );
+  // Solana mainnet and devnet share the "solana" wormhole chain name, so fall back
+  // to the multisig's cluster to pick between them.
+  return (
+    chains.find(
+      (chain) => chain.isMainnet() === (cluster === "mainnet-beta"),
+    ) ?? chains[0]
+  );
+}
+
+// UpgradeableLoaderState::Buffer is a 4-byte enum tag followed by an
+// Option<Pubkey> authority; the ELF starts right after it.
+const BPF_BUFFER_HEADER_SIZE = 37;
+// UpgradeableLoaderState::ProgramData is a 4-byte enum tag, a u64 deploy slot and
+// then an Option<Pubkey> authority.
+const BPF_PROGRAM_DATA_AUTHORITY_OFFSET = 12;
+const BPF_PROGRAM_DATA_HEADER_SIZE = 45;
+
+type ReceiverDataSource = { chain: number; emitter: PublicKey };
+type ReceiverConfig = {
+  validDataSources: ReceiverDataSource[];
+  singleUpdateFeeInLamports: BN;
+};
+
+function sha256(data: Buffer): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+function accountAddress(
+  instruction: MultisigInstruction,
+  name: string,
+): PublicKey {
+  const account = instruction.accounts.named[name];
+  if (account === undefined) {
+    throw new Error(`${instruction.name} has no ${name} account`);
+  }
+  return account.pubkey;
+}
+
+async function fetchReceiverConfig(
+  connection: Connection,
+  config: PublicKey,
+): Promise<ReceiverConfig | undefined> {
+  const account = await connection.getAccountInfo(config);
+  if (account === null) {
+    return undefined;
+  }
+  const { receiver } = new PythSolanaReceiver({
+    connection,
+    wallet: new Wallet(Keypair.generate()), // dummy wallet
+  });
+  return receiver.coder.accounts.decode<ReceiverConfig>("Config", account.data);
+}
+
+async function checkReceiverInstruction(
+  instruction: AnchorMultisigInstruction,
+  connection: Connection,
+  chainLabel: string,
+): Promise<void> {
+  const config = accountAddress(instruction, "config");
+  console.log(
+    `\nVerifying Pyth Solana Receiver ${instruction.name} on ${chainLabel}`,
+  );
+
+  if (instruction.name === "setDataSources") {
+    for (const source of instruction.args
+      .validDataSources as ReceiverDataSource[]) {
+      console.log(
+        `  new data source: chain ${source.chain} emitter ${source.emitter.toBase58()}`,
+      );
+    }
+  } else {
+    console.log(
+      `  new fee: ${String(instruction.args.singleUpdateFeeInLamports)} lamports`,
+    );
+  }
+
+  const current = await fetchReceiverConfig(connection, config);
+  if (current === undefined) {
+    console.log(
+      `${chainLabel}  CONFIG DOES NOT EXIST — ${config.toBase58()} holds no account, the instruction will fail`,
+    );
+    return;
+  }
+  if (instruction.name === "setDataSources") {
+    for (const source of current.validDataSources) {
+      console.log(
+        `${chainLabel}  Config:${config.toBase58()} current data source: chain ${source.chain} emitter ${source.emitter.toBase58()}`,
+      );
+    }
+  } else {
+    console.log(
+      `${chainLabel}  Config:${config.toBase58()} current fee:${current.singleUpdateFeeInLamports.toString()} lamports`,
+    );
+  }
+}
+
+async function checkProgramUpgrade(
+  instruction: BpfUpgradableLoaderInstruction,
+  connection: Connection,
+  chainLabel: string,
+): Promise<void> {
+  const program = accountAddress(instruction, "program");
+  const programData = accountAddress(instruction, "programData");
+  const buffer = accountAddress(instruction, "buffer");
+  const spill = accountAddress(instruction, "spill");
+  const upgradeAuthority = accountAddress(instruction, "upgradeAuthority");
+
+  console.log(`\nVerifying program Upgrade on ${chainLabel}`);
+  console.log(`  program:          ${program.toBase58()}`);
+  console.log(`  programData:      ${programData.toBase58()}`);
+  console.log(`  buffer:           ${buffer.toBase58()}`);
+  console.log(`  spill:            ${spill.toBase58()}`);
+  console.log(`  upgradeAuthority: ${upgradeAuthority.toBase58()}`);
+
+  const bufferAccount = await connection.getAccountInfo(buffer);
+  if (bufferAccount === null) {
+    console.log(
+      `${chainLabel}  BUFFER DOES NOT EXIST — ${buffer.toBase58()} holds no account, the upgrade will fail`,
+    );
+  } else {
+    const elf = bufferAccount.data.subarray(BPF_BUFFER_HEADER_SIZE);
+    console.log(
+      `${chainLabel}  new ELF length:${elf.length} sha256:${sha256(elf)}`,
+    );
+  }
+
+  const programDataAccount = await connection.getAccountInfo(programData);
+  if (programDataAccount === null) {
+    console.log(
+      `${chainLabel}  PROGRAM DATA DOES NOT EXIST — ${programData.toBase58()} holds no account, the upgrade will fail`,
+    );
+    return;
+  }
+  const deployed = programDataAccount.data.subarray(
+    BPF_PROGRAM_DATA_HEADER_SIZE,
+  );
+  console.log(
+    `${chainLabel}  deployed ELF length:${deployed.length} sha256:${sha256(deployed)}`,
+  );
+
+  const hasAuthority =
+    programDataAccount.data[BPF_PROGRAM_DATA_AUTHORITY_OFFSET] !== 0;
+  if (!hasAuthority) {
+    console.log(
+      `${chainLabel}  PROGRAM IS IMMUTABLE — ${programData.toBase58()} has no upgrade authority, the upgrade will fail`,
+    );
+    return;
+  }
+  const currentAuthority = new PublicKey(
+    programDataAccount.data.subarray(
+      BPF_PROGRAM_DATA_AUTHORITY_OFFSET + 1,
+      BPF_PROGRAM_DATA_HEADER_SIZE,
+    ),
+  );
+  if (currentAuthority.equals(upgradeAuthority)) {
+    console.log(
+      `${chainLabel}  upgrade authority matches:${currentAuthority.toBase58()}`,
+    );
+  } else {
+    console.log(
+      `${chainLabel}  UPGRADE AUTHORITY MISMATCH — ${programData.toBase58()} is controlled by ${currentAuthority.toBase58()} but the instruction signs as ${upgradeAuthority.toBase58()}, the upgrade will fail`,
+    );
+  }
+}
+
+async function checkSvmInstruction(
+  instruction: MultisigInstruction,
+  connection: Connection,
+  chainLabel: string,
+): Promise<void> {
+  if (
+    instruction instanceof AnchorMultisigInstruction &&
+    instruction.program === MultisigInstructionProgram.SolanaReceiver &&
+    (instruction.name === "setDataSources" || instruction.name === "setFee")
+  ) {
+    await checkReceiverInstruction(instruction, connection, chainLabel);
+  } else if (
+    instruction instanceof BpfUpgradableLoaderInstruction &&
+    instruction.name === "Upgrade"
+  ) {
+    await checkProgramUpgrade(instruction, connection, chainLabel);
+  } else {
+    console.log(
+      `\n${chainLabel}  NOT CHECKED — ${getProgramName(instruction.program)} ${instruction.name}`,
+    );
+  }
+}
+
+async function checkExecutePostedVaa(
+  action: ExecutePostedVaa,
+  multisigParser: MultisigParser,
+  cluster: PythCluster,
+): Promise<void> {
+  console.log(`\nVerifying ExecutePostedVaa on ${action.targetChainId}`);
+  const chain = svmChainFor(action.targetChainId, cluster);
+  if (chain === undefined) {
+    console.log(
+      `  NO SVM CHAIN IN STORE FOR ${action.targetChainId} — ${action.instructions.length} inner instruction(s) not checked`,
+    );
+    return;
+  }
+  for (const inner of action.instructions) {
+    await checkSvmInstruction(
+      multisigParser.parseInstruction(inner),
+      chain.getConnection(),
+      chain.getId(),
+    );
+  }
 }
 
 function pythContractsOn(chain: EvmChain): EvmPriceFeedContract[] {
@@ -109,9 +341,23 @@ async function main() {
       programId: instruction.programId,
     });
   });
+  const clusterConnection = new Connection(getPythClusterApiUrl(cluster));
 
   for (const instruction of parsedInstructions) {
+    if (
+      instruction instanceof AnchorMultisigInstruction ||
+      instruction instanceof BpfUpgradableLoaderInstruction
+    ) {
+      await checkSvmInstruction(instruction, clusterConnection, cluster);
+    }
     if (instruction instanceof WormholeMultisigInstruction) {
+      if (instruction.governanceAction instanceof ExecutePostedVaa) {
+        await checkExecutePostedVaa(
+          instruction.governanceAction,
+          multisigParser,
+          cluster,
+        );
+      }
       if (instruction.governanceAction instanceof EvmSetWormholeAddress) {
         console.log(
           `Verifying EVM set wormhole address on ${instruction.governanceAction.targetChainId}`,
@@ -148,22 +394,13 @@ async function main() {
         }
       }
       if (instruction.governanceAction instanceof EvmUpgradeContract) {
-        console.log(
-          `Verifying EVM Upgrade Contract on ${instruction.governanceAction.targetChainId}`,
-        );
-        for (const chain of Object.values(DefaultStore.chains)) {
-          if (
-            chain instanceof EvmChain &&
-            chain.isMainnet() === (cluster === "mainnet-beta") &&
-            chain.wormholeChainName ===
-              instruction.governanceAction.targetChainId
-          ) {
-            const address = instruction.governanceAction.address;
-            const contract = new EvmPriceFeedContract(chain, address);
-            const code = await contract.getCodeDigestWithoutAddress();
-            // this should be the same keccak256 of the deployedCode property generated by truffle
-            console.log(`${chain.getId()}  Address:${address} digest:${code}`);
-          }
+        const { address, targetChainId } = instruction.governanceAction;
+        console.log(`Verifying EVM Upgrade Contract on ${targetChainId}`);
+        for (const chain of evmChainsFor(targetChainId)) {
+          const contract = new EvmPriceFeedContract(chain, address);
+          const code = await contract.getCodeDigestWithoutAddress();
+          // this should be the same keccak256 of the deployedCode property generated by truffle
+          console.log(`${chain.getId()}  Address:${address} digest:${code}`);
         }
       }
       if (instruction.governanceAction instanceof CosmosUpgradeContract) {
@@ -198,7 +435,7 @@ async function main() {
             newFee ?? `<expo ${newFeeExpo} exceeds ${SetFee.MAX_EXPO}>`
           } (${newFeeValue} * 10^${newFeeExpo})`,
         );
-        for (const chain of evmChainsFor(targetChainId, cluster)) {
+        for (const chain of evmChainsFor(targetChainId)) {
           for (const contract of pythContractsOn(chain)) {
             const currentFee = await contract.getBaseUpdateFee();
             console.log(
@@ -219,7 +456,7 @@ async function main() {
             requested ?? `<expo ${expo} exceeds ${WithdrawFee.MAX_EXPO}>`
           }`,
         );
-        for (const chain of evmChainsFor(targetChainId, cluster)) {
+        for (const chain of evmChainsFor(targetChainId)) {
           const web3 = chain.getWeb3();
           const hasCode = (await web3.eth.getCode(recipient)) !== "0x";
           const recipientBalance = BigInt(await web3.eth.getBalance(recipient));

--- a/contract_manager/src/store/chains/SvmChains.json
+++ b/contract_manager/src/store/chains/SvmChains.json
@@ -13,5 +13,54 @@
     "rpcUrl": "https://api.devnet.solana.com",
     "type": "SvmChain",
     "wormholeChainName": "solana"
+  },
+  {
+    "id": "fogo_mainnet",
+    "mainnet": true,
+    "rpcUrl": "https://mainnet.fogo.io",
+    "type": "SvmChain",
+    "wormholeChainName": "fogo_mainnet"
+  },
+  {
+    "id": "fogo_testnet",
+    "mainnet": false,
+    "rpcUrl": "https://testnet.fogo.io",
+    "type": "SvmChain",
+    "wormholeChainName": "fogo_testnet"
+  },
+  {
+    "id": "eclipse_mainnet",
+    "mainnet": true,
+    "rpcUrl": "https://mainnetbeta-rpc.eclipse.xyz",
+    "type": "SvmChain",
+    "wormholeChainName": "eclipse_mainnet"
+  },
+  {
+    "id": "eclipse_testnet",
+    "mainnet": false,
+    "rpcUrl": "https://testnet.dev2.eclipsenetwork.xyz",
+    "type": "SvmChain",
+    "wormholeChainName": "eclipse_testnet"
+  },
+  {
+    "id": "sonic_mainnet",
+    "mainnet": true,
+    "rpcUrl": "https://api.mainnet-alpha.sonic.game",
+    "type": "SvmChain",
+    "wormholeChainName": "sonic_mainnet"
+  },
+  {
+    "id": "sonic_testnet",
+    "mainnet": false,
+    "rpcUrl": "https://api.testnet.sonic.game",
+    "type": "SvmChain",
+    "wormholeChainName": "sonic_testnet"
+  },
+  {
+    "id": "sonic_devnet",
+    "mainnet": false,
+    "rpcUrl": "https://api.testnet.sonic.game",
+    "type": "SvmChain",
+    "wormholeChainName": "sonic_devnet"
   }
 ]


### PR DESCRIPTION
`check_proposal.ts` is what we point DAO reviewers at to decode a governance proposal before voting, but it only had branches for Wormhole governance actions targeting EVM/Cosmos/Sui/IOTA. A proposal whose instructions execute on SVM decoded to *nothing*: the script exited 0 having printed zero lines. For a verification tool that failure mode is the dangerous one — a clean run is indistinguishable from a clean bill of health, and the Pyth Core SVM upgrade proposal had to be checked by hand with the `solana` CLI instead.

This adds the three instruction shapes an SVM proposal actually uses.

**`AnchorMultisigInstruction` against the Pyth Solana Receiver.** `setDataSources` and `setFee` print the proposed values, then fetch the receiver config account named in the instruction and print the current values next to them — the same shape as the existing EVM `SetFee` branch. Reading the config account the instruction itself names (rather than re-deriving the PDA) means the comparison is against the exact account the instruction will write, and works for both the default and pro-compatible receiver deployments.

**`BpfUpgradableLoaderInstruction` / `Upgrade`.** Prints program, programData, buffer, spill and upgradeAuthority, then fetches the buffer, strips the 37-byte `UpgradeableLoaderState::Buffer` header and reports the staged ELF's length and SHA-256, alongside the same for the currently deployed program so the reviewer can see what is being replaced. It also cross-checks the authority recorded in the programData account against the authority the instruction signs as: a mismatch (or an immutable program) means the upgrade reverts, which is exactly the class of thing this script should catch before a vote rather than after execution.

**`ExecutePostedVaa`.** Recurses into the inner instructions and resolves them against the *target* chain's RPC rather than the cluster the multisig lives on, so remote-executed SVM instructions get the same treatment as local ones.

## Loud about what it skips

Every path that cannot check something now says so on stdout. An inner instruction whose target chain is absent from the store prints `NO SVM CHAIN IN STORE FOR <target> — N inner instruction(s) not checked`; an SVM instruction with no branch prints `NOT CHECKED — <program> <name>`. Silence was the original bug, so partial coverage that names its gaps is the point.

## Chain store

`SvmChains.json` had only `solana_mainnet` and `solana_devnet`, so `fogo_mainnet` — where half of the SVM proposal executes — was unresolvable. Added the SVM chains whose RPCs are already recorded in-repo (`SVM_CHAINS` in `target_chains/solana/cli/src/main.rs`, plus `fogo_testnet` from the deployments repo): both Fogo networks, both Eclipse networks, and the three Sonic networks. Each endpoint was probed with `getGenesisHash` and answered. `mantis_*`, `atlas_testnet` and `eclipse_devnet` exist in `RECEIVER_CHAINS` but have no RPC recorded anywhere, so they are deliberately left out — they now hit the loud "no chain in store" path instead of a guessed URL.

## Chain lookup for EVM targets

`evmChainsFor` filtered on `chain.isMainnet() === (cluster === "mainnet-beta")`, where `--cluster` is the cluster the *multisig* lives on, not the cluster of the *target* chain. A mainnet-beta proposal that targets testnet chains — as the Pyth Core EVM upgrade does for 14 of its 33 — printed a `Verifying …` header for each with no per-chain line beneath it. `wormholeChainName` is unique across all 203 entries in `EvmChains.json` (every entry inherits it from its unique `id`), so it identifies the target on its own and the cluster filter is dropped. When nothing matches, the helper now says so instead of returning an empty list silently. The `EvmUpgradeContract` branch, which had the same filter inline, is switched over to the helper.

## Verification

Run against the live Pyth Core SVM upgrade proposal `EUWsLWhBScsuKkkwUuyKrXfL9UATuKvAWzLzvQUJEEom` on `mainnet-beta`. Before: zero lines. After, all 6 instructions decode — 3 locally and 3 through `ExecutePostedVaa` on Fogo:

```
Verifying Pyth Solana Receiver setFee on fogo_mainnet
  new fee: 0 lamports
fogo_mainnet  Config:DaWUKXCyXsnzcvLUyeJRWou8KTn7XtadgTsdhJ6RHS7b current fee:1 lamports

Verifying program Upgrade on fogo_mainnet
  program:          HDwcJBJXjL9FpJ7UBsYBtaDjsBUhuLCUYoz3zr8SWWaQ
  programData:      CmumsQAU6TvqW2VLFVySBjQYKqKDeUPMBVdrxJ2YoK1
  buffer:           EGq9aToMraKE6sJhnS6yWrwbS7BeEbZVRvyJGJ15DhUK
  spill:            DgpbK8SiypiUHBkBTAunMnwRWF3McGGR4iKxTrTfTXq4
  upgradeAuthority: DgpbK8SiypiUHBkBTAunMnwRWF3McGGR4iKxTrTfTXq4
fogo_mainnet  new ELF length:426864 sha256:51c30071d5e70492c2c48be869ac29b9f036b5fe2c3552743e01faf4b3160ca2
fogo_mainnet  deployed ELF length:1355328 sha256:30e13e3a7369e79eea22dc24769350b1385150328109020cbea58e993db2a4d7
fogo_mainnet  upgrade authority matches:DgpbK8SiypiUHBkBTAunMnwRWF3McGGR4iKxTrTfTXq4
```

Every printed value was then re-derived independently from raw `getAccountInfo` responses with a hand-written Borsh and `UpgradeableLoaderState` decoder, on both Solana mainnet-beta and Fogo mainnet, and matches line for line. The staged buffer digest `51c30071…` is identical on both chains. Both loud-skip paths were exercised by temporarily perturbing the tree. Full transcript, commands and explorer links are on the tracking issue.

## Please sequence this after the fault-tolerance PR

This touches the same file as the `SetDataSources` / RPC-fault-tolerance change and depends on it operationally. Dropping the cluster filter means the EVM proposal now reaches testnet RPCs, and one of them (`sepolia`) rejects free-plan access — without that PR's per-instruction `try`/`catch`, the run aborts there instead of logging and continuing. That PR is not on `main` yet, so this is based on `main` and the `try`/`catch` is deliberately not duplicated here. The two conflict textually in `main()`; whichever lands second needs a rebase, and I would suggest landing the fault-tolerance one first.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/4023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->