### PR TITLE
fix(hermes-client): fail pull:schema loudly instead of writing a broken schema.json

### DIFF
--- a/apps/hermes/client/js/package.json
+++ b/apps/hermes/client/js/package.json
@@ -89,7 +89,7 @@
     "clean": "rm -rf ./dist",
     "example": "node lib/examples/HermesClient.js",
     "prepublishOnly": "pnpm run build",
-    "pull:schema": "curl -o schema.json -z schema.json https://pyth.dourolabs.app/docs/hermes/openapi.json",
+    "pull:schema": "curl -fsS -o schema.json https://pyth.dourolabs.app/docs/hermes/openapi.json",
     "version": "pnpm run format && git add -A src"
   },
   "type": "module",


### PR DESCRIPTION
## Problem

`pull:schema` ran `curl` without `-f`, so when the schema endpoint errors, the HTTP error body is silently written over `schema.json`. The `-z schema.json` flag then makes it worse: the broken file's fresh mtime turns every subsequent pull into a conditional request, so the bad file is never replaced and the build never self-heals.

This is exactly what happened when `hermes.pyth.network/docs/openapi.json` went away: 0-byte `schema.json` files broke `build:schemas` and, through the turbo graph, every dependent package (`@pythnetwork/pyth-solana-receiver`, `@pythnetwork/xc-admin-common`, `@pythnetwork/contract-manager`, ...). #4029 re-pointed the URL to `pyth.dourolabs.app`, which fixes fetches on a clean checkout, but any machine that already has a broken `schema.json` stays wedged, and the silent-corruption failure mode remains for the next endpoint change.

## Fix

`curl -fsS -o schema.json <url>`: a failed fetch now exits non-zero and writes nothing, so `pull:schema` fails visibly and a later retry actually re-downloads.

## Verified

- Success path: `pnpm run pull:schema` fetches the 41KB Lazer Hermes schema; `pnpm turbo build --filter @pythnetwork/hermes-client` is green.
- Failure path: against the dead `hermes.pyth.network` URL, curl exits 56 and no file is written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/4033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->