### PR TITLE
developer-hub: mark Pyth Core upgrade as completed in banner

### DIFF
--- a/apps/developer-hub/src/components/MigrationBanner/index.tsx
+++ b/apps/developer-hub/src/components/MigrationBanner/index.tsx
@@ -22,8 +22,8 @@ export const MigrationBanner = () => {
         className="hover:underline"
         href="/price-feeds/core/upgrade/preparing"
       >
-        Pyth Core upgrade August 26, 2026 at 16:00 UTC. Every Core user will
-        need an API Key. Learn more →
+        Pyth Core upgrade completed successfully on August 26, 2026. Hermes now
+        requires an API Key. Get yours →
       </Link>
     </Banner>
   );


### PR DESCRIPTION
## What

Updates the Developer Hub banner copy to say the Pyth Core upgrade completed successfully, and points the call to action at getting an API key. Copy only — routes, styling, and link target are unchanged.

## Why

The cutover has happened, so the forward-looking "upgrade August 26, 2026 at 16:00 UTC" wording is stale. The remaining actionable item for readers is authentication: `hermes.pyth.network` now rejects unauthenticated requests, so anyone without a key is already broken.

## Verification

- Confirmed the cutover is live before changing the copy: `hermes.pyth.network/v2/updates/price/latest` returns `401 unauthorized` without a key and `200` with one, serving the same payload as `pyth.dourolabs.app/hermes`.
- `biome check` clean on the changed file.
- Ran the dev server and confirmed the new banner renders on `/`, `/price-feeds/core`, and `/price-feeds/core/upgrade/preparing`, and is still absent on `/entropy`.
- Vercel preview: https://developer-hub-git-hydra-i-fyfcrprhead-pyth-network.vercel.app

The red `build` / `test` checks are pre-existing and unrelated to this diff. `@pythnetwork/hermes-client#build:schemas` runs `openapi-zod-client ./schema.json`, where `schema.json` comes from `curl https://hermes.pyth.network/docs/openapi.json` — a URL that now returns `404` after the cutover, so the file lands empty and the parser rejects it. The last green `build` on any PR was 2026-08-25T19:21Z, ~21h before the cutover. Tracked separately.