### PR TITLE
deploy(entropy): Ink mainnet

### DIFF
--- a/apps/entropy-explorer/src/entropy-deployments.tsx
+++ b/apps/entropy-explorer/src/entropy-deployments.tsx
@@ -214,16 +214,6 @@ export const EntropyDeployments = {
     name: "HyperEVM",
     rpc: "https://rpc.hyperliquid.xyz/evm",
   },
-  ink: {
-    address: "0xD458261E832415CFd3BAE5E416FdF3230ce6F134",
-    chainId: 57_073,
-    explorerAccountTemplate: "https://explorer.inkonchain.com/address/$ADDRESS",
-    explorerTxTemplate: "https://explorer.inkonchain.com/tx/$ADDRESS",
-    icon: "https://icons.llamao.fi/icons/chains/rsz_ink.jpg?w=20&h=20",
-    isTestnet: false,
-    name: "Ink",
-    rpc: "https://rpc-gel.inkonchain.com",
-  },
   "kaia-kairos-testnet": {
     address: "0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320",
     chainId: 1001,
@@ -243,6 +233,16 @@ export const EntropyDeployments = {
     isTestnet: false,
     name: "Kaia Mainnet",
     rpc: "https://rpc.ankr.com/klaytn",
+  },
+  "kraken-ink": {
+    address: "0xD458261E832415CFd3BAE5E416FdF3230ce6F134",
+    chainId: 57_073,
+    explorerAccountTemplate: "https://explorer.inkonchain.com/address/$ADDRESS",
+    explorerTxTemplate: "https://explorer.inkonchain.com/tx/$ADDRESS",
+    icon: "https://icons.llamao.fi/icons/chains/rsz_ink.jpg?w=20&h=20",
+    isTestnet: false,
+    name: "Ink",
+    rpc: "https://rpc-gel.inkonchain.com",
   },
   "lightlink-pegasus-testnet": {
     address: "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",

--- a/apps/entropy-explorer/src/entropy-deployments.tsx
+++ b/apps/entropy-explorer/src/entropy-deployments.tsx
@@ -214,6 +214,16 @@ export const EntropyDeployments = {
     name: "HyperEVM",
     rpc: "https://rpc.hyperliquid.xyz/evm",
   },
+  ink: {
+    address: "0xD458261E832415CFd3BAE5E416FdF3230ce6F134",
+    chainId: 57_073,
+    explorerAccountTemplate: "https://explorer.inkonchain.com/address/$ADDRESS",
+    explorerTxTemplate: "https://explorer.inkonchain.com/tx/$ADDRESS",
+    icon: "https://icons.llamao.fi/icons/chains/rsz_ink.jpg?w=20&h=20",
+    isTestnet: false,
+    name: "Ink",
+    rpc: "https://rpc-gel.inkonchain.com",
+  },
   "kaia-kairos-testnet": {
     address: "0x36825bf3Fbdf5a29E2d5148bfe7Dcf7B5639e320",
     chainId: 1001,

--- a/contract_manager/src/store/chains/EvmChains.json
+++ b/contract_manager/src/store/chains/EvmChains.json
@@ -1144,7 +1144,7 @@
     "id": "kraken_ink_mainnet",
     "mainnet": true,
     "networkId": 57073,
-    "rpcUrl": "https://ink-public.nodies.app",
+    "rpcUrl": "https://rpc-gel.inkonchain.com",
     "type": "EvmChain"
   },
   {

--- a/contract_manager/src/store/contracts/EvmEntropyContracts.json
+++ b/contract_manager/src/store/contracts/EvmEntropyContracts.json
@@ -220,5 +220,10 @@
     "chain": "taiko_mainnet",
     "deprecated": true,
     "type": "EvmEntropyContract"
+  },
+  {
+    "address": "0xD458261E832415CFd3BAE5E416FdF3230ce6F134",
+    "chain": "kraken_ink_mainnet",
+    "type": "EvmEntropyContract"
   }
 ]

--- a/contract_manager/src/store/contracts/EvmExecutorContracts.json
+++ b/contract_manager/src/store/contracts/EvmExecutorContracts.json
@@ -323,5 +323,10 @@
     "address": "0x26DD80569a8B23768A1d80869Ed7339e07595E85",
     "chain": "flow_mainnet",
     "type": "EvmExecutorContract"
+  },
+  {
+    "address": "0xDd24F84d36BF92C65F92307595335bdFab5Bbd21",
+    "chain": "kraken_ink_mainnet",
+    "type": "EvmExecutorContract"
   }
 ]


### PR DESCRIPTION
Deploys Entropy on Ink mainnet (`kraken_ink_mainnet`, chain id 57073) and records it in the contract store.

- **Entropy** proxy `0xD458261E832415CFd3BAE5E416FdF3230ce6F134` (impl `0x5f3c61944CEb01B3eAef861251Fb1E0f14b848fb`, v2.0.0): owner/admin = executor, default provider `0x52DeaA1c84233F7bb8C8A45baeDE41091c616506`, pythFee 1 wei.
- **Executor** proxy `0xDd24F84d36BF92C65F92307595335bdFab5Bbd21` (impl `0x26DD80569a8B23768A1d80869Ed7339e07595E85`, v0.1.1), governance source Solana / `0x5635979a…b12e9e`.
- Keeper and provider topped up with 0.01 ETH each. All state checked with `cast call` after deploy.
- `EvmChains.json`: switch the Ink RPC to `https://rpc-gel.inkonchain.com`; `ink-public.nodies.app` now returns 403 (paid plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yo8hEGiYsDHZdn1sqxj9s