### PR TITLE
docs(developer-hub): require Pyth API key in Hermes Beta examples

### DIFF
--- a/apps/developer-hub/content/docs/price-feeds/core/api-instances-and-providers/hermes.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/api-instances-and-providers/hermes.mdx
@@ -23,6 +23,11 @@ URL: https://hermes.pyth.network
 For developers building on **Aptos testnet**, **Sui testnet** or **Near testnet**, please use the Hermes Beta endpoint:
 URL: https://hermes-beta.pyth.network
 
+Like all Hermes endpoints, the Hermes Beta endpoint requires authentication:
+pass your Pyth API key as a Bearer token (`Authorization: Bearer $PYTH_API_KEY`).
+Requests without a valid key fail with an authorization error.
+[Register at Pyth Terminal →](https://pythdata.app/signup?utm_source=developer-hub&utm_campaign=core-upgrade&utm_content=callout-hermes-beta)
+
 </Callout>
 
 ### Rate limits

--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/iota.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/iota.mdx
@@ -122,7 +122,11 @@ import { IotaPriceServiceConnection, IotaPythClient } from "@pythnetwork/pyth-io
 import { Transaction } from "@iota/iota-sdk/transactions";
 
 // Get the Stable Hermes service URL from https://docs.pyth.network/price-feeds/api-instances-and-providers/hermes
-const connection = new IotaPriceServiceConnection("https://hermes-beta.pyth.network");
+const connection = new IotaPriceServiceConnection(
+  "https://hermes-beta.pyth.network",
+  // The endpoint requires a Pyth API key: https://docs.pyth.network/price-feeds/core/api-instances-and-providers/hermes
+  { accessToken: process.env.PYTH_API_KEY },
+);
 
 const priceIDs = [
   // You can find the IDs of prices at https://docs.pyth.network/price-feeds/price-feeds

--- a/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/near.mdx
+++ b/apps/developer-hub/content/docs/price-feeds/core/use-real-time-data/pull-integration/near.mdx
@@ -70,7 +70,7 @@ Update the Pyth Oracle contract with new price feed data in two main steps:
 
 You can obtain an off-chain price feed using Pyth's [Hermes API](https://hermes-beta.pyth.network/docs/).
 
-To use these endpoints, you will need to provide a Price Feed ID and ensure you are targeting the correct network. See [Getting Started](#getting-started) for more information.
+To use these endpoints, you will need to provide a Price Feed ID and ensure you are targeting the correct network. See [Getting Started](#getting-started) for more information. All Hermes endpoints require authentication with a [Pyth API key](https://docs.pyth.network/price-feeds/core/api-instances-and-providers/hermes), passed as a Bearer token.
 
 Here is a node.js example of fetching the latest price feed using `/v2/updates/price/latest` endpoint:
 
@@ -93,6 +93,7 @@ async function getHermesPriceData(priceId, network) {
     // Fetch the price data from the Hermes API
     const response = await axios.get(
       `${url}/v2/updates/price/latest?ids[]=${priceId}`,
+      { headers: { Authorization: `Bearer ${process.env.PYTH_API_KEY}` } },
     );
 
     return response.data.binary.data[0];


### PR DESCRIPTION
## Summary

Three developer-hub pages still present Hermes Beta (`hermes-beta.pyth.network`) as an unauthenticated endpoint, but its update endpoints now require a Pyth API key — so following those guides as written fails with `401 unauthorized`. This change documents the key requirement on the Hermes instances page and passes the Bearer token in the NEAR and IOTA pull-integration examples, matching how the Sui and Solana guides already handle it.

## Verification

All commands executed 2026-08-26 ~03:00 UTC.

**1. The NEAR guide's example code, run verbatim, fails on testnet:**

```
$ node repro-near-guide.js
--- as written in the guide (testnet):
Error: unauthorized
--- as written in the guide (mainnet):
Error: Price ids not found: 0xf9c0172ba10dfa4d...
```

(the mainnet error is expected feed-ID validation — a testnet ID queried against mainnet — which confirms that endpoint itself responds normally)

**2. Confirmed the Bearer header is what the endpoint expects:**

```
$ curl -s -w ' [%{http_code}]' 'https://hermes-beta.pyth.network/v2/updates/price/latest?ids%5B%5D=0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43'
unauthorized [401]

$ curl -H 'Authorization: Bearer invalid-token-test' -w ' [%{http_code}]' <same URL>
Not entitled: feed e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43 (invalid API key) [403]
```

An invalid key gets past the 401 gate to entitlement validation, so `Authorization: Bearer <key>` is precisely the expected mechanism. Honest limitation: I could not demonstrate an authenticated 200 without registering a real Pyth Terminal account.

**3. The corrected snippets reuse the established in-repo idiom:** `sui.mdx`/`solana.mdx` already use `{ accessToken: process.env.PYTH_API_KEY }` / `Authorization: Bearer $PYTH_API_KEY`, and `IotaPriceServiceConnection` inherits `PriceServiceConnectionConfig.accessToken`, which is sent as the Authorization header (price_service/client/js/src/PriceServiceConnection.ts).

## Possible follow-ups (intentionally not changed here)

- `pull-integration/fuel.mdx`, `starknet.mdx` and `stacks.mdx` snippets still call `hermes.pyth.network` without a token; those will need auth after the August 26 cutover.
- `target_chains/sui/cli-iota` builds `PriceServiceConnection(argv.endpoint)` with no config, so it currently has no way to pass a token.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/4025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->