### PR TITLE
feat(contract_manager): add Lazer SVM contracts for solana devnet + fogo testnet

### DIFF
--- a/contract_manager/src/store/contracts/SolanaLazerContracts.json
+++ b/contract_manager/src/store/contracts/SolanaLazerContracts.json
@@ -3,5 +3,15 @@
     "chain": "solana_mainnet",
     "programId": "pytd2yyk641x7ak7mkaasSJVXh6YYZnC7wTmtgAyxPt",
     "type": "SolanaLazerContract"
+  },
+  {
+    "chain": "solana_devnet",
+    "programId": "pytd2yyk641x7ak7mkaasSJVXh6YYZnC7wTmtgAyxPt",
+    "type": "SolanaLazerContract"
+  },
+  {
+    "chain": "fogo_testnet",
+    "programId": "pytd2yyk641x7ak7mkaasSJVXh6YYZnC7wTmtgAyxPt",
+    "type": "SolanaLazerContract"
   }
 ]


### PR DESCRIPTION
## What

Add `SolanaLazerContract` entries for `solana_devnet` and `fogo_testnet` to
`contract_manager/src/store/contracts/SolanaLazerContracts.json`, both pointing
at the canonical program id `pytd2yyk641x7ak7mkaasSJVXh6YYZnC7wTmtgAyxPt`.

## Why

The `pyth_lazer_solana_contract` program is deployed and initialized on Solana
devnet and Fogo testnet at the same program id as mainnet, but only the mainnet
entry was in the store — so governance scripts and reads couldn't reach them.
Fogo mainnet is intentionally omitted because the program is not deployed
there yet.

## Verification

For each RPC, fetched the program account and the singleton Storage PDA
(`3rdJbqfnagQ4yx9HXJViD4zc4xpiSqmFsKpPuSCQVyQL`) via `getAccountInfo` and
checked the Anchor discriminator + size matched the layout `SolanaLazerContract`
expects:

| chain | program | Storage PDA | discriminator | size |
| --- | --- | --- | --- | --- |
| solana_mainnet | deployed | initialized | `d175ffb9c4af4409` | 381 |
| solana_devnet  | deployed | initialized | `d175ffb9c4af4409` | 381 |
| fogo_testnet   | deployed | initialized | `d175ffb9c4af4409` | 381 |
| fogo_mainnet   | not deployed | — | — | — |

Also verified the store still loads with every contract entry pointing to a
known chain. `pnpm turbo build` was not run because `@pythnetwork/price-service-sdk`
fails to build on `main` (unrelated TypeScript typing regression, reproduces
without this diff).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pyth-network/pyth-crosschain/pull/4043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->