### PR TITLE
fix(ondo-recorder): redact api_key and ClickHouse password from Debug

### DIFF
--- a/apps/ondo-recorder/Cargo.lock
+++ b/apps/ondo-recorder/Cargo.lock
@@ -483,6 +483,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,6 +1217,7 @@ dependencies = [
  "clap",
  "clickhouse",
  "config",
+ "derivative",
  "futures",
  "prometheus",
  "reqwest",

--- a/apps/ondo-recorder/Cargo.toml
+++ b/apps/ondo-recorder/Cargo.toml
@@ -10,6 +10,7 @@ chrono = { version = "0.4.38", features = ["clock"] }
 clap = { version = "4.5.38", features = ["derive"] }
 clickhouse = { version = "0.12.2", default-features = false, features = ["rustls-tls", "lz4"] }
 config = { version = "0.14.1", default-features = false, features = ["yaml"] }
+derivative = "2.2.0"
 futures = "0.3.31"
 prometheus = "0.13.4"
 reqwest = { version = "0.11.22", default-features = false, features = ["json", "rustls-tls"] }

--- a/apps/ondo-recorder/src/config.rs
+++ b/apps/ondo-recorder/src/config.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use config::{Environment, File};
+use derivative::Derivative;
 use serde::{de::DeserializeOwned, Deserialize};
 use thiserror::Error;
 
@@ -14,11 +15,13 @@ pub enum ConfigError {
     Invalid(String),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
+#[derive(Clone, Derivative, Eq, PartialEq, Deserialize)]
+#[derivative(Debug)]
 pub struct ClickHouseTarget {
     pub host: String,
     pub port: u16,
     pub username: String,
+    #[derivative(Debug = "ignore")]
     pub password: String,
     pub secure: bool,
     pub database: String,
@@ -32,9 +35,11 @@ pub struct TokenConfig {
     pub sizes: Vec<u32>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Derivative)]
+#[derivative(Debug)]
 pub struct AppConfig {
     pub api_url: String,
+    #[derivative(Debug = "ignore")]
     pub api_key: String,
     pub duration: String,
     pub tokens: Vec<TokenConfig>,

--- a/apps/ondo-recorder/tests/test_config.rs
+++ b/apps/ondo-recorder/tests/test_config.rs
@@ -238,6 +238,58 @@ clickhouse:
     let _ = fs::remove_file(config_file);
 }
 
+/// `AppConfig` is `Debug`, so any `tracing::info!(?config)` or `dbg!(config)`
+/// renders every field. The two secrets must not be among them.
+///
+/// Sibling recorders redact the same way — see hyperliquid-recorder, which does
+/// log the whole config at startup, and binance-recorder (#3861).
+#[test]
+fn test_debug_output_redacts_secrets() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    clear_env_vars([
+        "ONDO_RECORDER__ONDO__API_KEY",
+        "ONDO_RECORDER__CLICKHOUSE__URL",
+        "ONDO_RECORDER__CLICKHOUSE__PASSWORD",
+    ]);
+
+    let config_file = temp_yaml_path("ondo-config-redaction");
+    let yaml = r#"
+ondo:
+  api_key: "super-secret-api-key"
+tokens:
+  - symbol: "NVDAon"
+    chain_id: "ethereum-1"
+clickhouse:
+  url: "http://127.0.0.1:8123"
+  user: "recorder"
+  password: "super-secret-password"
+"#;
+    fs::write(&config_file, yaml).expect("write yaml config");
+    let config = AppConfig::from_sources(Some(&config_file)).expect("config should parse");
+
+    // The values really are loaded — otherwise the assertions below pass vacuously.
+    assert_eq!(config.api_key, "super-secret-api-key");
+    assert_eq!(config.clickhouse.password, "super-secret-password");
+
+    let rendered = format!("{config:?}");
+    assert!(
+        !rendered.contains("super-secret-api-key"),
+        "api_key leaked into Debug output: {rendered}"
+    );
+    assert!(
+        !rendered.contains("super-secret-password"),
+        "ClickHouse password leaked into Debug output: {rendered}"
+    );
+
+    // Non-secret fields stay visible, so the redaction is targeted.
+    assert!(
+        rendered.contains("recorder"),
+        "ClickHouse username should still be shown: {rendered}"
+    );
+
+    let _ = fs::remove_file(config_file);
+}
+
 fn clear_env_vars<'a>(keys: impl IntoIterator<Item = &'a str>) {
     for key in keys {
         std::env::remove_var(key);

--- a/apps/ondo-recorder/tests/test_config.rs
+++ b/apps/ondo-recorder/tests/test_config.rs
@@ -238,11 +238,11 @@ clickhouse:
     let _ = fs::remove_file(config_file);
 }
 
-/// `AppConfig` is `Debug`, so any `tracing::info!(?config)` or `dbg!(config)`
-/// renders every field. The two secrets must not be among them.
-///
-/// Sibling recorders redact the same way — see hyperliquid-recorder, which does
-/// log the whole config at startup, and binance-recorder (#3861).
+/// `AppConfig` derives `Debug`, so any `tracing::info!(?config)` or
+/// `dbg!(config)` renders every field it holds. Two of those fields are
+/// credentials — `api_key` is sent as the `x-api-key` header on every Ondo API
+/// request, and `clickhouse.password` authenticates the database writer — so
+/// neither may appear in that output.
 #[test]
 fn test_debug_output_redacts_secrets() {
     let _lock = ENV_LOCK.lock().expect("env lock poisoned");


### PR DESCRIPTION
`ondo-recorder` is the only recorder that derives a blanket `Debug` over its secrets.

- `AppConfig.api_key` — the Ondo credential, sent as the `x-api-key` header in [`poller.rs`](https://github.com/pyth-network/pyth-crosschain/blob/main/apps/ondo-recorder/src/poller.rs#L176)
- `ClickHouseTarget.password` — plaintext DB password

A single `tracing::info!(?config)` or `dbg!(config)` renders both into the log sink. Reverting just `config.rs` and keeping the new test shows exactly that:

```
api_key leaked into Debug output: AppConfig { api_url: "...", api_key: "super-secret-api-key",
  duration: "short", tokens: [...], clickhouse: ClickHouseTarget { host: "127.0.0.1", port: 8123,
  username: "recorder", password: "super-secret-password", secure: false, ... } }
```

## Why this one was missed

This is the same issue #3861 fixed in `binance-recorder`, which itself mirrored `hyperliquid-recorder`. The sweep just didn't reach ondo:

| | created | ClickHouse password | upstream credential |
|---|---|---|---|
| hyperliquid-recorder | 2026-05-04 | redacted | `quicknode_auth_token` redacted |
| **ondo-recorder** | **2026-05-04** | **not redacted** | **`api_key` not redacted** |
| binance-recorder | 2026-06-18 | redacted by #3861 | none |
| okx-recorder | 2026-08-13 | redacted | none |

binance was written after hyperliquid but copied the unredacted pattern, and #3861 fixed it 11 days later without touching ondo. okx was written after #3861 and picked up the fixed pattern. Ondo is the only one left, and the only recorder that has an upstream API credential at all.

## The fix

The same `derivative` treatment the other three use, applied to both secrets. `derivative = "2.2.0"` matches the sibling manifests exactly, and the `Cargo.lock` delta is only the new dependency. The fields stay plain `String`, so every call site is unchanged.

**No leak is reachable today** — ondo's `main.rs` never `Debug`-prints the config, unlike hyperliquid's, which logs the whole thing at startup and is safe only because of this redaction. So this closes the gap rather than stopping an active leak, which is the same posture #3861 took.

I deliberately left the private `ClickHouseConfig` deserialization struct alone. It derives `Debug` over a password in **all four** recorders, but it is never printed and never escapes `from_sources`, so widening the change there seemed like scope creep. Happy to include it if you'd rather have it uniform.

## Testing

Adds `test_debug_output_redacts_secrets`: asserts both values are loaded (so the assertions can't pass vacuously), that neither appears in the rendered `Debug`, and that the non-secret username still does. No sibling has such a test — they rely on the derive alone.

- fails on unpatched `config.rs` with both secrets in plaintext, passes with the change
- `cargo test` — 13 passed across the crate
- `cargo fmt --check` and `cargo clippy --all-targets -- --deny warnings` clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/4037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->