### PR TITLE
deploy(arc): pro-compatible Core, Executor and PythLazer on Arc mainnet

### DIFF
--- a/contract_manager/src/store/chains/EvmChains.json
+++ b/contract_manager/src/store/chains/EvmChains.json
@@ -1440,5 +1440,12 @@
     "networkId": 46630,
     "rpcUrl": "https://rpc.testnet.chain.robinhood.com",
     "type": "EvmChain"
+  },
+  {
+    "id": "arc",
+    "mainnet": true,
+    "networkId": 5042,
+    "rpcUrl": "https://rpc.mainnet.arc.io",
+    "type": "EvmChain"
   }
 ]

--- a/contract_manager/src/store/contracts/EvmExecutorContracts.json
+++ b/contract_manager/src/store/contracts/EvmExecutorContracts.json
@@ -333,5 +333,10 @@
     "address": "0xCcD7e24e71ba746CBc758C39CBAb11f4E0dfc46F",
     "chain": "ethereum",
     "type": "EvmExecutorContract"
+  },
+  {
+    "address": "0x0708325268dF9F66270F1401206434524814508b",
+    "chain": "arc",
+    "type": "EvmExecutorContract"
   }
 ]

--- a/contract_manager/src/store/contracts/EvmLazerContracts.json
+++ b/contract_manager/src/store/contracts/EvmLazerContracts.json
@@ -193,5 +193,10 @@
     "address": "0xACeA761c27A909d4D3895128EBe6370FDE2dF481",
     "chain": "ethereum",
     "type": "EvmLazerContract"
+  },
+  {
+    "address": "0xACeA761c27A909d4D3895128EBe6370FDE2dF481",
+    "chain": "arc",
+    "type": "EvmLazerContract"
   }
 ]

--- a/contract_manager/src/store/contracts/EvmPriceFeedContracts.json
+++ b/contract_manager/src/store/contracts/EvmPriceFeedContracts.json
@@ -1164,5 +1164,11 @@
     "chain": "sei_evm_mainnet",
     "type": "EvmPriceFeedContract",
     "deploymentType": "pro-compatible-production"
+  },
+  {
+    "address": "0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a",
+    "chain": "arc",
+    "type": "EvmPriceFeedContract",
+    "deploymentType": "pro-compatible-production"
   }
 ]

--- a/contract_manager/src/store/contracts/EvmWormholeContracts.json
+++ b/contract_manager/src/store/contracts/EvmWormholeContracts.json
@@ -1186,5 +1186,17 @@
     "chain": "sei_evm_mainnet",
     "type": "EvmWormholeContract",
     "deploymentType": "pro-compatible-production"
+  },
+  {
+    "address": "0xb27e5ca259702f209a29225d0eDdC131039C9933",
+    "chain": "arc",
+    "type": "EvmWormholeContract",
+    "deploymentType": "pro-compatible-production"
+  },
+  {
+    "address": "0x87047526937246727E4869C5f76A347160e08672",
+    "chain": "arc",
+    "type": "EvmWormholeContract",
+    "deploymentType": "stable"
   }
 ]

--- a/governance/xc_admin/packages/xc_admin_common/src/chains.ts
+++ b/governance/xc_admin/packages/xc_admin_common/src/chains.ts
@@ -137,6 +137,7 @@ export const RECEIVER_CHAINS = {
   // (30) — matching the precedent set by Sui (`iota_sui_*`) and Cardano.
   stellar_mainnet: 60100,
   robinhood: 60101,
+  arc: 60102,
 
   // Testnets as a separate chain ids (to use stable data sources and governance for them)
   injective_testnet: 60013,


### PR DESCRIPTION
Store entries for Arc mainnet (`arc`, chain 5042, Wormhole 60102), deployed 2026-09-01.

| Contract | Address |
|---|---|
| Core (pro-compatible, v1.4.6) | `0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a` |
| Pro Wormhole receiver | `0xb27e5ca259702f209a29225d0eDdC131039C9933` |
| Executor (v0.1.1) | `0x0708325268dF9F66270F1401206434524814508b` |
| Stable Wormhole receiver | `0x87047526937246727E4869C5f76A347160e08672` |
| PythLazer (v0.2.0, owner = Executor) | `0xACeA761c27A909d4D3895128EBe6370FDE2dF481` |

Verified on-chain: bytecode matches local artifacts, config matches `pro-compatible-production`, live pro-VAA and Lazer payload replays succeed.

Arc mainnet has no open public RPC yet (`rpc.mainnet.arc.io` is gated), so the store uses it as a placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcVtZhe1fBR2c5mvLFpubZ
