### PR TITLE
deploy(lazer): Ethereum mainnet

### DIFF
--- a/contract_manager/src/store/chains/EvmChains.json
+++ b/contract_manager/src/store/chains/EvmChains.json
@@ -182,7 +182,7 @@
     "mainnet": true,
     "nativeToken": "ETH",
     "networkId": 1,
-    "rpcUrl": "https://eth1.lava.build",
+    "rpcUrl": "https://ethereum-rpc.publicnode.com",
     "type": "EvmChain"
   },
   {

--- a/contract_manager/src/store/contracts/EvmExecutorContracts.json
+++ b/contract_manager/src/store/contracts/EvmExecutorContracts.json
@@ -328,5 +328,10 @@
     "address": "0xDd24F84d36BF92C65F92307595335bdFab5Bbd21",
     "chain": "kraken_ink_mainnet",
     "type": "EvmExecutorContract"
+  },
+  {
+    "address": "0xCcD7e24e71ba746CBc758C39CBAb11f4E0dfc46F",
+    "chain": "ethereum",
+    "type": "EvmExecutorContract"
   }
 ]

--- a/contract_manager/src/store/contracts/EvmLazerContracts.json
+++ b/contract_manager/src/store/contracts/EvmLazerContracts.json
@@ -188,5 +188,10 @@
     "address": "0xACeA761c27A909d4D3895128EBe6370FDE2dF481",
     "chain": "sei_evm_mainnet",
     "type": "EvmLazerContract"
+  },
+  {
+    "address": "0xACeA761c27A909d4D3895128EBe6370FDE2dF481",
+    "chain": "ethereum",
+    "type": "EvmLazerContract"
   }
 ]


### PR DESCRIPTION
Deploys Pyth Lazer on Ethereum mainnet (chain id 1) with a dedicated Executor, and records both in the contract store.

- **PythLazer** proxy `0xACeA761c27A909d4D3895128EBe6370FDE2dF481` (impl `0xD8f4A467AbeC64Bc944eee1325B9007879B6555b`, v0.2.0, CreateX-deterministic, bytecode identical to the 0.2.0 impl on Etherlink). Trusted signer `0x26FB61A864c758AE9fBA027a96010480658385B9` (expires 2077357410), verification fee 1 wei.
- **Executor** proxy `0xCcD7e24e71ba746CBc758C39CBAb11f4E0dfc46F` (impl `0x395921B642bA511D421Ae834fef56Ac886735CA2`, v0.1.1), initialized with the existing stable receiver `0x74f09cb3c7e2A01865f424FD14F6dc9A14E3e94E`, Wormhole chain id 2, governance source Solana / `0x5635979a…b12e9e`.
- Lazer `owner()` transferred from the deployer EOA to the executor (tx `0x035ca84dd44c32f208da0ab8f87935ce34bb3f78913dcf61cebf25341dbceb69`).
- `EvmChains.json`: switch the `ethereum` RPC to `https://ethereum-rpc.publicnode.com`; `eth1.lava.build` now returns HTTP 410 (discontinued).
- The pro-compatible Core on Ethereum (`0x14b9932cc9AC8Ee03301665a8644A753f46D8552`, from #3686) already existed and is untouched.

Verification (all via `cast` after deploy): `version()` 0.2.0, `owner()` = executor, `getTrustedSigners()` as above, executor impl matches the local artifact with immutables masked, executor init args decoded from the creation tx. Live-payload replay: a fresh feed-3 update from the Lazer API passes `verifyUpdate` on this contract and recovers the trusted signer; the same payload on Etherlink's Lazer recovers the same signer; 0 wei fee reverts `Insufficient fee provided` and a garbage payload reverts `input too short`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yo8hEGiYsDHZdn1sqxj9s

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/4036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->